### PR TITLE
Feat: AGEZT_ALLOW_ALL master switch — allow every capability (M611)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **`AGEZT_ALLOW_ALL=1` — one switch to allow everything.** For a single-operator
+  dev box where the safe-by-default gating is just friction, this master switch
+  sets *every* governed capability to L4 (allow) and opens the http/browser tools
+  to any host (including loopback and the private network) — so no tool call is
+  denied or prompts. Off by default (the project stays safe-by-default for
+  everyone else); a loud startup banner makes it impossible to enable silently.
+  The built-in catastrophe hard-deny rails (fork-bomb, `dd` to a raw device)
+  deliberately remain — they guard against self-destruction, not normal tool use,
+  and are no-ops on Windows. Restrict later from the Policy view or by unsetting
+  the flag. Verified: with it on, every capability reports L4 and a real
+  `http GET https://example.com` succeeds (200) where it was previously
+  hard-denied. (M611)
 - **Grant or restrict tool capabilities from the cockpit — no restart.** The Web
   UI Policy view was read-only (decision stats + log); enabling a default-denied
   capability meant editing env vars and restarting. It is now a control center:

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -230,7 +230,24 @@ func runDaemon(stdout, stderr io.Writer) int {
 		hardDeny = append(hardDeny, extra...)
 		askPolicyDesc += fmt.Sprintf("; +%d operator deny rule(s)", len(extra))
 	}
-	edictEng := edict.New(edict.Options{AskPolicy: askPolicy, HardDeny: hardDeny})
+	edictOpts := edict.Options{AskPolicy: askPolicy, HardDeny: hardDeny}
+	// Master permissive switch (M611): AGEZT_ALLOW_ALL=1 sets EVERY governed
+	// capability to L4 (allow) so nothing is denied or prompts — a single-operator
+	// dev convenience ("default everything allowed, restrict later"). The built-in
+	// catastrophe hard-deny rails (fork-bomb, dd-to-raw-device) deliberately stay,
+	// since they guard against self-destruction rather than gate normal tools, and
+	// are no-ops on Windows anyway. Loud banner so this is never silent.
+	permissive := os.Getenv(brand.EnvPrefix+"ALLOW_ALL") == "1"
+	if permissive {
+		lv := make(map[edict.Capability]edict.TrustLevel, len(edict.AllCapabilities()))
+		for _, c := range edict.AllCapabilities() {
+			lv[c] = edict.LevelAllow
+		}
+		edictOpts.Levels = lv
+		askPolicyDesc += "; ALLOW_ALL (every capability L4)"
+		fmt.Fprintln(stderr, "WARNING: AGEZT_ALLOW_ALL=1 — every capability is set to allow (L4). Not for production; restrict via the Policy view or unset to restore defaults.")
+	}
+	edictEng := edict.New(edictOpts)
 
 	tools, pluginManifest, toolsDesc, err := buildTools(baseDir, stderr, ward)
 	if err != nil {
@@ -3481,18 +3498,24 @@ func buildTools(baseDir string, stderr io.Writer, ward warden.Engine) (map[strin
 			}
 		}
 	}
-	if os.Getenv(brand.EnvPrefix+"HTTP_ALLOW_ALL") == "1" {
+	// Master permissive switch (M611): AGEZT_ALLOW_ALL=1 implies the full open
+	// posture for the network tools too — any host, including loopback and the
+	// private network — so "everything allowed" really means everything.
+	allowAll := os.Getenv(brand.EnvPrefix+"ALLOW_ALL") == "1"
+	if allowAll || os.Getenv(brand.EnvPrefix+"HTTP_ALLOW_ALL") == "1" {
 		ht.AllowAll = true
-		fmt.Fprintln(stderr, "WARNING: AGEZT_HTTP_ALLOW_ALL=1 disables the http host allowlist.")
+		if !allowAll {
+			fmt.Fprintln(stderr, "WARNING: AGEZT_HTTP_ALLOW_ALL=1 disables the http host allowlist.")
+		}
 	}
 	// Egress guard (M16): by default the http tool refuses internal/metadata
 	// addresses even for allowlisted/AllowAll hosts. Relax per range for local use.
 	egress := "guarded"
-	if os.Getenv(brand.EnvPrefix+"HTTP_ALLOW_LOOPBACK") == "1" {
+	if allowAll || os.Getenv(brand.EnvPrefix+"HTTP_ALLOW_LOOPBACK") == "1" {
 		ht.AllowLoopback = true
 		egress = "loopback-ok"
 	}
-	if os.Getenv(brand.EnvPrefix+"HTTP_ALLOW_PRIVATE") == "1" {
+	if allowAll || os.Getenv(brand.EnvPrefix+"HTTP_ALLOW_PRIVATE") == "1" {
 		ht.AllowPrivate = true
 		if egress == "loopback-ok" {
 			egress = "loopback+private-ok"
@@ -3519,16 +3542,18 @@ func buildTools(baseDir string, stderr io.Writer, ward warden.Engine) (map[strin
 			}
 		}
 	}
-	if os.Getenv(brand.EnvPrefix+"BROWSER_ALLOW_ALL") == "1" {
+	if allowAll || os.Getenv(brand.EnvPrefix+"BROWSER_ALLOW_ALL") == "1" {
 		br.AllowAll = true
-		fmt.Fprintln(stderr, "WARNING: AGEZT_BROWSER_ALLOW_ALL=1 disables the browser host allowlist.")
+		if !allowAll {
+			fmt.Fprintln(stderr, "WARNING: AGEZT_BROWSER_ALLOW_ALL=1 disables the browser host allowlist.")
+		}
 	}
 	// Egress guard (M16): browser.read refuses internal/metadata addresses by
 	// default, even for allowlisted/AllowAll hosts. Relax per range for local use.
-	if os.Getenv(brand.EnvPrefix+"BROWSER_ALLOW_LOOPBACK") == "1" {
+	if allowAll || os.Getenv(brand.EnvPrefix+"BROWSER_ALLOW_LOOPBACK") == "1" {
 		br.AllowLoopback = true
 	}
-	if os.Getenv(brand.EnvPrefix+"BROWSER_ALLOW_PRIVATE") == "1" {
+	if allowAll || os.Getenv(brand.EnvPrefix+"BROWSER_ALLOW_PRIVATE") == "1" {
 		br.AllowPrivate = true
 		fmt.Fprintln(stderr, "WARNING: AGEZT_BROWSER_ALLOW_PRIVATE=1 lets browser.read reach the private network.")
 	}

--- a/kernel/controlplane/config.go
+++ b/kernel/controlplane/config.go
@@ -34,6 +34,7 @@ import (
 // so the inventory can no longer silently rot.
 var configEnvVars = []string{
 	"AGEZT_ACP_AGENT_CMD",
+	"AGEZT_ALLOW_ALL",
 	"AGEZT_ANOMALY_MAX_TOOLCALLS",
 	"AGEZT_ANOMALY_WINDOW",
 	"AGEZT_API_ADDR",


### PR DESCRIPTION
## Summary
For a single-operator dev box, safe-by-default policy gating is just friction. This adds **one master switch** that makes everything permissive:

- **edict**: `AGEZT_ALLOW_ALL=1` sets every governed capability to **L4 (allow)** — nothing denied or prompts.
- **http/browser tools**: the same flag implies `AllowAll` + loopback + private, so the network tools reach any host.
- **Off by default** (project stays safe-by-default); **loud startup banner** prevents silent enablement; registered in `configEnvVars`.

The built-in **catastrophe hard-deny rails** (fork-bomb, `dd` to a raw device) deliberately remain — they guard against self-destruction, not normal tool use, and are no-ops on Windows. Restrict later from the Policy view (M610) or unset the flag.

## Verified end-to-end
With the switch on: `edict show` reports every capability at L4, the banner + `http(allow_all=true)` / `browser.read(allow_all=true)` appear, and a real `http GET https://example.com` returns **200** where it was previously hard-denied (`hosts=0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)