### PR TITLE
Fix: register browser.read/memory/world capabilities + UnknownAllow (M613)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 
 ## [Unreleased]
 
+### Fixed
+- **`browser.read`, `memory`, and `world` were silently un-grantable — now
+  first-class.** These three tools mapped to capabilities the policy engine never
+  registered, so every call hit the unknown-capability default-deny — and worse,
+  they couldn't even be granted (the policy control center / `agt edict level`
+  reject unknown capabilities), so `AGEZT_ALLOW_ALL` *still* left them denied.
+  They're now proper capabilities with sensible defaults (`browser.read` L2 like
+  `http.get`; `memory`/`world` L4), listed in the Policy view and grantable at
+  runtime. Verified: `browser.read https://example.com` now succeeds (200) where
+  it was permanently denied. (M613)
+- **`AGEZT_ALLOW_ALL` now truly covers everything, including future tools.** Added
+  an `UnknownAllow` engine option (set under the master switch) so a capability
+  with no configured level is allowed rather than default-denied — so a plugin
+  tool introducing a brand-new capability is covered too. The hard-deny
+  catastrophe rails still fire first. (M613)
+
 ### Added
 - **Flight recorder — scrub and replay any run, step by step.** A new Replay view
   turns a run's journaled event arc into a playable timeline: pick a run, then

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -244,6 +244,7 @@ func runDaemon(stdout, stderr io.Writer) int {
 			lv[c] = edict.LevelAllow
 		}
 		edictOpts.Levels = lv
+		edictOpts.UnknownAllow = true // also allow capabilities not in the known set (M613)
 		askPolicyDesc += "; ALLOW_ALL (every capability L4)"
 		fmt.Fprintln(stderr, "WARNING: AGEZT_ALLOW_ALL=1 — every capability is set to allow (L4). Not for production; restrict via the Policy view or unset to restore defaults.")
 	}

--- a/kernel/edict/browser_caps_test.go
+++ b/kernel/edict/browser_caps_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+
+package edict
+
+import "testing"
+
+// browser.read / memory / world were tool capabilities the engine never
+// registered, so they hit the unknown-capability default-deny and were
+// impossible to use or grant (M613). These pin that they're now first-class.
+
+func TestNewlyRegisteredCaps_HaveDefaultsAndAreAllowed(t *testing.T) {
+	e := New(Options{}) // defaults, AskAllow
+	for _, cap := range []Capability{CapBrowserRead, CapMemory, CapWorld} {
+		if _, ok := e.Levels()[cap]; !ok {
+			t.Errorf("%q must have a default trust level (was unregistered)", cap)
+		}
+		// Under the default AskAllow, none of these should land on a hard deny.
+		if o := e.Decide(cap, "{}"); o.Decision == DecisionDeny {
+			t.Errorf("%q decided %v (reason %q); want not-deny under defaults", cap, o.Decision, o.Reason)
+		}
+	}
+}
+
+func TestNewlyRegisteredCaps_InAllCapabilities(t *testing.T) {
+	all := map[Capability]bool{}
+	for _, c := range AllCapabilities() {
+		all[c] = true
+	}
+	for _, c := range []Capability{CapBrowserRead, CapMemory, CapWorld} {
+		if !all[c] {
+			t.Errorf("AllCapabilities() is missing %q — the policy control center can't list/grant it", c)
+		}
+	}
+}
+
+// UnknownAllow flips an unconfigured capability from default-deny to allow, so
+// AGEZT_ALLOW_ALL covers even capabilities not in DefaultLevels (e.g. a future
+// plugin tool), while hard-deny still fires first.
+func TestUnknownAllow_AllowsUnconfiguredCap(t *testing.T) {
+	const novel = Capability("some.plugin.cap")
+
+	strict := New(Options{})
+	if o := strict.Decide(novel, "{}"); o.Decision != DecisionDeny {
+		t.Errorf("default engine: unconfigured cap should default-deny, got %v", o.Decision)
+	}
+
+	permissive := New(Options{UnknownAllow: true})
+	if o := permissive.Decide(novel, "{}"); o.Decision != DecisionAllow {
+		t.Errorf("UnknownAllow: unconfigured cap should allow, got %v (%q)", o.Decision, o.Reason)
+	}
+	// Hard-deny still wins even under UnknownAllow.
+	if o := permissive.Decide(CapShell, "rm -rf /"); !o.HardDenied {
+		t.Error("UnknownAllow must not bypass the hard-deny floor")
+	}
+}
+
+// The tool→capability map resolves the three tools to their registered caps.
+func TestToolMap_ResolvesNewTools(t *testing.T) {
+	cases := map[string]Capability{
+		"browser.read": CapBrowserRead,
+		"memory":       CapMemory,
+		"world":        CapWorld,
+	}
+	for tool, want := range cases {
+		if got := CapabilityForToolCall(tool, []byte(`{}`)); got != want {
+			t.Errorf("CapabilityForToolCall(%q) = %q, want %q", tool, got, want)
+		}
+	}
+}

--- a/kernel/edict/edict.go
+++ b/kernel/edict/edict.go
@@ -79,6 +79,22 @@ const (
 	// turning something on/off in the operator's home warrants confirmation, even
 	// though it is already constrained to a service allowlist.
 	CapHomeAssistantCall Capability = "homeassistant.call"
+
+	// CapBrowserRead gates the `browser.read` tool: fetching a web page and
+	// returning its visible text. A network read, so ask-first by default (folds
+	// to allow under AskAllow) — symmetric with CapHTTPGet; the tool's own host
+	// allowlist is the second gate. Previously UNREGISTERED, which made
+	// browser.read permanently default-denied and ungrantable via the policy
+	// surface (M613).
+	CapBrowserRead Capability = "browser.read"
+	// CapMemory gates the `memory` tool: persisting/recalling durable knowledge
+	// in the operator's own local store. Low risk, Allow by default. Previously
+	// unregistered → default-denied (M613).
+	CapMemory Capability = "memory"
+	// CapWorld gates the `world` tool: reading/growing the local world-model
+	// graph. Low risk, Allow by default. Previously unregistered → default-denied
+	// (M613).
+	CapWorld Capability = "world"
 )
 
 // TrustLevel encodes the trust ladder (DECISIONS F3).
@@ -361,15 +377,23 @@ type Options struct {
 	HardDeny []HardDenyRule
 	// AskPolicy chooses how to fold L1..L3. Default: AskAllow.
 	AskPolicy AskPolicy
+	// UnknownAllow flips the default for a capability with no configured level
+	// from default-DENY to allow (M613). Off by default (secure-default: an
+	// unknown capability is refused). The daemon sets it under AGEZT_ALLOW_ALL so
+	// "allow everything" truly covers capabilities not in DefaultLevels —
+	// including ones a future plugin tool introduces — not just the known set.
+	// Hard-deny rules still apply first, so the catastrophe rails hold.
+	UnknownAllow bool
 }
 
 // Engine is the policy decision engine. Safe for concurrent use.
 type Engine struct {
-	mu        sync.RWMutex
-	levels    map[Capability]TrustLevel
-	hardDeny  []HardDenyRule
-	askPolicy AskPolicy
-	rtSeq     int // monotonic counter naming runtime-added hard-deny rules
+	mu           sync.RWMutex
+	levels       map[Capability]TrustLevel
+	hardDeny     []HardDenyRule
+	askPolicy    AskPolicy
+	unknownAllow bool // M613: treat unconfigured capabilities as allow, not deny
+	rtSeq        int  // monotonic counter naming runtime-added hard-deny rules
 }
 
 // RuntimeRulePrefix names rules added at runtime via AddHardDeny. The
@@ -458,9 +482,10 @@ func New(opt Options) *Engine {
 		hd = DefaultHardDeny()
 	}
 	return &Engine{
-		levels:    levels,
-		hardDeny:  hd,
-		askPolicy: opt.AskPolicy,
+		levels:       levels,
+		hardDeny:     hd,
+		askPolicy:    opt.AskPolicy,
+		unknownAllow: opt.UnknownAllow,
 	}
 }
 
@@ -485,6 +510,10 @@ func DefaultLevels() map[Capability]TrustLevel {
 
 		CapHomeAssistantRead: LevelAllow,    // read entity state; low risk, allowlist-filtered
 		CapHomeAssistantCall: LevelAskFirst, // actuate the physical world; confirm before acting
+
+		CapBrowserRead: LevelAskFirst, // L2 network read, symmetric with http.get; host allowlist is the 2nd gate
+		CapMemory:      LevelAllow,    // local knowledge store; low risk
+		CapWorld:       LevelAllow,    // local world-model graph; low risk
 	}
 }
 
@@ -523,6 +552,7 @@ func AllCapabilities() []Capability {
 		CapHTTPGet, CapHTTPPost, CapProviderCall, CapDelegate, CapCoding,
 		CapACPAgent, CapRemoteRun, CapNotify,
 		CapHomeAssistantRead, CapHomeAssistantCall,
+		CapBrowserRead, CapMemory, CapWorld,
 	}
 	slices.Sort(caps)
 	return caps
@@ -622,15 +652,21 @@ func (e *Engine) DecideWithCeiling(cap Capability, input string, ceiling TrustLe
 	// 2. Look up the trust level for this capability.
 	lvl, ok := e.levels[cap]
 	if !ok {
-		// Unknown capability: default-deny (the strict reading of B0c +
-		// secure-defaults). The user must explicitly grant a level via
-		// Options.Levels to use a new capability.
-		return Outcome{
-			Decision:   DecisionDeny,
-			Capability: cap,
-			Level:      LevelDeny,
-			Reason:     fmt.Sprintf("no trust level configured for %q (default-deny)", cap),
+		// Unknown capability. Default-deny is the strict, secure default (the
+		// user must explicitly grant a level). But under UnknownAllow (M613, set
+		// by AGEZT_ALLOW_ALL) an unconfigured capability is treated as L4 so
+		// "allow everything" covers tools whose capability isn't in DefaultLevels
+		// — including future plugin tools. Hard-deny already ran above, so the
+		// catastrophe rails still hold.
+		if !e.unknownAllow {
+			return Outcome{
+				Decision:   DecisionDeny,
+				Capability: cap,
+				Level:      LevelDeny,
+				Reason:     fmt.Sprintf("no trust level configured for %q (default-deny)", cap),
+			}
 		}
+		lvl = LevelAllow
 	}
 
 	// 2b. Clamp to the per-call ceiling (SPEC-16 §4): autonomy within this context

--- a/kernel/edict/toolmap.go
+++ b/kernel/edict/toolmap.go
@@ -37,6 +37,12 @@ func CapabilityForToolCall(toolName string, input json.RawMessage) Capability {
 			return CapFileDelete
 		}
 		return Capability("file." + p.Op)
+	case "browser.read":
+		return CapBrowserRead
+	case "memory":
+		return CapMemory
+	case "world":
+		return CapWorld
 	case "delegate":
 		return CapDelegate
 	case "coding":


### PR DESCRIPTION
## Summary
Found while auditing tools on Windows: **`browser.read` was denied even with `AGEZT_ALLOW_ALL=1`**. Root cause — three tools (`browser.read`, `memory`, `world`) mapped (via `CapabilityForToolCall`'s default branch) to capabilities the edict engine **never registered**. So:

- Every call hit the unknown-capability **default-deny**.
- They were **ungrantable** — the policy control center / `agt edict level` validate against `AllCapabilities()`, which didn't include them.
- `AGEZT_ALLOW_ALL` only set levels for `AllCapabilities()`, so it missed them too — "allow everything" still denied `browser.read`.

## Fixes
- **edict**: add `CapBrowserRead`/`CapMemory`/`CapWorld` constants, default levels (`browser.read` L2 like `http.get`; `memory`/`world` L4), and `AllCapabilities()` entries — now listed + grantable.
- **edict**: new `Options.UnknownAllow` — treat an unconfigured capability as allow instead of default-deny (hard-deny still runs first). The daemon sets it under `AGEZT_ALLOW_ALL` so the master switch covers capabilities not in the known set, **including future plugin tools**.
- **toolmap**: explicit cases for the three tools.

## Tests
New-cap defaults / `AllCapabilities` membership / not-denied-under-defaults; `UnknownAllow` allows an unconfigured cap but not past hard-deny; toolmap resolution. All edict/controlplane/runtime/cmd suites green.

## Verified (real DeepSeek, Windows)
`browser.read https://example.com` now returns **200** and the agent reports the heading ("Example Domain"), where it was previously permanently hard-denied. `edict show` now lists `browser.read`/`memory`/`world` at L4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)