### PR TITLE
Feat: official Python SDK for the REST API (M571)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,20 @@ jobs:
             exit 1
           fi
 
+  python-sdk:
+    name: python-sdk
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      # The SDK and its tests are standard-library only — no pip install needed.
+      - name: Test the Python SDK
+        run: |
+          cd sdk/python
+          python -m unittest discover -s tests
+
   multi-arch:
     name: cross-build (${{ matrix.goos }}/${{ matrix.goarch }})
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,13 @@
 # frontend TS incremental build cache
 *.tsbuildinfo
 
+# python build/test artifacts
+__pycache__/
+*.pyc
+*.egg-info/
+/sdk/python/build/
+/sdk/python/dist/
+
 # agent working notes + local agent config — never committed
 next.md
 .claude/

--- a/.project/PHASE-M571-PYTHON-SDK-REPORT.md
+++ b/.project/PHASE-M571-PYTHON-SDK-REPORT.md
@@ -1,0 +1,68 @@
+# Phase M571 — Official Python SDK for the REST API
+
+**Type:** Feature (SDK; realizes the Python half of decision A4)
+**Date:** 2026-06-07
+**Branch:** `feat-python-sdk`
+
+## Goal
+
+Ship a first-class Python client for Agezt's native REST API (`/api/v1`), opening
+the daemon to the Python ecosystem. Hold to the project's stdlib-first ethos: the
+client and its tests use the Python standard library only — no third-party
+dependencies, and CI runs the tests with no `pip install`.
+
+## What shipped
+
+### `sdk/python/` (new)
+- `pyproject.toml` — package `agezt` v1.0.0, `requires-python >=3.9`, **zero
+  runtime dependencies**.
+- `agezt/client.py` — `Client(base_url, token, timeout=30, tenant=None)`:
+  - `health()` → `GET /api/v1/health`
+  - `models()` → `GET /api/v1/models`
+  - `run(intent, model=None)` → `POST /api/v1/runs` (blocking) → `RunResult`
+    (correlation_id, model, status, answer)
+  - `run_stream(intent, model=None)` → `POST /api/v1/runs` with
+    `Accept: text/event-stream`, an iterator of `StreamEvent`
+    (`start`/`token`/`done`/`error`) parsed from SSE (handles multi-line `data:`
+    and `:` heartbeats)
+  - `get_run(correlation_id)` → `GET /api/v1/runs/{id}`
+  - bearer-token auth; optional `tenant` → `X-Agezt-Tenant`; non-2xx →
+    `APIError(status, type, message)` (parses both the `{"error":{type,message}}`
+    shape and the failed-run `{"status":"failed","error":"…"}` shape).
+- `agezt/errors.py` — `AgeztError` / `APIError`.
+- `agezt/__init__.py`, `README.md`.
+
+### `sdk/python/tests/test_client.py` (new — 7 tests, all pass)
+`unittest` against a stdlib `http.server` mock: health, models, sync run (+ model
+forwarding), failed run → `APIError(502)`, SSE streaming (start/token×2 with a
+heartbeat/done, token reassembly), get_run, and bad-token → `APIError(401)`.
+
+### CI
+- `.github/workflows/ci.yml`: a `python-sdk` job (`actions/setup-python`,
+  `python -m unittest discover -s tests`). No `pip install` — stdlib only.
+
+## Verification
+
+- **Unit:** `python -m unittest` in `sdk/python` — 7/7 pass.
+- **Full Go gate** unaffected: `GOMAXPROCS=3 go test ./... -p 2` exit 0 (77
+  packages); no Go files changed; `go.mod`/`go.sum` unchanged; the new
+  `frontend-dist-in-sync` and existing jobs are untouched.
+- **Runtime smoke (executable proof, criterion-7):** booted the real daemon with
+  `AGEZT_REST_ADDR` set, read the minted bearer token from the banner, and drove
+  it with the SDK: `health()` → v1.0.0; `models()` → mock; `run("ping")` →
+  `completed` / `[echo]\nping`; `run_stream("hello")` parsed the SSE
+  (`start`/`done`); `get_run()` → 6-event arc; wrong token → `APIError(401)`;
+  0 panics.
+
+## Counts
+
+- Go packages 77, Go tests 2440 (unchanged — the SDK is Python, separate from the
+  Go test count). Python SDK: 7 unittest cases.
+- No Go dependency added; the Python SDK has zero runtime dependencies.
+
+## Out of scope (documented follow-ups)
+
+- TypeScript SDK (the other A4 SDK) — its own follow-up.
+- An async client (`asyncio`/`aiohttp`) — the current client is synchronous +
+  a streaming generator, dependency-free.
+- Publishing to PyPI (packaging is ready; release is an ops step).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **Official Python SDK** (`sdk/python`, `pip install agezt`). A standard-library-only
+  client for the daemon's REST API (`/api/v1`) — `Client(base_url, token)` with
+  `health()`, `models()`, `run()` (blocking), `run_stream()` (Server-Sent Events →
+  `start`/`token`/`done`/`error`), and `get_run()`; bearer-token auth, optional
+  `tenant` for multi-tenant daemons; non-2xx raises `APIError`. No third-party
+  dependencies (urllib + json), and the tests are `unittest` against a stdlib
+  http.server mock, so CI runs them with no `pip install`. Realizes the Python
+  half of decision A4's "SDKs in Go/TS/Python/Rust". (M571)
 - **WhatsApp is now a messaging channel** (Meta WhatsApp Cloud API) — the eighth
   channel. `plugins/channels/whatsapp` serves Meta's inbound webhook: the GET
   verification handshake (echoes `hub.challenge` when `hub.verify_token` matches)

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,0 +1,74 @@
+# Agezt Python SDK
+
+The official Python client for the [Agezt](https://github.com/agezt/agezt)
+agentic OS. It talks to a running Agezt daemon's native REST API (`/api/v1`) —
+the same governed kernel loop `agt run` uses (Edict policy, the journal, cost
+governance) — over plain HTTP with a bearer token.
+
+**Standard library only — no runtime dependencies.**
+
+## Install
+
+```bash
+pip install agezt          # from PyPI (when published)
+# or, from this repo:
+pip install ./sdk/python
+```
+
+The client itself is pure stdlib, so you can also just vendor the `agezt/`
+package directly.
+
+## Quick start
+
+Start a daemon with the REST API enabled and note the token it prints:
+
+```bash
+AGEZT_REST_ADDR=127.0.0.1:8800 agezt
+#   rest api : http://127.0.0.1:8800/api/v1  (Authorization: Bearer <token>)
+```
+
+```python
+from agezt import Client
+
+c = Client("http://127.0.0.1:8800", token="<token>")
+
+print(c.health())          # {'status': 'ok', 'version': '1.0.0', ...}
+print(c.models()["default"])
+
+# Blocking run — returns the final answer.
+result = c.run("summarise the latest commits")
+print(result.answer)
+
+# Streaming run — tokens as the agent produces them.
+for ev in c.run_stream("write a haiku about Go"):
+    if ev.event == "token":
+        print(ev.data.get("text", ""), end="", flush=True)
+
+# The journaled event arc of a past run.
+arc = c.get_run(result.correlation_id)
+print(arc["count"], "events")
+```
+
+## API
+
+| Method | REST endpoint | Returns |
+|---|---|---|
+| `health()` | `GET /api/v1/health` | `dict` (status, version, default_model, model_count) |
+| `models()` | `GET /api/v1/models` | `dict` (`default`, `models`) |
+| `run(intent, model=None)` | `POST /api/v1/runs` | `RunResult` (correlation_id, model, status, answer) |
+| `run_stream(intent, model=None)` | `POST /api/v1/runs` (SSE) | iterator of `StreamEvent` (`start`/`token`/`done`/`error`) |
+| `get_run(correlation_id)` | `GET /api/v1/runs/{id}` | `dict` (correlation_id, count, events) |
+
+`Client(base_url, token, timeout=30, tenant=None)` — pass `tenant` to target an
+isolated tenant (sent as the `X-Agezt-Tenant` header) on a multi-tenant daemon.
+
+Non-2xx responses raise `agezt.APIError` (`.status`, `.type`, `.message`).
+
+## Tests
+
+Standard-library `unittest`, no third-party deps:
+
+```bash
+cd sdk/python
+python -m unittest discover -s tests
+```

--- a/sdk/python/agezt/__init__.py
+++ b/sdk/python/agezt/__init__.py
@@ -1,0 +1,24 @@
+"""Official Python client for the Agezt agentic OS.
+
+Talks to a running Agezt daemon's native REST API (``/api/v1``) — the same
+governed kernel loop ``agt run`` uses (Edict policy, the journal, cost
+governance) — over plain HTTP with a bearer token. Standard library only.
+
+    from agezt import Client
+
+    c = Client("http://127.0.0.1:8800", token="…")
+    print(c.health()["version"])
+    result = c.run("summarise the latest commits")
+    print(result.answer)
+
+    # stream tokens as they are produced
+    for ev in c.run_stream("write a haiku about Go"):
+        if ev.event == "token":
+            print(ev.data.get("text", ""), end="", flush=True)
+"""
+
+from .client import Client, RunResult, StreamEvent
+from .errors import AgeztError, APIError
+
+__all__ = ["Client", "RunResult", "StreamEvent", "AgeztError", "APIError"]
+__version__ = "1.0.0"

--- a/sdk/python/agezt/client.py
+++ b/sdk/python/agezt/client.py
@@ -1,0 +1,196 @@
+"""HTTP client for the Agezt REST API (``/api/v1``). Standard library only."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterator, List, Optional
+
+from .errors import APIError
+
+__all__ = ["Client", "RunResult", "StreamEvent"]
+
+
+@dataclass
+class RunResult:
+    """A completed (non-streaming) run."""
+
+    correlation_id: str
+    model: str
+    status: str
+    answer: str
+
+    @classmethod
+    def _from(cls, d: Dict[str, Any]) -> "RunResult":
+        return cls(
+            correlation_id=d.get("correlation_id", ""),
+            model=d.get("model", ""),
+            status=d.get("status", ""),
+            answer=d.get("answer", ""),
+        )
+
+
+@dataclass
+class StreamEvent:
+    """One Server-Sent Event from a streaming run.
+
+    ``event`` is one of ``start``, ``token``, ``done``, ``error``; ``data`` is
+    the decoded JSON payload (e.g. ``{"text": "…"}`` for ``token``).
+    """
+
+    event: str
+    data: Dict[str, Any] = field(default_factory=dict)
+
+
+class Client:
+    """A client for a running Agezt daemon's REST API.
+
+    Args:
+        base_url: the daemon's REST address, e.g. ``http://127.0.0.1:8800``.
+        token: the bearer token (the daemon's admin token or a tenant token).
+        timeout: per-request timeout in seconds.
+        tenant: optional tenant id, sent as the ``X-Agezt-Tenant`` header.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        token: str,
+        timeout: float = 30.0,
+        tenant: Optional[str] = None,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self.timeout = timeout
+        self.tenant = tenant
+
+    # --- public API -------------------------------------------------------
+
+    def health(self) -> Dict[str, Any]:
+        """Return the daemon's liveness + version summary."""
+        return self._get("/api/v1/health")
+
+    def models(self) -> Dict[str, Any]:
+        """Return ``{"default": id, "models": [ids…]}``."""
+        return self._get("/api/v1/models")
+
+    def run(self, intent: str, model: Optional[str] = None) -> RunResult:
+        """Execute an intent and return the final answer (blocking).
+
+        Raises APIError if the run fails or the request is rejected.
+        """
+        body: Dict[str, Any] = {"intent": intent}
+        if model:
+            body["model"] = model
+        return RunResult._from(self._post_json("/api/v1/runs", body))
+
+    def run_stream(
+        self, intent: str, model: Optional[str] = None
+    ) -> Iterator[StreamEvent]:
+        """Execute an intent, yielding StreamEvents (start/token/done/error) as
+        the agent produces them.
+        """
+        body: Dict[str, Any] = {"intent": intent, "stream": True}
+        if model:
+            body["model"] = model
+        data = json.dumps(body).encode("utf-8")
+        req = self._request("POST", "/api/v1/runs", data=data, accept="text/event-stream")
+        try:
+            resp = urllib.request.urlopen(req, timeout=self.timeout)
+        except urllib.error.HTTPError as e:
+            raise self._api_error(e) from None
+        with resp:
+            yield from _parse_sse(resp)
+
+    def get_run(self, correlation_id: str) -> Dict[str, Any]:
+        """Return the journaled event arc of a past run."""
+        return self._get("/api/v1/runs/" + urllib.parse.quote(correlation_id))
+
+    # --- internals --------------------------------------------------------
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        data: Optional[bytes] = None,
+        accept: str = "application/json",
+    ) -> urllib.request.Request:
+        req = urllib.request.Request(self.base_url + path, data=data, method=method)
+        req.add_header("Authorization", "Bearer " + self.token)
+        req.add_header("Accept", accept)
+        if data is not None:
+            req.add_header("Content-Type", "application/json")
+        if self.tenant:
+            req.add_header("X-Agezt-Tenant", self.tenant)
+        return req
+
+    def _get(self, path: str) -> Dict[str, Any]:
+        return self._do(self._request("GET", path))
+
+    def _post_json(self, path: str, body: Dict[str, Any]) -> Dict[str, Any]:
+        data = json.dumps(body).encode("utf-8")
+        return self._do(self._request("POST", path, data=data))
+
+    def _do(self, req: urllib.request.Request) -> Dict[str, Any]:
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                raw = resp.read()
+        except urllib.error.HTTPError as e:
+            raise self._api_error(e) from None
+        if not raw:
+            return {}
+        return json.loads(raw.decode("utf-8"))
+
+    @staticmethod
+    def _api_error(e: urllib.error.HTTPError) -> APIError:
+        typ, msg = "", ""
+        try:
+            body = json.loads(e.read().decode("utf-8"))
+            err = body.get("error")
+            if isinstance(err, dict):  # {"error": {"type", "message"}}
+                typ = err.get("type", "")
+                msg = err.get("message", "")
+            elif isinstance(err, str):  # failed-run body: {"status":"failed","error": "…"}
+                typ = body.get("status", "")
+                msg = err
+        except Exception:
+            pass
+        return APIError(e.code, typ, msg)
+
+
+def _parse_sse(stream) -> Iterator[StreamEvent]:
+    """Parse a text/event-stream into StreamEvents. Each event is the lines up to
+    a blank line: ``event:`` names it, ``data:`` (possibly multi-line) is its
+    JSON payload."""
+    event = "message"
+    data_lines: List[str] = []
+    for raw in stream:
+        line = raw.decode("utf-8").rstrip("\n").rstrip("\r")
+        if line == "":
+            if data_lines:
+                payload: Dict[str, Any] = {}
+                joined = "\n".join(data_lines)
+                try:
+                    payload = json.loads(joined)
+                except ValueError:
+                    payload = {"raw": joined}
+                yield StreamEvent(event=event, data=payload)
+            event = "message"
+            data_lines = []
+            continue
+        if line.startswith(":"):  # SSE comment / heartbeat
+            continue
+        if line.startswith("event:"):
+            event = line[len("event:"):].strip()
+        elif line.startswith("data:"):
+            data_lines.append(line[len("data:"):].lstrip())
+    # Flush a trailing event with no terminating blank line.
+    if data_lines:
+        joined = "\n".join(data_lines)
+        try:
+            yield StreamEvent(event=event, data=json.loads(joined))
+        except ValueError:
+            yield StreamEvent(event=event, data={"raw": joined})

--- a/sdk/python/agezt/errors.py
+++ b/sdk/python/agezt/errors.py
@@ -1,0 +1,25 @@
+"""Exceptions raised by the Agezt client."""
+
+from __future__ import annotations
+
+
+class AgeztError(Exception):
+    """Base class for all errors raised by this package."""
+
+
+class APIError(AgeztError):
+    """The daemon returned a non-2xx response.
+
+    Attributes:
+        status: the HTTP status code.
+        type: the machine-readable error type from the body
+            (``error.type``), or ``""`` when absent.
+        message: the human-readable message from the body, or the raw body.
+    """
+
+    def __init__(self, status: int, type: str = "", message: str = "") -> None:
+        self.status = status
+        self.type = type
+        self.message = message
+        detail = message or type or "request failed"
+        super().__init__(f"agezt: HTTP {status}: {detail}")

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "agezt"
+version = "1.0.0"
+description = "Official Python client for the Agezt agentic OS REST API (/api/v1)."
+readme = "README.md"
+requires-python = ">=3.9"
+license = "MIT"
+authors = [{ name = "Agezt" }]
+keywords = ["agezt", "agent", "llm", "ai", "automation"]
+# Standard-library only — no runtime dependencies, mirroring Agezt's
+# stdlib-first ethos. The client uses urllib + json from the stdlib.
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/agezt/agezt"
+Source = "https://github.com/agezt/agezt/tree/main/sdk/python"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["agezt*"]

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -1,0 +1,134 @@
+"""Tests for the Agezt Python client, against a stdlib http.server mock.
+
+No third-party dependencies: run with ``python -m unittest`` from sdk/python.
+"""
+
+import json
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import sys
+from pathlib import Path
+
+# Make the package importable when run from the repo without installation.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agezt import APIError, Client  # noqa: E402
+
+
+class _Handler(BaseHTTPRequestHandler):
+    # Set per-test on the server instance.
+    def log_message(self, *args):  # silence test noise
+        pass
+
+    def _auth_ok(self):
+        return self.headers.get("Authorization") == "Bearer testtoken"
+
+    def _json(self, code, obj):
+        body = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if not self._auth_ok():
+            self._json(401, {"error": {"type": "unauthorized", "message": "missing or invalid token"}})
+            return
+        if self.path == "/api/v1/health":
+            self._json(200, {"status": "ok", "version": "test", "default_model": "m", "model_count": 1})
+        elif self.path == "/api/v1/models":
+            self._json(200, {"default": "m", "models": ["m", "n"]})
+        elif self.path.startswith("/api/v1/runs/"):
+            self._json(200, {"correlation_id": "c1", "count": 2, "events": [{"seq": 1}, {"seq": 2}]})
+        else:
+            self._json(404, {"error": {"type": "not_found", "message": "nope"}})
+
+    def do_POST(self):
+        if not self._auth_ok():
+            self._json(401, {"error": {"type": "unauthorized", "message": "bad token"}})
+            return
+        length = int(self.headers.get("Content-Length", "0"))
+        body = json.loads(self.rfile.read(length) or b"{}")
+        self.server.last_body = body
+        if body.get("intent") == "boom":
+            self._json(502, {"correlation_id": "c2", "model": "m", "status": "failed", "error": "provider exploded"})
+            return
+        if body.get("stream"):
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.end_headers()
+            for frame in (
+                'event: start\ndata: {"correlation_id": "c3", "model": "m"}\n\n',
+                'event: token\ndata: {"text": "hel"}\n\n',
+                ": heartbeat\n\n",
+                'event: token\ndata: {"text": "lo"}\n\n',
+                'event: done\ndata: {"correlation_id": "c3", "status": "completed", "answer": "hello"}\n\n',
+            ):
+                self.wfile.write(frame.encode())
+            return
+        self._json(200, {"correlation_id": "c4", "model": body.get("model", "m"), "status": "completed", "answer": "pong"})
+
+
+class ClientTest(unittest.TestCase):
+    def setUp(self):
+        self.srv = HTTPServer(("127.0.0.1", 0), _Handler)
+        self.srv.last_body = None
+        self.t = threading.Thread(target=self.srv.serve_forever, daemon=True)
+        self.t.start()
+        port = self.srv.server_address[1]
+        self.c = Client(f"http://127.0.0.1:{port}", token="testtoken", timeout=5)
+
+    def tearDown(self):
+        self.srv.shutdown()
+        self.srv.server_close()
+
+    def test_health(self):
+        h = self.c.health()
+        self.assertEqual(h["status"], "ok")
+        self.assertEqual(h["version"], "test")
+
+    def test_models(self):
+        m = self.c.models()
+        self.assertEqual(m["default"], "m")
+        self.assertIn("n", m["models"])
+
+    def test_run_sync(self):
+        r = self.c.run("ping", model="m")
+        self.assertEqual(r.status, "completed")
+        self.assertEqual(r.answer, "pong")
+        self.assertEqual(r.correlation_id, "c4")
+        # the model option is forwarded
+        self.assertEqual(self.srv.last_body.get("model"), "m")
+
+    def test_run_failure_raises(self):
+        with self.assertRaises(APIError) as cm:
+            self.c.run("boom")
+        self.assertEqual(cm.exception.status, 502)
+        self.assertIn("provider exploded", cm.exception.message)
+
+    def test_run_stream(self):
+        events = list(self.c.run_stream("hi"))
+        kinds = [e.event for e in events]
+        self.assertEqual(kinds, ["start", "token", "token", "done"])
+        tokens = "".join(e.data.get("text", "") for e in events if e.event == "token")
+        self.assertEqual(tokens, "hello")
+        self.assertEqual(events[-1].data.get("answer"), "hello")
+
+    def test_get_run(self):
+        arc = self.c.get_run("c1")
+        self.assertEqual(arc["count"], 2)
+        self.assertEqual(len(arc["events"]), 2)
+
+    def test_bad_token_raises_401(self):
+        bad = Client(self.c.base_url, token="WRONG", timeout=5)
+        with self.assertRaises(APIError) as cm:
+            bad.health()
+        self.assertEqual(cm.exception.status, 401)
+        self.assertEqual(cm.exception.type, "unauthorized")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

A first-class **Python client** for Agezt's native REST API (`/api/v1`), opening the daemon to the Python ecosystem — the Python half of decision A4's SDK set. **Standard library only: no runtime dependencies, and CI runs the tests with no `pip install`.**

`Client(base_url, token, timeout=30, tenant=None)`:
- `health()` · `models()`
- `run(intent, model=None)` → `RunResult` (blocking)
- `run_stream(intent, model=None)` → iterator of `StreamEvent` (`start`/`token`/`done`/`error`, parsed from SSE — handles multi-line `data:` + `:` heartbeats)
- `get_run(correlation_id)`
- bearer-token auth; optional `tenant` → `X-Agezt-Tenant`; non-2xx → `APIError(status, type, message)` (handles both the `{error:{type,message}}` and failed-run `{status,error}` shapes).

## Verification
- 7 `unittest` tests against a stdlib `http.server` mock (health/models/sync-run/failed-run/SSE-stream/get_run/bad-token) — all pass.
- New CI job `python-sdk` (`setup-python` + `python -m unittest`). Go suite unaffected (no Go change; 77 pkgs; `go.mod` unchanged).
- **Runtime smoke**: booted the real daemon with `AGEZT_REST_ADDR`, read the minted token, drove it with the SDK — `health()` v1.0.0, `models()` mock, `run("ping")` → `[echo]\nping`, `run_stream` parsed the SSE, `get_run` → 6-event arc, wrong token → `APIError(401)`; 0 panics.

Detail in `.project/PHASE-M571-PYTHON-SDK-REPORT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)