### PR TITLE
Fix: stream token deltas through the Governor (M597)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 
 ## [Unreleased]
 
+### Fixed
+- **Live token streaming now works with real providers.** The agent loop streams
+  token/reasoning deltas only when its provider satisfies `agent.StreamingProvider`,
+  but every real run goes through the `Governor` (routing + fallback + budget),
+  which implemented only `agent.Provider` — so the streaming branch never engaged
+  and the Web UI Chat (and `agt run`) collapsed each answer into one chunk instead
+  of streaming it live. The Governor now implements `CompleteStream`, routing the
+  streaming call through the exact same pre-flight gates, fallback chain and usage
+  accounting as `Complete` (a non-streaming chain entry, e.g. the offline mock
+  fallback, degrades gracefully to no deltas). Verified against real DeepSeek: a
+  run that previously emitted 0 `llm.token` events now streams 90+ per answer, and
+  the Chat renders progressively.
+
 ### Added
 - **Copy a whole answer in Chat** — finished agent replies now have a Copy button
   next to their meta line, copying the full answer to the clipboard (complements

--- a/kernel/governor/governor.go
+++ b/kernel/governor/governor.go
@@ -297,13 +297,17 @@ func (e *ErrNoProviders) Error() string {
 
 func (e *ErrNoProviders) Unwrap() error { return e.Last }
 
-// Complete implements agent.Provider. It performs routing + fallback +
-// budget accounting; the agent tool-loop sees a single Provider.
+// preflightAndRoute runs every pre-call gate (task/down-route model remap,
+// capability + strict-pricing gates, rate-limit and budget pre-checks) against
+// req — mutating it in place where a gate remaps the model — then resolves and
+// announces the provider chain. Shared by Complete and CompleteStream so the
+// governed call is byte-for-byte identical whether or not the response streams.
+// Returns the routed chain, or a non-nil error if any gate refuses the call.
 //
 // Routing hints can be smuggled via the request: not exposed at the
 // agent.Provider boundary in M1.b. The future Planner will pass options
 // through a richer interface.
-func (g *Governor) Complete(ctx context.Context, req agent.CompletionRequest) (*agent.CompletionResponse, error) {
+func (g *Governor) preflightAndRoute(req *agent.CompletionRequest) ([]*ProviderInfo, error) {
 	// Per-task-type model override (M1.ll). Mutates the request's
 	// Model field before any downstream sees it — providers, audit
 	// events, and usage accounting all observe the overridden model
@@ -459,7 +463,7 @@ func (g *Governor) Complete(ctx context.Context, req agent.CompletionRequest) (*
 		return nil, fmt.Errorf("%w: %q", ErrUnpricedModel, req.Model)
 	}
 
-	chain := g.routeChain(req)
+	chain := g.routeChain(*req)
 	if len(chain) == 0 {
 		return nil, errors.New("governor: no eligible providers")
 	}
@@ -480,6 +484,15 @@ func (g *Governor) Complete(ctx context.Context, req agent.CompletionRequest) (*
 		},
 	})
 
+	return chain, nil
+}
+
+// runChain executes req against the routed provider chain, recording usage on
+// the first success and falling back on retryable errors. callOne performs the
+// actual provider call for one chain entry — Complete passes the non-streaming
+// call, CompleteStream the streaming one — so routing, fallback and usage
+// accounting are identical for both.
+func (g *Governor) runChain(ctx context.Context, req agent.CompletionRequest, chain []*ProviderInfo, callOne func(*ProviderInfo) (*agent.CompletionResponse, error)) (*agent.CompletionResponse, error) {
 	tried := make([]string, 0, len(chain))
 	var lastErr error
 	for i, p := range chain {
@@ -487,7 +500,7 @@ func (g *Governor) Complete(ctx context.Context, req agent.CompletionRequest) (*
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		resp, err := p.Provider.Complete(ctx, req)
+		resp, err := callOne(p)
 		if err == nil {
 			g.recordUsage(p, req, resp)
 			return resp, nil
@@ -514,6 +527,41 @@ func (g *Governor) Complete(ctx context.Context, req agent.CompletionRequest) (*
 		}
 	}
 	return nil, &ErrNoProviders{Tried: tried, Last: lastErr}
+}
+
+// Complete implements agent.Provider: the full pre-call gate set, routing and
+// fallback over the non-streaming provider call. The agent tool-loop sees a
+// single Provider.
+func (g *Governor) Complete(ctx context.Context, req agent.CompletionRequest) (*agent.CompletionResponse, error) {
+	chain, err := g.preflightAndRoute(&req)
+	if err != nil {
+		return nil, err
+	}
+	return g.runChain(ctx, req, chain, func(p *ProviderInfo) (*agent.CompletionResponse, error) {
+		return p.Provider.Complete(ctx, req)
+	})
+}
+
+// CompleteStream implements agent.StreamingProvider so the GOVERNED provider
+// streams token/reasoning deltas to the loop (M1.q.y) instead of collapsing to
+// a single response — through the exact same routing, fallback, budget and usage
+// path as Complete. Before this, the governor (which every real run goes
+// through) only satisfied agent.Provider, so the loop's streaming branch never
+// engaged and the Web UI Chat never streamed live with a real provider. A chain
+// entry that isn't itself streaming-capable (e.g. the offline mock fallback) is
+// called non-streaming and simply yields no deltas; the assembled response still
+// flows back unchanged.
+func (g *Governor) CompleteStream(ctx context.Context, req agent.CompletionRequest, onChunk func(agent.Chunk) error) (*agent.CompletionResponse, error) {
+	chain, err := g.preflightAndRoute(&req)
+	if err != nil {
+		return nil, err
+	}
+	return g.runChain(ctx, req, chain, func(p *ProviderInfo) (*agent.CompletionResponse, error) {
+		if sp, ok := p.Provider.(agent.StreamingProvider); ok {
+			return sp.CompleteStream(ctx, req, onChunk)
+		}
+		return p.Provider.Complete(ctx, req)
+	})
 }
 
 // SpentMicrocents returns the total spend for the current UTC day so far.

--- a/kernel/governor/governor_test.go
+++ b/kernel/governor/governor_test.go
@@ -1123,3 +1123,120 @@ func TestStrictCapabilities_AllowsToolCapableModel(t *testing.T) {
 		t.Errorf("tool-capable model should pass; got %v", err)
 	}
 }
+
+// streamingFake implements both agent.Provider and agent.StreamingProvider,
+// emitting a fixed list of text deltas on the streaming path.
+type streamingFake struct {
+	fakeProvider
+	deltas []string
+}
+
+func (p *streamingFake) CompleteStream(ctx context.Context, _ agent.CompletionRequest, onChunk func(agent.Chunk) error) (*agent.CompletionResponse, error) {
+	p.calls.Add(1)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if p.err != nil {
+		return nil, p.err
+	}
+	for _, d := range p.deltas {
+		if err := onChunk(agent.Chunk{TextDelta: d}); err != nil {
+			return nil, err
+		}
+	}
+	return p.resp, nil
+}
+
+// The crux of the streaming bug (M597): the governor MUST satisfy
+// agent.StreamingProvider, otherwise the agent loop's streaming branch never
+// engages for any real run (every run goes through the governor) and the Web UI
+// Chat never streams live.
+var _ agent.StreamingProvider = (*governor.Governor)(nil)
+
+// CompleteStream routes through a streaming-capable provider, forwards its
+// deltas to onChunk, and returns the assembled response.
+func TestGovernor_CompleteStreamForwardsDeltas(t *testing.T) {
+	b, _ := newBus(t)
+	r := governor.NewRegistry()
+	sf := &streamingFake{fakeProvider: fakeProvider{name: "p1", resp: okResp("m", 10, 5)}, deltas: []string{"Hel", "lo"}}
+	mustRegister(t, r, &governor.ProviderInfo{Name: "p1", Provider: sf, AuthMode: governor.AuthAPIKey})
+	g, err := governor.New(governor.Config{Registry: r, Bus: b})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	var got string
+	resp, err := g.CompleteStream(context.Background(), agent.CompletionRequest{Model: "m"}, func(c agent.Chunk) error {
+		got += c.TextDelta
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("CompleteStream: %v", err)
+	}
+	if got != "Hello" {
+		t.Errorf("forwarded deltas = %q want %q", got, "Hello")
+	}
+	if resp == nil || resp.Message.Content != "ok from m" {
+		t.Errorf("assembled response = %+v", resp)
+	}
+	if n := sf.calls.Load(); n != 1 {
+		t.Errorf("provider calls = %d want 1", n)
+	}
+}
+
+// A chain entry that is NOT streaming-capable (e.g. the offline mock fallback)
+// is called non-streaming: no deltas, but the response still flows back — so
+// streaming degrades gracefully instead of breaking the run.
+func TestGovernor_CompleteStreamNonStreamingProviderCompletes(t *testing.T) {
+	b, _ := newBus(t)
+	r := governor.NewRegistry()
+	fp := &fakeProvider{name: "p1", resp: okResp("m", 1, 1)} // no CompleteStream
+	mustRegister(t, r, &governor.ProviderInfo{Name: "p1", Provider: fp, AuthMode: governor.AuthAPIKey})
+	g, err := governor.New(governor.Config{Registry: r, Bus: b})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	deltas := 0
+	resp, err := g.CompleteStream(context.Background(), agent.CompletionRequest{Model: "m"}, func(agent.Chunk) error {
+		deltas++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("CompleteStream: %v", err)
+	}
+	if resp == nil || resp.Message.Content != "ok from m" {
+		t.Errorf("response = %+v", resp)
+	}
+	if deltas != 0 {
+		t.Errorf("non-streaming provider yielded %d deltas, want 0", deltas)
+	}
+}
+
+// Streaming uses the SAME routing+fallback path as Complete: a retryable error
+// from the streaming primary falls back to the next chain entry.
+func TestGovernor_CompleteStreamFallsBack(t *testing.T) {
+	b, _ := newBus(t)
+	r := governor.NewRegistry()
+	primary := &streamingFake{fakeProvider: fakeProvider{name: "p1", err: errors.New("upstream 503")}, deltas: []string{"x"}}
+	fallback := &fakeProvider{name: "p2", resp: okResp("m2", 1, 1)}
+	mustRegister(t, r,
+		&governor.ProviderInfo{Name: "p1", Provider: primary, AuthMode: governor.AuthAPIKey},
+		&governor.ProviderInfo{Name: "p2", Provider: fallback, IsFallback: true},
+	)
+	g, err := governor.New(governor.Config{Registry: r, Bus: b})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	resp, err := g.CompleteStream(context.Background(), agent.CompletionRequest{Model: "m"}, func(agent.Chunk) error { return nil })
+	if err != nil {
+		t.Fatalf("CompleteStream: %v", err)
+	}
+	if resp == nil || resp.Message.Content != "ok from m2" {
+		t.Errorf("expected fallback response, got %+v", resp)
+	}
+	if primary.calls.Load() != 1 || fallback.calls.Load() != 1 {
+		t.Errorf("calls: primary=%d fallback=%d (want 1,1)", primary.calls.Load(), fallback.calls.Load())
+	}
+}


### PR DESCRIPTION
## The bug (found while validating with real DeepSeek)

Live token streaming **never worked for any real run**. The agent loop streams deltas only when `cfg.Provider.(agent.StreamingProvider)` holds — but **every real run goes through the `Governor`** (routing + fallback + budget), which implemented only `agent.Provider`, not `CompleteStream`. So the type-assertion always failed and the loop took the non-streaming branch, collapsing each answer into one chunk.

The Web UI **Chat was built around streaming** (token caret, progressive text); with a real provider it only ever popped the whole answer in at once. The underlying openai provider already had a full streaming implementation — it was just never reachable behind the governor.

**Ground truth:** a real DeepSeek run emitted **0** `llm.token` events before this fix.

## The fix

The `Governor` now implements `agent.StreamingProvider`. The pre-call gates (task/down-route remap, capability + strict-pricing gates, rate-limit and budget pre-checks) and the routed provider loop (fallback + usage accounting) are extracted into shared **`preflightAndRoute`** + **`runChain`** helpers; both `Complete` and the new `CompleteStream` go through them — so routing, fallback, budget and usage are **byte-for-byte identical** whether or not the response streams. A chain entry that isn't streaming-capable (the offline mock fallback) is called non-streaming and simply yields no deltas; the assembled response still flows back. Pure mechanical extraction — all existing governor/agent/runtime/controlplane tests pass unchanged.

## Tests

- Compile-time `var _ agent.StreamingProvider = (*Governor)(nil)` — the crux (guarantees the governor satisfies the interface).
- `CompleteStream` forwards deltas + returns the assembled response.
- Non-streaming chain entry degrades gracefully (no deltas, still completes).
- Falls back on a retryable error from the streaming primary.

## Verification

Real DeepSeek (`deepseek-v4-pro`), end to end: the same kind of run now streams **15** (CLI haiku) / **98** (Web UI Chat list) `llm.token` deltas through governor → loop → bus → SSE → browser; **zero console errors**.

Local CI-equivalent battery (⚠️ org GitHub Actions minutes still exhausted — hosted CI fails at startup, steps=0, unrelated):
- `go build ./...` ✓ · `go vet` + `staticcheck ./kernel/governor` ✓ · gofmt staged LF blobs ✓
- `go test ./kernel/{governor,agent,runtime,controlplane}` ✓ (4 new governor tests) · `go.mod`/`go.sum` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)