### PR TITLE
Feat: host-environment awareness + shell/file workspace coherence (M609)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **The agent now knows its host — no more blind `ls` on Windows.** Every run's
+  system prompt gains a concise *runtime environment* preamble: the host OS/arch,
+  the exact shell the shell tool uses (with command-style guidance — native
+  Windows `dir`/`type`/`copy` vs POSIX `ls`/`cat`/`cp`), the shared workspace
+  directory, the date, and the tools available this run. Before this, on a
+  Windows box the model reflexively tried `ls`/`cat`/`more`, burned iterations on
+  "not recognized" errors, then adapted; now it uses the right commands from the
+  first call (a verified 6+-iteration trial-and-error run dropped to 4 clean
+  iterations). On by default; `AGEZT_ENV_INJECT=off` disables it. (M609)
 - **Live run steering — fly a running agent from the cockpit.** You can now grab
   the controls of an in-flight agent without cancelling it: **pause** it at the
   next iteration boundary, **single-step** one iteration at a time, **resume**,
@@ -42,6 +51,13 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
   sibling governors keep their own separately-settable ceilings.
 
 ### Fixed
+- **The shell and file tools now agree on "here".** The shell tool ran in the
+  daemon's process CWD while the file tool was scoped to the workspace root, so an
+  agent's `dir`/`ls` (shell) and `file read x` (file) saw *different* directories
+  — every `file read` of a file the agent had just listed via shell failed "cannot
+  find the file." The shell tool now runs in the same workspace root as the file
+  tool. Verified end-to-end: shell `cd` and the file tool now resolve identical
+  paths, and cross-tool file reads succeed. (M609)
 - **The agent stops burning iterations on policy-denied tools.** The loop offered
   the model *every* registered tool, even ones the policy would always refuse
   (e.g. a default-denied `browser.read`), so the model could waste several

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -293,6 +293,10 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// disables post-run proposal.
 	skillOn := !strings.EqualFold(os.Getenv(brand.EnvPrefix+"SKILLS"), "off")
 	forgeOn := !strings.EqualFold(os.Getenv(brand.EnvPrefix+"FORGE"), "off")
+	// Host-environment preamble (M609): on by default — the model needs to know
+	// its OS/shell/workspace to act correctly (esp. on Windows). AGEZT_ENV_INJECT=off
+	// disables it for operators who pin everything via a custom system prompt.
+	envInjectOn := !strings.EqualFold(os.Getenv(brand.EnvPrefix+"ENV_INJECT"), "off")
 	// Multi-agent delegation (P6-MULTI-01): the `delegate` tool lets a lead
 	// agent spawn bounded sub-agents. On by default; AGEZT_SUBAGENT=off disables
 	// it, AGEZT_SUBAGENT_DEPTH sets how deep delegation may nest (default 1).
@@ -395,6 +399,8 @@ func runDaemon(stdout, stderr io.Writer) int {
 		WorldInject:                worldOn,
 		WorldTool:                  worldOn,
 		WorldTopK:                  5,
+		EnvironmentInject:          envInjectOn,
+		WorkspaceRoot:              workspaceRoot(baseDir),
 		SkillInject:                skillOn,
 		SkillTopK:                  3,
 		SkillForge:                 forgeOn,
@@ -3423,6 +3429,17 @@ func pluginLogLine(r *redact.Redactor, prefix, line string) string {
 // configuration from env vars; defaults are safe (file tool scoped to a
 // per-instance workspace, http tool default-deny). The shell tool runs
 // every command through the supplied Warden engine.
+// workspaceRoot resolves the directory the file and shell tools share:
+// $AGEZT_WORKSPACE, or <baseDir>/workspace by default. Used by buildTools (to
+// scope the tools) and by the kernel Config (to tell the model where it is via
+// the M609 environment preamble), so the two never drift.
+func workspaceRoot(baseDir string) string {
+	if ws := os.Getenv(brand.EnvPrefix + "WORKSPACE"); ws != "" {
+		return ws
+	}
+	return filepath.Join(baseDir, "workspace")
+}
+
 func buildTools(baseDir string, stderr io.Writer, ward warden.Engine) (map[string]agent.Tool, []kernelruntime.PluginInfo, string, error) {
 	out := map[string]agent.Tool{}
 	var registered []string
@@ -3432,17 +3449,21 @@ func buildTools(baseDir string, stderr io.Writer, ward warden.Engine) (map[strin
 	// AGEZT_PLUGINS entries are configured.
 	var manifestEntries []kernelruntime.PluginInfo
 
+	// Workspace root — both the file tool (scoped to it) and the shell tool (runs
+	// in it, M609) use this so `dir`/`ls` (shell) and `file read x` (file) agree
+	// on what "here" is.
+	wsRoot := workspaceRoot(baseDir)
+
 	// shell — always registered, routed through Warden. Effective
 	// isolation profile depends on host OS (M1.c: always ProfileNone
-	// with the request journaled as a downgrade on non-Linux).
-	out["shell"] = shell.NewWithWarden(ward)
+	// with the request journaled as a downgrade on non-Linux). Runs in the
+	// shared workspace root (M609) so it sees the same files as the file tool.
+	sh := shell.NewWithWarden(ward)
+	sh.WorkDir = wsRoot
+	out["shell"] = sh
 	registered = append(registered, "shell(warden=requested-namespace)")
 
-	// file — scoped to $AGEZT_WORKSPACE (default <baseDir>/workspace).
-	wsRoot := os.Getenv(brand.EnvPrefix + "WORKSPACE")
-	if wsRoot == "" {
-		wsRoot = filepath.Join(baseDir, "workspace")
-	}
+	// file — scoped to the same workspace root.
 	ft, err := filetool.New(wsRoot)
 	if err != nil {
 		return nil, nil, "", fmt.Errorf("file tool: %w", err)

--- a/kernel/runtime/environment_internal_test.go
+++ b/kernel/runtime/environment_internal_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agezt/agezt/kernel/agent"
+)
+
+// envFakeTool is a minimal agent.Tool with a controllable name/description for
+// asserting the preamble's tool list.
+type envFakeTool struct {
+	name, desc string
+}
+
+func (f envFakeTool) Definition() agent.ToolDef {
+	return agent.ToolDef{Name: f.name, Description: f.desc, InputSchema: json.RawMessage(`{"type":"object"}`)}
+}
+func (envFakeTool) Invoke(context.Context, json.RawMessage) (agent.Result, error) {
+	return agent.Result{Output: "ok"}, nil
+}
+
+// envShellTool also implements shellHinter so the preamble can report an exact,
+// override-aware shell.
+type envShellTool struct {
+	envFakeTool
+	bin, arg string
+}
+
+func (s envShellTool) ShellHint() (string, string) { return s.bin, s.arg }
+
+func TestInjectEnvironment_CoreFields(t *testing.T) {
+	when := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	tools := map[string]agent.Tool{
+		"file":  envFakeTool{name: "file", desc: "Read, write, and search files within the workspace. Long details follow here."},
+		"shell": envShellTool{envFakeTool{name: "shell", desc: "Run a command."}, "cmd", "/C"},
+	}
+	out := injectEnvironment("BASE PERSONA", `C:\ws`, tools, when)
+
+	for _, want := range []string{
+		"## Runtime environment",
+		"OS / arch: " + runtime.GOOS,
+		`C:\ws`,
+		"2026-06-08",
+		"- shell —",
+		"- file —",
+		"BASE PERSONA", // base prompt preserved at the end
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("preamble missing %q\n---\n%s", want, out)
+		}
+	}
+	// The shell hint must win: cmd /C reported with Windows guidance regardless of host.
+	if !strings.Contains(out, "cmd /C") {
+		t.Errorf("expected the shell tool's exact hint 'cmd /C':\n%s", out)
+	}
+	if !strings.Contains(out, "NOT ls/cat/rm") {
+		t.Errorf("cmd shell must carry Windows command guidance:\n%s", out)
+	}
+	// First-sentence trimming: the file tool's long description is clipped.
+	if strings.Contains(out, "Long details follow") {
+		t.Errorf("tool description should be trimmed to the first sentence:\n%s", out)
+	}
+}
+
+func TestShellGuidance_ByInterpreter(t *testing.T) {
+	cases := map[string]string{
+		"cmd":            "Windows",
+		`C:\Win\cmd.exe`: "Windows",
+		"powershell":     "PowerShell",
+		"pwsh":           "PowerShell",
+		"sh":             "POSIX",
+		"/bin/bash":      "POSIX",
+	}
+	for bin, want := range cases {
+		got := shellGuidance(bin)
+		if !strings.Contains(got, want) {
+			t.Errorf("shellGuidance(%q) = %q, want it to mention %q", bin, got, want)
+		}
+	}
+}
+
+func TestFirstSentence(t *testing.T) {
+	if got := firstSentence("Run a command. More stuff."); got != "Run a command." {
+		t.Errorf("got %q", got)
+	}
+	if got := firstSentence("One line only"); got != "One line only" {
+		t.Errorf("got %q", got)
+	}
+	if got := firstSentence("First line\nsecond line"); got != "First line" {
+		t.Errorf("multiline trim got %q", got)
+	}
+}

--- a/kernel/runtime/environment_test.go
+++ b/kernel/runtime/environment_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+
+package runtime_test
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	"encoding/json"
+
+	"github.com/agezt/agezt/kernel/agent"
+	kruntime "github.com/agezt/agezt/kernel/runtime"
+	"github.com/agezt/agezt/plugins/providers/mock"
+)
+
+// fileLikeTool is a stand-in named "file" so the preamble's tool list has a
+// predictable entry to assert on.
+type fileLikeTool struct{}
+
+func (fileLikeTool) Definition() agent.ToolDef {
+	return agent.ToolDef{Name: "file", Description: "Read and write files. Extra detail.", InputSchema: json.RawMessage(`{"type":"object"}`)}
+}
+func (fileLikeTool) Invoke(context.Context, json.RawMessage) (agent.Result, error) {
+	return agent.Result{Output: "ok"}, nil
+}
+
+// TestEnvironmentInject_ReachesSystemPrompt: with EnvironmentInject on, the
+// host-environment preamble (OS, workspace, tools) is prepended to the system
+// prompt the provider actually receives, ahead of the configured persona (M609).
+func TestEnvironmentInject_ReachesSystemPrompt(t *testing.T) {
+	prov := mock.New(mock.FinalText("ok"))
+	var system string
+	var mu sync.Mutex
+	prov.OnRequest = func(req agent.CompletionRequest) {
+		mu.Lock()
+		system = req.System
+		mu.Unlock()
+	}
+
+	k, err := kruntime.Open(kruntime.Config{
+		BaseDir:           t.TempDir(),
+		Provider:          prov,
+		Tools:             map[string]agent.Tool{"file": fileLikeTool{}},
+		System:            "YOU ARE A HELPFUL PERSONA",
+		EnvironmentInject: true,
+		WorkspaceRoot:     `/tmp/ws-test`,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { k.Close() })
+
+	if _, _, err := k.Run(context.Background(), "do something"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+
+	for _, want := range []string{
+		"## Runtime environment",
+		"OS / arch: " + runtime.GOOS,
+		"/tmp/ws-test",
+		"- file —",
+		"YOU ARE A HELPFUL PERSONA",
+	} {
+		if !strings.Contains(system, want) {
+			t.Errorf("system prompt missing %q\n---\n%s", want, system)
+		}
+	}
+	// Preamble precedes the persona.
+	if strings.Index(system, "Runtime environment") > strings.Index(system, "HELPFUL PERSONA") {
+		t.Error("environment preamble should come before the configured persona")
+	}
+}
+
+// TestEnvironmentInject_OffByConfig: with EnvironmentInject false the preamble
+// is absent and the persona is sent verbatim.
+func TestEnvironmentInject_OffByConfig(t *testing.T) {
+	prov := mock.New(mock.FinalText("ok"))
+	var system string
+	prov.OnRequest = func(req agent.CompletionRequest) { system = req.System }
+
+	k, err := kruntime.Open(kruntime.Config{
+		BaseDir:           t.TempDir(),
+		Provider:          prov,
+		System:            "PERSONA ONLY",
+		EnvironmentInject: false,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { k.Close() })
+	if _, _, err := k.Run(context.Background(), "hi"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if strings.Contains(system, "Runtime environment") {
+		t.Errorf("preamble must be absent when EnvironmentInject is off:\n%s", system)
+	}
+	if system != "PERSONA ONLY" {
+		t.Errorf("persona = %q want verbatim 'PERSONA ONLY'", system)
+	}
+}

--- a/kernel/runtime/runtime.go
+++ b/kernel/runtime/runtime.go
@@ -16,6 +16,8 @@ import (
 	"fmt"
 	"maps"
 	"path/filepath"
+	stdruntime "runtime"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -239,6 +241,19 @@ type Config struct {
 	// shadow→active promotion gate. Off by default (it spends extra provider
 	// calls). Only meaningful when SkillForge/skills are in use.
 	ShadowEval bool
+
+	// EnvironmentInject, when true, prepends a concise "runtime environment"
+	// preamble to the system prompt for every run (M609): the host OS/arch, the
+	// shell the shell tool uses, the shared workspace directory, today's date,
+	// and the available tools. Without it the model flies blind about its host —
+	// e.g. it tries `ls`/`cat` on a Windows box where the shell is `cmd`, burning
+	// iterations on "not recognized" errors before adapting. The preamble is
+	// derived fresh per run (cfg.Now) so the date is always current.
+	EnvironmentInject bool
+	// WorkspaceRoot is the absolute directory the file and shell tools both
+	// operate in. Surfaced to the model by the environment preamble so it
+	// references the right path. Empty omits the workspace line.
+	WorkspaceRoot string
 
 	// ArtifactThreshold is the tool-output byte size above which the agent loop
 	// offloads the output to the content-addressed artifact store and journals a
@@ -1317,6 +1332,15 @@ func (k *Kernel) RunWith(ctx context.Context, corr, intent string) (string, erro
 		runTools = filterTools(k.tools, allow)
 	}
 
+	// Host-environment preamble (M609): prepend OS/arch, the shell the shell tool
+	// uses, the shared workspace dir, the date, and THIS run's tools — so the
+	// model acts correctly on this host instead of guessing. Injected last (after
+	// memory/world/skills and after runTools is resolved) so it sits at the top of
+	// the system prompt and reflects any per-run tool restriction.
+	if k.cfg.EnvironmentInject {
+		system = injectEnvironment(system, k.cfg.WorkspaceRoot, runTools, time.Now())
+	}
+
 	// Context budget (SPEC-10 §3): an explicit budget wins; otherwise, in auto
 	// mode, derive one from the resolved model's catalog context window. An
 	// unknown model leaves compaction off (0).
@@ -1516,6 +1540,95 @@ func injectSkills(system string, hits []skill.Scored) string {
 		b.WriteString(system)
 	}
 	return b.String()
+}
+
+// shellHinter is the optional interface a shell-like tool implements to tell the
+// environment preamble the EXACT interpreter it runs (binary + flag), so the
+// guidance reflects an operator's shell override rather than a GOOS guess.
+type shellHinter interface{ ShellHint() (string, string) }
+
+// injectEnvironment prepends a concise host-environment preamble to the system
+// prompt (M609): OS/arch, the shell the shell tool uses (with command-style
+// guidance so the model doesn't try `ls` on Windows), the shared workspace dir,
+// the date, and the run's available tools. This is the single highest-leverage
+// fix for blind trial-and-error tool use on non-Unix hosts. `now` is passed in
+// for deterministic tests.
+func injectEnvironment(system, workspaceRoot string, tools map[string]agent.Tool, now time.Time) string {
+	var b strings.Builder
+	b.WriteString("## Runtime environment\n")
+	b.WriteString("You run on a real host — act for THIS environment, do not assume Unix.\n")
+	fmt.Fprintf(&b, "- OS / arch: %s / %s\n", stdruntime.GOOS, stdruntime.GOARCH)
+
+	// Shell line: prefer the shell tool's own hint (honours overrides); fall back
+	// to the GOOS default the shell tool would pick.
+	shellBin, shellArg := defaultShellHint()
+	if t, ok := tools["shell"]; ok {
+		if h, ok := t.(shellHinter); ok {
+			shellBin, shellArg = h.ShellHint()
+		}
+	}
+	fmt.Fprintf(&b, "- Shell tool runs commands via `%s %s`. %s\n", shellBin, shellArg, shellGuidance(shellBin))
+
+	if workspaceRoot != "" {
+		fmt.Fprintf(&b, "- Working directory (shell + file tools both operate here): %s\n", workspaceRoot)
+	}
+	fmt.Fprintf(&b, "- Today: %s\n", now.Format("2006-01-02"))
+
+	if len(tools) > 0 {
+		names := make([]string, 0, len(tools))
+		for name := range tools {
+			names = append(names, name)
+		}
+		slices.Sort(names)
+		b.WriteString("- Tools available this run:\n")
+		for _, name := range names {
+			fmt.Fprintf(&b, "  - %s — %s\n", name, firstSentence(tools[name].Definition().Description))
+		}
+	}
+	b.WriteString("Some capabilities require operator approval and may be denied; if a call is denied, adapt your approach rather than repeating it.\n")
+
+	if system != "" {
+		b.WriteString("\n")
+		b.WriteString(system)
+	}
+	return b.String()
+}
+
+// defaultShellHint mirrors the shell tool's platform default for callers that
+// can't reach the live tool (e.g. tools map without a shell). cmd on Windows,
+// sh elsewhere — kept in sync with plugins/tools/shell.resolveShell.
+func defaultShellHint() (string, string) {
+	if stdruntime.GOOS == "windows" {
+		return "cmd", "/C"
+	}
+	return "sh", "-c"
+}
+
+// shellGuidance returns one line of command-style advice keyed off the shell
+// binary, so the model uses native commands (the #1 source of wasted iterations
+// on Windows was the model reflexively trying `ls`/`cat`/`rm`).
+func shellGuidance(shellBin string) string {
+	switch strings.ToLower(filepath.Base(shellBin)) {
+	case "cmd", "cmd.exe":
+		return "Use native Windows commands (dir, type, copy, del, move, findstr) — NOT ls/cat/rm/cp/mv/grep. Chain with `&&`."
+	case "powershell", "powershell.exe", "pwsh", "pwsh.exe":
+		return "Use PowerShell cmdlets (Get-ChildItem, Get-Content, Copy-Item, Remove-Item) or their aliases."
+	default:
+		return "Use standard POSIX commands (ls, cat, grep, rm). Chain with `&&`."
+	}
+}
+
+// firstSentence trims a tool description to its first sentence (or first line),
+// keeping the environment preamble compact when a tool has a long description.
+func firstSentence(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		s = s[:i]
+	}
+	if i := strings.Index(s, ". "); i >= 0 {
+		s = s[:i+1]
+	}
+	return strings.TrimSpace(s)
 }
 
 // maybeForge folds the run's journal by correlation, and if the run made at

--- a/plugins/tools/shell/shell.go
+++ b/plugins/tools/shell/shell.go
@@ -56,6 +56,13 @@ type Tool struct {
 	// "needs isolation" tool per SPEC-06 §2). On non-Linux this
 	// downgrades to ProfileNone with a journal event.
 	Profile warden.Profile
+	// WorkDir is the working directory commands run in. Empty inherits the
+	// daemon's process CWD. The daemon sets this to the file tool's workspace
+	// root so the shell and file tools agree on what "here" is — otherwise an
+	// agent's `dir`/`ls` (shell, daemon CWD) and `file read x` (file tool,
+	// workspace root) see different directories, which is deeply confusing
+	// (M609).
+	WorkDir string
 }
 
 // New returns a Tool with platform defaults and a no-bus Warden engine.
@@ -131,6 +138,7 @@ func (t *Tool) Invoke(ctx context.Context, raw json.RawMessage) (agent.Result, e
 	res, err := w.Run(ctx, warden.Spec{
 		Profile: profile,
 		Argv:    []string{shellBin, shellArg, in.Command},
+		WorkDir: t.WorkDir, // M609: run where the file tool operates (empty = inherit CWD)
 		Limits: warden.Limits{
 			Timeout:        timeout,
 			MaxOutputBytes: MaxOutputBytes,
@@ -176,6 +184,13 @@ func (t *Tool) Invoke(ctx context.Context, raw json.RawMessage) (agent.Result, e
 	}
 	return agent.Result{Output: string(combined)}, nil
 }
+
+// ShellHint reports the shell binary and command flag this tool will use on
+// the current host (e.g. "cmd","/C" on Windows, "sh","-c" elsewhere). The
+// runtime's host-environment preamble (M609) calls it so the model is told the
+// EXACT shell — including an operator's override — rather than guessing from
+// GOOS. Part of the implicit "shell hinter" interface the runtime looks for.
+func (t *Tool) ShellHint() (string, string) { return t.resolveShell() }
 
 func (t *Tool) resolveShell() (string, string) {
 	if t.Shell != "" {

--- a/plugins/tools/shell/shell_test.go
+++ b/plugins/tools/shell/shell_test.go
@@ -5,6 +5,7 @@ package shell
 import (
 	"context"
 	"encoding/json"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -121,6 +122,34 @@ func TestShell_RunsCommand(t *testing.T) {
 	}
 	if !strings.Contains(r.Output, "hello") {
 		t.Errorf("output missing 'hello': %q", r.Output)
+	}
+}
+
+// TestShell_WorkDir runs in a configured directory so the shell and file tools
+// can be made to agree on "here" (M609). Uses the platform's print-CWD command.
+func TestShell_WorkDir(t *testing.T) {
+	dir := t.TempDir()
+	sh := New()
+	sh.WorkDir = dir
+	cmd := "pwd"
+	if runtime.GOOS == "windows" {
+		cmd = "cd"
+	}
+	in, _ := json.Marshal(shellInput{Command: cmd})
+	r, err := sh.Invoke(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if r.IsError {
+		t.Fatalf("unexpected IsError; output=%s", r.Output)
+	}
+	// Resolve both sides through EvalSymlinks: t.TempDir on macOS is under
+	// /var → /private/var, and `pwd` reports the resolved form.
+	wantAbs, _ := filepath.EvalSymlinks(dir)
+	got := strings.TrimSpace(r.Output)
+	gotAbs, _ := filepath.EvalSymlinks(got)
+	if !strings.EqualFold(gotAbs, wantAbs) && !strings.EqualFold(got, dir) {
+		t.Errorf("shell ran in %q, want WorkDir %q", got, dir)
 	}
 }
 


### PR DESCRIPTION
## Summary
Make tool use actually work on Windows (and improve it everywhere) by fixing two related root causes observed live with a real model on a Windows host.

**The problem:** the agent flew blind about its host — it ran `ls -la` ("not recognized"), `more` ("not recognized"), `file read README.md` ("cannot find the file"), burning iterations before adapting. Two causes:
1. The model was never told its OS/shell/workspace → it assumed Unix.
2. The shell tool ran in the daemon's CWD while the file tool was scoped to the workspace root → `dir` (shell) and `file read x` (file) saw **different** directories.

## Fixes
- **runtime**: a per-run *runtime environment* preamble (`Config.EnvironmentInject`, on by default) prepends OS/arch, the **exact** shell the shell tool uses (new `ShellHint`, honours overrides) with command-style guidance (Windows `dir`/`type` vs POSIX `ls`/`cat`), the workspace dir, the date, and the run's tools.
- **shell tool**: new `WorkDir` (→ `warden.Spec.WorkDir` → `cmd.Dir`); the daemon sets it to the file tool's workspace root so both agree on "here".
- **daemon**: shared `workspaceRoot()` feeds both tools and `Config.WorkspaceRoot`; `AGEZT_ENV_INJECT=off` opts out.

## Tests
- `injectEnvironment` (fields, ordering, shell-hint-wins, description trimming), `shellGuidance` by interpreter, `firstSentence`, shell `WorkDir` (cross-platform), integration: preamble reaches the provider's system prompt (and absent when off). Full suites green.

## End-to-end (real DeepSeek, Windows)
The exact task that previously failed with `ls`/`more`/not-found now runs `dir`/`type` from the **first** call and resolves file reads — **6+ trial-and-error iterations → 4 clean ones**, and the model explicitly confirmed the workspace path "matching the runtime environment".

🤖 Generated with [Claude Code](https://claude.com/claude-code)