### PR TITLE
Feat: proactive self-monitoring — daemon watches its own health (M628)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **Proactive self-monitoring — the daemon watches its OWN health.** A new pulse
+  observer (`self:health`) samples the daemon's recent reliability from its own
+  journal — tool-error rate (`tool.invoked` vs `tool.result` errors) and
+  run-failure rate (`task.completed` vs `task.failed`) — and, when that health
+  *transitions* between healthy / degraded / critical, emits a Delta that flows
+  through the existing pulse pipeline (salience → initiative → briefing) and is
+  delivered over whatever channels are wired. This turns the system's
+  self-observation (the reactive Analyst, which answers when asked) into proactive
+  self-monitoring (it tells you, unprompted, the moment its health changes). Edge-
+  triggered, so it never floods: the first poll is a silent baseline, unchanged
+  levels stay silent, and a thin sample can't manufacture an alert (min-sample
+  guard). On by default; `AGEZT_PULSE_HEALTH=off` disables it, `=<float>` overrides
+  the tool-error-rate degrade threshold (default 0.30). Verified live: a burst of
+  failing tool calls produced the alert *"daemon health healthy → degraded: tool
+  errors 4/12 (33%), run failures 0/11 (0%)"* with no operator prompt. (M628)
 - **`web_search` tool — the agent can now DISCOVER, not just fetch.** A new
   in-process tool runs a keyword query against a public engine (DuckDuckGo's
   no-JS HTML endpoint, keyless) and returns the top results as structured

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -3025,6 +3025,20 @@ func buildPulse(k *kernelruntime.Kernel, ward warden.Engine, model string, stdou
 			}
 		}
 	}
+	// Self-health observer (M628): the daemon watches its OWN run/tool
+	// reliability and briefs the operator when its health transitions
+	// (healthy↔degraded↔critical) — proactive self-monitoring, not just the
+	// reactive Analyst. On by default (the whole point is to watch unprompted);
+	// AGEZT_PULSE_HEALTH=off disables it, =<float> overrides the tool-error-rate
+	// degrade threshold (default 0.30).
+	if hv := os.Getenv(brand.EnvPrefix + "PULSE_HEALTH"); !strings.EqualFold(hv, "off") {
+		degradeAt := 0.0 // observer falls back to its default
+		if f, err := strconv.ParseFloat(hv, 64); err == nil && f > 0 {
+			degradeAt = f
+		}
+		obs = append(obs, pulse.NewHealthObserver(healthStatFromJournal(k), degradeAt, 0))
+		parts = append(parts, "self:health")
+	}
 	useLLM := strings.EqualFold(os.Getenv(brand.EnvPrefix+"PULSE_LLM"), "on")
 
 	eng := pulse.New(pulse.Config{
@@ -3046,6 +3060,46 @@ func buildPulse(k *kernelruntime.Kernel, ward warden.Engine, model string, stdou
 		observers = strings.Join(parts, ",")
 	}
 	return eng, fmt.Sprintf("dial=%s cadence=%s observers=[%s]", dial, cadence, observers)
+}
+
+// healthStatFromJournal returns a pulse.HealthStatFunc that samples the
+// daemon's recent reliability from the tail of its own journal: tool.invoked /
+// tool.result(error) for tool reliability, and task.completed / task.failed for
+// run reliability. It reads only the last healthWindow events so the scan is
+// cheap and the assessment reflects RECENT behaviour, not all-time history.
+func healthStatFromJournal(k *kernelruntime.Kernel) pulse.HealthStatFunc {
+	const healthWindow = 2000
+	return func(context.Context) (pulse.HealthStat, error) {
+		j := k.Journal()
+		if j == nil {
+			return pulse.HealthStat{}, nil
+		}
+		evs, err := j.Tail(healthWindow)
+		if err != nil {
+			return pulse.HealthStat{}, err
+		}
+		var st pulse.HealthStat
+		for _, e := range evs {
+			switch e.Kind {
+			case event.KindToolInvoked:
+				st.ToolCalls++
+			case event.KindToolResult:
+				var p struct {
+					Error bool `json:"error"`
+				}
+				_ = json.Unmarshal(e.Payload, &p)
+				if p.Error {
+					st.ToolErrors++
+				}
+			case event.KindTaskCompleted:
+				st.Runs++
+			case event.KindTaskFailed:
+				st.Runs++
+				st.FailedRuns++
+			}
+		}
+		return st, nil
+	}
 }
 
 // buildGovernor constructs the routing layer: one primary provider

--- a/kernel/pulse/health.go
+++ b/kernel/pulse/health.go
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: MIT
+
+package pulse
+
+import (
+	"context"
+	"fmt"
+)
+
+// HealthStat is a compact snapshot of the daemon's OWN recent operational
+// health, sampled from the journal. It is deliberately small — the observer
+// works in ratios, not raw events — so the data source (the journal scan in
+// the daemon) stays cheap and the observer stays unit-testable.
+type HealthStat struct {
+	ToolCalls  int // tool.invoked count in the window
+	ToolErrors int // tool.result with error=true in the window
+	Runs       int // task.completed + task.failed in the window
+	FailedRuns int // task.failed in the window
+}
+
+// HealthStatFunc returns the current health snapshot. It decouples the
+// HealthObserver from the journal/controlplane exactly as DiskFreeFunc
+// decouples the DiskObserver from the OS — the daemon owns the data source,
+// tests inject a fake.
+type HealthStatFunc func(ctx context.Context) (HealthStat, error)
+
+// healthLevel is the observer's three-state assessment of the snapshot.
+type healthLevel int
+
+const (
+	healthOK healthLevel = iota
+	healthDegraded
+	healthCritical
+)
+
+func (l healthLevel) String() string {
+	switch l {
+	case healthCritical:
+		return "critical"
+	case healthDegraded:
+		return "degraded"
+	default:
+		return "healthy"
+	}
+}
+
+// DefaultHealthDegradeAt is the tool-error-rate at which health is judged
+// "degraded" — matches the threshold the Analyst view already uses when it
+// grades a system (≥30% tool errors reads as unhealthy).
+const DefaultHealthDegradeAt = 0.30
+
+// DefaultHealthMinSample is the minimum number of samples (tool calls or runs)
+// on an axis before that axis is allowed to move the assessment — so a single
+// early failure can't flap the daemon into a "critical" alert.
+const DefaultHealthMinSample = 5
+
+// HealthObserver watches the daemon's own run/tool reliability and emits a
+// Delta when its health *transitions* between healthy / degraded / critical —
+// turning the system's self-observation (the reactive Analyst) into proactive
+// self-monitoring: the operator is briefed (over whatever channels pulse feeds)
+// the moment the daemon's own health changes, without anyone having to ask.
+//
+// Like DiskObserver it tracks edge transitions, not levels: it stays silent on
+// every poll where the level is unchanged, so it never floods. The first poll
+// establishes the baseline and emits nothing.
+type HealthObserver struct {
+	stat      HealthStatFunc
+	degradeAt float64 // tool-error-rate floor for "degraded"
+	minSample int
+
+	prev     healthLevel
+	hasState bool
+}
+
+// NewHealthObserver constructs a health observer. degradeAt<=0 falls back to
+// DefaultHealthDegradeAt; minSample<=0 to DefaultHealthMinSample.
+func NewHealthObserver(stat HealthStatFunc, degradeAt float64, minSample int) *HealthObserver {
+	if degradeAt <= 0 {
+		degradeAt = DefaultHealthDegradeAt
+	}
+	if minSample <= 0 {
+		minSample = DefaultHealthMinSample
+	}
+	return &HealthObserver{stat: stat, degradeAt: degradeAt, minSample: minSample}
+}
+
+// Name implements Observer.
+func (o *HealthObserver) Name() string { return "self:health" }
+
+// assess maps a snapshot to a health level. Each axis (tool errors, run
+// failures) only counts once it has at least minSample observations, so a thin
+// sample can't manufacture an alert. The level is the worse of the two axes.
+func (o *HealthObserver) assess(s HealthStat) healthLevel {
+	level := healthOK
+	worsen := func(l healthLevel) {
+		if l > level {
+			level = l
+		}
+	}
+
+	if s.ToolCalls >= o.minSample {
+		rate := float64(s.ToolErrors) / float64(s.ToolCalls)
+		switch {
+		case rate >= 2*o.degradeAt || rate >= 0.6:
+			worsen(healthCritical)
+		case rate >= o.degradeAt:
+			worsen(healthDegraded)
+		}
+	}
+	if s.Runs >= o.minSample {
+		rate := float64(s.FailedRuns) / float64(s.Runs)
+		switch {
+		case rate >= 0.5:
+			worsen(healthCritical)
+		case rate >= 0.25:
+			worsen(healthDegraded)
+		}
+	}
+	return level
+}
+
+// Poll implements Observer. It emits a Delta only when the assessed level
+// changes from the previously-seen level (after a baseline first poll).
+func (o *HealthObserver) Poll(ctx context.Context) ([]Delta, error) {
+	if o.stat == nil {
+		return nil, nil
+	}
+	s, err := o.stat(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("health: %w", err)
+	}
+	level := o.assess(s)
+
+	prev := o.prev
+	prevKnown := o.hasState
+	o.prev = level
+	o.hasState = true
+
+	if !prevKnown || prev == level {
+		return nil, nil // baseline or no transition
+	}
+
+	toolRate, runRate := 0.0, 0.0
+	if s.ToolCalls > 0 {
+		toolRate = float64(s.ToolErrors) / float64(s.ToolCalls)
+	}
+	if s.Runs > 0 {
+		runRate = float64(s.FailedRuns) / float64(s.Runs)
+	}
+	metrics := fmt.Sprintf("tool errors %d/%d (%.0f%%), run failures %d/%d (%.0f%%)",
+		s.ToolErrors, s.ToolCalls, toolRate*100, s.FailedRuns, s.Runs, runRate*100)
+
+	worsening := level > prev
+	var summary string
+	var sev Severity
+	var kind string
+	if worsening {
+		kind = "health_degraded"
+		summary = fmt.Sprintf("daemon health %s → %s: %s", prev, level, metrics)
+		if level == healthCritical {
+			sev = SevCritical
+		} else {
+			sev = SevHigh
+		}
+	} else {
+		kind = "health_recovered"
+		summary = fmt.Sprintf("daemon health recovered %s → %s: %s", prev, level, metrics)
+		sev = SevMedium
+	}
+
+	return []Delta{{
+		Source:  o.Name(),
+		Kind:    kind,
+		Summary: summary,
+		Before:  prev.String(),
+		After:   level.String(),
+		Hints:   map[string]string{"severity": string(sev)},
+	}}, nil
+}

--- a/kernel/pulse/health_test.go
+++ b/kernel/pulse/health_test.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+
+package pulse
+
+import (
+	"context"
+	"testing"
+)
+
+// statSeq returns a HealthStatFunc that yields the given snapshots in order,
+// repeating the last one once exhausted.
+func statSeq(snaps ...HealthStat) HealthStatFunc {
+	i := 0
+	return func(context.Context) (HealthStat, error) {
+		s := snaps[i]
+		if i < len(snaps)-1 {
+			i++
+		}
+		return s, nil
+	}
+}
+
+func poll(t *testing.T, o *HealthObserver) []Delta {
+	t.Helper()
+	d, err := o.Poll(context.Background())
+	if err != nil {
+		t.Fatalf("Poll error: %v", err)
+	}
+	return d
+}
+
+func TestHealth_BaselineFirstPollSilent(t *testing.T) {
+	// Even an unhealthy first poll establishes a baseline and emits nothing —
+	// there's no transition to report yet.
+	o := NewHealthObserver(statSeq(HealthStat{ToolCalls: 10, ToolErrors: 9}), 0, 0)
+	if d := poll(t, o); len(d) != 0 {
+		t.Fatalf("first poll should be silent, got %v", d)
+	}
+}
+
+func TestHealth_EmitsOnDegradeTransition(t *testing.T) {
+	o := NewHealthObserver(statSeq(
+		HealthStat{ToolCalls: 10, ToolErrors: 0},  // healthy baseline
+		HealthStat{ToolCalls: 10, ToolErrors: 4},  // 40% → degraded
+	), 0, 0)
+	poll(t, o) // baseline
+	d := poll(t, o)
+	if len(d) != 1 {
+		t.Fatalf("want 1 delta on degrade, got %d", len(d))
+	}
+	if d[0].Kind != "health_degraded" {
+		t.Errorf("kind = %q, want health_degraded", d[0].Kind)
+	}
+	if d[0].After != "degraded" || d[0].Before != "healthy" {
+		t.Errorf("transition = %s→%s, want healthy→degraded", d[0].Before, d[0].After)
+	}
+	if d[0].Hints["severity"] != string(SevHigh) {
+		t.Errorf("severity = %q, want high", d[0].Hints["severity"])
+	}
+}
+
+func TestHealth_CriticalSeverityOnSevereErrors(t *testing.T) {
+	o := NewHealthObserver(statSeq(
+		HealthStat{ToolCalls: 10, ToolErrors: 0}, // healthy
+		HealthStat{ToolCalls: 10, ToolErrors: 7}, // 70% → critical
+	), 0, 0)
+	poll(t, o)
+	d := poll(t, o)
+	if len(d) != 1 || d[0].After != "critical" {
+		t.Fatalf("want critical transition, got %v", d)
+	}
+	if d[0].Hints["severity"] != string(SevCritical) {
+		t.Errorf("severity = %q, want critical", d[0].Hints["severity"])
+	}
+}
+
+func TestHealth_RunFailureAxis(t *testing.T) {
+	// No tool errors at all, but half the runs failed → degraded/critical from
+	// the run axis alone.
+	o := NewHealthObserver(statSeq(
+		HealthStat{Runs: 10, FailedRuns: 0},
+		HealthStat{Runs: 10, FailedRuns: 5}, // 50% → critical
+	), 0, 0)
+	poll(t, o)
+	d := poll(t, o)
+	if len(d) != 1 || d[0].After != "critical" {
+		t.Fatalf("run-failure axis should drive critical, got %v", d)
+	}
+}
+
+func TestHealth_RecoveryEmitsMediumSilentNoFlap(t *testing.T) {
+	o := NewHealthObserver(statSeq(
+		HealthStat{ToolCalls: 10, ToolErrors: 0}, // healthy baseline
+		HealthStat{ToolCalls: 10, ToolErrors: 5}, // degraded
+		HealthStat{ToolCalls: 10, ToolErrors: 5}, // still degraded → silent
+		HealthStat{ToolCalls: 10, ToolErrors: 0}, // recovered
+	), 0, 0)
+	poll(t, o) // baseline
+	if d := poll(t, o); len(d) != 1 || d[0].Kind != "health_degraded" {
+		t.Fatalf("want degrade, got %v", d)
+	}
+	if d := poll(t, o); len(d) != 0 {
+		t.Fatalf("unchanged level must be silent, got %v", d)
+	}
+	d := poll(t, o)
+	if len(d) != 1 || d[0].Kind != "health_recovered" {
+		t.Fatalf("want recovery, got %v", d)
+	}
+	if d[0].Hints["severity"] != string(SevMedium) {
+		t.Errorf("recovery severity = %q, want medium", d[0].Hints["severity"])
+	}
+}
+
+func TestHealth_ThinSampleCannotAlert(t *testing.T) {
+	// 2/2 tool errors is 100% but below minSample — must not alert.
+	o := NewHealthObserver(statSeq(
+		HealthStat{ToolCalls: 10, ToolErrors: 0}, // healthy baseline (enough sample)
+		HealthStat{ToolCalls: 2, ToolErrors: 2},  // 100% but thin → stays healthy
+	), 0, 0)
+	poll(t, o)
+	if d := poll(t, o); len(d) != 0 {
+		t.Fatalf("thin sample must not alert, got %v", d)
+	}
+}
+
+func TestHealth_NilStatFuncIsSafe(t *testing.T) {
+	o := NewHealthObserver(nil, 0, 0)
+	if d := poll(t, o); d != nil {
+		t.Fatalf("nil stat func should yield no deltas, got %v", d)
+	}
+	if o.Name() != "self:health" {
+		t.Errorf("name = %q", o.Name())
+	}
+}


### PR DESCRIPTION
## What

A new pulse observer **`self:health`** that turns the system's self-*observation* (the reactive Analyst, which answers when asked) into proactive self-*monitoring*: the daemon samples its **own** recent reliability from the journal and briefs the operator — **unprompted** — the moment its health transitions.

## How

- **Signal**: tool-error rate (`tool.invoked` vs `tool.result` errors) and run-failure rate (`task.completed` vs `task.failed`), over the last 2000 journal events (recent behaviour, cheap scan).
- **Three levels** (healthy / degraded / critical) — the worse of the two axes; degrade threshold defaults to `0.30` (matches the Analyst's grading).
- **Edge-triggered** like `DiskObserver`: first poll is a silent baseline, unchanged levels stay silent (never floods), and a min-sample guard stops a thin sample from manufacturing an alert.
- **Decoupled** via a `HealthStatFunc` data source (mirrors `DiskFreeFunc`) so the `pulse` package stays independent and unit-testable; the daemon wires the journal scan.
- **On by default**; `AGEZT_PULSE_HEALTH=off` disables, `=<float>` overrides the threshold. Boot banner now lists `observers=[self:health]`.

The `Delta` flows through the existing pulse pipeline (`salience → initiative → briefing → channel sinks`), so a degradation is delivered wherever pulse already delivers (Telegram/Slack/Discord/webhook/email/…).

## Tested

- Unit tests: baseline-silence, degrade/critical transitions, both axes, recovery, no-flap on unchanged level, thin-sample guard, nil safety.
- Full `go test ./...` green (capped).
- **Verified live end-to-end** against the real daemon: a burst of failing tool calls produced, with **no operator prompt**, the journaled chain `observer.delta → salience.scored → initiative.taken → briefing.sent` with the alert:
  > daemon health healthy → degraded: tool errors 4/12 (33%), run failures 0/11 (0%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)