### PR TITLE
Feat: `agt ha` operator CLI for Home Assistant (M578)

### DIFF
--- a/.project/PHASE-M578-AGT-HA-CLI-REPORT.md
+++ b/.project/PHASE-M578-AGT-HA-CLI-REPORT.md
@@ -1,0 +1,71 @@
+# Phase M578 — `agt ha` operator CLI for Home Assistant
+
+**Type:** Feature (CLI; M575 follow-up — operator complement to the HA tool)
+**Date:** 2026-06-08
+**Branch:** `feat-agt-ha-cli`
+
+## Goal
+
+Give the operator a direct Home Assistant client from the terminal: read state,
+discover the service registry, and call services — without a running daemon. This
+complements the agent-facing `homeassistant` TOOL (M575): the tool is fail-closed
+behind read/service allowlists so a prompt-injected agent is constrained, whereas
+this CLI is the OPERATOR acting with their own authority, so it has full access.
+`agt ha services` is also the introspection an operator uses to discover which
+`domain.service` names to put in `AGEZT_HOMEASSISTANT_TOOL_SERVICES`.
+
+## What shipped
+
+### `cmd/agt/ha.go` (new) — `agt ha <command>`
+Self-contained; reads `AGEZT_HOMEASSISTANT_URL`/`_TOKEN` and talks to HA's REST
+API directly (`net/http` only, no daemon, no new dependency):
+- **`states [entity_id] [--json]`** — GET `/api/states[/{id}]`. All entities print
+  as sorted `entity_id = state` lines + a count; one entity prints as pretty JSON.
+- **`services [--json]`** — GET `/api/services`, printed as sorted `domain.service`
+  lines + a count (the service-registry introspection).
+- **`call <domain.service> [--entity id] [--data '<json>'] [--json]`** — POST
+  `/api/services/{domain}/{service}` with the data object (+ merged `entity_id`);
+  prints `called X.Y ok` and the changed-states result.
+- Missing URL/token → exit 2 with a hint; transport error / non-2xx → exit 1 with
+  the status; bad `--data` JSON or a non-dotted target → exit 2. `--json` prints
+  raw responses; bodies are size-capped (1 MiB) for display.
+
+### Wiring
+- `cmd/agt/main.go`: `case "ha"` dispatch + a line in `agt help`.
+
+### Tests — `cmd/agt/ha_test.go` (new; 10 tests)
+Against an `httptest` HA mock (env pointed at it, asserting the bearer token):
+no-config fail-closed (exit 2); help; states-all listing + count; single-entity
+pretty JSON; services `domain.service` listing + count; call POSTs with merged
+`entity_id` + forwarded data; call requires a dotted target; bad `--data` JSON;
+unknown subcommand; non-2xx → exit 1 with `HTTP 500`.
+
+## Verification
+
+- **Unit:** `cmd/agt -run TestHA` — 10/10 pass.
+- **Full gate:** `GOMAXPROCS=3 go test ./... -p 2 -count=1` exit 0 (80 packages).
+  `go vet` + `staticcheck` clean on `cmd/agt`; gofmt clean. `go.mod`/`go.sum`
+  unchanged.
+- **Runtime smoke (executable proof, criterion-7):** built the real `agt` binary,
+  pointed it at a mock HA, and ran each subcommand:
+  - `agt ha services` → `climate.set_temperature` / `light.turn_off` /
+    `light.turn_on` + `(3 services)`.
+  - `agt ha states` → `light.living_room = on` / `lock.front_door = locked` +
+    `(2 entities)`.
+  - `agt ha states light.living_room` → pretty JSON with attributes.
+  - `agt ha call light.turn_off --entity light.living_room` → `called
+    light.turn_off ok` + result; the mock confirmed `POST
+    /api/services/light/turn_off {"entity_id":"light.living_room"}`. All
+    bearer-authenticated.
+
+## Counts
+
+- Packages unchanged (80); `cmd/agt` gains 10 tests → tree 2463 → **2473**.
+
+## Out of scope (documented follow-ups)
+
+- Routing `agt ha` through the daemon's control plane (current direct-to-HA design
+  is simpler and works without a daemon; a control-plane variant could reuse the
+  in-process tool + its allowlists for a "what would the agent be allowed to do?"
+  view).
+- Entity-registry introspection beyond states (areas, devices).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **`agt ha` — an operator-facing Home Assistant client.** `agt ha states
+  [entity_id]` reads entity state (all as `entity_id = state` lines, or one as
+  pretty JSON), `agt ha services` lists the service registry as sorted
+  `domain.service` names (the introspection an operator uses to populate
+  `AGEZT_HOMEASSISTANT_TOOL_SERVICES`), and `agt ha call <domain.service>
+  [--entity id] [--data '<json>']` calls a service. It reads
+  `AGEZT_HOMEASSISTANT_URL`/`_TOKEN` and talks to HA directly (no daemon needed)
+  — the operator complement to the agent-facing `homeassistant` tool (M575):
+  full access by the operator's own authority, where the tool stays fail-closed
+  behind allowlists. `--json` prints raw responses; `net/http` only. (M578)
 - **The Web UI's Runs view now shows structured run-detail cards.** Expanding a
   run no longer dumps a flat event list first — it renders a summary (status,
   model, iterations, token in/out + cached, cost, duration) derived from the

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Agezt nodes** back — with capability-aware **auto-routing**, **failover**, and
 bounded delegation **loop guard** — and now each **tenant federates to its own
 peer set**; events push out via **HMAC-signed webhooks**. See
 [CHANGELOG.md](CHANGELOG.md).
-**Tests:** 2463 passing across 80 packages.
+**Tests:** 2473 passing across 80 packages.
 **Dependencies:** one (`lukechampine.com/blake3`) + one transitive.
 
 ## What you get
@@ -197,6 +197,7 @@ agt catalog sync [--local]             refresh models.dev (offline-capable)
 agt memory … / agt world … / agt skill …   the cognitive loop (add/list/forget/…)
 agt reflect run                        review behaviour, decay stale knowledge
 agt approvals / approve / deny         the HITL queue
+agt send --channel … / agt ha …        push a message · control Home Assistant
 agt why <id> --payload                 walk the audit chain
 agt halt / resume / shutdown           stop · resume · graceful exit
 ```

--- a/cmd/agt/ha.go
+++ b/cmd/agt/ha.go
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/agezt/agezt/internal/brand"
+)
+
+// cmdHA implements `agt ha …` — an operator-facing Home Assistant client that
+// reads entity state, lists the service registry, and calls services directly
+// against the HA instance configured by AGEZT_HOMEASSISTANT_URL/_TOKEN.
+//
+// This is the operator complement to the agent-facing `homeassistant` TOOL
+// (M575): the tool is fail-closed behind read/service allowlists so a
+// prompt-injected agent is constrained, whereas this CLI is the OPERATOR acting
+// with their own authority — so it has full access and needs no daemon running.
+// `agt ha services` is also the introspection the operator uses to discover
+// which `domain.service` names to put in AGEZT_HOMEASSISTANT_TOOL_SERVICES.
+const (
+	haCLITimeout = 30 * time.Second
+	haMaxBody    = 1 << 20 // cap the response we read for display (1 MiB)
+)
+
+func haUsage(w io.Writer) {
+	fmt.Fprintf(w, "usage: %s ha <command>\n", brand.CLI)
+	fmt.Fprintf(w, "operator-facing Home Assistant client (reads %sHOMEASSISTANT_URL/_TOKEN)\n\n", brand.EnvPrefix)
+	fmt.Fprintf(w, "commands:\n")
+	fmt.Fprintf(w, "  states [entity_id] [--json]      list all entity states, or one entity\n")
+	fmt.Fprintf(w, "  services [--json]                list the service registry (domain.service)\n")
+	fmt.Fprintf(w, "  call <domain.service> [opts]     call a service\n")
+	fmt.Fprintf(w, "      --entity <id>                target entity (e.g. light.living_room)\n")
+	fmt.Fprintf(w, "      --data '<json>'              extra service data (e.g. '{\"brightness\":128}')\n")
+	fmt.Fprintf(w, "      --json                       print the raw JSON response\n")
+}
+
+func cmdHA(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		haUsage(stdout)
+		return 0
+	}
+	base := strings.TrimRight(strings.TrimSpace(os.Getenv(brand.EnvPrefix+"HOMEASSISTANT_URL")), "/")
+	token := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "HOMEASSISTANT_TOKEN"))
+	if base == "" || token == "" {
+		fmt.Fprintf(stderr, "%s ha: set %sHOMEASSISTANT_URL and %sHOMEASSISTANT_TOKEN\n", brand.CLI, brand.EnvPrefix, brand.EnvPrefix)
+		return 2
+	}
+	sub, rest := args[0], args[1:]
+	switch sub {
+	case "states":
+		return haStates(base, token, rest, stdout, stderr)
+	case "services":
+		return haServices(base, token, rest, stdout, stderr)
+	case "call":
+		return haCall(base, token, rest, stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "%s ha: unknown command %q\n", brand.CLI, sub)
+		haUsage(stderr)
+		return 2
+	}
+}
+
+// haStates reads all entity states (sorted "entity_id = state" lines) or one
+// entity (pretty JSON). --json prints the raw response.
+func haStates(base, token string, args []string, stdout, stderr io.Writer) int {
+	var entity string
+	raw := false
+	for _, a := range args {
+		switch {
+		case a == "--json":
+			raw = true
+		case strings.HasPrefix(a, "-"):
+			fmt.Fprintf(stderr, "%s ha states: unknown flag %q\n", brand.CLI, a)
+			return 2
+		case entity == "":
+			entity = a
+		default:
+			fmt.Fprintf(stderr, "%s ha states: too many arguments\n", brand.CLI)
+			return 2
+		}
+	}
+
+	if entity != "" {
+		status, body, err := haRequest(http.MethodGet, base, token, "/api/states/"+url.PathEscape(entity), nil)
+		if code := haCheck(status, body, err, stderr); code != 0 {
+			return code
+		}
+		return printBodyJSON(body, raw, stdout)
+	}
+
+	status, body, err := haRequest(http.MethodGet, base, token, "/api/states", nil)
+	if code := haCheck(status, body, err, stderr); code != 0 {
+		return code
+	}
+	if raw {
+		return printBodyJSON(body, true, stdout)
+	}
+	var states []struct {
+		EntityID string `json:"entity_id"`
+		State    string `json:"state"`
+	}
+	if err := json.Unmarshal(body, &states); err != nil {
+		fmt.Fprintf(stderr, "%s ha states: parse response: %v\n", brand.CLI, err)
+		return 1
+	}
+	sort.Slice(states, func(i, j int) bool { return states[i].EntityID < states[j].EntityID })
+	for _, s := range states {
+		fmt.Fprintf(stdout, "%s = %s\n", s.EntityID, s.State)
+	}
+	fmt.Fprintf(stdout, "(%d entities)\n", len(states))
+	return 0
+}
+
+// haServices lists the service registry as sorted "domain.service" lines (the
+// names an operator puts in AGEZT_HOMEASSISTANT_TOOL_SERVICES). --json is raw.
+func haServices(base, token string, args []string, stdout, stderr io.Writer) int {
+	raw := false
+	for _, a := range args {
+		if a == "--json" {
+			raw = true
+			continue
+		}
+		fmt.Fprintf(stderr, "%s ha services: unknown argument %q\n", brand.CLI, a)
+		return 2
+	}
+	status, body, err := haRequest(http.MethodGet, base, token, "/api/services", nil)
+	if code := haCheck(status, body, err, stderr); code != 0 {
+		return code
+	}
+	if raw {
+		return printBodyJSON(body, true, stdout)
+	}
+	var domains []struct {
+		Domain   string                     `json:"domain"`
+		Services map[string]json.RawMessage `json:"services"`
+	}
+	if err := json.Unmarshal(body, &domains); err != nil {
+		fmt.Fprintf(stderr, "%s ha services: parse response: %v\n", brand.CLI, err)
+		return 1
+	}
+	var names []string
+	for _, d := range domains {
+		for svc := range d.Services {
+			names = append(names, d.Domain+"."+svc)
+		}
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		fmt.Fprintln(stdout, n)
+	}
+	fmt.Fprintf(stdout, "(%d services)\n", len(names))
+	return 0
+}
+
+// haCall calls a service: `agt ha call <domain.service> [--entity id] [--data json]`.
+func haCall(base, token string, args []string, stdout, stderr io.Writer) int {
+	var target, entity, data string
+	raw := false
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--json":
+			raw = true
+		case a == "--entity":
+			if i+1 >= len(args) {
+				fmt.Fprintf(stderr, "%s ha call: --entity needs a value\n", brand.CLI)
+				return 2
+			}
+			i++
+			entity = args[i]
+		case strings.HasPrefix(a, "--entity="):
+			entity = strings.TrimPrefix(a, "--entity=")
+		case a == "--data":
+			if i+1 >= len(args) {
+				fmt.Fprintf(stderr, "%s ha call: --data needs a value\n", brand.CLI)
+				return 2
+			}
+			i++
+			data = args[i]
+		case strings.HasPrefix(a, "--data="):
+			data = strings.TrimPrefix(a, "--data=")
+		case strings.HasPrefix(a, "-"):
+			fmt.Fprintf(stderr, "%s ha call: unknown flag %q\n", brand.CLI, a)
+			return 2
+		case target == "":
+			target = a
+		default:
+			fmt.Fprintf(stderr, "%s ha call: unexpected argument %q\n", brand.CLI, a)
+			return 2
+		}
+	}
+	domain, service, ok := strings.Cut(target, ".")
+	if !ok || domain == "" || service == "" {
+		fmt.Fprintf(stderr, "usage: %s ha call <domain.service> [--entity id] [--data json]\n", brand.CLI)
+		return 2
+	}
+
+	payload := map[string]any{}
+	if strings.TrimSpace(data) != "" {
+		if err := json.Unmarshal([]byte(data), &payload); err != nil {
+			fmt.Fprintf(stderr, "%s ha call: --data is not valid JSON: %v\n", brand.CLI, err)
+			return 2
+		}
+	}
+	if entity != "" {
+		payload["entity_id"] = entity
+	}
+	enc, err := json.Marshal(payload)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s ha call: %v\n", brand.CLI, err)
+		return 1
+	}
+
+	path := "/api/services/" + url.PathEscape(domain) + "/" + url.PathEscape(service)
+	status, body, err := haRequest(http.MethodPost, base, token, path, enc)
+	if code := haCheck(status, body, err, stderr); code != 0 {
+		return code
+	}
+	fmt.Fprintf(stdout, "called %s.%s ok\n", domain, service)
+	return printBodyJSON(body, raw, stdout)
+}
+
+// haRequest performs one bearer-authenticated request with a size-capped read.
+func haRequest(method, base, token, path string, body []byte) (int, []byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), haCLITimeout)
+	defer cancel()
+	var r io.Reader
+	if body != nil {
+		r = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, base+path, r)
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	out, err := io.ReadAll(io.LimitReader(resp.Body, haMaxBody+1))
+	if err != nil {
+		return resp.StatusCode, nil, err
+	}
+	if len(out) > haMaxBody {
+		out = out[:haMaxBody]
+	}
+	return resp.StatusCode, out, nil
+}
+
+// haCheck turns a transport error or non-2xx status into a CLI error (exit 1),
+// or returns 0 to proceed.
+func haCheck(status int, body []byte, err error, stderr io.Writer) int {
+	if err != nil {
+		fmt.Fprintf(stderr, "%s ha: %v\n", brand.CLI, err)
+		return 1
+	}
+	if status/100 != 2 {
+		msg := strings.TrimSpace(string(body))
+		if msg == "" {
+			msg = http.StatusText(status)
+		}
+		fmt.Fprintf(stderr, "%s ha: HTTP %d: %s\n", brand.CLI, status, msg)
+		return 1
+	}
+	return 0
+}
+
+// printBodyJSON pretty-prints a JSON body (or echoes it raw when it isn't JSON,
+// or when raw is requested).
+func printBodyJSON(body []byte, raw bool, stdout io.Writer) int {
+	if raw {
+		fmt.Fprintln(stdout, strings.TrimRight(string(body), "\n"))
+		return 0
+	}
+	var buf bytes.Buffer
+	if err := json.Indent(&buf, body, "", "  "); err != nil {
+		// Not JSON — echo as-is rather than failing.
+		fmt.Fprintln(stdout, strings.TrimRight(string(body), "\n"))
+		return 0
+	}
+	fmt.Fprintln(stdout, buf.String())
+	return 0
+}

--- a/cmd/agt/ha_test.go
+++ b/cmd/agt/ha_test.go
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// haMockServer is a minimal Home Assistant REST stand-in for the CLI tests.
+type haMockServer struct {
+	mu       sync.Mutex
+	srv      *httptest.Server
+	lastPost map[string]json.RawMessage // "domain/service" → body
+	auth     string
+}
+
+func newHAMock(t *testing.T) *haMockServer {
+	t.Helper()
+	m := &haMockServer{lastPost: map[string]json.RawMessage{}}
+	m.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		m.auth = r.Header.Get("Authorization")
+		m.mu.Unlock()
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/states":
+			_, _ = io.WriteString(w, `[
+				{"entity_id":"light.living_room","state":"on"},
+				{"entity_id":"sensor.temperature","state":"21.5"}
+			]`)
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/states/"):
+			id := strings.TrimPrefix(r.URL.Path, "/api/states/")
+			_, _ = io.WriteString(w, `{"entity_id":"`+id+`","state":"on"}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/services":
+			_, _ = io.WriteString(w, `[
+				{"domain":"light","services":{"turn_on":{},"turn_off":{}}},
+				{"domain":"lock","services":{"unlock":{}}}
+			]`)
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/api/services/"):
+			ds := strings.TrimPrefix(r.URL.Path, "/api/services/")
+			body, _ := io.ReadAll(r.Body)
+			m.mu.Lock()
+			m.lastPost[ds] = json.RawMessage(body)
+			m.mu.Unlock()
+			_, _ = io.WriteString(w, `[{"entity_id":"light.living_room","state":"off"}]`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(m.srv.Close)
+	return m
+}
+
+// configure points the CLI at the mock and sets a token via env.
+func (m *haMockServer) configure(t *testing.T) {
+	t.Helper()
+	t.Setenv("AGEZT_HOMEASSISTANT_URL", m.srv.URL)
+	t.Setenv("AGEZT_HOMEASSISTANT_TOKEN", "tok123")
+}
+
+func runHA(args ...string) (string, string, int) {
+	var out, errOut bytes.Buffer
+	code := cmdHA(args, &out, &errOut)
+	return out.String(), errOut.String(), code
+}
+
+func TestHA_NoConfigFailsClosed(t *testing.T) {
+	t.Setenv("AGEZT_HOMEASSISTANT_URL", "")
+	t.Setenv("AGEZT_HOMEASSISTANT_TOKEN", "")
+	_, errOut, code := runHA("states")
+	if code != 2 || !strings.Contains(errOut, "HOMEASSISTANT_URL") {
+		t.Fatalf("want exit 2 + hint, got code=%d err=%q", code, errOut)
+	}
+}
+
+func TestHA_Help(t *testing.T) {
+	out, _, code := runHA("--help")
+	if code != 0 || !strings.Contains(out, "states") || !strings.Contains(out, "call <domain.service>") {
+		t.Fatalf("help missing commands; code=%d out=%q", code, out)
+	}
+}
+
+func TestHA_StatesAll(t *testing.T) {
+	m := newHAMock(t)
+	m.configure(t)
+	out, _, code := runHA("states")
+	if code != 0 {
+		t.Fatalf("exit=%d", code)
+	}
+	if !strings.Contains(out, "light.living_room = on") || !strings.Contains(out, "sensor.temperature = 21.5") {
+		t.Errorf("states listing wrong:\n%s", out)
+	}
+	if !strings.Contains(out, "(2 entities)") {
+		t.Errorf("missing count: %s", out)
+	}
+	if m.auth != "Bearer tok123" {
+		t.Errorf("auth = %q", m.auth)
+	}
+}
+
+func TestHA_StatesOneEntityJSON(t *testing.T) {
+	m := newHAMock(t)
+	m.configure(t)
+	out, _, code := runHA("states", "light.living_room")
+	if code != 0 || !strings.Contains(out, `"entity_id": "light.living_room"`) {
+		t.Fatalf("pretty single-entity state expected; code=%d out=%q", code, out)
+	}
+}
+
+func TestHA_ServicesListsDomainDotService(t *testing.T) {
+	m := newHAMock(t)
+	m.configure(t)
+	out, _, code := runHA("services")
+	if code != 0 {
+		t.Fatalf("exit=%d", code)
+	}
+	for _, want := range []string{"light.turn_on", "light.turn_off", "lock.unlock", "(3 services)"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("services output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestHA_CallPostsServiceWithEntityAndData(t *testing.T) {
+	m := newHAMock(t)
+	m.configure(t)
+	out, _, code := runHA("call", "light.turn_on", "--entity", "light.living_room", "--data", `{"brightness":128}`)
+	if code != 0 {
+		t.Fatalf("exit=%d out=%q", code, out)
+	}
+	if !strings.Contains(out, "called light.turn_on ok") {
+		t.Errorf("missing confirmation: %s", out)
+	}
+	m.mu.Lock()
+	body := m.lastPost["light/turn_on"]
+	m.mu.Unlock()
+	if body == nil {
+		t.Fatalf("no POST to light/turn_on; got %v", m.lastPost)
+	}
+	var sent map[string]any
+	_ = json.Unmarshal(body, &sent)
+	if sent["entity_id"] != "light.living_room" {
+		t.Errorf("entity_id not merged: %v", sent)
+	}
+	if sent["brightness"].(float64) != 128 {
+		t.Errorf("data not forwarded: %v", sent)
+	}
+}
+
+func TestHA_CallRequiresDottedTarget(t *testing.T) {
+	m := newHAMock(t)
+	m.configure(t)
+	_, errOut, code := runHA("call", "turn_on") // no domain.service
+	if code != 2 || !strings.Contains(errOut, "domain.service") {
+		t.Fatalf("want exit 2 + usage, got code=%d err=%q", code, errOut)
+	}
+}
+
+func TestHA_CallBadDataJSON(t *testing.T) {
+	m := newHAMock(t)
+	m.configure(t)
+	_, errOut, code := runHA("call", "light.turn_on", "--data", "{not json}")
+	if code != 2 || !strings.Contains(errOut, "valid JSON") {
+		t.Fatalf("want exit 2 on bad --data, got code=%d err=%q", code, errOut)
+	}
+}
+
+func TestHA_UnknownSubcommand(t *testing.T) {
+	m := newHAMock(t)
+	m.configure(t)
+	_, errOut, code := runHA("frobnicate")
+	if code != 2 || !strings.Contains(errOut, "unknown command") {
+		t.Fatalf("want exit 2, got code=%d err=%q", code, errOut)
+	}
+}
+
+func TestHA_Non2xxSurfacesError(t *testing.T) {
+	// A server that always 500s → the CLI reports HTTP 500, exit 1.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		_, _ = io.WriteString(w, "boom")
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("AGEZT_HOMEASSISTANT_URL", srv.URL)
+	t.Setenv("AGEZT_HOMEASSISTANT_TOKEN", "t")
+	_, errOut, code := runHA("states")
+	if code != 1 || !strings.Contains(errOut, "HTTP 500") {
+		t.Fatalf("want exit 1 + HTTP 500, got code=%d err=%q", code, errOut)
+	}
+}

--- a/cmd/agt/main.go
+++ b/cmd/agt/main.go
@@ -139,6 +139,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 		return cmdInbox(args[1:], stdout, stderr)
 	case "send":
 		return cmdSend(args[1:], stdout, stderr)
+	case "ha":
+		return cmdHA(args[1:], stdout, stderr)
 	case "peers":
 		return cmdPeers(args[1:], stdout, stderr)
 	case "schedule":
@@ -248,6 +250,7 @@ func printHelp(w io.Writer) {
 	fmt.Fprintf(w, "  reflect show [--json]                 print the latest reflection report\n")
 	fmt.Fprintf(w, "  inbox [N] [--json]                    unified channel conversations (newest first)\n")
 	fmt.Fprintf(w, "  send --channel KIND --to ID <text>    push an outbound message through a channel\n")
+	fmt.Fprintf(w, "  ha <states|services|call>             operator-facing Home Assistant client\n")
 	fmt.Fprintf(w, "  vault status                          show vault encryption state + path\n")
 	fmt.Fprintf(w, "  vault encrypt                         migrate plaintext vault to encrypted (set AGEZT_VAULT_PASSPHRASE)\n")
 	fmt.Fprintf(w, "  vault decrypt                         migrate encrypted vault back to plaintext\n")


### PR DESCRIPTION
## Summary

Adds `agt ha <command>`, an **operator-facing Home Assistant client** — the complement to the agent-facing `homeassistant` tool (M575). Where the tool is **fail-closed behind read/service allowlists** (so a prompt-injected agent is constrained), this CLI is the **operator acting with their own authority**: full access, and **no daemon needed**.

## Commands

- `agt ha states [entity_id] [--json]` — all entities as `entity_id = state` lines (+ count), or one entity as pretty JSON.
- `agt ha services [--json]` — the service registry as sorted `domain.service` names — the **introspection** an operator uses to populate `AGEZT_HOMEASSISTANT_TOOL_SERVICES`.
- `agt ha call <domain.service> [--entity id] [--data '<json>'] [--json]` — POST a service with the data object (+ merged `entity_id`).

Reads `AGEZT_HOMEASSISTANT_URL`/`_TOKEN`, talks to HA's REST API directly (`net/http` only, **no new dependency**). Missing config → exit 2 with a hint; transport error / non-2xx → exit 1 with the status; bad `--data` / non-dotted target → exit 2.

## Changes

- `cmd/agt/ha.go` (new) + `cmd/agt/ha_test.go` (10 tests).
- `cmd/agt/main.go` — dispatch + `agt help` line.
- README + CHANGELOG + phase report.

## Verification

- `go test ./cmd/agt -run TestHA` → 10/10. Full gate `GOMAXPROCS=3 go test ./... -p 2` → **exit 0 (80 pkgs / 2473 tests)**. vet + staticcheck + gofmt clean; `go.mod`/`go.sum` unchanged.
- **Runtime smoke (criterion-7):** the real `agt` binary against a mock HA — `agt ha services` listed `climate.set_temperature`/`light.turn_off`/`light.turn_on`; `agt ha states` listed entities; `agt ha states light.living_room` pretty-printed; `agt ha call light.turn_off --entity light.living_room` → `called light.turn_off ok`, mock confirmed `POST /api/services/light/turn_off {"entity_id":"light.living_room"}`. All bearer-authenticated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)