### PR TITLE
Feat: official TypeScript SDK for the REST API (M572)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,24 @@ jobs:
           cd sdk/python
           python -m unittest discover -s tests
 
+  typescript-sdk:
+    name: typescript-sdk
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: sdk/typescript/package-lock.json
+      # Only devDep is TypeScript; the SDK itself has zero runtime deps. `npm test`
+      # type-checks + compiles (tsc) then runs the node:test suite.
+      - name: Test the TypeScript SDK
+        run: |
+          cd sdk/typescript
+          npm ci
+          npm test
+
   multi-arch:
     name: cross-build (${{ matrix.goos }}/${{ matrix.goarch }})
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,11 @@ __pycache__/
 /sdk/python/build/
 /sdk/python/dist/
 
+# typescript SDK deps + build output (the npm package is built in CI / on publish;
+# package-lock.json IS committed so `npm ci` is reproducible)
+/sdk/typescript/node_modules/
+/sdk/typescript/dist/
+
 # agent working notes + local agent config — never committed
 next.md
 .claude/

--- a/.project/PHASE-M572-TYPESCRIPT-SDK-REPORT.md
+++ b/.project/PHASE-M572-TYPESCRIPT-SDK-REPORT.md
@@ -1,0 +1,65 @@
+# Phase M572 — Official TypeScript SDK for the REST API
+
+**Type:** Feature (SDK; completes the TS half of decision A4)
+**Date:** 2026-06-07
+**Branch:** `feat-typescript-sdk`
+
+## Goal
+
+Ship a first-class TypeScript/JavaScript client for Agezt's REST API (`/api/v1`),
+mirroring the Python SDK (M571) so JS/TS apps (Node and browser) can drive the
+daemon. Keep the runtime dependency-free (platform `fetch`); the only dev
+dependency is TypeScript, and tests use Node's built-in test runner.
+
+## What shipped
+
+### `sdk/typescript/` (new)
+- `package.json` — `@agezt/sdk` v1.0.0, ESM, `engines.node >=18`, **zero runtime
+  dependencies**; devDeps: `typescript` + `@types/node`. `npm test` = `tsc`
+  (type-check + build to `dist/`) then `node --test`.
+- `src/client.ts` — `class Client(baseUrl, token, { timeoutMs=30000, tenant? })`:
+  - `health()` / `models()` / `getRun(id)` (typed JSON GETs)
+  - `run(intent, model?)` → `Promise<RunResult>` (blocking POST)
+  - `runStream(intent, model?)` → `AsyncGenerator<StreamEvent>` parsed from the
+    SSE `ReadableStream` (handles `\n\n` and `\r\n\r\n` frame separators,
+    multi-line `data:`, `:` heartbeats)
+  - bearer auth; optional `tenant` → `X-Agezt-Tenant`; per-request `AbortController`
+    timeout; non-2xx → `APIError(status, type, detail)` (parses both the
+    `{error:{type,message}}` and failed-run `{status,error}` shapes).
+- `src/errors.ts` (`AgeztError`/`APIError`), `src/index.ts` (public exports),
+  `tsconfig.json` (NodeNext, strict, declarations), `README.md`.
+
+### `sdk/typescript/test/client.test.ts` (new — 7 tests, all pass)
+`node:test` + `node:assert/strict` against a `node:http` mock: health, models,
+sync run (+ model forwarding), failed run → `APIError(502)`, SSE streaming
+(start/token×2 with a heartbeat/done + token reassembly), getRun, bad-token →
+`APIError(401)`.
+
+### Build / CI
+- `.github/workflows/ci.yml`: a `typescript-sdk` job (`actions/setup-node` 22,
+  npm cache, `npm ci` + `npm test`).
+- `.gitignore`: `sdk/typescript/node_modules/` + `dist/` (the npm package is built
+  in CI / on publish); `package-lock.json` IS committed for reproducible `npm ci`.
+
+## Verification
+
+- **Unit:** `npm test` in `sdk/typescript` — `tsc` clean, 7/7 node:test pass.
+- **Full Go gate** unaffected: `GOMAXPROCS=3 go test ./... -p 2` exit 0 (77
+  packages); no Go change; `go.mod` unchanged.
+- **Runtime smoke (executable proof, criterion-7):** booted the real daemon with
+  `AGEZT_REST_ADDR`, read the minted token, drove it with the compiled SDK:
+  `health()` v1.0.0, `models()` mock, `run("ping")` → `completed`/`[echo]\nping`,
+  `runStream("hello")` parsed the SSE (`start`/`done`), `getRun()` → 6-event arc,
+  wrong token → `APIError(401)`; 0 panics.
+
+## Counts
+
+- Go packages 77, Go tests 2440 (unchanged — TS SDK is separate). TS SDK: 7
+  node:test cases.
+- No Go dependency added; the TS SDK has zero runtime dependencies.
+
+## Out of scope (documented follow-ups)
+
+- Publishing to npm (packaging ready; release is an ops step).
+- A browser usage example / bundler guidance (the client is already
+  browser-compatible via `fetch`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **Official TypeScript SDK** (`sdk/typescript`, `@agezt/sdk`). A
+  zero-runtime-dependency client for the daemon's REST API (`/api/v1`) built on the
+  platform `fetch` (Node 18+ and browsers): `new Client(baseUrl, token, {timeoutMs,
+  tenant})` with `health()`, `models()`, `run()`, `runStream()` (an
+  `AsyncGenerator` over Server-Sent Events → `start`/`token`/`done`/`error`), and
+  `getRun()`; bearer-token auth; non-2xx throws `APIError`. The only dev dependency
+  is TypeScript; tests use the Node built-in runner (`node:test`) against a
+  `node:http` mock — no third-party test framework. Completes the TS half of
+  decision A4's SDK set. (M572)
 - **Official Python SDK** (`sdk/python`, `pip install agezt`). A standard-library-only
   client for the daemon's REST API (`/api/v1`) — `Client(base_url, token)` with
   `health()`, `models()`, `run()` (blocking), `run_stream()` (Server-Sent Events →

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1,0 +1,73 @@
+# Agezt TypeScript SDK
+
+The official TypeScript/JavaScript client for the
+[Agezt](https://github.com/agezt/agezt) agentic OS. It talks to a running Agezt
+daemon's native REST API (`/api/v1`) — the same governed kernel loop `agt run`
+uses (Edict policy, the journal, cost governance) — over `fetch` with a bearer
+token.
+
+**Zero runtime dependencies** (uses the platform `fetch` + `ReadableStream`);
+works in Node 18+ and modern browsers.
+
+## Install
+
+```bash
+npm install @agezt/sdk
+```
+
+## Quick start
+
+Start a daemon with the REST API enabled and note the token it prints:
+
+```bash
+AGEZT_REST_ADDR=127.0.0.1:8800 agezt
+#   rest api : http://127.0.0.1:8800/api/v1  (Authorization: Bearer <token>)
+```
+
+```ts
+import { Client } from "@agezt/sdk";
+
+const c = new Client("http://127.0.0.1:8800", "<token>");
+
+console.log((await c.health()).version);
+console.log((await c.models()).default);
+
+// Blocking run.
+const result = await c.run("summarise the latest commits");
+console.log(result.answer);
+
+// Streaming run — tokens as the agent produces them.
+for await (const ev of c.runStream("write a haiku about Go")) {
+  if (ev.event === "token") process.stdout.write(String(ev.data.text ?? ""));
+}
+
+// The journaled event arc of a past run.
+const arc = await c.getRun(result.correlation_id);
+console.log(arc.count, "events");
+```
+
+## API
+
+| Method | REST endpoint | Returns |
+|---|---|---|
+| `health()` | `GET /api/v1/health` | `Promise<Health>` |
+| `models()` | `GET /api/v1/models` | `Promise<Models>` |
+| `run(intent, model?)` | `POST /api/v1/runs` | `Promise<RunResult>` |
+| `runStream(intent, model?)` | `POST /api/v1/runs` (SSE) | `AsyncGenerator<StreamEvent>` (`start`/`token`/`done`/`error`) |
+| `getRun(correlationId)` | `GET /api/v1/runs/{id}` | `Promise<RunArc>` |
+
+`new Client(baseUrl, token, { timeoutMs?, tenant? })` — pass `tenant` to target an
+isolated tenant (sent as `X-Agezt-Tenant`) on a multi-tenant daemon.
+
+Non-2xx responses throw `APIError` (`.status`, `.type`, `.detail`).
+
+## Develop / test
+
+The only dev dependency is TypeScript; tests use the Node built-in test runner
+(`node:test`) against a `node:http` mock — no third-party test framework.
+
+```bash
+cd sdk/typescript
+npm ci
+npm test      # tsc (type-check + build) then node --test
+```

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,0 +1,51 @@
+{
+  "name": "@agezt/sdk",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@agezt/sdk",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^22.10.0",
+        "typescript": "^5.7.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@agezt/sdk",
+  "version": "1.0.0",
+  "description": "Official TypeScript/JavaScript client for the Agezt agentic OS REST API (/api/v1).",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": ["dist", "README.md"],
+  "engines": { "node": ">=18" },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "tsc -p tsconfig.json && node --test dist/test/client.test.js"
+  },
+  "keywords": ["agezt", "agent", "llm", "ai", "automation", "sdk"],
+  "repository": { "type": "git", "url": "https://github.com/agezt/agezt", "directory": "sdk/typescript" },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "typescript": "^5.7.2"
+  }
+}

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -1,0 +1,201 @@
+import { APIError } from "./errors.js";
+
+/** Daemon health summary (`GET /api/v1/health`). */
+export interface Health {
+  status: string;
+  version: string;
+  default_model: string;
+  model_count: number;
+}
+
+/** Available models (`GET /api/v1/models`). */
+export interface Models {
+  default: string;
+  models: string[];
+}
+
+/** A completed (non-streaming) run. */
+export interface RunResult {
+  correlation_id: string;
+  model: string;
+  status: string;
+  answer: string;
+}
+
+/** One Server-Sent Event from a streaming run. `event` is one of
+ * `start` | `token` | `done` | `error`; `data` is the decoded JSON payload. */
+export interface StreamEvent {
+  event: string;
+  data: Record<string, unknown>;
+}
+
+/** The journaled event arc of a past run (`GET /api/v1/runs/{id}`). */
+export interface RunArc {
+  correlation_id: string;
+  count: number;
+  events: unknown[];
+}
+
+export interface ClientOptions {
+  /** Per-request timeout in milliseconds (default 30000). */
+  timeoutMs?: number;
+  /** Optional tenant id, sent as the `X-Agezt-Tenant` header. */
+  tenant?: string;
+}
+
+/**
+ * A client for a running Agezt daemon's REST API.
+ *
+ * ```ts
+ * const c = new Client("http://127.0.0.1:8800", "<token>");
+ * console.log((await c.health()).version);
+ * const r = await c.run("summarise the latest commits");
+ * for await (const ev of c.runStream("write a haiku")) {
+ *   if (ev.event === "token") process.stdout.write(String(ev.data.text ?? ""));
+ * }
+ * ```
+ */
+export class Client {
+  private readonly baseUrl: string;
+  private readonly token: string;
+  private readonly timeoutMs: number;
+  private readonly tenant?: string;
+
+  constructor(baseUrl: string, token: string, opts: ClientOptions = {}) {
+    this.baseUrl = baseUrl.replace(/\/+$/, "");
+    this.token = token;
+    this.timeoutMs = opts.timeoutMs ?? 30000;
+    this.tenant = opts.tenant;
+  }
+
+  health(): Promise<Health> {
+    return this.getJSON<Health>("/api/v1/health");
+  }
+
+  models(): Promise<Models> {
+    return this.getJSON<Models>("/api/v1/models");
+  }
+
+  /** Execute an intent and resolve with the final answer (blocking). Throws
+   * APIError if the run fails or the request is rejected. */
+  async run(intent: string, model?: string): Promise<RunResult> {
+    const body: Record<string, unknown> = { intent };
+    if (model) body.model = model;
+    const res = await this.fetch("POST", "/api/v1/runs", JSON.stringify(body));
+    if (!res.ok) throw await apiError(res);
+    return (await res.json()) as RunResult;
+  }
+
+  /** Execute an intent, yielding StreamEvents (start/token/done/error) as the
+   * agent produces them. */
+  async *runStream(intent: string, model?: string): AsyncGenerator<StreamEvent> {
+    const body: Record<string, unknown> = { intent, stream: true };
+    if (model) body.model = model;
+    const res = await this.fetch("POST", "/api/v1/runs", JSON.stringify(body), "text/event-stream");
+    if (!res.ok) throw await apiError(res);
+    if (!res.body) return;
+    yield* parseSSE(res.body);
+  }
+
+  getRun(correlationId: string): Promise<RunArc> {
+    return this.getJSON<RunArc>("/api/v1/runs/" + encodeURIComponent(correlationId));
+  }
+
+  // --- internals ---
+
+  private async getJSON<T>(path: string): Promise<T> {
+    const res = await this.fetch("GET", path);
+    if (!res.ok) throw await apiError(res);
+    return (await res.json()) as T;
+  }
+
+  private fetch(method: string, path: string, body?: string, accept = "application/json"): Promise<Response> {
+    const headers: Record<string, string> = {
+      Authorization: "Bearer " + this.token,
+      Accept: accept,
+    };
+    if (body !== undefined) headers["Content-Type"] = "application/json";
+    if (this.tenant) headers["X-Agezt-Tenant"] = this.tenant;
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), this.timeoutMs);
+    return fetch(this.baseUrl + path, { method, headers, body, signal: ac.signal }).finally(() =>
+      clearTimeout(timer),
+    );
+  }
+}
+
+async function apiError(res: Response): Promise<APIError> {
+  let type = "";
+  let detail = "";
+  try {
+    const body = (await res.json()) as Record<string, unknown>;
+    const err = body.error;
+    if (err && typeof err === "object") {
+      const e = err as Record<string, unknown>;
+      type = String(e.type ?? "");
+      detail = String(e.message ?? "");
+    } else if (typeof err === "string") {
+      // failed-run body: { status: "failed", error: "…" }
+      type = String(body.status ?? "");
+      detail = err;
+    }
+  } catch {
+    /* non-JSON body */
+  }
+  return new APIError(res.status, type, detail);
+}
+
+/** Parse a text/event-stream ReadableStream into StreamEvents. */
+async function* parseSSE(stream: ReadableStream<Uint8Array>): AsyncGenerator<StreamEvent> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      let sep: number;
+      while ((sep = indexOfFrameEnd(buf)) >= 0) {
+        const frame = buf.slice(0, sep);
+        buf = buf.slice(sep).replace(/^(\r?\n){1,2}/, "");
+        const ev = parseFrame(frame);
+        if (ev) yield ev;
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const ev = parseFrame(buf);
+  if (ev) yield ev;
+}
+
+// indexOfFrameEnd returns the index of the blank-line separator (\n\n or
+// \r\n\r\n) ending the first frame, or -1.
+function indexOfFrameEnd(s: string): number {
+  const a = s.indexOf("\n\n");
+  const b = s.indexOf("\r\n\r\n");
+  if (a < 0) return b;
+  if (b < 0) return a;
+  return Math.min(a, b);
+}
+
+function parseFrame(frame: string): StreamEvent | null {
+  let event = "message";
+  const dataLines: string[] = [];
+  for (const raw of frame.split("\n")) {
+    const line = raw.replace(/\r$/, "");
+    if (line === "" || line.startsWith(":")) continue;
+    if (line.startsWith("event:")) event = line.slice(6).trim();
+    else if (line.startsWith("data:")) dataLines.push(line.slice(5).replace(/^ /, ""));
+  }
+  if (dataLines.length === 0) return null;
+  const joined = dataLines.join("\n");
+  let data: Record<string, unknown>;
+  try {
+    data = JSON.parse(joined) as Record<string, unknown>;
+  } catch {
+    data = { raw: joined };
+  }
+  return { event, data };
+}

--- a/sdk/typescript/src/errors.ts
+++ b/sdk/typescript/src/errors.ts
@@ -1,0 +1,23 @@
+/** Base class for all errors thrown by this package. */
+export class AgeztError extends Error {}
+
+/**
+ * Thrown when the daemon returns a non-2xx response.
+ *
+ * - `status` — the HTTP status code.
+ * - `type` — the machine-readable error type from the body (`error.type`), or "".
+ * - `detail` — the human-readable message from the body, or the raw body.
+ */
+export class APIError extends AgeztError {
+  readonly status: number;
+  readonly type: string;
+  readonly detail: string;
+
+  constructor(status: number, type = "", detail = "") {
+    super(`agezt: HTTP ${status}: ${detail || type || "request failed"}`);
+    this.name = "APIError";
+    this.status = status;
+    this.type = type;
+    this.detail = detail;
+  }
+}

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Official TypeScript/JavaScript client for the Agezt agentic OS.
+ *
+ * Talks to a running Agezt daemon's native REST API (`/api/v1`) — the same
+ * governed kernel loop `agt run` uses — over `fetch` with a bearer token.
+ * Zero runtime dependencies (uses the platform `fetch`); works in Node 18+ and
+ * modern browsers.
+ *
+ * ```ts
+ * import { Client } from "@agezt/sdk";
+ * const c = new Client("http://127.0.0.1:8800", "<token>");
+ * const r = await c.run("summarise the latest commits");
+ * console.log(r.answer);
+ * ```
+ */
+export { Client } from "./client.js";
+export type {
+  ClientOptions,
+  Health,
+  Models,
+  RunResult,
+  RunArc,
+  StreamEvent,
+} from "./client.js";
+export { AgeztError, APIError } from "./errors.js";

--- a/sdk/typescript/test/client.test.ts
+++ b/sdk/typescript/test/client.test.ts
@@ -1,0 +1,125 @@
+import { after, before, test } from "node:test";
+import assert from "node:assert/strict";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { type AddressInfo } from "node:net";
+
+import { APIError, Client } from "../src/index.js";
+
+let server: Server;
+let base: string;
+let lastBody: Record<string, unknown> | null = null;
+
+function json(res: ServerResponse, code: number, obj: unknown): void {
+  const body = JSON.stringify(obj);
+  res.writeHead(code, { "Content-Type": "application/json" });
+  res.end(body);
+}
+
+function authOK(req: IncomingMessage): boolean {
+  return req.headers["authorization"] === "Bearer testtoken";
+}
+
+before(async () => {
+  server = createServer((req, res) => {
+    if (!authOK(req)) {
+      json(res, 401, { error: { type: "unauthorized", message: "missing or invalid token" } });
+      return;
+    }
+    const url = req.url ?? "";
+    if (req.method === "GET" && url === "/api/v1/health") {
+      json(res, 200, { status: "ok", version: "test", default_model: "m", model_count: 1 });
+      return;
+    }
+    if (req.method === "GET" && url === "/api/v1/models") {
+      json(res, 200, { default: "m", models: ["m", "n"] });
+      return;
+    }
+    if (req.method === "GET" && url.startsWith("/api/v1/runs/")) {
+      json(res, 200, { correlation_id: "c1", count: 2, events: [{ seq: 1 }, { seq: 2 }] });
+      return;
+    }
+    if (req.method === "POST" && url === "/api/v1/runs") {
+      let raw = "";
+      req.on("data", (c) => (raw += c));
+      req.on("end", () => {
+        const body = JSON.parse(raw || "{}") as Record<string, unknown>;
+        lastBody = body;
+        if (body.intent === "boom") {
+          json(res, 502, { correlation_id: "c2", model: "m", status: "failed", error: "provider exploded" });
+          return;
+        }
+        if (body.stream) {
+          res.writeHead(200, { "Content-Type": "text/event-stream" });
+          res.write('event: start\ndata: {"correlation_id":"c3","model":"m"}\n\n');
+          res.write('event: token\ndata: {"text":"hel"}\n\n');
+          res.write(": heartbeat\n\n");
+          res.write('event: token\ndata: {"text":"lo"}\n\n');
+          res.write('event: done\ndata: {"correlation_id":"c3","status":"completed","answer":"hello"}\n\n');
+          res.end();
+          return;
+        }
+        json(res, 200, { correlation_id: "c4", model: body.model ?? "m", status: "completed", answer: "pong" });
+      });
+      return;
+    }
+    json(res, 404, { error: { type: "not_found", message: "nope" } });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as AddressInfo).port;
+  base = `http://127.0.0.1:${port}`;
+});
+
+after(() => server.close());
+
+function client(token = "testtoken"): Client {
+  return new Client(base, token, { timeoutMs: 5000 });
+}
+
+test("health", async () => {
+  const h = await client().health();
+  assert.equal(h.status, "ok");
+  assert.equal(h.version, "test");
+});
+
+test("models", async () => {
+  const m = await client().models();
+  assert.equal(m.default, "m");
+  assert.ok(m.models.includes("n"));
+});
+
+test("run (sync) forwards the model and returns the answer", async () => {
+  const r = await client().run("ping", "m");
+  assert.equal(r.status, "completed");
+  assert.equal(r.answer, "pong");
+  assert.equal(r.correlation_id, "c4");
+  assert.equal(lastBody?.model, "m");
+});
+
+test("a failed run throws APIError(502)", async () => {
+  await assert.rejects(
+    () => client().run("boom"),
+    (e: unknown) => e instanceof APIError && e.status === 502 && e.detail.includes("provider exploded"),
+  );
+});
+
+test("runStream yields start/token/token/done and reassembles tokens", async () => {
+  const events = [];
+  for await (const ev of client().runStream("hi")) events.push(ev);
+  assert.deepEqual(events.map((e) => e.event), ["start", "token", "token", "done"]);
+  const tokens = events.filter((e) => e.event === "token").map((e) => String(e.data.text ?? "")).join("");
+  assert.equal(tokens, "hello");
+  assert.equal(events.at(-1)?.data.answer, "hello");
+});
+
+test("getRun returns the event arc", async () => {
+  const arc = await client().getRun("c1");
+  assert.equal(arc.count, 2);
+  assert.equal(arc.events.length, 2);
+});
+
+test("a bad token throws APIError(401)", async () => {
+  await assert.rejects(
+    () => client("WRONG").health(),
+    (e: unknown) => e instanceof APIError && e.status === 401 && e.type === "unauthorized",
+  );
+});

--- a/sdk/typescript/tsconfig.json
+++ b/sdk/typescript/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM"],
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
## Summary

A first-class **TypeScript/JavaScript client** for Agezt's REST API (`/api/v1`), mirroring the Python SDK (M571) — completes the TS half of decision A4's SDK set. **Zero runtime dependencies** (platform `fetch` + `ReadableStream`); works in Node 18+ and browsers.

`new Client(baseUrl, token, { timeoutMs?, tenant? })`:
- `health()` · `models()` · `getRun(id)`
- `run(intent, model?)` → `Promise<RunResult>` (blocking)
- `runStream(intent, model?)` → `AsyncGenerator<StreamEvent>` (`start`/`token`/`done`/`error`, parsed from the SSE `ReadableStream` — handles `\r\n\r\n`, multi-line `data:`, `:` heartbeats)
- bearer auth; optional `tenant` → `X-Agezt-Tenant`; `AbortController` timeout; non-2xx throws `APIError`.

## Verification
- 7 tests via the Node built-in runner (`node:test`) against a `node:http` mock (health/models/sync-run/failed-run/SSE-stream/getRun/bad-token) — all pass; `tsc` strict + declarations clean.
- New CI job `typescript-sdk` (`setup-node` 22 + `npm ci` + `npm test`). `node_modules`/`dist` gitignored; `package-lock.json` committed. Go suite unaffected (77 pkgs; `go.mod` unchanged).
- **Runtime smoke**: booted the real daemon with `AGEZT_REST_ADDR`, drove it with the compiled SDK — `health()` v1.0.0, `run("ping")` → `[echo]\nping`, `runStream` parsed the SSE, `getRun` → 6-event arc, wrong token → `APIError(401)`; 0 panics.

Detail in `.project/PHASE-M572-TYPESCRIPT-SDK-REPORT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)