### PR TITLE
Feat: individual sub-agents are steerable from the cockpit (M631)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **Steer an individual sub-agent — the cockpit reaches into the tree.** Live
+  steering (pause / single-step / inject directive / resume, M608) was wired only
+  for the top-level lead; sub-agents ran un-steerable. Now every sub-agent
+  registers its own steering control under its own correlation, so the per-run
+  control API (`/api/run/{pause,resume,step,steer}`) — and therefore the existing
+  Runs-view cockpit, which lists sub-agent runs and shows `SteerControls` for any
+  live one — can pause or redirect a *specific* worker deep in a delegation tree,
+  not just the lead. The pause/steer/resume events are journaled under the
+  sub-agent's own timeline. Verified with a live two-run test that pauses, steers,
+  and resumes a running sub-agent addressed by its own correlation. (M631)
 - **Depth-aware delegation graph + deep-tree root fix.** The Agents view's
   delegation graph now tags each sub-agent with its nesting level (`L1`, `L2`, …)
   so a deep tree reads at a glance — a depth-2 worker is visibly distinct from a

--- a/kernel/runtime/runtime_steer_test.go
+++ b/kernel/runtime/runtime_steer_test.go
@@ -141,6 +141,151 @@ func TestSteerRun_PauseInjectResume(t *testing.T) {
 	}
 }
 
+// subDelegateSteerProvider drives a two-run conversation: the LEAD delegates
+// once; the CHILD loops on the tick tool until it sees an operator-steering
+// directive, then ends. Roles are told apart by the first user message — the
+// child's delegated task is prefixed CHILD-TASK.
+type subDelegateSteerProvider struct{}
+
+func (subDelegateSteerProvider) Name() string { return "sub-steer" }
+
+func (subDelegateSteerProvider) Complete(_ context.Context, req agent.CompletionRequest) (*agent.CompletionResponse, error) {
+	var firstUser string
+	for _, m := range req.Messages {
+		if m.Role == agent.RoleUser {
+			firstUser = m.Content
+			break
+		}
+	}
+	if strings.HasPrefix(strings.TrimSpace(firstUser), "CHILD-TASK") {
+		// Child path: end once steered, else keep ticking.
+		for _, m := range req.Messages {
+			if strings.Contains(m.Content, "[operator steering] finish now") {
+				return &agent.CompletionResponse{
+					Message:    agent.Message{Role: agent.RoleAssistant, Content: "child-steered-done"},
+					StopReason: agent.StopEndTurn,
+				}, nil
+			}
+		}
+		return &agent.CompletionResponse{
+			Message:    agent.Message{Role: agent.RoleAssistant, ToolCalls: []agent.ToolCall{{ID: "t", Name: "tick", Input: json.RawMessage(`{}`)}}},
+			StopReason: agent.StopToolUse,
+		}, nil
+	}
+	// Lead path: delegate once, then finish after the child's answer returns.
+	for _, m := range req.Messages {
+		if m.Role == agent.RoleTool {
+			return &agent.CompletionResponse{
+				Message:    agent.Message{Role: agent.RoleAssistant, Content: "lead-done"},
+				StopReason: agent.StopEndTurn,
+			}, nil
+		}
+	}
+	return &agent.CompletionResponse{
+		Message:    agent.Message{Role: agent.RoleAssistant, ToolCalls: []agent.ToolCall{{ID: "d", Name: "delegate", Input: json.RawMessage(`{"task":"CHILD-TASK loop until steered"}`)}}},
+		StopReason: agent.StopToolUse,
+	}, nil
+}
+
+// TestSteerRun_SubAgentIndividuallySteerable proves an INDIVIDUAL sub-agent
+// (not just the top-level lead) can be paused / steered / resumed from the
+// cockpit (M631): the steering control is registered under the child's own
+// correlation, so the per-run control API reaches into the delegation tree.
+func TestSteerRun_SubAgentIndividuallySteerable(t *testing.T) {
+	k, err := runtime.Open(runtime.Config{
+		BaseDir:          t.TempDir(),
+		Provider:         subDelegateSteerProvider{},
+		Tools:            map[string]agent.Tool{"tick": tickTool{}},
+		SubAgentTool:     true,
+		SubAgentMaxDepth: 1,
+		MaxIter:          500, // headroom so timing can't exhaust the child loop
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { k.Close() })
+
+	col := &collector{}
+	col.watch(k)
+
+	leadCorr := k.NewCorrelation()
+	done := make(chan struct {
+		ans string
+		err error
+	}, 1)
+	go func() {
+		ans, e := k.RunWith(context.Background(), leadCorr, "lead-task: delegate then report")
+		done <- struct {
+			ans string
+			err error
+		}{ans, e}
+	}()
+
+	// Wait for the sub-agent to spawn and capture its correlation.
+	childCorr := ""
+	for deadline := time.Now().Add(3 * time.Second); time.Now().Before(deadline) && childCorr == ""; {
+		for _, e := range col.ofKind(event.KindSubAgentSpawned) {
+			var p struct {
+				Child string `json:"child_correlation"`
+			}
+			_ = json.Unmarshal(e.Payload, &p)
+			if p.Child != "" {
+				childCorr = p.Child
+			}
+		}
+		if childCorr == "" {
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	if childCorr == "" {
+		t.Fatal("sub-agent never spawned")
+	}
+	if childCorr == leadCorr {
+		t.Fatal("child correlation must differ from the lead")
+	}
+
+	// The SUB-AGENT — addressed by its own correlation — must be steerable.
+	if !k.PauseRun(childCorr) {
+		t.Fatal("PauseRun returned false for the live sub-agent (control not registered?)")
+	}
+	if paused, _, ok := k.RunControlState(childCorr); !ok || !paused {
+		t.Fatalf("sub-agent RunControlState = (paused=%v ok=%v), want paused & ok", paused, ok)
+	}
+	if !k.SteerRun(childCorr, "finish now") {
+		t.Fatal("SteerRun returned false for the live sub-agent")
+	}
+	if !k.ResumeRun(childCorr) {
+		t.Fatal("ResumeRun returned false for the paused sub-agent")
+	}
+
+	select {
+	case r := <-done:
+		if r.err != nil {
+			t.Fatalf("run errored: %v", r.err)
+		}
+		if r.ans != "lead-done" {
+			t.Errorf("answer = %q want lead-done", r.ans)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("steered sub-agent run did not finish")
+	}
+
+	// pause/steer/resume must be journaled under the CHILD correlation — proving
+	// the control surface (and its audit) is the sub-agent's, not the lead's.
+	kinds := map[event.Kind]bool{}
+	_ = k.Journal().Range(func(e *event.Event) error {
+		if e.CorrelationID == childCorr {
+			kinds[e.Kind] = true
+		}
+		return nil
+	})
+	for _, want := range []event.Kind{event.KindRunPaused, event.KindRunSteered, event.KindRunResumed} {
+		if !kinds[want] {
+			t.Errorf("missing %s event on the SUB-AGENT timeline", want)
+		}
+	}
+}
+
 // TestSteerRun_UnknownReturnsFalse: steering a non-existent run is a no-op
 // reporting false, never a panic.
 func TestSteerRun_UnknownReturnsFalse(t *testing.T) {

--- a/kernel/runtime/subagent.go
+++ b/kernel/runtime/subagent.go
@@ -164,11 +164,23 @@ func (k *Kernel) runSubAgent(ctx context.Context, task string) (string, error) {
 	childCorr := k.NewCorrelation()
 	actor := "subagent-" + childCorr
 
-	// This child may itself delegate; release its own fan-out tally when it
-	// returns so the map doesn't accumulate across a long-lived kernel.
+	// Live-steering control surface for the sub-agent (M631): registered under
+	// the child's own correlation so an operator can pause / single-step / steer
+	// / resume an INDIVIDUAL sub-agent from the cockpit — reaching into the
+	// delegation tree, not just the top-level lead (M608 only wired RunWith).
+	// Wired into the child loop via LoopConfig.Steer below.
+	rc := newRunControl()
+	k.mu.Lock()
+	k.steers[childCorr] = rc
+	k.mu.Unlock()
+
+	// This child may itself delegate; release its own fan-out tally and steering
+	// control when it returns so the maps don't accumulate across a long-lived
+	// kernel.
 	defer func() {
 		k.mu.Lock()
 		delete(k.fanout, childCorr)
+		delete(k.steers, childCorr)
 		k.mu.Unlock()
 	}()
 
@@ -216,6 +228,7 @@ func (k *Kernel) runSubAgent(ctx context.Context, task string) (string, error) {
 		Actor:         actor,
 		CorrelationID: childCorr,
 		Policy:        k.policyHook,
+		Steer:         rc, // M631: individual sub-agent steering
 	}, task)
 	if err != nil {
 		return "", fmt.Errorf("sub-agent %s: %w", childCorr, err)


### PR DESCRIPTION
## What

Live steering — pause / single-step / inject directive / resume (M608) — was registered **only for the top-level lead**; sub-agents ran un-steerable. Now an operator can pause or redirect a **specific worker deep in a delegation tree**, not just the lead.

## How

`runSubAgent` now creates a `runControl` for the child, registers it under the child's **own** correlation (`k.steers[childCorr]`), passes it as `LoopConfig.Steer`, and releases it on return. Because every steer method resolves by correlation (`controlFor → k.steers[corr]`), the existing per-run control API (`/api/run/{pause,resume,step,steer}`) **and the Runs-view cockpit** — which already lists sub-agent runs and shows `SteerControls` for any live run — now drive sub-agents with **no UI change**. The pause/steer/resume events journal under the sub-agent's own timeline.

## Tested

New two-run test: spawns a sub-agent that loops on a tick tool, captures its child correlation from `subagent.spawned`, then **pauses it** (asserts `RunControlState` reports paused & ok), injects `"finish now"`, **resumes**, and verifies the run completes with `run.paused`/`run.steered`/`run.resumed` all journaled under the **child** correlation — proving the control surface is the sub-agent's, not the lead's. Full `go test ./...` + `vet` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)