### PR TITLE
Fix: TypeScript SDK package main pointed at a non-existent path + shipped tests

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -4,15 +4,15 @@
   "description": "Official TypeScript/JavaScript client for the Agezt agentic OS REST API (/api/v1).",
   "license": "MIT",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js"
     }
   },
-  "files": ["dist", "README.md"],
+  "files": ["dist/src", "README.md"],
   "engines": { "node": ">=18" },
   "scripts": {
     "build": "tsc -p tsconfig.json",


### PR DESCRIPTION
Release-readiness bug found while verifying SDK packaging.

`tsc` (rootDir ".", include ["src","test"]) emits `dist/src/*` and `dist/test/*`, but `main`/`types`/`exports` pointed at `dist/index.js` — **which never exists**, so `import "@agezt/sdk"` fails to resolve for any consumer. CI didn't catch it because the test imports `../src/index.js` directly, not the package export. `files: ["dist"]` also shipped the compiled tests.

Fix: point `main`/`types`/`exports` at `dist/src/index.{js,d.ts}`; restrict `files` to `["dist/src", "README.md"]`.

**Verified locally:** built entry resolves (consumer import of the package main exports `Client`/`APIError`/`AgeztError`); `npm pack` ships 8 files (`dist/src/*` + README + package.json, **no** `dist/test`); `npm test` passes **7/7**. No dependency/lockfile change. (CI is the same org-Actions-quota outage as #22–#24 — the `typescript-sdk` job (`npm ci && npm test`) is replicated locally green.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)