### PR TITLE
Feat: web_search tool — agent can discover URLs, not just fetch them (M627)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **`web_search` tool — the agent can now DISCOVER, not just fetch.** A new
+  in-process tool runs a keyword query against a public engine (DuckDuckGo's
+  no-JS HTML endpoint, keyless) and returns the top results as structured
+  `{title, url, snippet}` records — closing the gap where the agent could fetch a
+  URL it was handed (http / browser.read) but couldn't *find* one. Keyless (no
+  operator secret), SSRF-guarded (the same netguard egress guard that refuses
+  internal/metadata addresses), and fail-soft: a flaky search or an empty page
+  returns an empty result set with a note, never a hard error that fails a run.
+  Governed by a new `web.search` capability (L2, ask-first — the engine host is
+  fixed, the query is the only operator input); allowed under `AGEZT_ALLOW_ALL`.
+  Verified end-to-end against the live daemon: the model called `web_search`,
+  the policy gate decided `web.search`, and it returned the correct URL. (M627)
 - **Analyst — the daemon reasons about itself.** A new AI observability view:
   ask a natural-language question about the running system and it gathers a live
   snapshot (run stats, per-tool error rates, cache savings, recent runs) and asks

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -91,6 +91,7 @@ import (
 	"github.com/agezt/agezt/plugins/tools/notify"
 	"github.com/agezt/agezt/plugins/tools/peer"
 	"github.com/agezt/agezt/plugins/tools/shell"
+	"github.com/agezt/agezt/plugins/tools/websearch"
 )
 
 func main() {
@@ -3430,6 +3431,9 @@ func wireNetguardAudit(tools map[string]agent.Tool, b *bus.Bus) {
 	if br, ok := tools["browser"].(*browser.Tool); ok {
 		br.OnBlock = publish("browser")
 	}
+	if ws, ok := tools["web_search"].(*websearch.Tool); ok {
+		ws.OnBlock = publish("web_search")
+	}
 }
 
 // pluginLogLine formats a plugin's stderr line for the daemon log, scrubbing
@@ -3572,6 +3576,20 @@ func buildTools(baseDir string, stderr io.Writer, ward warden.Engine) (map[strin
 	} else {
 		registered = append(registered, fmt.Sprintf("browser.read(hosts=%d)", len(br.AllowedHosts)))
 	}
+
+	// web_search — keyword search against a public engine, returning result
+	// titles/URLs/snippets. The capability that lets the agent DISCOVER a URL
+	// (then fetch it with http/browser.read), not just fetch one it was handed.
+	// The engine host is fixed, so there's no host allowlist; the egress guard
+	// still refuses internal/metadata addresses (relaxed under ALLOW_ALL for
+	// parity with the other network tools). Always registered — no secret needed.
+	ws := websearch.New()
+	if allowAll {
+		ws.AllowLoopback = true
+		ws.AllowPrivate = true
+	}
+	out["web_search"] = ws
+	registered = append(registered, "web_search(duckduckgo)")
 
 	// coding — external coding-agent bridge (P6-CODE). Registered only when
 	// AGEZT_CODING_CMD is set (the command that runs Claude Code / Codex / Aider

--- a/kernel/edict/edict.go
+++ b/kernel/edict/edict.go
@@ -95,6 +95,11 @@ const (
 	// graph. Low risk, Allow by default. Previously unregistered → default-denied
 	// (M613).
 	CapWorld Capability = "world"
+	// CapWebSearch gates the `web_search` tool: running a keyword query against a
+	// public search engine and returning result titles/URLs/snippets. A network
+	// read with no operator-controlled target host (the engine is fixed), so it
+	// is ask-first by default — symmetric with CapBrowserRead/CapHTTPGet (M627).
+	CapWebSearch Capability = "web.search"
 )
 
 // TrustLevel encodes the trust ladder (DECISIONS F3).
@@ -514,6 +519,7 @@ func DefaultLevels() map[Capability]TrustLevel {
 		CapBrowserRead: LevelAskFirst, // L2 network read, symmetric with http.get; host allowlist is the 2nd gate
 		CapMemory:      LevelAllow,    // local knowledge store; low risk
 		CapWorld:       LevelAllow,    // local world-model graph; low risk
+		CapWebSearch:   LevelAskFirst, // L2 network read; engine host is fixed, query is the only operator input
 	}
 }
 
@@ -552,7 +558,7 @@ func AllCapabilities() []Capability {
 		CapHTTPGet, CapHTTPPost, CapProviderCall, CapDelegate, CapCoding,
 		CapACPAgent, CapRemoteRun, CapNotify,
 		CapHomeAssistantRead, CapHomeAssistantCall,
-		CapBrowserRead, CapMemory, CapWorld,
+		CapBrowserRead, CapMemory, CapWorld, CapWebSearch,
 	}
 	slices.Sort(caps)
 	return caps

--- a/kernel/edict/toolmap.go
+++ b/kernel/edict/toolmap.go
@@ -39,6 +39,8 @@ func CapabilityForToolCall(toolName string, input json.RawMessage) Capability {
 		return Capability("file." + p.Op)
 	case "browser.read":
 		return CapBrowserRead
+	case "web_search":
+		return CapWebSearch
 	case "memory":
 		return CapMemory
 	case "world":

--- a/plugins/tools/websearch/websearch.go
+++ b/plugins/tools/websearch/websearch.go
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: MIT
+
+// Package websearch is the in-process web-search tool. It runs a keyword
+// query against a public search engine (DuckDuckGo's no-JS HTML endpoint)
+// and returns the top results as structured {title, url, snippet} records —
+// the capability that lets the agent *discover* a URL, not just fetch one it
+// was already given (M627).
+//
+// Design notes:
+//   - Keyless: DuckDuckGo's html endpoint needs no API key, so the tool works
+//     out of the box with no operator secret.
+//   - SSRF-guarded: the request goes through a netguard-protected client that
+//     refuses internal/metadata addresses, exactly like the http/browser tools.
+//   - Fail-soft: a network error or an unparseable page returns an empty result
+//     set with a note, never a hard error — a flaky search must not fail a run.
+//
+// The engine host is fixed (the operator cannot point it at an arbitrary
+// host), so the only operator-controlled input is the query string; that is
+// why its capability (edict.CapWebSearch) is a low-risk network read.
+package websearch
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"html"
+	"io"
+	stdhttp "net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/netguard"
+)
+
+// DefaultTimeout caps a single search request.
+const DefaultTimeout = 15 * time.Second
+
+// maxResponseBytes caps the result page we parse.
+const maxResponseBytes = 1 << 20 // 1 MiB
+
+// DefaultLimit is how many results we return when the model doesn't ask for a
+// specific count; MaxLimit caps it so one call can't flood the context.
+const (
+	DefaultLimit = 6
+	MaxLimit     = 15
+)
+
+// engineURL is the no-JS DuckDuckGo HTML endpoint. Fixed by design — the
+// operator never controls the target host, only the query.
+const engineURL = "https://html.duckduckgo.com/html/"
+
+// Tool is the web_search implementation of agent.Tool.
+type Tool struct {
+	// HTTP overrides the default client. When nil, the tool builds a
+	// netguard-protected client (default-deny to internal/metadata addresses)
+	// honouring AllowLoopback/AllowPrivate. Setting it bypasses the guard.
+	HTTP *stdhttp.Client
+	// AllowLoopback / AllowPrivate relax the egress guard for the default
+	// client. Default false — the search engine is public, so neither is needed
+	// in normal use; they exist only for parity with the other network tools and
+	// for tests that point engineURL at a local stub.
+	AllowLoopback bool
+	AllowPrivate  bool
+	// UserAgent is sent on every request. A browser-like UA is the default
+	// because the HTML endpoint serves a stripped/blocked page to obvious bots.
+	UserAgent string
+	// Endpoint overrides engineURL (tests point it at a local fixture server).
+	Endpoint string
+	// OnBlock, if set, is called (resolved IP, reason) when the egress guard
+	// refuses a dial — wired by the daemon to journal a netguard.blocked event.
+	OnBlock func(ip, reason string)
+}
+
+// DefaultUserAgent mimics a desktop browser; the engine returns a usable page
+// for it where a generic client UA gets an empty/blocked response.
+const DefaultUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
+	"AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+
+// New returns a Tool with safe defaults: SSRF-guarded egress, 15s timeout,
+// browser-like User-Agent.
+func New() *Tool { return &Tool{UserAgent: DefaultUserAgent} }
+
+func (t *Tool) client() *stdhttp.Client {
+	if t.HTTP != nil {
+		return t.HTTP
+	}
+	var opts []netguard.Option
+	if t.AllowLoopback {
+		opts = append(opts, netguard.AllowLoopback())
+	}
+	if t.AllowPrivate {
+		opts = append(opts, netguard.AllowPrivate())
+	}
+	if t.OnBlock != nil {
+		opts = append(opts, netguard.OnBlock(t.OnBlock))
+	}
+	return netguard.New(opts...).HTTPClient(DefaultTimeout)
+}
+
+// Definition implements agent.Tool.
+func (t *Tool) Definition() agent.ToolDef {
+	return agent.ToolDef{
+		Name: "web_search",
+		Description: "Search the web for a keyword query and return the top results " +
+			"as a list of {title, url, snippet}. Use this to DISCOVER pages when you " +
+			"don't already have a URL; then fetch the most relevant one with the " +
+			"http or browser.read tool to read its contents.",
+		InputSchema: json.RawMessage(`{
+  "type": "object",
+  "required": ["query"],
+  "properties": {
+    "query": {"type":"string", "description":"The search query (plain keywords)."},
+    "limit": {"type":"integer", "description":"Max results to return (default 6, max 15)."}
+  }
+}`),
+	}
+}
+
+type searchInput struct {
+	Query string `json:"query"`
+	Limit int    `json:"limit,omitempty"`
+}
+
+// Result is one parsed search hit.
+type Result struct {
+	Title   string `json:"title"`
+	URL     string `json:"url"`
+	Snippet string `json:"snippet"`
+}
+
+// Invoke implements agent.Tool.
+func (t *Tool) Invoke(ctx context.Context, raw json.RawMessage) (agent.Result, error) {
+	var in searchInput
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return agent.Result{}, fmt.Errorf("web_search: parse input: %w", err)
+	}
+	q := strings.TrimSpace(in.Query)
+	if q == "" {
+		return errResult("query required"), nil
+	}
+	limit := in.Limit
+	if limit <= 0 {
+		limit = DefaultLimit
+	}
+	if limit > MaxLimit {
+		limit = MaxLimit
+	}
+
+	endpoint := t.Endpoint
+	if endpoint == "" {
+		endpoint = engineURL
+	}
+	reqURL := endpoint + "?q=" + url.QueryEscape(q)
+	req, err := stdhttp.NewRequestWithContext(ctx, stdhttp.MethodGet, reqURL, nil)
+	if err != nil {
+		return errResult("build request: " + err.Error()), nil
+	}
+	ua := t.UserAgent
+	if ua == "" {
+		ua = DefaultUserAgent
+	}
+	req.Header.Set("User-Agent", ua)
+	req.Header.Set("Accept", "text/html")
+
+	resp, err := t.client().Do(req)
+	if err != nil {
+		// Fail-soft: a flaky search must not fail the run.
+		return softResult(q, nil, "search request failed: "+err.Error()), nil
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if resp.StatusCode >= 400 {
+		return softResult(q, nil, fmt.Sprintf("search engine returned HTTP %d", resp.StatusCode)), nil
+	}
+
+	results := parseResults(string(body), limit)
+	if len(results) == 0 {
+		return softResult(q, nil, "no results found"), nil
+	}
+	return softResult(q, results, ""), nil
+}
+
+// resultLink matches DuckDuckGo HTML result anchors; snippet matches the
+// adjacent snippet block. The endpoint's markup is stable (it's the
+// deliberately-simple no-JS variant).
+var (
+	reLink    = regexp.MustCompile(`(?s)<a[^>]*class="result__a"[^>]*href="([^"]+)"[^>]*>(.*?)</a>`)
+	reSnippet = regexp.MustCompile(`(?s)<a[^>]*class="result__snippet"[^>]*>(.*?)</a>`)
+	reTag     = regexp.MustCompile(`<[^>]+>`)
+	reSpace   = regexp.MustCompile(`\s+`)
+)
+
+// parseResults extracts up to limit hits from a DuckDuckGo HTML result page.
+func parseResults(body string, limit int) []Result {
+	links := reLink.FindAllStringSubmatch(body, -1)
+	snips := reSnippet.FindAllStringSubmatch(body, -1)
+	out := make([]Result, 0, len(links))
+	for i, m := range links {
+		u := cleanURL(m[1])
+		if u == "" {
+			continue
+		}
+		title := cleanText(m[2])
+		if title == "" {
+			continue
+		}
+		snip := ""
+		if i < len(snips) {
+			snip = cleanText(snips[i][1])
+		}
+		out = append(out, Result{Title: title, URL: u, Snippet: snip})
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out
+}
+
+// cleanURL strips DuckDuckGo's redirect wrapper (//duckduckgo.com/l/?uddg=…)
+// so the model gets the real destination URL.
+func cleanURL(raw string) string {
+	u := strings.TrimSpace(raw)
+	if u == "" {
+		return ""
+	}
+	if strings.HasPrefix(u, "//") {
+		u = "https:" + u
+	}
+	if pu, err := url.Parse(u); err == nil {
+		if real := pu.Query().Get("uddg"); real != "" {
+			u = real
+		}
+	}
+	if !strings.HasPrefix(u, "http://") && !strings.HasPrefix(u, "https://") {
+		return ""
+	}
+	return u
+}
+
+// cleanText strips HTML tags, unescapes entities, and collapses whitespace.
+func cleanText(s string) string {
+	s = reTag.ReplaceAllString(s, "")
+	s = html.UnescapeString(s)
+	s = reSpace.ReplaceAllString(s, " ")
+	return strings.TrimSpace(s)
+}
+
+// softResult renders the {query, count, results, note?} payload the model
+// receives. note carries a graceful "why empty" explanation when present; it
+// never sets IsError, so a no-result search reads as a fact, not a failure.
+func softResult(query string, results []Result, note string) agent.Result {
+	if results == nil {
+		results = []Result{}
+	}
+	out := map[string]any{
+		"query":   query,
+		"count":   len(results),
+		"results": results,
+	}
+	if note != "" {
+		out["note"] = note
+	}
+	enc, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return errResult("marshal: " + err.Error())
+	}
+	return agent.Result{Output: string(enc)}
+}
+
+func errResult(msg string) agent.Result {
+	return agent.Result{Output: "web_search: " + msg, IsError: true}
+}

--- a/plugins/tools/websearch/websearch_test.go
+++ b/plugins/tools/websearch/websearch_test.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+
+package websearch
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// sampleHTML mimics the DuckDuckGo no-JS result markup the tool parses,
+// including the //duckduckgo.com/l/?uddg= redirect wrapper.
+const sampleHTML = `<!DOCTYPE html><html><body>
+<div class="result">
+  <a rel="nofollow" class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fgithub.com%2Fagiresearch%2FAIOS">AIOS: <b>AI</b> Agent OS</a>
+  <a class="result__snippet" href="x">AIOS is an <b>AI</b> agent operating &amp; system.</a>
+</div>
+<div class="result">
+  <a rel="nofollow" class="result__a" href="https://example.com/agentic">Agentic OS direct link</a>
+  <a class="result__snippet" href="y">A   plain    snippet with   spaces.</a>
+</div>
+</body></html>`
+
+func newStub(t *testing.T, body string, status int) *Tool {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return &Tool{Endpoint: srv.URL, HTTP: srv.Client()}
+}
+
+func invoke(t *testing.T, tool *Tool, in map[string]any) map[string]any {
+	t.Helper()
+	raw, _ := json.Marshal(in)
+	res, err := tool.Invoke(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("Invoke error: %v", err)
+	}
+	var out map[string]any
+	if uerr := json.Unmarshal([]byte(res.Output), &out); uerr != nil {
+		t.Fatalf("output not JSON (%q): %v", res.Output, uerr)
+	}
+	return out
+}
+
+func TestDefinition(t *testing.T) {
+	d := New().Definition()
+	if d.Name != "web_search" {
+		t.Fatalf("name = %q, want web_search", d.Name)
+	}
+	if !json.Valid(d.InputSchema) {
+		t.Fatal("input schema is not valid JSON")
+	}
+}
+
+func TestParsesResultsAndDecodesRedirect(t *testing.T) {
+	tool := newStub(t, sampleHTML, 200)
+	out := invoke(t, tool, map[string]any{"query": "agentic os"})
+
+	if out["count"].(float64) != 2 {
+		t.Fatalf("count = %v, want 2", out["count"])
+	}
+	results := out["results"].([]any)
+	first := results[0].(map[string]any)
+	if first["url"] != "https://github.com/agiresearch/AIOS" {
+		t.Errorf("redirect not decoded: url = %q", first["url"])
+	}
+	if first["title"] != "AIOS: AI Agent OS" {
+		t.Errorf("title tags/entities not stripped: %q", first["title"])
+	}
+	if first["snippet"] != "AIOS is an AI agent operating & system." {
+		t.Errorf("snippet not cleaned: %q", first["snippet"])
+	}
+	// Whitespace in the second snippet should be collapsed.
+	second := results[1].(map[string]any)
+	if second["snippet"] != "A plain snippet with spaces." {
+		t.Errorf("whitespace not collapsed: %q", second["snippet"])
+	}
+}
+
+func TestLimitCapsResults(t *testing.T) {
+	tool := newStub(t, sampleHTML, 200)
+	out := invoke(t, tool, map[string]any{"query": "agentic os", "limit": 1})
+	if out["count"].(float64) != 1 {
+		t.Fatalf("count = %v, want 1 (limit honoured)", out["count"])
+	}
+}
+
+func TestEmptyQueryIsError(t *testing.T) {
+	res, err := New().Invoke(context.Background(), json.RawMessage(`{"query":"  "}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("empty query should be an error result")
+	}
+}
+
+func TestFailSoftOnHTTPError(t *testing.T) {
+	tool := newStub(t, "boom", 503)
+	out := invoke(t, tool, map[string]any{"query": "x"})
+	if out["count"].(float64) != 0 {
+		t.Fatalf("count = %v, want 0 on HTTP error", out["count"])
+	}
+	note, _ := out["note"].(string)
+	if !strings.Contains(note, "503") {
+		t.Errorf("note should explain the HTTP error, got %q", note)
+	}
+}
+
+func TestNoResultsIsSoft(t *testing.T) {
+	tool := newStub(t, "<html><body>nothing here</body></html>", 200)
+	out := invoke(t, tool, map[string]any{"query": "x"})
+	if out["count"].(float64) != 0 {
+		t.Fatalf("count = %v, want 0", out["count"])
+	}
+	res, _ := tool.Invoke(context.Background(), json.RawMessage(`{"query":"x"}`))
+	if res.IsError {
+		t.Error("a no-result search must not be an error result")
+	}
+}


### PR DESCRIPTION
## What

Adds an in-process **`web_search`** tool: a keyword query against DuckDuckGo's keyless no-JS HTML endpoint, returning the top results as structured `{title, url, snippet}` records.

This closes the single biggest capability gap toward "an agent that acts on the world." Until now the agent could *fetch* a URL it was handed (`http` / `browser.read`) but had no way to **find** one. `web_search` is the discovery half of that loop: search → pick the best hit → fetch it.

## How

- **Keyless** — no operator secret; works out of the box.
- **SSRF-guarded** — reuses the `netguard` egress guard (refuses internal/metadata addresses), exactly like the `http`/`browser` tools.
- **Fail-soft** — a network error or unparseable page returns an empty result set with a `note`, never a hard error that fails a run.
- **Governed** — new edict capability `web.search` (L2 ask-first; the engine host is fixed, the query is the only operator input), wired into `DefaultLevels`, `AllCapabilities`, and the tool→capability map. Allowed under `AGEZT_ALLOW_ALL`.
- Registered unconditionally in the daemon tool map — boot banner now lists `web_search(duckduckgo)` — with its egress `OnBlock` journaling `netguard.blocked` events like the other network tools.

## Tested

- Unit tests (local fixture server, **no network**): result parsing + `uddg=` redirect decode + whitespace cleanup, `limit` capping, empty-query error, fail-soft on HTTP error / no results.
- Full Go suite green (`go test ./...`, GOMAXPROCS capped).
- **Verified end-to-end against the live daemon** with the real provider: the model called `web_search`, the policy gate decided `web.search` (journal seq 190→191→192), and it returned the correct URL — 2 iters, \$0.0026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)