### PR TITLE
Feat: Web UI unit tests (Vitest) + frontend-test CI gate (M579)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,22 @@ jobs:
             exit 1
           fi
 
+  frontend-test:
+    name: frontend-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: frontend/.nvmrc
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Unit-test the Web UI logic (Vitest)
+        run: |
+          cd frontend
+          npm ci
+          npm test
+
   python-sdk:
     name: python-sdk
     runs-on: ubuntu-latest

--- a/.project/PHASE-M579-WEBUI-VITEST-REPORT.md
+++ b/.project/PHASE-M579-WEBUI-VITEST-REPORT.md
@@ -1,0 +1,63 @@
+# Phase M579 — Web UI unit tests (Vitest) + CI gate
+
+**Type:** Feature (test infrastructure; closes the standing front-end test gap)
+**Date:** 2026-06-08
+**Branch:** `feat-webui-vitest`
+
+## Goal
+
+The React Web UI had grown to 17 views plus real derivation logic (M577's
+`deriveDetail`) with **zero automated tests** — every change was verified only by
+manual browser smoke. Add a Vitest unit suite for the pure logic and a CI gate so
+front-end regressions are caught automatically, offline, on every push.
+
+## What shipped
+
+### Extracted pure logic — `frontend/src/lib/rundetail.ts` (new)
+`deriveDetail` (folds a run's journaled event arc into the summary + tool-call
+breakdown) and `num` were inlined in `Runs.tsx`; moved to a pure, React-free
+module so they can be unit-tested directly. `Runs.tsx` now imports them — a
+bundle-neutral refactor (the committed `kernel/webui/dist` is **unchanged**, so
+`frontend-dist-in-sync` stays green without touching the embed).
+
+### Tests (19, Vitest)
+- `lib/rundetail.test.ts` (11): folds an out-of-order arc into the right summary
+  (status/model/iterations/answer); sums budget tokens + cost and sets
+  `hasBudget`; groups tool calls by `call_id` with capability + verdict
+  (result-wins); `hasBudget=false` when no budget event; denied/hard-denied
+  capture; failed-run error→answer; empty arc; `num` coercion/guards.
+- `lib/format.test.ts` (5): `money` (microcents→$), `pct` (rate→%, em-dash on
+  zero denom), `byDescValue`.
+- `lib/utils.test.ts` (3): `clip`, `prettyJSON`, `fmtTime`.
+
+### Tooling + CI
+- `frontend/package.json`: `vitest@^4` devDependency (v4 — the v3 advisory
+  GHSA-5xrq-8626-4rwp only affects the unused `--ui` server; v4 audits clean,
+  `npm audit` → 0 vulnerabilities) + `"test": "vitest run"`.
+- `frontend/vitest.config.ts`: node environment, `@` alias, `src/**/*.test.ts` —
+  kept separate from `vite.config.ts` so tests don't pull in the React/Tailwind
+  build plugins.
+- `.github/workflows/ci.yml`: new **`frontend-test`** job (ubuntu, `npm ci &&
+  npm test`) — the 19th CI check.
+- `Makefile`: `make frontend-test`.
+
+## Verification
+
+- `cd frontend && npm test` → **3 files, 19 tests passed**.
+- `cd frontend && npm run build` → `tsc --noEmit` (now type-checks the test files
+  too) clean + Vite emitted dist **byte-identical** to the committed bundle (the
+  refactor is bundle-neutral; `git status` shows no `dist/` change).
+- `npm audit` → 0 vulnerabilities.
+- No Go source changed → Go tree unaffected (`go.mod`/`go.sum` unchanged); Vitest
+  is dev-only and never enters the `go:embed`-ded `dist`, so the "one Go
+  dependency" story holds.
+
+## Counts
+
+- Go packages/tests unchanged (80 / 2473). New: **19 Web UI unit tests**; CI
+  checks 18 → **19**.
+
+## Out of scope (documented follow-ups)
+
+- Component/DOM tests (jsdom + Testing Library) and Playwright E2E in CI — this
+  pass covers the pure logic; rendering is still verified by manual browser smoke.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **The Web UI now has a unit-test suite (Vitest) and a CI gate.** The React app
+  had zero automated tests — every change relied on manual browser smoke. The
+  run-detail derivation logic is extracted to a pure `lib/rundetail.ts`
+  (`deriveDetail` folds a journaled event arc into the summary + tool-call
+  breakdown) and covered by Vitest alongside the `format`/`utils` helpers (19
+  tests). A new `frontend-test` CI job (`npm ci && npm test`) runs them on every
+  push, and `make frontend-test` runs them locally. Dev-only tooling — Vitest is
+  not bundled into the embedded `dist`, and adds zero Go modules. (M579)
 - **`agt ha` — an operator-facing Home Assistant client.** `agt ha states
   [entity_id]` reads entity state (all as `entity_id = state` lines, or one as
   pretty JSON), `agt ha services` lists the service registry as sorted

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GEN_PKG  := gen
 
 export CGO_ENABLED := 0
 
-.PHONY: all help gen frontend-build build install run test vet fmt lint clean check deps-check
+.PHONY: all help gen frontend-build frontend-test build install run test vet fmt lint clean check deps-check
 
 all: build ## (default) build all binaries
 
@@ -23,6 +23,9 @@ gen: $(GEN_FILE) ## regenerate SDK types from the contract
 
 frontend-build: ## build the React Web UI → kernel/webui/dist (committed, go:embed)
 	cd frontend && npm ci && npm run build
+
+frontend-test: ## unit-test the Web UI logic (Vitest)
+	cd frontend && npm ci && npm test
 
 $(GEN_FILE): $(CONTRACT) tools/jsonschemagen/main.go
 	@mkdir -p $(dir $(GEN_FILE))

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Agezt nodes** back — with capability-aware **auto-routing**, **failover**, and
 bounded delegation **loop guard** — and now each **tenant federates to its own
 peer set**; events push out via **HMAC-signed webhooks**. See
 [CHANGELOG.md](CHANGELOG.md).
-**Tests:** 2473 passing across 80 packages.
+**Tests:** 2473 passing across 80 packages (+ 19 Web UI unit tests via Vitest).
 **Dependencies:** one (`lukechampine.com/blake3`) + one transitive.
 
 ## What you get

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,7 +29,8 @@
         "@vitejs/plugin-react": "^4.3.4",
         "tailwindcss": "^4.0.0",
         "typescript": "^5.7.2",
-        "vite": "^6.0.7"
+        "vite": "^6.0.7",
+        "vitest": "^4.1.8"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1896,6 +1897,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
@@ -2225,6 +2233,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
@@ -2273,6 +2292,13 @@
         "@types/d3-interpolate": "*",
         "@types/d3-selection": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -2332,6 +2358,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xyflow/react": {
       "version": "12.11.0",
       "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.0.tgz",
@@ -2384,6 +2523,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -2453,6 +2602,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
@@ -2655,6 +2814,13 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
@@ -2705,6 +2871,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -3147,6 +3333,27 @@
         "node": ">=18"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
+      "integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3357,6 +3564,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3366,6 +3580,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "2.6.1",
@@ -3398,6 +3626,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -3413,6 +3658,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -3598,6 +3853,113 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yallist": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.1.4",
@@ -32,6 +33,7 @@
     "@vitejs/plugin-react": "^4.3.4",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.2",
-    "vite": "^6.0.7"
+    "vite": "^6.0.7",
+    "vitest": "^4.1.8"
   }
 }

--- a/frontend/src/lib/format.test.ts
+++ b/frontend/src/lib/format.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { money, pct, byDescValue } from "@/lib/format";
+
+describe("money", () => {
+  it("renders microcents (1e-9 USD) as a 4-dp dollar string", () => {
+    expect(money(0)).toBe("$0.0000");
+    expect(money(1_000_000)).toBe("$0.0010"); // 1e6 microcents = $0.001
+    expect(money(5_000_000_000)).toBe("$5.0000");
+    expect(money(undefined)).toBe("$0.0000");
+  });
+});
+
+describe("pct", () => {
+  it("formats a 0..1 rate as an integer percent", () => {
+    expect(pct(0.5)).toBe("50%");
+    expect(pct(0.333)).toBe("33%");
+    expect(pct(undefined)).toBe("0%");
+  });
+  it("returns an em dash when the denominator is zero", () => {
+    expect(pct(0.5, 0)).toBe("—");
+    expect(pct(0.5, 3)).toBe("50%");
+  });
+});
+
+describe("byDescValue", () => {
+  it("sorts keys by descending numeric value", () => {
+    expect(byDescValue({ a: 1, b: 9, c: 5 })).toEqual(["b", "c", "a"]);
+  });
+  it("handles an empty object", () => {
+    expect(byDescValue({})).toEqual([]);
+  });
+});

--- a/frontend/src/lib/rundetail.test.ts
+++ b/frontend/src/lib/rundetail.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { deriveDetail, num } from "@/lib/rundetail";
+import type { AgentEvent } from "@/lib/events";
+
+// A realistic HA-tool run arc (mirrors what /api/journal returns), deliberately
+// out of seq order to prove deriveDetail sorts before folding.
+const arc: AgentEvent[] = [
+  { seq: 0, kind: "task.received", payload: {} },
+  { seq: 1, kind: "llm.request", payload: { iter: 0, model: "mock" } },
+  { seq: 2, kind: "llm.response", payload: { iter: 0, tool_calls: 1 } },
+  { seq: 3, kind: "policy.decision", payload: { call_id: "c1", tool: "homeassistant", capability: "homeassistant.call", allow: true } },
+  { seq: 4, kind: "tool.invoked", payload: { call_id: "c1", tool: "homeassistant" } },
+  { seq: 5, kind: "tool.result", payload: { call_id: "c1", tool: "homeassistant", output: "called light.turn_off ok", error: false } },
+  { seq: 8, kind: "budget.consumed", payload: { model: "mock", input_tokens: 100, output_tokens: 20, cached_input_tokens: 10, cost_microcents: 5000 } },
+  { seq: 6, kind: "llm.request", payload: { iter: 1, model: "mock" } },
+  { seq: 7, kind: "policy.decision", payload: { call_id: "c2", tool: "homeassistant", capability: "homeassistant.read", allow: true } },
+  { seq: 9, kind: "tool.result", payload: { call_id: "c2", tool: "homeassistant", output: '{"state":"off"}', error: false } },
+  { seq: 10, kind: "task.completed", payload: { answer: "done" } },
+];
+
+describe("deriveDetail", () => {
+  it("folds the arc into a summary regardless of input order", () => {
+    const d = deriveDetail(arc);
+    expect(d.status).toBe("completed");
+    expect(d.model).toBe("mock");
+    expect(d.iterations).toBe(2); // iters 0 and 1 → max+1
+    expect(d.answer).toBe("done");
+  });
+
+  it("sums budget tokens + cost and sets hasBudget", () => {
+    const d = deriveDetail(arc);
+    expect(d.hasBudget).toBe(true);
+    expect(d.inputTokens).toBe(100);
+    expect(d.outputTokens).toBe(20);
+    expect(d.cachedTokens).toBe(10);
+    expect(d.costMicrocents).toBe(5000);
+  });
+
+  it("groups tool calls by call_id with capability + verdict, result wins", () => {
+    const d = deriveDetail(arc);
+    expect(d.toolCalls).toHaveLength(2);
+    const [a, b] = d.toolCalls;
+    expect(a.callId).toBe("c1");
+    expect(a.capability).toBe("homeassistant.call");
+    expect(a.allow).toBe(true);
+    expect(a.error).toBe(false);
+    expect(a.output).toBe("called light.turn_off ok");
+    expect(b.capability).toBe("homeassistant.read");
+  });
+
+  it("marks hasBudget false when no budget event was journaled", () => {
+    const d = deriveDetail([
+      { seq: 1, kind: "llm.request", payload: { iter: 0, model: "mock" } },
+      { seq: 2, kind: "task.completed", payload: { answer: "hi" } },
+    ]);
+    expect(d.hasBudget).toBe(false);
+    expect(d.inputTokens).toBe(0);
+    expect(d.toolCalls).toHaveLength(0);
+  });
+
+  it("captures a denied / hard-denied tool call", () => {
+    const d = deriveDetail([
+      { seq: 1, kind: "policy.decision", payload: { call_id: "x", tool: "shell", capability: "shell", allow: false, hard_denied: true } },
+    ]);
+    expect(d.toolCalls).toHaveLength(1);
+    expect(d.toolCalls[0].allow).toBe(false);
+    expect(d.toolCalls[0].hardDenied).toBe(true);
+  });
+
+  it("records a failed run's error as the answer", () => {
+    const d = deriveDetail([{ seq: 1, kind: "task.failed", payload: { error: "boom" } }]);
+    expect(d.status).toBe("failed");
+    expect(d.answer).toBe("boom");
+  });
+
+  it("handles an empty arc", () => {
+    const d = deriveDetail([]);
+    expect(d.iterations).toBe(0);
+    expect(d.toolCalls).toHaveLength(0);
+    expect(d.status).toBeUndefined();
+  });
+});
+
+describe("num", () => {
+  it("coerces and guards non-finite values", () => {
+    expect(num(5)).toBe(5);
+    expect(num("7")).toBe(7);
+    expect(num(undefined)).toBe(0);
+    expect(num("nope")).toBe(0);
+    expect(num(null)).toBe(0);
+  });
+});

--- a/frontend/src/lib/rundetail.ts
+++ b/frontend/src/lib/rundetail.ts
@@ -1,0 +1,109 @@
+import type { AgentEvent } from "@/lib/events";
+
+// One tool call, assembled across the policy.decision / tool.invoked /
+// tool.result events that share a call_id.
+export interface ToolCall {
+  callId: string;
+  tool: string;
+  capability?: string;
+  allow?: boolean;
+  hardDenied?: boolean;
+  error?: boolean;
+  output?: string;
+}
+
+// RunDetail is the structured summary derived from a run's journaled event arc —
+// the UI computes it, the kernel stays the source of truth (the raw events are
+// always available below).
+export interface RunDetail {
+  model?: string;
+  iterations: number;
+  inputTokens: number;
+  outputTokens: number;
+  cachedTokens: number;
+  costMicrocents: number;
+  hasBudget: boolean;
+  status?: string;
+  answer?: string;
+  toolCalls: ToolCall[];
+}
+
+export function num(v: unknown): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+// deriveDetail folds a run's journaled event arc into a RunDetail. Pure (no
+// React), so it is unit-tested directly. Events are processed oldest→newest by
+// seq, so later events (e.g. tool.result) win over earlier (tool.invoked), and
+// tool calls are grouped by call_id.
+export function deriveDetail(arc: AgentEvent[]): RunDetail {
+  const d: RunDetail = {
+    iterations: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cachedTokens: 0,
+    costMicrocents: 0,
+    hasBudget: false,
+    toolCalls: [],
+  };
+  const byCall = new Map<string, ToolCall>();
+  const call = (id: string): ToolCall => {
+    let c = byCall.get(id);
+    if (!c) {
+      c = { callId: id, tool: "" };
+      byCall.set(id, c);
+    }
+    return c;
+  };
+  const sorted = [...arc].sort((a, b) => num(a.seq) - num(b.seq));
+  for (const e of sorted) {
+    const p = e.payload || {};
+    switch (e.kind) {
+      case "llm.request":
+      case "llm.response":
+        d.iterations = Math.max(d.iterations, num(p.iter) + 1);
+        if (p.model) d.model = String(p.model);
+        break;
+      case "budget.consumed":
+        d.hasBudget = true;
+        d.costMicrocents += num(p.cost_microcents);
+        d.inputTokens += num(p.input_tokens);
+        d.outputTokens += num(p.output_tokens);
+        d.cachedTokens += num(p.cached_input_tokens);
+        if (p.model && !d.model) d.model = String(p.model);
+        break;
+      case "policy.decision": {
+        const c = call(String(p.call_id || ""));
+        if (p.tool) c.tool = String(p.tool);
+        if (p.capability) c.capability = String(p.capability);
+        c.allow = !!p.allow;
+        c.hardDenied = !!p.hard_denied;
+        break;
+      }
+      case "tool.invoked": {
+        const c = call(String(p.call_id || ""));
+        if (p.tool) c.tool = String(p.tool);
+        break;
+      }
+      case "tool.result": {
+        const c = call(String(p.call_id || ""));
+        if (p.tool) c.tool = String(p.tool);
+        c.error = !!p.error;
+        if (p.output != null) c.output = String(p.output);
+        break;
+      }
+      case "task.completed":
+        d.status = "completed";
+        if (p.answer != null) d.answer = String(p.answer);
+        break;
+      case "task.failed":
+        d.status = "failed";
+        if (p.error != null) d.answer = String(p.error);
+        break;
+    }
+  }
+  // Drop the synthetic empty-id bucket if nothing real landed in it.
+  d.toolCalls = [...byCall.values()].filter((c) => c.callId !== "" || c.tool !== "");
+  return d;
+}

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { clip, prettyJSON, fmtTime } from "@/lib/utils";
+
+describe("clip", () => {
+  it("truncates with an ellipsis past the limit", () => {
+    expect(clip("hello world", 5)).toBe("hell…");
+    expect(clip("hi", 5)).toBe("hi");
+  });
+  it("stringifies non-strings and guards nullish", () => {
+    expect(clip(12345, 3)).toBe("12…");
+    expect(clip(null, 5)).toBe("");
+    expect(clip(undefined, 5)).toBe("");
+  });
+});
+
+describe("prettyJSON", () => {
+  it("indents valid JSON", () => {
+    expect(prettyJSON('{"a":1}')).toBe('{\n  "a": 1\n}');
+  });
+  it("returns the input unchanged when it is not JSON", () => {
+    expect(prettyJSON("not json")).toBe("not json");
+    expect(prettyJSON("")).toBe("");
+  });
+});
+
+describe("fmtTime", () => {
+  it("returns empty for a falsy timestamp", () => {
+    expect(fmtTime(0)).toBe("");
+    expect(fmtTime(undefined)).toBe("");
+  });
+  it("formats a real epoch-ms to a non-empty string", () => {
+    expect(fmtTime(1_700_000_000_000).length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/views/Runs.tsx
+++ b/frontend/src/views/Runs.tsx
@@ -8,6 +8,7 @@ import { Badge, statusVariant } from "@/components/ui/badge";
 import { KeyValue, Muted, ErrorText } from "@/components/JsonView";
 import { fmtTime, clip } from "@/lib/utils";
 import { money } from "@/lib/format";
+import { deriveDetail, num, type ToolCall } from "@/lib/rundetail";
 import type { AgentEvent } from "@/lib/events";
 
 interface Run {
@@ -16,111 +17,6 @@ interface Run {
   intent?: string;
   duration_ms?: number;
   started_unix_ms?: number;
-}
-
-// One tool call, assembled across the policy.decision / tool.invoked /
-// tool.result events that share a call_id.
-interface ToolCall {
-  callId: string;
-  tool: string;
-  capability?: string;
-  allow?: boolean;
-  hardDenied?: boolean;
-  error?: boolean;
-  output?: string;
-}
-
-// RunDetail is the structured summary derived from a run's journaled event arc —
-// the UI computes it, the kernel stays the source of truth (the raw events are
-// always available below).
-interface RunDetail {
-  model?: string;
-  iterations: number;
-  inputTokens: number;
-  outputTokens: number;
-  cachedTokens: number;
-  costMicrocents: number;
-  hasBudget: boolean;
-  status?: string;
-  answer?: string;
-  toolCalls: ToolCall[];
-}
-
-function num(v: unknown): number {
-  const n = Number(v);
-  return Number.isFinite(n) ? n : 0;
-}
-
-function deriveDetail(arc: AgentEvent[]): RunDetail {
-  const d: RunDetail = {
-    iterations: 0,
-    inputTokens: 0,
-    outputTokens: 0,
-    cachedTokens: 0,
-    costMicrocents: 0,
-    hasBudget: false,
-    toolCalls: [],
-  };
-  const byCall = new Map<string, ToolCall>();
-  const call = (id: string): ToolCall => {
-    let c = byCall.get(id);
-    if (!c) {
-      c = { callId: id, tool: "" };
-      byCall.set(id, c);
-    }
-    return c;
-  };
-  // Process oldest→newest so later events (results) win over earlier (invoked).
-  const sorted = [...arc].sort((a, b) => num(a.seq) - num(b.seq));
-  for (const e of sorted) {
-    const p = e.payload || {};
-    switch (e.kind) {
-      case "llm.request":
-      case "llm.response":
-        d.iterations = Math.max(d.iterations, num(p.iter) + 1);
-        if (p.model) d.model = String(p.model);
-        break;
-      case "budget.consumed":
-        d.hasBudget = true;
-        d.costMicrocents += num(p.cost_microcents);
-        d.inputTokens += num(p.input_tokens);
-        d.outputTokens += num(p.output_tokens);
-        d.cachedTokens += num(p.cached_input_tokens);
-        if (p.model && !d.model) d.model = String(p.model);
-        break;
-      case "policy.decision": {
-        const c = call(String(p.call_id || ""));
-        if (p.tool) c.tool = String(p.tool);
-        if (p.capability) c.capability = String(p.capability);
-        c.allow = !!p.allow;
-        c.hardDenied = !!p.hard_denied;
-        break;
-      }
-      case "tool.invoked": {
-        const c = call(String(p.call_id || ""));
-        if (p.tool) c.tool = String(p.tool);
-        break;
-      }
-      case "tool.result": {
-        const c = call(String(p.call_id || ""));
-        if (p.tool) c.tool = String(p.tool);
-        c.error = !!p.error;
-        if (p.output != null) c.output = String(p.output);
-        break;
-      }
-      case "task.completed":
-        d.status = "completed";
-        if (p.answer != null) d.answer = String(p.answer);
-        break;
-      case "task.failed":
-        d.status = "failed";
-        if (p.error != null) d.answer = String(p.error);
-        break;
-    }
-  }
-  // Drop the synthetic empty-id bucket if nothing real landed in it.
-  d.toolCalls = [...byCall.values()].filter((c) => c.callId !== "" || c.tool !== "");
-  return d;
 }
 
 function ToolCallRow({ c }: { c: ToolCall }) {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+// Vitest config kept separate from vite.config.ts so the unit tests don't pull
+// in the React/Tailwind build plugins — they exercise pure logic (lib/*), so a
+// plain node environment with the "@" alias is all that's needed.
+export default defineConfig({
+  resolve: { alias: { "@": path.resolve(import.meta.dirname, "src") } },
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

The React Web UI had grown to 17 views plus real derivation logic (M577's `deriveDetail`) with **zero automated tests** — every change relied on manual browser smoke. This adds a **Vitest unit suite** for the pure logic and a **CI gate** so front-end regressions are caught automatically, offline, on every push.

## Changes

- **Extract** M577's run-detail derivation (`deriveDetail` + `num`) from `Runs.tsx` into a pure, React-free **`lib/rundetail.ts`** so it can be unit-tested directly. `Runs.tsx` imports it — a **bundle-neutral refactor**: the committed `kernel/webui/dist` is unchanged, so `frontend-dist-in-sync` stays green untouched.
- **19 Vitest tests**: `lib/rundetail` (arc→summary/tool-calls folding, budget sums, capability+verdict grouping, denied/failed/empty cases), `lib/format` (`money`/`pct`/`byDescValue`), `lib/utils` (`clip`/`prettyJSON`/`fmtTime`).
- `frontend/package.json`: `vitest@^4` devDep + `"test": "vitest run"`; `vitest.config.ts` (node env, `@` alias, separate from `vite.config.ts` so tests skip the build plugins).
- New CI job **`frontend-test`** (`npm ci && npm test`) — the 19th check; `make frontend-test` for local parity.

> Vitest v4 (not v3): the v3 critical advisory GHSA-5xrq-8626-4rwp only affects the unused `vitest --ui` server; v4 audits clean (`npm audit` → 0 vulnerabilities).

## Verification

- `cd frontend && npm test` → **3 files, 19 tests passed**.
- `cd frontend && npm run build` → `tsc --noEmit` (now type-checks the tests too) clean + Vite emitted dist **byte-identical** to the committed bundle (`git status` shows no `dist/` change).
- `npm audit` → 0 vulnerabilities.
- **No Go source changed** → Go tree unaffected (`go.mod`/`go.sum` unchanged); Vitest is dev-only and never enters the `go:embed`-ded `dist`, so the one-Go-dependency story holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)