### PR TITLE
Feat: Web UI end-to-end browser test in CI (Playwright) (M583)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,35 @@ jobs:
           npm ci
           npm test
 
+  webui-e2e:
+    name: webui-e2e
+    runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: '0'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: frontend/.nvmrc
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Build binaries
+        run: |
+          go build -o /tmp/agezt ./cmd/agezt
+          go build -o /tmp/agt ./cmd/agt
+      # The SPA tested is the committed go:embed bundle in kernel/webui/dist —
+      # no `npm run build` here; we drive what actually ships.
+      - name: Install Web UI deps + Playwright browser
+        run: |
+          cd frontend
+          npm ci
+          npx playwright install --with-deps chromium
+      - name: Web UI e2e (real daemon, headless browser)
+        run: bash scripts/webui-e2e.sh /tmp/agezt /tmp/agt
+
   python-sdk:
     name: python-sdk
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,12 @@
 /frontend/node_modules/
 # frontend TS incremental build cache
 *.tsbuildinfo
+# Playwright e2e artifacts (the spec in frontend/e2e/ IS committed; only run
+# output + downloaded browsers are ignored)
+/frontend/test-results/
+/frontend/playwright-report/
+/frontend/blob-report/
+/frontend/.playwright/
 
 # python build/test artifacts
 __pycache__/

--- a/.project/PHASE-M583-WEBUI-E2E-PLAYWRIGHT-REPORT.md
+++ b/.project/PHASE-M583-WEBUI-E2E-PLAYWRIGHT-REPORT.md
@@ -1,0 +1,71 @@
+# PHASE M583 — Web UI end-to-end browser test in CI (Playwright)
+
+**Status:** DONE — local, gated (full e2e ran green locally), ready for branch/PR.
+**Scope:** The last clearly-offline-verifiable webui polish item. Vitest logic
+(M579) + component/DOM (M581) tests already cover units; this adds a real
+**browser** E2E that drives the shipped, `go:embed`-ded SPA against a live daemon.
+
+## What shipped
+
+- **`frontend/e2e/webui.spec.ts`** — one Playwright test that:
+  1. loads the Web UI at its tokenized URL (`?token=…`);
+  2. asserts the shell (`h1 agezt · console`) + the `● live` SSE indicator;
+  3. Overview → `Status` heading + real status keys (`active_runs`, `daemon`);
+  4. Runs → the seeded run renders as a card (`completed` · `hello e2e`); expanding
+     it shows the run-detail cards — `Final answer` + `[echo] hello e2e` — proving
+     the journal → deriveDetail pipeline (M577/M580) end to end in a browser;
+  5. World → the React Flow panel mounts (`World` heading);
+  6. **zero console errors / pageerrors** throughout — the strict-CSP regression
+     guard (M566 shipped `script-src 'self'`), now automated rather than eyeballed.
+- **`frontend/playwright.config.ts`** — chromium, `workers: 1`, `retries: 2` on CI,
+  reads the full URL from `AGEZT_WEBUI_URL`. Separate from vite/vitest config.
+- **`scripts/webui-e2e.sh`** + **`make webui-e2e`** — boots a keyless
+  `AGEZT_DEMO_ECHO` daemon with `AGEZT_WEB_ADDR`, seeds one intent (`agt run`),
+  greps the tokenized Web UI URL from the daemon log, and runs `npx playwright
+  test`. Mirrors `scripts/e2e-smoke.sh` (build/boot/wait-ready/cleanup-trap).
+- **CI `webui-e2e` job** — setup-go + setup-node, build binaries, `npm ci`,
+  `npx playwright install --with-deps chromium`, run the harness. New gate.
+
+## Key navigation finding (real bug it would have caught)
+
+The UI holds an open `/events` SSE stream, so `page.goto(..., {waitUntil:
+"networkidle"})` **never settles** → 30s timeout. Fixed to `domcontentloaded` +
+explicit element waits. (Any future "wait for network idle" on an SSE page is a
+latent hang; the spec documents this.)
+
+## dist byte-identity (the M581 trap, handled)
+
+Tailwind v4 auto-scans every source file, so the new e2e spec churned the CSS
+bundle (and cascaded the JS hash) on first rebuild — exactly the M581 failure mode.
+Fixed with `@source not "../e2e/**"` in `src/index.css`; rebuilt dist verified
+**byte-for-byte identical** to the committed bundle (`git status kernel/webui/dist`
+clean), so `frontend-dist-in-sync` stays green. Vitest `include` is `src/**/*.test.*`
+and tsconfig `include` is `["src", …]`, so the spec is invisible to both — verified
+Vitest still reports 28 tests.
+
+## Gate (all green locally)
+
+- `bash scripts/webui-e2e.sh <agezt> <agt>` → daemon ready, run seeded, URL
+  resolved, **Playwright 1 passed** (≈440ms). Full real-browser proof, offline.
+- Re-ran the spec standalone against a hand-booted daemon: pass.
+- `npm test` (Vitest) still 28/28; `npm run build` clean; dist unchanged.
+- Go tree untouched — `go build ./...` clean, `go.mod` unchanged, full Go suite
+  still 80 pkgs green.
+
+## Wiring
+
+- `frontend/package.json`: `@playwright/test ^1.60` devDep (3 pkgs, `npm audit`
+  0 vulns) + `"test:e2e": "playwright test"`. `package-lock.json` updated.
+- `frontend/src/index.css`: `@source not "../e2e/**"`.
+- `.gitignore`: `/frontend/test-results/`, `playwright-report/`, `blob-report/`,
+  `.playwright/` (the spec in `frontend/e2e/` IS committed; only run output +
+  downloaded browsers are ignored).
+- `.github/workflows/ci.yml`: `webui-e2e` job. `Makefile`: `webui-e2e` target.
+- `CHANGELOG.md` Unreleased entry (M583).
+
+## State after M583
+
+Offline-verifiable feature well is now genuinely dry. Remaining DEFERRED items
+(Signal/Tunnels/Marketplace channels, SDK publish to PyPI/npm/crates.io) all touch
+external services / secrets / networks → need an explicit owner steer; not
+autonomously decidable. `agt migrate` has no real migration → skip (padding).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **The Web UI now has a real browser end-to-end test in CI.** A Playwright suite
+  (`frontend/e2e/webui.spec.ts`) drives the actual `go:embed`-ded production SPA in
+  headless Chromium against a live keyless demo daemon: it asserts the shell + live
+  SSE indicator render, navigation between views works, the Overview shows real
+  daemon status, a submitted run renders as an expandable run-detail card (proving
+  the journal → cards pipeline, M577/M580), the World panel mounts, and there are
+  **zero console errors under the strict CSP** (the M566 regression guard, now
+  automated). A reusable harness (`scripts/webui-e2e.sh`, `make webui-e2e`) boots
+  the daemon, seeds a run, and resolves the tokenized Web UI URL from its log; a new
+  CI job **`webui-e2e`** (20th… now 21st check) builds the binaries, installs the
+  browser, and runs it. Dev-only: `@playwright/test` is a devDependency, the e2e
+  specs are excluded from Tailwind's content scan (`@source not "../e2e/**"`) and
+  from Vitest's `include`, so the committed `dist` is byte-for-byte unchanged. (M583)
 - **Official Rust SDK** (`sdk/rust`, crate `agezt`). A zero-runtime-dependency
   client for the daemon's REST API (`/api/v1`) — `Client::new(base_url, token)`
   with `health()`, `models()`, `run()` (blocking), `run_stream()` (an

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GEN_PKG  := gen
 
 export CGO_ENABLED := 0
 
-.PHONY: all help gen frontend-build frontend-test build install run test vet fmt lint clean check deps-check
+.PHONY: all help gen frontend-build frontend-test webui-e2e build install run test vet fmt lint clean check deps-check
 
 all: build ## (default) build all binaries
 
@@ -26,6 +26,10 @@ frontend-build: ## build the React Web UI → kernel/webui/dist (committed, go:e
 
 frontend-test: ## unit-test the Web UI logic (Vitest)
 	cd frontend && npm ci && npm test
+
+webui-e2e: build ## drive the embedded Web UI in a headless browser (Playwright)
+	cd frontend && npm ci && npx playwright install --with-deps chromium
+	bash scripts/webui-e2e.sh $(BIN_DIR)/agezt $(BIN_DIR)/agt
 
 $(GEN_FILE): $(CONTRACT) tools/jsonschemagen/main.go
 	@mkdir -p $(dir $(GEN_FILE))

--- a/frontend/e2e/webui.spec.ts
+++ b/frontend/e2e/webui.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect, type ConsoleMessage } from "@playwright/test";
+
+// The full Web UI URL (incl. ?token=…) of a running demo daemon, exported by the
+// harness. Failing fast here beats a confusing navigation error.
+const URL = process.env.AGEZT_WEBUI_URL;
+
+test.describe("Agezt Web UI — embedded SPA against a real daemon", () => {
+  test("loads, navigates core views, renders live data, no console errors", async ({
+    page,
+  }) => {
+    expect(URL, "AGEZT_WEBUI_URL must be set by the harness").toBeTruthy();
+
+    // Strict-CSP regression guard: the M566 rebuild ships under `script-src
+    // 'self'`, so any inline-script/eval/asset violation surfaces as a console
+    // error. Collect them (and uncaught page errors) and assert none at the end.
+    const errors: string[] = [];
+    page.on("console", (m: ConsoleMessage) => {
+      if (m.type() === "error") errors.push(m.text());
+    });
+    page.on("pageerror", (e) => errors.push(String(e)));
+
+    // NOT `networkidle`: the UI holds an open `/events` SSE stream, so the
+    // network is never idle. Wait for the DOM, then assert on elements.
+    await page.goto(URL!, { waitUntil: "domcontentloaded" });
+
+    // --- Shell + live SSE indicator -------------------------------------
+    await expect(
+      page.getByRole("heading", { level: 1, name: /agezt · console/i }),
+    ).toBeVisible();
+    await expect(page.getByText("● live")).toBeVisible();
+
+    // --- Overview: live status pulled from the daemon -------------------
+    await page.getByRole("button", { name: "Overview" }).click();
+    await expect(
+      page.getByRole("heading", { level: 2, name: "Status" }),
+    ).toBeVisible();
+    // The status grid is real daemon state, not a static placeholder
+    // (`active_runs` is unique to the Overview status keys).
+    await expect(page.getByText("active_runs", { exact: true })).toBeVisible();
+    await expect(page.getByText("daemon", { exact: true })).toBeVisible();
+
+    // --- Runs: the intent the harness submitted renders as a card -------
+    await page.getByRole("button", { name: "Runs" }).click();
+    await expect(
+      page.getByRole("heading", { level: 2, name: "Runs" }),
+    ).toBeVisible();
+    const run = page.getByRole("button", { name: /hello e2e/ });
+    await expect(run).toBeVisible();
+    await expect(run).toContainText("completed");
+
+    // Expanding the run derives the detail cards (M577/M580) from its journal
+    // arc — proving the journal → run-detail pipeline end to end in a browser.
+    await run.click();
+    await expect(page.getByText("Final answer", { exact: true })).toBeVisible();
+    await expect(page.getByText("[echo] hello e2e")).toBeVisible();
+
+    // --- World: the React Flow panel mounts -----------------------------
+    await page.getByRole("button", { name: "World" }).click();
+    await expect(
+      page.getByRole("heading", { level: 2, name: "World" }),
+    ).toBeVisible();
+
+    expect(errors, `console errors:\n${errors.join("\n")}`).toEqual([]);
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "tailwind-merge": "^2.6.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@tailwindcss/vite": "^4.0.0",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",
@@ -1078,6 +1079,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -3871,6 +3888,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.1.4",
@@ -26,6 +27,7 @@
     "tailwind-merge": "^2.6.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/vite": "^4.0.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// End-to-end tests drive the REAL embedded Web UI — the production bundle that
+// is `go:embed`-ded into the agezt daemon — in a headless browser. The harness
+// (`scripts/webui-e2e.sh`, run by `make webui-e2e` and CI) boots a keyless demo
+// daemon and exports `AGEZT_WEBUI_URL`: the full Web UI URL including the
+// `?token=…` query the browser authenticates with. The spec reads that env var.
+//
+// Kept separate from vite/vitest config: Playwright transpiles `e2e/*.spec.ts`
+// itself, and Vitest's `include` is `src/**/*.test.*`, so the two suites never
+// overlap.
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: "list",
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  use: {
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+});

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,9 +2,10 @@
 @import "@xyflow/react/dist/style.css";
 
 /* Keep test files out of the production CSS scan: Tailwind v4 auto-detects every
-   source file, so class strings that appear only in *.test.tsx assertions must
-   not leak into (or churn) the shipped bundle. */
+   source file, so class strings that appear only in *.test.tsx assertions — or in
+   the Playwright e2e specs — must not leak into (or churn) the shipped bundle. */
 @source not "./**/*.test.{ts,tsx}";
+@source not "../e2e/**";
 
 /* Class-based dark mode: `.dark` on <html> toggles the palette. */
 @custom-variant dark (&:is(.dark *));

--- a/scripts/webui-e2e.sh
+++ b/scripts/webui-e2e.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# webui-e2e.sh — boot the real agezt daemon (keyless echo mock) with the Web UI
+# enabled, submit one intent so the Runs view has a card, then drive the
+# go:embed-ded production SPA in a headless browser with Playwright. Asserts the
+# shell + live SSE indicator render, navigation works, live daemon status and the
+# run-detail cards show real data, and there are ZERO console errors under the
+# strict CSP. Exits non-zero on any failure.
+#
+#   make webui-e2e                                   # build, then run this
+#   scripts/webui-e2e.sh /path/to/agezt /path/to/agt # against prebuilt binaries
+#
+# The frontend deps + Playwright browser must already be installed
+# (cd frontend && npm ci && npx playwright install --with-deps chromium).
+# CPU-capped (GOMAXPROCS=3) per project convention. Linux/macOS/git-bash.
+set -uo pipefail
+
+fail() { echo "WEBUI-E2E FAIL: $*" >&2; exit 1; }
+ok()   { echo "  ok: $*"; }
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+AGEZT_BIN="${1:-}"; AGT_BIN="${2:-}"
+TMP="$(mktemp -d)"; export GOMAXPROCS=3
+cleanup() { [ -n "${DPID:-}" ] && kill "$DPID" 2>/dev/null; sleep 1; rm -rf "$TMP" 2>/dev/null || true; }
+trap cleanup EXIT
+
+if [ -z "$AGEZT_BIN" ]; then
+  echo "building binaries…"
+  go build -o "$TMP/agezt" ./cmd/agezt || fail "build agezt"
+  go build -o "$TMP/agt"   ./cmd/agt   || fail "build agt"
+  AGEZT_BIN="$TMP/agezt"; AGT_BIN="$TMP/agt"
+fi
+
+export AGEZT_HOME="$TMP/home"; mkdir -p "$AGEZT_HOME"
+"$AGT_BIN" catalog sync --local >/dev/null 2>&1 || fail "catalog sync"
+
+PORT_WEB=18787
+echo "starting daemon (demo echo, Web UI on :$PORT_WEB)…"
+AGEZT_DEMO_ECHO=1 AGEZT_WEB_ADDR=127.0.0.1:$PORT_WEB \
+  "$AGEZT_BIN" > "$AGEZT_HOME/daemon.log" 2>&1 &
+DPID=$!
+for _ in $(seq 1 50); do grep -q 'daemon ready' "$AGEZT_HOME/daemon.log" 2>/dev/null && break; sleep 0.3; done
+grep -q 'daemon ready' "$AGEZT_HOME/daemon.log" || fail "daemon did not become ready:\n$(cat "$AGEZT_HOME/daemon.log")"
+sleep 1
+ok "daemon ready"
+
+# Submit an intent so the Runs view has a completed run to render + expand.
+"$AGT_BIN" run "hello e2e" -q 2>&1 | grep -q '\[echo\]' || fail "agt run did not echo"
+ok "seeded a run (hello e2e)"
+
+# The daemon logs the Web UI URL with its one-time token in the query string.
+URL=$(grep -oE "http://127\.0\.0\.1:$PORT_WEB/\?token=[a-f0-9]+" "$AGEZT_HOME/daemon.log" | head -1)
+[ -n "$URL" ] || fail "could not find the Web UI URL in the daemon log"
+ok "web ui url resolved"
+
+echo "running Playwright against the embedded SPA…"
+cd "$REPO_ROOT/frontend" || fail "cd frontend"
+AGEZT_WEBUI_URL="$URL" npx playwright test || fail "playwright e2e"
+ok "Playwright e2e passed"
+
+echo "WEBUI-E2E PASS"


### PR DESCRIPTION
Adds a real **headless-browser E2E** that drives the actual `go:embed`-ded production SPA against a live keyless demo daemon — the last clearly-offline-verifiable Web UI item (Vitest logic M579 + component/DOM M581 already cover units).

## What

- **`frontend/e2e/webui.spec.ts`** — loads the tokenized Web UI URL and asserts:
  - shell (`h1 agezt · console`) + `● live` SSE indicator;
  - Overview live status (`active_runs`, `daemon`);
  - the seeded run renders as an **expandable run-detail card** (`Final answer` / `[echo] hello e2e`) — proving the journal → cards pipeline (M577/M580) in a real browser;
  - the World React Flow panel mounts;
  - **zero console errors under the strict CSP** (the M566 `script-src 'self'` guard, now automated).
- **`frontend/playwright.config.ts`** — chromium, `workers: 1`, `retries: 2` on CI, reads `AGEZT_WEBUI_URL`.
- **`scripts/webui-e2e.sh`** + **`make webui-e2e`** — boot `AGEZT_DEMO_ECHO` daemon with `AGEZT_WEB_ADDR`, seed a run, grep the tokenized URL from the log, run Playwright. Mirrors `scripts/e2e-smoke.sh`.
- **CI `webui-e2e` job** — setup-go + setup-node, build binaries, `npm ci`, `npx playwright install --with-deps chromium`, run the harness.

## Notes

- **SSE**: `page.goto(..., {waitUntil: "networkidle"})` never settles (the UI holds an open `/events` stream) → switched to `domcontentloaded` + element waits.
- **dist byte-identity** (the M581 trap): Tailwind v4 scans all source, so the e2e spec churned the CSS+JS bundle. Fixed with `@source not "../e2e/**"` in `index.css`; committed `dist` verified **byte-for-byte identical** → `frontend-dist-in-sync` stays green. Vitest `include` + tsconfig exclude the spec (Vitest still 28 tests).
- Dev-only: `@playwright/test` devDep (npm audit 0 vulns); `test-results/` etc. gitignored.

## Verification

`bash scripts/webui-e2e.sh <agezt> <agt>` ran **green locally** (daemon ready → run seeded → URL resolved → Playwright 1 passed, ~440ms). No Go touched; `go.mod` unchanged; `go build ./...` clean. Phase report: `.project/PHASE-M583-WEBUI-E2E-PLAYWRIGHT-REPORT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)