### PR TITLE
Fix: drop policy-denied tools from later offers (M605)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Fixed
+- **The agent stops burning iterations on policy-denied tools.** The loop offered
+  the model *every* registered tool, even ones the policy would always refuse
+  (e.g. a default-denied `browser.read`), so the model could waste several
+  iterations — and tokens — requesting calls that get denied. The loop now drops a
+  tool from the set offered to the model once the policy has refused it (hard-deny
+  once, or any deny twice) in a run. The M116 guard only caught an identical
+  (tool,input) repeat; this catches the same tool retried with new inputs.
+  Observed with a real reasoning model: the offered-tool count fell 7→6 right after
+  two `browser.read` denials, ending the retries.
 - **Live token streaming now works with real providers.** The agent loop streams
   token/reasoning deltas only when its provider satisfies `agent.StreamingProvider`,
   but every real run goes through the `Governor` (routing + fallback + budget),

--- a/kernel/agent/agent.go
+++ b/kernel/agent/agent.go
@@ -634,6 +634,15 @@ func Run(ctx context.Context, cfg LoopConfig, userIntent string) (answer string,
 	// requested in this run, for the M116 loop guard.
 	callCounts := map[string]int{}
 
+	// toolDenials tracks how many times each tool has been refused by policy
+	// this run. Once a tool reaches maxToolDenials (or is hard-denied even once)
+	// it is dropped from the set offered to the model on later iterations — so
+	// the model stops burning iterations (and tokens) requesting a call the
+	// policy will always refuse (M605). The M116 guard only catches an identical
+	// (tool,input) repeat; this catches the same tool tried with new inputs.
+	toolDenials := map[string]int{}
+	const maxToolDenials = 2
+
 	// spentMicrocents accumulates this run's provider spend for the per-run cost
 	// cap (M166). A local stack variable — no shared state, no lifecycle, no
 	// cleanup — so the cap adds zero concurrency surface.
@@ -686,6 +695,21 @@ func Run(ctx context.Context, cfg LoopConfig, userIntent string) (answer string,
 			}
 		}
 
+		// Offer only the tools the policy hasn't repeatedly refused this run
+		// (M605). A no-op until a tool crosses the denial threshold, so the
+		// common case allocates nothing.
+		offered := tools
+		if len(toolDenials) > 0 {
+			filtered := make([]ToolDef, 0, len(tools))
+			for _, t := range tools {
+				if toolDenials[t.Name] >= maxToolDenials {
+					continue
+				}
+				filtered = append(filtered, t)
+			}
+			offered = filtered
+		}
+
 		// 2a. llm.request — record what was sent: message count plus the
 		// assembled context size, broken down by role (SPEC-10 §3.5 context
 		// observability — the foundation of the context inspector). Lets an
@@ -696,7 +720,7 @@ func Run(ctx context.Context, cfg LoopConfig, userIntent string) (answer string,
 			"iter":            iter,
 			"messages":        len(messages),
 			"model":           cfg.Model,
-			"tools":           len(tools),
+			"tools":           len(offered),
 			"context_chars":   ctxChars,
 			"context_by_role": ctxByRole,
 		}); err != nil {
@@ -707,7 +731,7 @@ func Run(ctx context.Context, cfg LoopConfig, userIntent string) (answer string,
 			Model:         cfg.Model,
 			System:        cfg.System,
 			Messages:      messages,
-			Tools:         tools,
+			Tools:         offered,
 			MaxTokens:     cfg.MaxTokens,
 			CorrelationID: cfg.CorrelationID, // M47: attribute spend to this run
 			JSONMode:      cfg.JSONMode,      // M314: structured-output request
@@ -895,6 +919,13 @@ func Run(ctx context.Context, cfg LoopConfig, userIntent string) (answer string,
 
 			var result Result
 			if !verdict.Allow {
+				// Count the refusal so a tool that's hard-denied (never allowed)
+				// or repeatedly refused is dropped from later iterations (M605).
+				if verdict.HardDenied {
+					toolDenials[tc.Name] = maxToolDenials
+				} else {
+					toolDenials[tc.Name]++
+				}
 				result = Result{
 					Output:  "tool call denied by policy: " + verdict.Reason,
 					IsError: true,

--- a/kernel/agent/agent_test.go
+++ b/kernel/agent/agent_test.go
@@ -294,6 +294,52 @@ func TestRun_PolicyDeny_SkipsToolInvoke(t *testing.T) {
 	}
 }
 
+// M605: a tool the policy hard-denies is dropped from the set offered to the
+// model on the next iteration — so the model can't keep burning iterations on a
+// call that will always be refused. Observable via llm.request's "tools" count:
+// it should fall from 1 (shell offered) to 0 (shell dropped after the denial).
+func TestRun_HardDeniedTool_DroppedFromLaterOffers(t *testing.T) {
+	b, j := newTestBus(t)
+	prov := mock.New(
+		mock.ToolUse("c1", "shell", map[string]string{"command": "echo nope"}),
+		mock.FinalText("ok, proceeding without it"),
+	)
+	denyShell := func(_ context.Context, _ agent.ToolCall) agent.PolicyVerdict {
+		return agent.PolicyVerdict{Allow: false, Capability: "shell", Reason: "denied", HardDenied: true}
+	}
+	if _, err := agent.Run(context.Background(), agent.LoopConfig{
+		Provider:      prov,
+		Tools:         map[string]agent.Tool{"shell": shell.New()},
+		Bus:           b,
+		Actor:         "agent-drop",
+		CorrelationID: "corr-drop",
+		Policy:        denyShell,
+	}, "run shell"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	var toolCounts []int
+	_ = j.Range(func(e *event.Event) error {
+		if e.Kind == event.KindLLMRequest {
+			var p struct {
+				Tools int `json:"tools"`
+			}
+			_ = json.Unmarshal(e.Payload, &p)
+			toolCounts = append(toolCounts, p.Tools)
+		}
+		return nil
+	})
+	if len(toolCounts) < 2 {
+		t.Fatalf("expected >=2 llm.request events, got %v", toolCounts)
+	}
+	if toolCounts[0] != 1 {
+		t.Errorf("first iteration should offer the shell tool (1), got %d", toolCounts[0])
+	}
+	if last := toolCounts[len(toolCounts)-1]; last != 0 {
+		t.Errorf("after a hard deny the shell tool should be dropped (0 offered), got %d", last)
+	}
+}
+
 func TestRun_UnknownTool_RecordedNotFatal(t *testing.T) {
 	b, _ := newTestBus(t)
 	prov := mock.New(


### PR DESCRIPTION
## The bug (found running real DeepSeek)

The agent loop offers the model **every** registered tool — including ones the policy will **always** refuse (e.g. a default-denied `browser.read` in the stock config). The model, not knowing the policy, requested `browser.read` repeatedly (a different URL each time), burning an iteration **and tokens** on each before being denied. The M116 loop guard only catches an identical `(tool,input)` repeat, so it never fired.

## The fix

The loop now tracks per-tool policy refusals for the run and **drops a tool from the set offered to the model** once it's been refused enough times — **hard-denied even once** (it will never be allowed), or **denied twice** (a couple of input retries are tolerated first). A `WouldAsk` verdict has `Allow=true`, so **ask-class tools are never dropped**. The filter is a no-op (zero allocation) until a tool is actually denied.

## Verification

- New unit test: `llm.request`'s offered-tool count falls **1 → 0** after a hard deny.
- Against **real DeepSeek** (`deepseek-v4-pro`): offered-tool count fell **7 → 6** immediately after two `browser.read` denials (`policy.decision` allow=false ×2), ending the retries while the run still finished with a good answer.

Local CI-equivalent battery (⚠️ org GitHub Actions minutes still exhausted — hosted CI fails at startup, steps=0, unrelated):
- `go build ./...` ✓ · `go vet` + `staticcheck ./kernel/agent` ✓ · gofmt staged LF blobs ✓ · `go test ./kernel/{agent,runtime,controlplane}` ✓ (1 new) · `go.mod`/`go.sum` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)