### PR TITLE
Feat: plugin registry/marketplace — agt plugin registry/install (M585)

### DIFF
--- a/.project/PHASE-M585-PLUGIN-REGISTRY-REPORT.md
+++ b/.project/PHASE-M585-PLUGIN-REGISTRY-REPORT.md
@@ -1,0 +1,69 @@
+# PHASE M585 — Plugin registry / marketplace (`agt plugin registry`)
+
+**Status:** DONE — local, gated (unit + full end-to-end daemon smoke green),
+ready for branch/PR. **Owner picked the plugin-catalog gap via AskUserQuestion**
+after I found the remote *skill* registry already exists.
+
+## Context — the marketplace was half-built
+
+Investigating "Marketplace" surfaced that the remote **skill** registry is already
+complete: `agt skill registry <url> --install <name>` (content-address-verified),
+`agt skill export --all` (publish). The genuine gap was **plugins** (native
+binaries). M585 fills it, mirroring the skill-registry shape, **without** weakening
+the plugin security model.
+
+## What shipped
+
+`agt plugin registry <dir|url> [--install <name>] [--dir <installdir>] [--json]`
+(`cmd/agt/plugin_registry.go`):
+- **Browse:** reads the registry's `index.json` (a `pluginIndex` of plugins, each
+  with per-platform `binaries` pinned by BLAKE3-256). Lists name/version/desc/
+  platforms; flags when there's no build for the running host.
+- **Install:** resolves the name → one plugin, selects the binary for
+  `runtime.GOOS/GOARCH`, downloads it (bounded — 256 MiB cap — from a directory or
+  an `http(s)` URL), **verifies BLAKE3 against the index pin in memory BEFORE
+  writing** (mismatch → refuse, nothing lands on disk), stages it under
+  `<paths.BaseDir>/plugins` (or `--dir`), and prints the exact `AGEZT_PLUGINS` +
+  `AGEZT_PLUGIN_PINS` lines to enable it.
+- **Operator authority preserved:** install = "fetch + verify + stage". It never
+  edits the daemon env or loads anything — the daemon runs a plugin only when the
+  operator wires it in. ("Autonomous, under your authority.")
+- **Untrusted-index hygiene:** binary/index filenames validated (no `/`, `\`,
+  `..`); a malformed pin in the index is rejected before any download.
+
+Shared plumbing added to `kernel/plugin/pin.go`: `HashBytes([]byte) string` (the
+in-memory sibling of `HashFile`, to verify a download before it touches disk) and
+`LooksLikePin(string) bool` (exported pin-format check). `net/http` only — no new
+dependency.
+
+## Tests + smoke (all green)
+
+- **7 unit tests** (`plugin_registry_test.go`): dir list; dir install verifies +
+  stages + prints the exact env lines; **tampered pin refused AND not written**;
+  missing name refused; no-build-for-host refused; unsafe filename (`../escape`)
+  refused; **remote (httptest) list + install** verifies the pin.
+- **Full end-to-end daemon smoke:** built the SDK `greet` example plugin, published
+  it into a directory registry (real binary + its real BLAKE3), `agt plugin
+  registry <dir> --install greet --dir …` → verified + staged + printed env; booted
+  the daemon with those exact `AGEZT_PLUGINS` + `AGEZT_PLUGIN_PINS` → `agt plugin
+  list` showed **`greet [pinned]`, 3 tools, no pin mismatch**. Proves the whole
+  catalog → install → verify → enable → daemon-loads-pinned loop, and that the pin
+  the registry emits is exactly what the daemon enforces.
+- gofmt clean on staged LF blobs; full Go suite green; `go build ./...` clean;
+  `go.mod` unchanged.
+
+## Note (cross-platform, documented)
+
+A Windows plugin binary must be named `*.exe` in the registry — the daemon execs by
+path and Windows needs the extension. The installer stages the file verbatim (the
+pin is content-addressed, name-independent), so this is a publisher-side naming
+convention (`tool-windows-amd64.exe`), surfaced here so it's not a surprise. The
+smoke initially reproduced the "executable file not found" failure with a no-`.exe`
+name, then passed once named correctly.
+
+## Backlog after M585
+
+Remaining DEFERRED items genuinely need an owner steer (external services /
+secrets): Tunnels (external relay → no offline smoke), SDK publish
+(PyPI/npm/crates.io → registry secrets). `agt migrate` = no real migration → skip.
+The marketplace (skills + plugins) is now complete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **A plugin registry/marketplace** — `agt plugin registry <dir|url> [--install
+  <name>]`. Completes the marketplace alongside the existing remote *skill*
+  registry (`agt skill registry`): browse a registry's plugins (an `index.json`
+  listing per-platform binaries, each pinned by its BLAKE3-256 digest), then
+  install one — the installer picks the build for the running OS/arch, downloads
+  it (bounded, from a directory or an `http(s)` URL), **verifies its BLAKE3 against
+  the index pin before writing anything** (a mismatch is refused and nothing lands
+  on disk), stages it under `<base>/plugins` (or `--dir`), and prints the exact
+  `AGEZT_PLUGINS` + `AGEZT_PLUGIN_PINS` lines to enable it. It never edits the
+  daemon's environment or loads anything: a plugin runs only when the operator
+  wires it in, so "install" is "fetch + verify + stage", under the operator's
+  authority. Untrusted index filenames are validated (no path traversal). Reuses
+  the daemon's BLAKE3 pin code (`plugin.HashBytes` / `LooksLikePin`); `net/http`
+  only, no new dependency. (M585)
 - **Signal is now a messaging channel** (via signal-cli-rest-api) — the eleventh
   channel. `plugins/channels/signal` is a duplex channel that talks to an
   operator-run [signal-cli-rest-api](https://github.com/bbernhard/signal-cli-rest-api)

--- a/cmd/agt/plugin.go
+++ b/cmd/agt/plugin.go
@@ -34,7 +34,7 @@ import (
 // hard "plugin pin mismatch" error rather than silent execution.
 func cmdPlugin(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
-		fmt.Fprintf(stderr, "%s plugin: subcommand required (new|hash|list)\n", brand.CLI)
+		fmt.Fprintf(stderr, "%s plugin: subcommand required (new|hash|list|registry)\n", brand.CLI)
 		return 2
 	}
 	switch args[0] {
@@ -44,6 +44,8 @@ func cmdPlugin(args []string, stdout, stderr io.Writer) int {
 		return cmdPluginHash(args[1:], stdout, stderr)
 	case "list":
 		return cmdPluginList(args[1:], stdout, stderr)
+	case "registry":
+		return cmdPluginRegistry(args[1:], stdout, stderr)
 	case "-h", "--help", "help":
 		fmt.Fprintf(stdout, "usage: %s plugin <subcommand>\n", brand.CLI)
 		fmt.Fprintf(stdout, "\n")
@@ -51,9 +53,11 @@ func cmdPlugin(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stdout, "  hash <path>      print the BLAKE3-256 hex digest of a plugin binary\n")
 		fmt.Fprintf(stdout, "                   (use the output in AGEZT_PLUGIN_PINS=\"<prefix>=<hash>\")\n")
 		fmt.Fprintf(stdout, "  list [--json]    list the external plugins the daemon spawned at startup\n")
+		fmt.Fprintf(stdout, "  registry <dir|url> [--install <name>]   browse/install plugins from a\n")
+		fmt.Fprintf(stdout, "                   registry (download + BLAKE3-verify; prints the env to enable)\n")
 		return 0
 	default:
-		fmt.Fprintf(stderr, "%s plugin: unknown subcommand %q (new|hash|list)\n", brand.CLI, args[0])
+		fmt.Fprintf(stderr, "%s plugin: unknown subcommand %q (new|hash|list|registry)\n", brand.CLI, args[0])
 		return 2
 	}
 }

--- a/cmd/agt/plugin_registry.go
+++ b/cmd/agt/plugin_registry.go
@@ -1,0 +1,367 @@
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/agezt/agezt/internal/brand"
+	"github.com/agezt/agezt/internal/paths"
+	"github.com/agezt/agezt/kernel/plugin"
+)
+
+// pluginRegistryIndexName is the manifest a plugin registry serves, mirroring the
+// skill registry's index.json: a static host offers no directory listing, so the
+// index enumerates what's available.
+const pluginRegistryIndexName = "index.json"
+
+// maxPluginIndexFetch bounds the index.json body. Plugin metadata is small text.
+const maxPluginIndexFetch = 8 << 20 // 8 MiB
+
+// maxPluginBinaryFetch bounds a downloaded plugin binary. Generous (plugins are
+// native executables) while still refusing a runaway body.
+const maxPluginBinaryFetch = 256 << 20 // 256 MiB
+
+// pluginIndex is the manifest of a plugin registry.
+type pluginIndex struct {
+	Tool            string        `json:"tool"`
+	FormatVersion   int           `json:"format_version"`
+	GeneratedUnixMS int64         `json:"generated_unix_ms,omitempty"`
+	Plugins         []indexPlugin `json:"plugins"`
+}
+
+// indexPlugin is one entry: shareable metadata plus the per-platform binaries it
+// ships, each pinned by its BLAKE3-256 digest (the same pin the daemon enforces
+// via AGEZT_PLUGIN_PINS).
+type indexPlugin struct {
+	Name        string        `json:"name"`
+	Version     string        `json:"version"`
+	Description string        `json:"description,omitempty"`
+	Prefix      string        `json:"prefix,omitempty"` // suggested AGEZT_PLUGINS prefix (defaults to Name)
+	Args        string        `json:"args,omitempty"`   // optional extra args after the path
+	Binaries    []indexBinary `json:"binaries"`
+}
+
+// indexBinary is one platform build of a plugin.
+type indexBinary struct {
+	OS     string `json:"os"`
+	Arch   string `json:"arch"`
+	File   string `json:"file"`
+	BLAKE3 string `json:"blake3"`
+}
+
+// cmdPluginRegistry implements `agt plugin registry <dir|url> [--install <name>]`.
+// It lists the plugins a registry offers, or downloads one, verifies its BLAKE3
+// pin, and writes it locally — then prints the exact AGEZT_PLUGINS / _PINS lines
+// to enable it. It NEVER edits the daemon's environment or loads anything: the
+// daemon runs a plugin only when the operator wires it in, so "install" stays
+// "fetch + verify + stage", under the operator's authority.
+func cmdPluginRegistry(args []string, stdout, stderr io.Writer) int {
+	source := ""
+	install := ""
+	installDir := ""
+	asJSON := false
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--json":
+			asJSON = true
+		case a == "--install":
+			if i+1 >= len(args) {
+				fmt.Fprintf(stderr, "%s plugin registry: --install needs a plugin name\n", brand.CLI)
+				return 2
+			}
+			i++
+			install = args[i]
+		case strings.HasPrefix(a, "--install="):
+			install = strings.TrimPrefix(a, "--install=")
+		case a == "--dir":
+			if i+1 >= len(args) {
+				fmt.Fprintf(stderr, "%s plugin registry: --dir needs a directory\n", brand.CLI)
+				return 2
+			}
+			i++
+			installDir = args[i]
+		case strings.HasPrefix(a, "--dir="):
+			installDir = strings.TrimPrefix(a, "--dir=")
+		case a == "-h" || a == "--help":
+			fmt.Fprintf(stdout, "usage: %s plugin registry <dir|url> [--json] [--install <name>] [--dir <installdir>]\n", brand.CLI)
+			fmt.Fprintf(stdout, "list the plugins a registry offers, or install one (download + BLAKE3-verify)\n")
+			fmt.Fprintf(stdout, "  --install <name>  download the named plugin's binary for this OS/arch,\n")
+			fmt.Fprintf(stdout, "                    verify its pin, and stage it (does NOT load it — prints\n")
+			fmt.Fprintf(stdout, "                    the AGEZT_PLUGINS/_PINS lines to enable it yourself)\n")
+			fmt.Fprintf(stdout, "  --dir <installdir>  where to write the binary (default <base>/plugins)\n")
+			fmt.Fprintf(stdout, "a remote registry is an http(s) URL serving index.json + binary files\n")
+			return 0
+		case strings.HasPrefix(a, "-"):
+			fmt.Fprintf(stderr, "%s plugin registry: unknown flag %q\n", brand.CLI, a)
+			return 2
+		default:
+			if source != "" {
+				fmt.Fprintf(stderr, "%s plugin registry: unexpected extra argument %q\n", brand.CLI, a)
+				return 2
+			}
+			source = a
+		}
+	}
+	if source == "" {
+		fmt.Fprintf(stderr, "%s plugin registry: a directory or http(s) URL is required\n", brand.CLI)
+		return 2
+	}
+
+	idx, ok := loadPluginIndex(source, stderr)
+	if !ok {
+		return 1
+	}
+	if install != "" {
+		return installPluginFromRegistry(source, idx, install, installDir, asJSON, stdout, stderr)
+	}
+	return listPluginRegistry(source, idx, asJSON, stdout, stderr)
+}
+
+// loadPluginIndex reads index.json from a directory or an http(s) URL.
+func loadPluginIndex(source string, stderr io.Writer) (pluginIndex, bool) {
+	var raw []byte
+	var ok bool
+	if isHTTPURL(source) {
+		raw, ok = httpGetBounded(strings.TrimRight(source, "/")+"/"+pluginRegistryIndexName, maxPluginIndexFetch, "index", stderr)
+	} else {
+		raw, ok = readRegistryFile(source, pluginRegistryIndexName, maxPluginIndexFetch, stderr)
+	}
+	if !ok {
+		return pluginIndex{}, false
+	}
+	var idx pluginIndex
+	if err := json.Unmarshal(raw, &idx); err != nil {
+		fmt.Fprintf(stderr, "%s plugin registry: parse %s: %v\n", brand.CLI, pluginRegistryIndexName, err)
+		return pluginIndex{}, false
+	}
+	return idx, true
+}
+
+// listPluginRegistry prints the registry's plugins (and whether a build exists
+// for the running OS/arch).
+func listPluginRegistry(source string, idx pluginIndex, asJSON bool, stdout, stderr io.Writer) int {
+	if asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(map[string]any{"source": source, "plugins": idx.Plugins, "count": len(idx.Plugins)})
+		return 0
+	}
+	if len(idx.Plugins) == 0 {
+		fmt.Fprintf(stdout, "registry at %s lists no plugins\n", source)
+		return 0
+	}
+	fmt.Fprintf(stdout, "%d plugin(s) at %s:\n", len(idx.Plugins), source)
+	for _, p := range idx.Plugins {
+		fmt.Fprintf(stdout, "\n  %-20s v%s\n", p.Name, p.Version)
+		if p.Description != "" {
+			fmt.Fprintf(stdout, "      %s\n", p.Description)
+		}
+		fmt.Fprintf(stdout, "      platforms: %s\n", strings.Join(platformList(p), ", "))
+		if _, ok := selectBinary(p); ok {
+			fmt.Fprintf(stdout, "      install: %s plugin registry %s --install %s\n", brand.CLI, source, p.Name)
+		} else {
+			fmt.Fprintf(stdout, "      (no build for this host, %s/%s)\n", runtime.GOOS, runtime.GOARCH)
+		}
+	}
+	return 0
+}
+
+// installPluginFromRegistry resolves a name to one plugin, downloads the binary
+// for this host, verifies its pin, stages it, and prints the enabling env lines.
+func installPluginFromRegistry(source string, idx pluginIndex, name, installDir string, asJSON bool, stdout, stderr io.Writer) int {
+	var match *indexPlugin
+	count := 0
+	for i := range idx.Plugins {
+		if idx.Plugins[i].Name == name {
+			match = &idx.Plugins[i]
+			count++
+		}
+	}
+	if count == 0 {
+		fmt.Fprintf(stderr, "%s plugin registry: no plugin named %q at %s\n", brand.CLI, name, source)
+		return 1
+	}
+	if count > 1 {
+		fmt.Fprintf(stderr, "%s plugin registry: %q is ambiguous (%d entries) at %s\n", brand.CLI, name, count, source)
+		return 1
+	}
+
+	bin, ok := selectBinary(*match)
+	if !ok {
+		fmt.Fprintf(stderr, "%s plugin registry: %q has no build for this host (%s/%s)\n", brand.CLI, name, runtime.GOOS, runtime.GOARCH)
+		return 1
+	}
+	if !safeRegistryFilename(bin.File) {
+		fmt.Fprintf(stderr, "%s plugin registry: refusing unsafe binary filename %q\n", brand.CLI, bin.File)
+		return 1
+	}
+	if !plugin.LooksLikePin(bin.BLAKE3) {
+		fmt.Fprintf(stderr, "%s plugin registry: %q has no valid BLAKE3 pin in the index — refusing\n", brand.CLI, name)
+		return 1
+	}
+
+	// Resolve the install directory (default <base>/plugins) and ensure it exists.
+	dir := installDir
+	if dir == "" {
+		base, err := paths.BaseDir()
+		if err != nil {
+			fmt.Fprintf(stderr, "%s plugin registry: resolve install dir: %v\n", brand.CLI, err)
+			return 1
+		}
+		dir = filepath.Join(base, "plugins")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		fmt.Fprintf(stderr, "%s plugin registry: create %s: %v\n", brand.CLI, dir, err)
+		return 1
+	}
+	dest := filepath.Join(dir, bin.File)
+
+	// Fetch the binary into memory (bounded), verify the pin BEFORE writing it to
+	// the final path, then write + chmod. Verifying first means a tampered binary
+	// never lands on disk under the operator's plugin dir.
+	var data []byte
+	if isHTTPURL(source) {
+		data, ok = httpGetBounded(strings.TrimRight(source, "/")+"/"+bin.File, maxPluginBinaryFetch, "binary", stderr)
+	} else {
+		data, ok = readRegistryFile(source, bin.File, maxPluginBinaryFetch, stderr)
+	}
+	if !ok {
+		return 1
+	}
+	got := plugin.HashBytes(data)
+	if got != strings.ToLower(strings.TrimSpace(bin.BLAKE3)) {
+		fmt.Fprintf(stderr, "%s plugin registry: BLAKE3 mismatch for %q — refusing to install\n", brand.CLI, name)
+		fmt.Fprintf(stderr, "  expected: %s\n  got:      %s\n", strings.ToLower(bin.BLAKE3), got)
+		return 1
+	}
+	if err := os.WriteFile(dest, data, 0o755); err != nil {
+		fmt.Fprintf(stderr, "%s plugin registry: write %s: %v\n", brand.CLI, dest, err)
+		return 1
+	}
+
+	prefix := match.Prefix
+	if prefix == "" {
+		prefix = match.Name
+	}
+	pluginsVal := prefix + "=" + dest
+	if strings.TrimSpace(match.Args) != "" {
+		pluginsVal += " " + strings.TrimSpace(match.Args)
+	}
+
+	if asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(map[string]any{
+			"installed": name,
+			"version":   match.Version,
+			"path":      dest,
+			"blake3":    got,
+			"env": map[string]string{
+				"AGEZT_PLUGINS":     pluginsVal,
+				"AGEZT_PLUGIN_PINS": prefix + "=" + got,
+			},
+		})
+		return 0
+	}
+
+	fmt.Fprintf(stdout, "installed %s v%s → %s\n", name, match.Version, dest)
+	fmt.Fprintf(stdout, "  verified blake3:%s\n", got)
+	fmt.Fprintf(stdout, "\nTo enable it, add to your daemon environment (it does not load until you do):\n")
+	// Plain shell double-quotes around the value (not %q Go-quoting, which would
+	// double-escape backslashes in a Windows path).
+	fmt.Fprintf(stdout, "  AGEZT_PLUGINS=\"%s\"\n", pluginsVal)
+	fmt.Fprintf(stdout, "  AGEZT_PLUGIN_PINS=\"%s\"\n", prefix+"="+got)
+	return 0
+}
+
+// selectBinary picks the registry binary matching the running OS/arch.
+func selectBinary(p indexPlugin) (indexBinary, bool) {
+	for _, b := range p.Binaries {
+		if b.OS == runtime.GOOS && b.Arch == runtime.GOARCH {
+			return b, true
+		}
+	}
+	return indexBinary{}, false
+}
+
+// platformList returns the sorted "os/arch" labels a plugin ships, for listing.
+func platformList(p indexPlugin) []string {
+	out := make([]string, 0, len(p.Binaries))
+	for _, b := range p.Binaries {
+		out = append(out, b.OS+"/"+b.Arch)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// safeRegistryFilename rejects anything but a plain filename — no path separators,
+// no traversal — since the name comes from an untrusted index.
+func safeRegistryFilename(name string) bool {
+	if name == "" {
+		return false
+	}
+	if strings.ContainsAny(name, "/\\") || strings.Contains(name, "..") {
+		return false
+	}
+	return true
+}
+
+// readRegistryFile reads relPath from a local directory registry, bounded.
+func readRegistryFile(dir, relPath string, max int64, stderr io.Writer) ([]byte, bool) {
+	if !safeRegistryFilename(relPath) {
+		fmt.Fprintf(stderr, "%s plugin registry: refusing unsafe index file %q\n", brand.CLI, relPath)
+		return nil, false
+	}
+	f, err := os.Open(filepath.Join(dir, relPath))
+	if err != nil {
+		fmt.Fprintf(stderr, "%s plugin registry: open %s: %v\n", brand.CLI, relPath, err)
+		return nil, false
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(f, max+1))
+	if err != nil {
+		fmt.Fprintf(stderr, "%s plugin registry: read %s: %v\n", brand.CLI, relPath, err)
+		return nil, false
+	}
+	if int64(len(data)) > max {
+		fmt.Fprintf(stderr, "%s plugin registry: %s exceeds the %d-byte cap\n", brand.CLI, relPath, max)
+		return nil, false
+	}
+	return data, true
+}
+
+// httpGetBounded GETs a URL with a bounded body and timeout.
+func httpGetBounded(url string, max int64, what string, stderr io.Writer) ([]byte, bool) {
+	client := &http.Client{Timeout: 60 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s plugin registry: fetch %s: %v\n", brand.CLI, url, err)
+		return nil, false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		fmt.Fprintf(stderr, "%s plugin registry: fetch %s: HTTP %d\n", brand.CLI, url, resp.StatusCode)
+		return nil, false
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, max+1))
+	if err != nil {
+		fmt.Fprintf(stderr, "%s plugin registry: read %s %s: %v\n", brand.CLI, what, url, err)
+		return nil, false
+	}
+	if int64(len(data)) > max {
+		fmt.Fprintf(stderr, "%s plugin registry: %s %s exceeds the %d-byte cap\n", brand.CLI, what, url, max)
+		return nil, false
+	}
+	return data, true
+}

--- a/cmd/agt/plugin_registry_test.go
+++ b/cmd/agt/plugin_registry_test.go
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/agezt/agezt/kernel/plugin"
+)
+
+// writeDirRegistry creates a directory registry holding one plugin whose binary
+// is `payload`, pinned to its real BLAKE3, with a build for the current host.
+// Returns the registry dir and the correct pin. `tamperPin` overrides the index
+// pin to a (wrong) value to exercise the mismatch path.
+func writeDirRegistry(t *testing.T, payload []byte, tamperPin string) (dir, pin, file string) {
+	t.Helper()
+	dir = t.TempDir()
+	file = "demo-" + runtime.GOOS + "-" + runtime.GOARCH
+	pin = plugin.HashBytes(payload)
+	indexPin := pin
+	if tamperPin != "" {
+		indexPin = tamperPin
+	}
+	idx := pluginIndex{
+		Tool:          "agezt",
+		FormatVersion: 1,
+		Plugins: []indexPlugin{{
+			Name:        "demo",
+			Version:     "1.0.0",
+			Description: "a demo tool plugin",
+			Prefix:      "demo",
+			Binaries: []indexBinary{{
+				OS:     runtime.GOOS,
+				Arch:   runtime.GOARCH,
+				File:   file,
+				BLAKE3: indexPin,
+			}},
+		}},
+	}
+	raw, _ := json.MarshalIndent(idx, "", "  ")
+	if err := os.WriteFile(filepath.Join(dir, "index.json"), raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, file), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir, pin, file
+}
+
+func runReg(t *testing.T, args ...string) (int, string, string) {
+	t.Helper()
+	var out, errb bytes.Buffer
+	code := cmdPluginRegistry(args, &out, &errb)
+	return code, out.String(), errb.String()
+}
+
+func TestPluginRegistry_ListDir(t *testing.T) {
+	dir, _, _ := writeDirRegistry(t, []byte("fake-binary-bytes"), "")
+	code, out, errs := runReg(t, dir)
+	if code != 0 {
+		t.Fatalf("list exit=%d stderr=%s", code, errs)
+	}
+	if !strings.Contains(out, "demo") || !strings.Contains(out, "v1.0.0") {
+		t.Errorf("list output missing plugin: %s", out)
+	}
+	if !strings.Contains(out, runtime.GOOS+"/"+runtime.GOARCH) {
+		t.Errorf("list output missing this platform: %s", out)
+	}
+}
+
+func TestPluginRegistry_InstallDirVerifiesAndStages(t *testing.T) {
+	payload := []byte("the real plugin binary")
+	dir, pin, file := writeDirRegistry(t, payload, "")
+	installDir := t.TempDir()
+
+	code, out, errs := runReg(t, dir, "--install", "demo", "--dir", installDir)
+	if code != 0 {
+		t.Fatalf("install exit=%d stderr=%s", code, errs)
+	}
+	dest := filepath.Join(installDir, file)
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("binary not staged: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Error("staged binary bytes differ from the registry payload")
+	}
+	// The exact enabling env lines must be printed (operator wires it in himself).
+	if !strings.Contains(out, `AGEZT_PLUGINS="demo=`+dest+`"`) {
+		t.Errorf("missing AGEZT_PLUGINS line: %s", out)
+	}
+	if !strings.Contains(out, `AGEZT_PLUGIN_PINS="demo=`+pin+`"`) {
+		t.Errorf("missing AGEZT_PLUGIN_PINS line: %s", out)
+	}
+}
+
+func TestPluginRegistry_InstallRefusesTamperedPin(t *testing.T) {
+	dir, _, file := writeDirRegistry(t, []byte("genuine"), strings.Repeat("a", 64))
+	installDir := t.TempDir()
+
+	code, _, errs := runReg(t, dir, "--install", "demo", "--dir", installDir)
+	if code == 0 {
+		t.Fatal("install must fail on a BLAKE3 mismatch")
+	}
+	if !strings.Contains(errs, "mismatch") {
+		t.Errorf("expected a mismatch error, got: %s", errs)
+	}
+	// A tampered binary must never land on disk.
+	if _, err := os.Stat(filepath.Join(installDir, file)); !os.IsNotExist(err) {
+		t.Error("a pin-mismatched binary must NOT be written")
+	}
+}
+
+func TestPluginRegistry_InstallMissingAndAmbiguous(t *testing.T) {
+	dir, _, _ := writeDirRegistry(t, []byte("x"), "")
+	if code, _, _ := runReg(t, dir, "--install", "nope", "--dir", t.TempDir()); code == 0 {
+		t.Error("installing a missing name must fail")
+	}
+}
+
+func TestPluginRegistry_NoBuildForHost(t *testing.T) {
+	dir := t.TempDir()
+	idx := pluginIndex{FormatVersion: 1, Plugins: []indexPlugin{{
+		Name: "demo", Version: "1.0.0",
+		Binaries: []indexBinary{{OS: "plan9", Arch: "mips", File: "demo-plan9-mips", BLAKE3: strings.Repeat("0", 64)}},
+	}}}
+	raw, _ := json.Marshal(idx)
+	_ = os.WriteFile(filepath.Join(dir, "index.json"), raw, 0o644)
+
+	code, _, errs := runReg(t, dir, "--install", "demo", "--dir", t.TempDir())
+	if code == 0 || !strings.Contains(errs, "no build for this host") {
+		t.Errorf("expected a no-build-for-host refusal, got code=%d stderr=%s", code, errs)
+	}
+}
+
+func TestPluginRegistry_RefusesUnsafeFilename(t *testing.T) {
+	dir := t.TempDir()
+	idx := pluginIndex{FormatVersion: 1, Plugins: []indexPlugin{{
+		Name: "demo", Version: "1.0.0",
+		Binaries: []indexBinary{{OS: runtime.GOOS, Arch: runtime.GOARCH, File: "../escape", BLAKE3: strings.Repeat("0", 64)}},
+	}}}
+	raw, _ := json.Marshal(idx)
+	_ = os.WriteFile(filepath.Join(dir, "index.json"), raw, 0o644)
+
+	code, _, errs := runReg(t, dir, "--install", "demo", "--dir", t.TempDir())
+	if code == 0 || !strings.Contains(errs, "unsafe") {
+		t.Errorf("expected an unsafe-filename refusal, got code=%d stderr=%s", code, errs)
+	}
+}
+
+func TestPluginRegistry_RemoteListAndInstall(t *testing.T) {
+	payload := []byte("remote plugin binary payload")
+	pin := plugin.HashBytes(payload)
+	file := "demo-" + runtime.GOOS + "-" + runtime.GOARCH
+	idx := pluginIndex{FormatVersion: 1, Plugins: []indexPlugin{{
+		Name: "demo", Version: "2.0.0", Prefix: "demo",
+		Binaries: []indexBinary{{OS: runtime.GOOS, Arch: runtime.GOARCH, File: file, BLAKE3: pin}},
+	}}}
+	idxRaw, _ := json.Marshal(idx)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/index.json"):
+			_, _ = w.Write(idxRaw)
+		case strings.HasSuffix(r.URL.Path, "/"+file):
+			_, _ = w.Write(payload)
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	defer srv.Close()
+
+	// list
+	if code, out, errs := runReg(t, srv.URL); code != 0 || !strings.Contains(out, "v2.0.0") {
+		t.Fatalf("remote list failed code=%d out=%s err=%s", code, out, errs)
+	}
+	// install
+	installDir := t.TempDir()
+	code, out, errs := runReg(t, srv.URL, "--install", "demo", "--dir", installDir)
+	if code != 0 {
+		t.Fatalf("remote install exit=%d stderr=%s", code, errs)
+	}
+	got, err := os.ReadFile(filepath.Join(installDir, file))
+	if err != nil || !bytes.Equal(got, payload) {
+		t.Fatalf("remote binary not staged correctly: %v", err)
+	}
+	if !strings.Contains(out, "verified blake3:"+pin) {
+		t.Errorf("expected verified pin in output: %s", out)
+	}
+}

--- a/kernel/plugin/pin.go
+++ b/kernel/plugin/pin.go
@@ -118,6 +118,22 @@ func HashFile(path string) (string, error) {
 	return hex.EncodeToString(sum), nil
 }
 
+// HashBytes returns the lowercase-hex BLAKE3-256 digest of data. The in-memory
+// sibling of HashFile, for verifying a downloaded plugin binary against its index
+// pin BEFORE it is written to the operator's plugin directory.
+func HashBytes(data []byte) string {
+	h := blake3.New(32, nil)
+	_, _ = h.Write(data)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// LooksLikePin reports whether s is a well-formed BLAKE3-256 pin (64-char
+// lowercase hex). Exported so the `agt plugin registry` installer can reject a
+// malformed pin in an untrusted index before downloading anything.
+func LooksLikePin(s string) bool {
+	return looksLikeBLAKE3Pin(strings.ToLower(strings.TrimSpace(s)))
+}
+
 // ErrPinMismatch is wrapped in the error VerifyPin returns when the
 // computed hash doesn't match the operator-supplied pin. Distinct
 // sentinel so the daemon can produce a tailored stderr message


### PR DESCRIPTION
Completes the **marketplace** alongside the existing remote *skill* registry. Owner picked this (the plugin-catalog gap) via AskUserQuestion after I found the remote **skill** registry already exists (`agt skill registry <url> --install`). M585 fills the **plugin** half (native binaries), mirroring that shape **without weakening the plugin security model**.

## What

`agt plugin registry <dir|url> [--install <name>] [--dir <installdir>] [--json]`:

- **Browse:** reads the registry's `index.json` (a `pluginIndex` of plugins, each with per-platform `binaries` pinned by BLAKE3-256). Lists name/version/description/platforms; flags when there's no build for the running host.
- **Install:** selects the binary for `runtime.GOOS/GOARCH`, downloads it (bounded, 256 MiB cap, from a directory or `http(s)` URL), **verifies BLAKE3 against the index pin in memory BEFORE writing** (mismatch → refuse, nothing lands on disk), stages it under `<base>/plugins` (or `--dir`), and prints the exact `AGEZT_PLUGINS` + `AGEZT_PLUGIN_PINS` lines to enable it.
- **Operator authority preserved:** install = *fetch + verify + stage*. It never edits the daemon env or loads anything — the daemon runs a plugin only when the operator wires it in. ("Autonomous, under your authority.")
- **Untrusted-index hygiene:** filenames validated (no `/`, `\`, `..`); a malformed index pin is rejected before any download.

`kernel/plugin/pin.go` gains `HashBytes` (in-memory sibling of `HashFile`, to verify a download before it touches disk) and `LooksLikePin` (exported pin-format check). `net/http` only — **no new dependency**.

## Tests + smoke

- **7 unit tests**: dir + remote (httptest) list/install; **tampered pin refused AND not written**; missing-name / no-build-for-host / unsafe-filename (`../escape`) refusals; exact env-line output asserted.
- **Full end-to-end daemon smoke:** built the SDK `greet` plugin, published it to a directory registry (real binary + real BLAKE3), installed it via the registry, then booted the daemon with the **printed** `AGEZT_PLUGINS` + `AGEZT_PLUGIN_PINS` → `agt plugin list` showed **`greet [pinned]`, 3 tools, no pin mismatch**. Proves the whole catalog → install → verify → enable → daemon-loads-pinned loop.
- gofmt clean on staged blobs; full Go suite green; **`go.mod` unchanged**. Phase report: `.project/PHASE-M585-PLUGIN-REGISTRY-REPORT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)