### PR TITLE
Feat: Python SDK asyncio client — AsyncClient (M576)

### DIFF
--- a/.project/PHASE-M576-PYTHON-ASYNC-CLIENT-REPORT.md
+++ b/.project/PHASE-M576-PYTHON-ASYNC-CLIENT-REPORT.md
@@ -1,0 +1,68 @@
+# Phase M576 — Python SDK asyncio client (`AsyncClient`)
+
+**Type:** Feature (SDK; completes sync+async parity for the Python client)
+**Date:** 2026-06-07
+**Branch:** `feat-python-async-client`
+
+## Goal
+
+Give the Python SDK (M571) an asyncio client so async Python code can drive a
+running Agezt daemon without blocking the event loop — matching the TypeScript
+SDK (M572), which is inherently async. Still standard-library only (no aiohttp),
+preserving the SDK's zero-dependency story.
+
+## What shipped
+
+### `sdk/python/agezt/aio.py` (new) — `AsyncClient`
+Mirrors `agezt.Client` method-for-method, every call awaitable:
+- `await health()`, `await models()`, `await run(intent, model=None) → RunResult`,
+  `await get_run(id)`, and `async for ev in run_stream(intent, model=None)`
+  yielding `StreamEvent`s (`start`/`token`/`done`/`error`).
+- `async with` support (`__aenter__`/`__aexit__`) + `aclose()` (no-op — the
+  client holds no persistent connection; provided for symmetry).
+- Same constructor `(base_url, token, timeout=30.0, tenant=None)`; `base_url`,
+  `token`, `timeout`, `tenant` exposed as read-only properties.
+
+**Implementation (stdlib-only, genuinely non-blocking):** the async layer reuses
+the synchronous `Client`'s request building, error mapping (`APIError`), and SSE
+parsing *verbatim* — it governs only *when* that work runs, not *how* the
+protocol is spoken. Unary calls run in the default thread executor
+(`loop.run_in_executor`). The streaming run drives the sync generator in a worker
+thread and bridges each parsed event to the event loop through an
+`asyncio.Queue` (`call_soon_threadsafe`), with a unique end-of-stream sentinel; a
+mid-stream error is routed through the queue and re-raised in the consuming
+coroutine. So `await`/`async for` never block the loop.
+
+### Exports + docs
+- `agezt/__init__.py`: `AsyncClient` added to the public API + `__all__`, with an
+  asyncio usage example in the package docstring.
+- `sdk/python/README.md`: new "Asyncio" section + API note.
+
+### Tests — `sdk/python/tests/test_aio.py` (new; 7 tests)
+`unittest.IsolatedAsyncioTestCase` against the SAME stdlib `http.server` mock as
+the sync tests (imports `_Handler` from `test_client`, no duplication). Covers:
+health+models, blocking run (+ model forwarding), failure → `APIError` (502),
+streaming (`start`/token/token/`done`, reassembled answer, heartbeat ignored),
+`get_run`, bad-token 401, and `async with` returning a usable client.
+
+## Verification
+
+- **SDK tests (as CI runs them):** `cd sdk/python && python -m unittest discover
+  -s tests` → **14 tests OK** (7 sync + 7 async). No third-party deps, no `pip
+  install`. (The error-path tests emit a benign `ResourceWarning` about
+  `HTTPError` cleanup — pre-existing in the sync client's error path; a warning,
+  not a failure; `unittest` returns OK.)
+- **No Go code touched** → Go build/test tree unaffected; `go.mod`/`go.sum`
+  unchanged. `__pycache__`/`*.pyc` stay gitignored (verified not staged).
+
+## Counts
+
+- Go packages/tests unchanged (80 / 2463 — this is a Python-only change).
+- Python SDK tests: 7 → **14**.
+
+## Out of scope (documented follow-ups)
+
+- Publishing the SDK to PyPI (needs release secrets/ops).
+- A pure-`asyncio`-sockets transport (current design wraps the proven sync
+  transport in an executor — correct and zero-dep; a native socket client would
+  remove the worker threads but re-implement HTTP/TLS/SSE by hand).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **The Python SDK now has an asyncio client.** `AsyncClient` (`from agezt import
+  AsyncClient`) mirrors the synchronous `Client` method-for-method, but every call
+  is awaitable and never blocks the event loop — `await c.run(...)`,
+  `async for ev in c.run_stream(...)`, plus `health`/`models`/`get_run` and
+  `async with` support. Still standard-library only (no aiohttp): the blocking
+  HTTP work runs in a thread executor and the streaming run is bridged to an async
+  iterator through an `asyncio.Queue`, reusing the sync client's request building,
+  error mapping, and SSE parsing verbatim. 7 new `unittest` tests
+  (`IsolatedAsyncioTestCase`) against the same stdlib http.server mock. (M576)
 - **Home Assistant is now a control TOOL**, not just an outbound channel — the
   agent can READ smart-home entity state and ACTUATE the house from inside a run.
   `plugins/tools/homeassistant` exposes two operations over the HA REST API:

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -49,6 +49,30 @@ arc = c.get_run(result.correlation_id)
 print(arc["count"], "events")
 ```
 
+## Asyncio
+
+`AsyncClient` mirrors `Client` method-for-method, but every call is awaitable
+and never blocks the event loop (the blocking HTTP work runs in a thread
+executor; the streaming run is delivered to `async for` through an
+`asyncio.Queue`). Still standard-library only.
+
+```python
+import asyncio
+from agezt import AsyncClient
+
+async def main():
+    async with AsyncClient("http://127.0.0.1:8800", token="<token>") as c:
+        print((await c.health())["version"])
+        result = await c.run("summarise the latest commits")
+        print(result.answer)
+
+        async for ev in c.run_stream("write a haiku about Go"):
+            if ev.event == "token":
+                print(ev.data.get("text", ""), end="", flush=True)
+
+asyncio.run(main())
+```
+
 ## API
 
 | Method | REST endpoint | Returns |
@@ -61,6 +85,8 @@ print(arc["count"], "events")
 
 `Client(base_url, token, timeout=30, tenant=None)` — pass `tenant` to target an
 isolated tenant (sent as the `X-Agezt-Tenant` header) on a multi-tenant daemon.
+`AsyncClient` takes the same arguments and exposes the same methods as
+coroutines (`await c.run(...)`, `async for ev in c.run_stream(...)`).
 
 Non-2xx responses raise `agezt.APIError` (`.status`, `.type`, `.message`).
 

--- a/sdk/python/agezt/__init__.py
+++ b/sdk/python/agezt/__init__.py
@@ -15,10 +15,33 @@ governance) — over plain HTTP with a bearer token. Standard library only.
     for ev in c.run_stream("write a haiku about Go"):
         if ev.event == "token":
             print(ev.data.get("text", ""), end="", flush=True)
+
+There is also an asyncio client with the same surface — every call is awaitable
+and never blocks the event loop::
+
+    import asyncio
+    from agezt import AsyncClient
+
+    async def main():
+        async with AsyncClient("http://127.0.0.1:8800", token="…") as c:
+            print((await c.run("summarise the latest commits")).answer)
+            async for ev in c.run_stream("write a haiku about Go"):
+                if ev.event == "token":
+                    print(ev.data.get("text", ""), end="", flush=True)
+
+    asyncio.run(main())
 """
 
+from .aio import AsyncClient
 from .client import Client, RunResult, StreamEvent
 from .errors import AgeztError, APIError
 
-__all__ = ["Client", "RunResult", "StreamEvent", "AgeztError", "APIError"]
+__all__ = [
+    "Client",
+    "AsyncClient",
+    "RunResult",
+    "StreamEvent",
+    "AgeztError",
+    "APIError",
+]
 __version__ = "1.0.0"

--- a/sdk/python/agezt/aio.py
+++ b/sdk/python/agezt/aio.py
@@ -1,0 +1,155 @@
+"""Asyncio client for the Agezt REST API (``/api/v1``). Standard library only.
+
+``AsyncClient`` mirrors the synchronous :class:`agezt.Client` method-for-method,
+but every call is awaitable and never blocks the event loop. It is built on the
+stdlib (``urllib`` + ``asyncio``) with no third-party dependency, matching
+Agezt's stdlib-first ethos: the blocking HTTP work runs in a thread executor, and
+the streaming run is bridged to an async iterator through an ``asyncio.Queue`` so
+tokens are delivered to ``async for`` as the agent produces them.
+
+    import asyncio
+    from agezt import AsyncClient
+
+    async def main():
+        async with AsyncClient("http://127.0.0.1:8800", token="…") as c:
+            print((await c.health())["version"])
+            result = await c.run("summarise the latest commits")
+            print(result.answer)
+
+            async for ev in c.run_stream("write a haiku about Go"):
+                if ev.event == "token":
+                    print(ev.data.get("text", ""), end="", flush=True)
+
+    asyncio.run(main())
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, AsyncIterator, Dict, Optional
+
+from .client import Client, RunResult, StreamEvent
+
+__all__ = ["AsyncClient"]
+
+
+class AsyncClient:
+    """An asyncio client for a running Agezt daemon's REST API.
+
+    Same constructor as :class:`agezt.Client`:
+
+    Args:
+        base_url: the daemon's REST address, e.g. ``http://127.0.0.1:8800``.
+        token: the bearer token (the daemon's admin token or a tenant token).
+        timeout: per-request timeout in seconds.
+        tenant: optional tenant id, sent as the ``X-Agezt-Tenant`` header.
+
+    The client holds no persistent connection, so it is cheap to create and
+    needs no teardown; :meth:`aclose` and ``async with`` are provided for
+    symmetry and forward-compatibility.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        token: str,
+        timeout: float = 30.0,
+        tenant: Optional[str] = None,
+    ) -> None:
+        # Reuse the synchronous client's request building, error mapping, and SSE
+        # parsing verbatim — the async layer only governs *when* that work runs
+        # (off the event loop), not *how* the protocol is spoken.
+        self._sync = Client(base_url, token, timeout=timeout, tenant=tenant)
+
+    # Expose the same read-only attributes as the sync client.
+    @property
+    def base_url(self) -> str:
+        return self._sync.base_url
+
+    @property
+    def token(self) -> str:
+        return self._sync.token
+
+    @property
+    def timeout(self) -> float:
+        return self._sync.timeout
+
+    @property
+    def tenant(self) -> Optional[str]:
+        return self._sync.tenant
+
+    # --- public API -------------------------------------------------------
+
+    async def health(self) -> Dict[str, Any]:
+        """Return the daemon's liveness + version summary."""
+        return await self._in_thread(self._sync.health)
+
+    async def models(self) -> Dict[str, Any]:
+        """Return ``{"default": id, "models": [ids…]}``."""
+        return await self._in_thread(self._sync.models)
+
+    async def run(self, intent: str, model: Optional[str] = None) -> RunResult:
+        """Execute an intent and return the final answer.
+
+        Raises APIError if the run fails or the request is rejected.
+        """
+        return await self._in_thread(lambda: self._sync.run(intent, model))
+
+    async def get_run(self, correlation_id: str) -> Dict[str, Any]:
+        """Return the journaled event arc of a past run."""
+        return await self._in_thread(lambda: self._sync.get_run(correlation_id))
+
+    async def run_stream(
+        self, intent: str, model: Optional[str] = None
+    ) -> AsyncIterator[StreamEvent]:
+        """Execute an intent, yielding StreamEvents (start/token/done/error) to
+        ``async for`` as the agent produces them.
+
+        The blocking SSE read runs in a worker thread; each parsed event is
+        handed to the event loop through an ``asyncio.Queue``, so awaiting the
+        next event never blocks the loop. An error raised mid-stream (e.g. a
+        non-2xx response) is re-raised in the consuming coroutine.
+        """
+        loop = asyncio.get_running_loop()
+        queue: "asyncio.Queue[Any]" = asyncio.Queue()
+        done = object()  # unique end-of-stream sentinel
+
+        def produce() -> None:
+            try:
+                for ev in self._sync.run_stream(intent, model):
+                    loop.call_soon_threadsafe(queue.put_nowait, ev)
+            except BaseException as exc:  # surface to the consumer, don't swallow
+                loop.call_soon_threadsafe(queue.put_nowait, exc)
+            finally:
+                loop.call_soon_threadsafe(queue.put_nowait, done)
+
+        # Fire-and-forget: the producer runs to completion as the consumer drains
+        # the queue. produce() routes all outcomes (events, error, end) through
+        # the queue, so the executor future never carries an exception itself.
+        loop.run_in_executor(None, produce)
+
+        while True:
+            item = await queue.get()
+            if item is done:
+                return
+            if isinstance(item, BaseException):
+                raise item
+            yield item
+
+    async def aclose(self) -> None:
+        """No-op: the client holds no persistent resources. Provided for symmetry."""
+        return None
+
+    async def __aenter__(self) -> "AsyncClient":
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        await self.aclose()
+
+    # --- internals --------------------------------------------------------
+
+    @staticmethod
+    async def _in_thread(fn: Any) -> Any:
+        """Run a blocking callable in the default executor, off the event loop."""
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, fn)

--- a/sdk/python/tests/test_aio.py
+++ b/sdk/python/tests/test_aio.py
@@ -1,0 +1,81 @@
+"""Tests for the Agezt asyncio client, against the same stdlib http.server mock
+used by the sync client tests. No third-party dependencies: run with
+``python -m unittest`` from sdk/python.
+"""
+
+import threading
+import unittest
+from http.server import HTTPServer
+
+import sys
+from pathlib import Path
+
+# Make the package importable when run from the repo without installation.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agezt import APIError, AsyncClient  # noqa: E402
+from test_client import _Handler  # noqa: E402  (reuse the sync test's mock handler)
+
+
+class AsyncClientTest(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.srv = HTTPServer(("127.0.0.1", 0), _Handler)
+        self.srv.last_body = None
+        self.t = threading.Thread(target=self.srv.serve_forever, daemon=True)
+        self.t.start()
+        port = self.srv.server_address[1]
+        self.c = AsyncClient(f"http://127.0.0.1:{port}", token="testtoken", timeout=5)
+
+    def tearDown(self):
+        self.srv.shutdown()
+        self.srv.server_close()
+
+    async def test_health_and_models(self):
+        h = await self.c.health()
+        self.assertEqual(h["status"], "ok")
+        self.assertEqual(h["version"], "test")
+        m = await self.c.models()
+        self.assertEqual(m["default"], "m")
+        self.assertIn("n", m["models"])
+
+    async def test_run_sync(self):
+        r = await self.c.run("ping", model="m")
+        self.assertEqual(r.status, "completed")
+        self.assertEqual(r.answer, "pong")
+        self.assertEqual(r.correlation_id, "c4")
+        self.assertEqual(self.srv.last_body.get("model"), "m")
+
+    async def test_run_failure_raises(self):
+        with self.assertRaises(APIError) as cm:
+            await self.c.run("boom")
+        self.assertEqual(cm.exception.status, 502)
+        self.assertIn("provider exploded", cm.exception.message)
+
+    async def test_run_stream(self):
+        events = [ev async for ev in self.c.run_stream("hi")]
+        kinds = [e.event for e in events]
+        self.assertEqual(kinds, ["start", "token", "token", "done"])
+        tokens = "".join(e.data.get("text", "") for e in events if e.event == "token")
+        self.assertEqual(tokens, "hello")
+        self.assertEqual(events[-1].data.get("answer"), "hello")
+
+    async def test_get_run(self):
+        arc = await self.c.get_run("c1")
+        self.assertEqual(arc["count"], 2)
+        self.assertEqual(len(arc["events"]), 2)
+
+    async def test_bad_token_raises_401(self):
+        async with AsyncClient(self.c.base_url, token="WRONG", timeout=5) as bad:
+            with self.assertRaises(APIError) as cm:
+                await bad.health()
+        self.assertEqual(cm.exception.status, 401)
+        self.assertEqual(cm.exception.type, "unauthorized")
+
+    async def test_context_manager_returns_client(self):
+        async with AsyncClient(self.c.base_url, token="testtoken", timeout=5) as c:
+            self.assertIsInstance(c, AsyncClient)
+            self.assertEqual((await c.health())["status"], "ok")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `agezt.AsyncClient`, the **async counterpart** to the synchronous `Client` (M571), so async Python code can drive a daemon **without blocking the event loop** — matching the inherently-async TypeScript SDK (M572). **Still standard-library only** (no aiohttp), preserving the SDK's zero-dependency story.

## What it does

`AsyncClient` mirrors `Client` method-for-method as coroutines:
- `await health()`, `await models()`, `await run(intent, model=None) → RunResult`, `await get_run(id)`
- `async for ev in run_stream(intent, model=None)` → `StreamEvent`s (`start`/`token`/`done`/`error`)
- `async with` support; same constructor `(base_url, token, timeout=30, tenant=None)`

## How (stdlib-only, genuinely non-blocking)

The async layer **reuses the sync client's request building, error mapping, and SSE parsing verbatim** — it governs only *when* that work runs, not *how* the protocol is spoken:
- Unary calls run in the default thread executor (`loop.run_in_executor`).
- The streaming run drives the sync generator in a worker thread and bridges each parsed event to the loop through an `asyncio.Queue` (`call_soon_threadsafe`) with an end-of-stream sentinel; a mid-stream error is routed through the queue and re-raised in the consuming coroutine.

So `await` / `async for` never block the event loop.

## Changes

- `sdk/python/agezt/aio.py` — `AsyncClient` (new).
- `sdk/python/agezt/__init__.py` — export `AsyncClient` + asyncio example in the docstring.
- `sdk/python/tests/test_aio.py` — 7 `IsolatedAsyncioTestCase` tests against the **same** stdlib `http.server` mock as the sync tests (reuses `_Handler`, no duplication).
- `sdk/python/README.md` — new "Asyncio" section.
- CHANGELOG + phase report.

## Verification

- `cd sdk/python && python -m unittest discover -s tests` → **14 OK** (7 sync + 7 async), no `pip install`, no third-party deps — exactly how the `python-sdk` CI job runs them.
- **No Go code touched** → Go build/test tree unaffected; `go.mod`/`go.sum` unchanged; `__pycache__`/`*.pyc` stay gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)