### PR TITLE
Feat: POST /v1/audio/transcriptions (voice HTTP upload source)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,11 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
   (with `{seconds}` / `{out}` placeholders; e.g. `arecord` on Linux, `ffmpeg` on
   macOS/Windows), keeping the one-dependency promise. Configured with
   `AGEZT_STT_API_URL` (default OpenAI), `AGEZT_STT_API_KEY` (or `OPENAI_API_KEY`),
-  and `AGEZT_STT_MODEL` (default `whisper-1`). A daemon HTTP upload endpoint
-  (`POST /v1/audio/transcriptions`) is a documented follow-up. (M587)
+  and `AGEZT_STT_MODEL` (default `whisper-1`). The daemon's OpenAI-compatible API
+  also gains **`POST /v1/audio/transcriptions`** (token-gated) when STT is
+  configured, so any OpenAI audio client can upload a clip to Agezt and get a
+  transcript — the third voice source, alongside the file and microphone CLIs.
+  (M587)
 - **Public tunnels** — expose a local Agezt HTTP service (the Web UI, else the REST
   API) to the public internet by supervising a tunnel binary. `kernel/tunnel`
   spawns `cloudflared` or `ngrok` (built-in presets) — or any custom command

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -61,6 +61,7 @@ import (
 	kernelruntime "github.com/agezt/agezt/kernel/runtime"
 	"github.com/agezt/agezt/kernel/skill"
 	"github.com/agezt/agezt/kernel/standing"
+	"github.com/agezt/agezt/kernel/stt"
 	"github.com/agezt/agezt/kernel/tenant"
 	"github.com/agezt/agezt/kernel/tunnel"
 	"github.com/agezt/agezt/kernel/ulid"
@@ -2525,6 +2526,20 @@ func buildOpenAIAPI(ctx context.Context, k *kernelruntime.Kernel, reg *tenant.Re
 			return kernelAPIEngine{tk}, tk.Bus(), nil
 		})
 		api.SetTenantAuthorizer(reg.Authorize)
+	}
+	// Speech-to-text upload (POST /v1/audio/transcriptions) — wired when an STT
+	// endpoint is configured (a key, or a custom URL for a local whisper server).
+	sttKey := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "STT_API_KEY"))
+	if sttKey == "" {
+		sttKey = strings.TrimSpace(os.Getenv("OPENAI_API_KEY"))
+	}
+	sttURL := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "STT_API_URL"))
+	if sttKey != "" || sttURL != "" {
+		api.SetTranscriber(stt.New(stt.Config{
+			APIURL: sttURL,
+			APIKey: sttKey,
+			Model:  strings.TrimSpace(os.Getenv(brand.EnvPrefix + "STT_MODEL")),
+		}))
 	}
 	srv := newGuardedHTTPServer(api.Handler())
 	go func() {

--- a/kernel/openaiapi/openaiapi.go
+++ b/kernel/openaiapi/openaiapi.go
@@ -26,6 +26,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -120,6 +121,17 @@ type Server struct {
 	// tenantAuth, when set, validates a per-tenant token against the tenant named
 	// in the X-Agezt-Tenant header. Nil means only the admin token authorizes.
 	tenantAuth TenantAuthorizer
+
+	// transcriber, when set, backs POST /v1/audio/transcriptions. Nil means the
+	// route reports "not configured" (no STT endpoint is wired).
+	transcriber Transcriber
+}
+
+// Transcriber turns uploaded audio into text — satisfied by *stt.Client. Lets the
+// OpenAI-compatible API expose /v1/audio/transcriptions without importing the STT
+// package (kept dependency-light + testable with a fake).
+type Transcriber interface {
+	Transcribe(ctx context.Context, filename string, audio []byte) (string, error)
 }
 
 // New builds a Server. token gates every request; bus drives streaming.
@@ -135,6 +147,10 @@ func (s *Server) SetTenantResolver(r TenantResolver) { s.resolve = r }
 // tenant (X-Agezt-Tenant header) may authorize with that tenant's own token
 // instead of the daemon admin token. The admin token still authorizes any tenant.
 func (s *Server) SetTenantAuthorizer(a TenantAuthorizer) { s.tenantAuth = a }
+
+// SetTranscriber wires the speech-to-text backend for POST
+// /v1/audio/transcriptions. Without it, that route reports "not configured".
+func (s *Server) SetTranscriber(t Transcriber) { s.transcriber = t }
 
 // bind resolves the Engine + bus for a request: the per-tenant pair when an
 // X-Agezt-Tenant header is present and a resolver is configured, else the
@@ -157,7 +173,55 @@ func (s *Server) Handler() http.Handler {
 	// EXACT match, so without this subtree handler a single-model GET (what the
 	// official SDKs' models.retrieve(id) issues for capability probing) would 404.
 	mux.HandleFunc("/v1/models/", s.auth(s.handleModelByID))
+	mux.HandleFunc("/v1/audio/transcriptions", s.auth(s.handleTranscription))
 	return mux
+}
+
+// audioMaxBytes bounds an uploaded audio body (OpenAI's own cap is 25 MiB).
+const audioMaxBytes = 25 << 20
+
+// handleTranscription implements POST /v1/audio/transcriptions — the
+// OpenAI-compatible speech-to-text upload. It reads the multipart `file`, hands
+// it to the configured STT backend, and returns `{"text": …}`, so any OpenAI
+// audio client can upload to Agezt and get a transcript (the "HTTP upload" voice
+// source, complementing `agt transcribe` and `agt listen`).
+func (s *Server) handleTranscription(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		writeErr(w, http.StatusMethodNotAllowed, "method_not_allowed", "POST required")
+		return
+	}
+	if s.transcriber == nil {
+		writeErr(w, http.StatusNotImplemented, "not_configured",
+			"speech-to-text is not configured: set AGEZT_STT_API_URL + AGEZT_STT_API_KEY")
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, audioMaxBytes)
+	if err := r.ParseMultipartForm(audioMaxBytes); err != nil {
+		writeErr(w, http.StatusBadRequest, "invalid_request_error", "expected multipart/form-data with a 'file' field: "+err.Error())
+		return
+	}
+	f, hdr, err := r.FormFile("file")
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, "invalid_request_error", "missing 'file' form field")
+		return
+	}
+	defer f.Close()
+	audio, err := io.ReadAll(f)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, "invalid_request_error", "read upload: "+err.Error())
+		return
+	}
+	filename := hdr.Filename
+	if filename == "" {
+		filename = "audio.wav"
+	}
+	text, err := s.transcriber.Transcribe(r.Context(), filename, audio)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "stt_error", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"text": text})
 }
 
 func (s *Server) auth(next http.HandlerFunc) http.HandlerFunc {

--- a/kernel/openaiapi/openaiapi_audio_test.go
+++ b/kernel/openaiapi/openaiapi_audio_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT
+
+package openaiapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type fakeTranscriber struct {
+	text     string
+	gotName  string
+	gotAudio []byte
+}
+
+func (f *fakeTranscriber) Transcribe(_ context.Context, name string, audio []byte) (string, error) {
+	f.gotName = name
+	f.gotAudio = audio
+	return f.text, nil
+}
+
+func multipartAudio(t *testing.T, field, filename string, audio []byte) (*bytes.Buffer, string) {
+	t.Helper()
+	var body bytes.Buffer
+	mw := multipart.NewWriter(&body)
+	if filename != "" {
+		fw, err := mw.CreateFormFile(field, filename)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _ = fw.Write(audio)
+	}
+	_ = mw.WriteField("model", "whisper-1")
+	_ = mw.Close()
+	return &body, mw.FormDataContentType()
+}
+
+func TestTranscription_UploadReturnsText(t *testing.T) {
+	srv := newAPIServer(t, &fakeEngine{model: "m"}, "tok")
+	ft := &fakeTranscriber{text: "the transcribed words"}
+	srv.SetTranscriber(ft)
+
+	body, ct := multipartAudio(t, "file", "clip.wav", []byte("RIFFfake-audio"))
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", body)
+	req.Header.Set("Content-Type", ct)
+	req.Header.Set("Authorization", "Bearer tok")
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("code = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var out struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Text != "the transcribed words" {
+		t.Errorf("text = %q", out.Text)
+	}
+	if ft.gotName != "clip.wav" || string(ft.gotAudio) != "RIFFfake-audio" {
+		t.Errorf("transcriber got name=%q audio=%q", ft.gotName, ft.gotAudio)
+	}
+}
+
+func TestTranscription_NotConfigured(t *testing.T) {
+	srv := newAPIServer(t, &fakeEngine{model: "m"}, "tok") // no SetTranscriber
+	body, ct := multipartAudio(t, "file", "a.wav", []byte("x"))
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", body)
+	req.Header.Set("Content-Type", ct)
+	req.Header.Set("Authorization", "Bearer tok")
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotImplemented {
+		t.Errorf("code = %d, want 501 (not configured)", rec.Code)
+	}
+}
+
+func TestTranscription_MethodAndMissingFile(t *testing.T) {
+	srv := newAPIServer(t, &fakeEngine{model: "m"}, "tok")
+	srv.SetTranscriber(&fakeTranscriber{text: "x"})
+	h := srv.Handler()
+
+	// GET → 405
+	get := httptest.NewRequest(http.MethodGet, "/v1/audio/transcriptions", nil)
+	get.Header.Set("Authorization", "Bearer tok")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, get)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("GET code = %d, want 405", rec.Code)
+	}
+
+	// POST without a file field → 400
+	body, ct := multipartAudio(t, "file", "", nil)
+	post := httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", body)
+	post.Header.Set("Content-Type", ct)
+	post.Header.Set("Authorization", "Bearer tok")
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, post)
+	if rec2.Code != http.StatusBadRequest {
+		t.Errorf("missing-file code = %d, want 400", rec2.Code)
+	}
+}
+
+func TestTranscription_RequiresAuth(t *testing.T) {
+	srv := newAPIServer(t, &fakeEngine{model: "m"}, "tok")
+	srv.SetTranscriber(&fakeTranscriber{text: "x"})
+	body, ct := multipartAudio(t, "file", "a.wav", []byte("x"))
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", body)
+	req.Header.Set("Content-Type", ct) // no Authorization
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("no-auth code = %d, want 401", rec.Code)
+	}
+}


### PR DESCRIPTION
Completes the voice feature's **third source** (after `agt transcribe` / `agt listen`): the daemon's OpenAI-compatible API now serves `POST /v1/audio/transcriptions`, so any OpenAI audio client can upload a clip to Agezt and get a transcript.

## What
- `openaiapi`: `Transcriber` interface (satisfied by `*stt.Client`) + `SetTranscriber`; `handleTranscription` — token-gated, multipart `file` (25 MiB cap via `MaxBytesReader`), proxies to the configured STT backend, returns `{"text": …}`. Reports **501 "not configured"** when no STT is wired.
- `main.go` wires `SetTranscriber` when `AGEZT_STT_API_KEY`/`OPENAI_API_KEY` or `AGEZT_STT_API_URL` is set.

## Tests + smoke
- **4 endpoint tests**: upload→text (fake transcriber captures the audio+filename), not-configured 501, GET 405 + missing-file 400, no-auth 401.
- **Daemon smoke**: `POST /v1/audio/transcriptions` to a live daemon (STT → mock) → `{"text":"the quick brown fox"}`; unauthenticated → 401.
- gofmt/staticcheck/vet clean; full Go suite green; 4× cross-build; **`go.mod` unchanged**.

> CI is the same org Actions-quota outage as #22–#28; every gate replicated locally green. Merging under arc authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)