### PR TITLE
Feat: schedule tool — the agent schedules its own future work (M634)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **`schedule` tool — the agent schedules its own future work.** A new
+  in-process tool lets the agent arrange future runs in the daemon's persistent
+  cadence store: one-shot after a delay (`op=in`), recurring interval
+  (`op=every`), daily at a wall-clock time (`op=daily`, optional weekday spec),
+  plus `list` / `remove`. A scheduled intent fires later as a fresh run through
+  the full governed loop — the autonomy primitive that turns "ask me again later"
+  into "I'll handle it then." Schedules it creates are tagged `source=agent` so an
+  operator sees and can prune them (`agt schedule list`). Governed by a new
+  ask-first `schedule` capability; allowed under `AGEZT_ALLOW_ALL`. Verified live
+  end-to-end with the real provider: the agent scheduled a one-shot, and ~40s
+  later it fired autonomously (`schedule.fired` → a new run). (M634)
 - **Live delegation activity in Mission Control.** The real-time telemetry
   terminal now folds `subagent.spawned` into its per-second buckets and shows a
   fifth live metric — `delegations/60s` — with its own sparkline, so multi-agent

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -90,6 +90,7 @@ import (
 	httptool "github.com/agezt/agezt/plugins/tools/http"
 	"github.com/agezt/agezt/plugins/tools/notify"
 	"github.com/agezt/agezt/plugins/tools/peer"
+	scheduletool "github.com/agezt/agezt/plugins/tools/schedule"
 	"github.com/agezt/agezt/plugins/tools/shell"
 	"github.com/agezt/agezt/plugins/tools/websearch"
 )
@@ -282,6 +283,13 @@ func runDaemon(stdout, stderr io.Writer) int {
 		notifyTool = notify.New() // unbound; Bind wires the sender once channels exist
 		tools["notify"] = notifyTool
 	}
+
+	// Self-scheduling tool (`schedule`, M634): the agent arranges its OWN future
+	// runs in the daemon's cadence store. Registered here (before the kernel
+	// starts, like notify) and Bound to the live store after the kernel opens.
+	// Always available — the schedule store is the kernel's and always exists.
+	scheduleTool := scheduletool.New()
+	tools["schedule"] = scheduleTool
 
 	// OnReload is invoked by the control plane's `provider_reload`
 	// command (and `agt provider reload`). It re-reads the vault,
@@ -1066,6 +1074,14 @@ func runDaemon(stdout, stderr io.Writer) int {
 	if notifyTool != nil {
 		notifyTool.Bind(channelSend, notifyTargets)
 		fmt.Fprintf(stdout, "  notify tool      : enabled (%d channel(s) the agent can ping)\n", len(notifyTargets))
+	}
+
+	// Bind the self-scheduling tool to the live cadence store (M634), now that the
+	// kernel (and its store) exist. The store is the same one the schedule engine
+	// ticks, so an agent-created schedule fires like any operator-added one.
+	if sched := k.Schedules(); sched != nil {
+		scheduleTool.Bind(sched)
+		fmt.Fprintf(stdout, "  schedule tool    : enabled (the agent can schedule its own future runs)\n")
 	}
 
 	// Scheduled intents (autonomy) — fire operator-configured intents on a timer

--- a/kernel/edict/edict.go
+++ b/kernel/edict/edict.go
@@ -100,6 +100,11 @@ const (
 	// read with no operator-controlled target host (the engine is fixed), so it
 	// is ask-first by default — symmetric with CapBrowserRead/CapHTTPGet (M627).
 	CapWebSearch Capability = "web.search"
+	// CapSchedule gates the `schedule` tool: the agent arranging its OWN future
+	// runs (one-shot / recurring / daily) in the daemon's cadence store. A
+	// genuine autonomy grant — a scheduled intent fires later through the full
+	// governed loop — so it is ask-first by default (M634).
+	CapSchedule Capability = "schedule"
 )
 
 // TrustLevel encodes the trust ladder (DECISIONS F3).
@@ -520,6 +525,7 @@ func DefaultLevels() map[Capability]TrustLevel {
 		CapMemory:      LevelAllow,    // local knowledge store; low risk
 		CapWorld:       LevelAllow,    // local world-model graph; low risk
 		CapWebSearch:   LevelAskFirst, // L2 network read; engine host is fixed, query is the only operator input
+		CapSchedule:    LevelAskFirst, // L2 autonomy grant; a scheduled intent runs later through the governed loop
 	}
 }
 
@@ -558,7 +564,7 @@ func AllCapabilities() []Capability {
 		CapHTTPGet, CapHTTPPost, CapProviderCall, CapDelegate, CapCoding,
 		CapACPAgent, CapRemoteRun, CapNotify,
 		CapHomeAssistantRead, CapHomeAssistantCall,
-		CapBrowserRead, CapMemory, CapWorld, CapWebSearch,
+		CapBrowserRead, CapMemory, CapWorld, CapWebSearch, CapSchedule,
 	}
 	slices.Sort(caps)
 	return caps

--- a/kernel/edict/toolmap.go
+++ b/kernel/edict/toolmap.go
@@ -41,6 +41,8 @@ func CapabilityForToolCall(toolName string, input json.RawMessage) Capability {
 		return CapBrowserRead
 	case "web_search":
 		return CapWebSearch
+	case "schedule":
+		return CapSchedule
 	case "memory":
 		return CapMemory
 	case "world":

--- a/plugins/tools/schedule/schedule.go
+++ b/plugins/tools/schedule/schedule.go
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: MIT
+
+// Package schedule is the in-process self-scheduling tool. It lets the agent
+// arrange its OWN future work — "remind me / do this later / every morning" —
+// by writing to the daemon's persistent cadence store, the same store the
+// `agt schedule` CLI and the AGEZT_SCHEDULE env jobs use. A scheduled intent
+// fires through the normal governed loop at its due time (M634).
+//
+// This is the autonomy primitive that turns a reactive assistant into a
+// proactive one: the agent can say "I'll check back in an hour" and actually
+// have it happen. Schedules it creates are tagged source="agent" so an operator
+// can see and prune them (`agt schedule list`).
+//
+// The tool is created unbound and Bound to the live store after the kernel
+// opens (the store is the kernel's), mirroring the notify tool's lifecycle.
+package schedule
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/cadence"
+)
+
+// store is the subset of *cadence.Store the tool needs — an interface so tests
+// can inject a fake without a real on-disk store.
+type store interface {
+	Add(intent string, interval time.Duration, model, source string, now time.Time) (cadence.Entry, error)
+	AddDaily(intent string, atMinutes, days int, tz, model, source string, now time.Time) (cadence.Entry, error)
+	AddOnce(intent string, at time.Time, model, source string, now time.Time) (cadence.Entry, error)
+	Remove(id string) (bool, error)
+	List() []cadence.Entry
+}
+
+// Tool implements agent.Tool. Created unbound via New(); Bind wires the store.
+type Tool struct {
+	mu    sync.RWMutex
+	store store
+	now   func() time.Time
+}
+
+// New returns an unbound schedule tool (no store until Bind).
+func New() *Tool { return &Tool{now: time.Now} }
+
+// Bind wires the live cadence store. Called once after the kernel opens.
+func (t *Tool) Bind(s *cadence.Store) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if s != nil {
+		t.store = s
+	}
+}
+
+func (t *Tool) current() (store, func() time.Time) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	now := t.now
+	if now == nil {
+		now = time.Now
+	}
+	return t.store, now
+}
+
+// Definition implements agent.Tool.
+func (t *Tool) Definition() agent.ToolDef {
+	return agent.ToolDef{
+		Name: "schedule",
+		Description: "Schedule your OWN future work: run an intent later (once after a " +
+			"delay, every interval, or daily at a wall-clock time), or list/remove your " +
+			"schedules. The intent fires as a fresh run at its due time. Use this to set " +
+			"reminders or recurring checks instead of asking the user to come back.",
+		InputSchema: json.RawMessage(`{
+  "type": "object",
+  "required": ["op"],
+  "properties": {
+    "op":       {"type":"string", "enum":["in","every","daily","list","remove"], "description":"in=one-shot after a delay; every=recurring interval; daily=at a wall-clock time; list; remove."},
+    "intent":   {"type":"string", "description":"The task to run at the scheduled time (for in/every/daily)."},
+    "delay":    {"type":"string", "description":"For op=in: how far out, e.g. \"30m\", \"2h\", \"24h\"."},
+    "interval": {"type":"string", "description":"For op=every: the firing period, e.g. \"1h\", \"15m\"."},
+    "at":       {"type":"string", "description":"For op=daily: wall-clock time \"HH:MM\" (24h, daemon local time)."},
+    "days":     {"type":"string", "description":"For op=daily (optional): which days, e.g. \"mon-fri\", \"weekends\". Default every day."},
+    "model":    {"type":"string", "description":"Optional model override for the scheduled run."},
+    "id":       {"type":"string", "description":"For op=remove: the schedule id to delete."}
+  }
+}`),
+	}
+}
+
+type input struct {
+	Op       string `json:"op"`
+	Intent   string `json:"intent"`
+	Delay    string `json:"delay"`
+	Interval string `json:"interval"`
+	At       string `json:"at"`
+	Days     string `json:"days"`
+	Model    string `json:"model"`
+	ID       string `json:"id"`
+}
+
+const source = "agent" // marks schedules the agent created, for operator visibility
+
+// Invoke implements agent.Tool.
+func (t *Tool) Invoke(_ context.Context, raw json.RawMessage) (agent.Result, error) {
+	var in input
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return agent.Result{}, fmt.Errorf("schedule: parse input: %w", err)
+	}
+	st, nowFn := t.current()
+	if st == nil {
+		return errResult("scheduling is not available on this daemon"), nil
+	}
+	now := nowFn()
+
+	switch in.Op {
+	case "in":
+		d, err := time.ParseDuration(in.Delay)
+		if err != nil || d <= 0 {
+			return errResult(`op=in needs a positive "delay" duration like "30m" or "2h"`), nil
+		}
+		e, err := st.AddOnce(in.Intent, now.Add(d), in.Model, source, now)
+		if err != nil {
+			return errResult(err.Error()), nil
+		}
+		return okEntry("scheduled once", e), nil
+
+	case "every":
+		d, err := time.ParseDuration(in.Interval)
+		if err != nil || d <= 0 {
+			return errResult(`op=every needs a positive "interval" like "1h" or "15m"`), nil
+		}
+		e, err := st.Add(in.Intent, d, in.Model, source, now)
+		if err != nil {
+			return errResult(err.Error()), nil
+		}
+		return okEntry("scheduled recurring", e), nil
+
+	case "daily":
+		mins, ok := parseHHMM(in.At)
+		if !ok {
+			return errResult(`op=daily needs an "at" time in HH:MM (24h)`), nil
+		}
+		days := 0 // 0 = every day
+		if in.Days != "" {
+			d, err := cadence.ParseDays(in.Days)
+			if err != nil {
+				return errResult("bad days spec: " + err.Error()), nil
+			}
+			days = d
+		}
+		e, err := st.AddDaily(in.Intent, mins, days, "", in.Model, source, now)
+		if err != nil {
+			return errResult(err.Error()), nil
+		}
+		return okEntry("scheduled daily", e), nil
+
+	case "remove":
+		if in.ID == "" {
+			return errResult(`op=remove needs an "id"`), nil
+		}
+		removed, err := st.Remove(in.ID)
+		if err != nil {
+			return errResult(err.Error()), nil
+		}
+		if !removed {
+			return errResult("no schedule with id " + in.ID), nil
+		}
+		return okJSON(map[string]any{"removed": in.ID}), nil
+
+	case "list":
+		entries := st.List()
+		out := make([]map[string]any, 0, len(entries))
+		for _, e := range entries {
+			out = append(out, entryView(e))
+		}
+		return okJSON(map[string]any{"count": len(out), "schedules": out}), nil
+
+	case "":
+		return errResult("op required (in|every|daily|list|remove)"), nil
+	default:
+		return errResult("unknown op " + in.Op + " (in|every|daily|list|remove)"), nil
+	}
+}
+
+// parseHHMM parses "HH:MM" (24h) into minutes since midnight. Returns ok=false
+// on any malformed input.
+func parseHHMM(s string) (int, bool) {
+	var h, m int
+	if n, err := fmt.Sscanf(s, "%d:%d", &h, &m); err != nil || n != 2 {
+		return 0, false
+	}
+	if h < 0 || h > 23 || m < 0 || m > 59 {
+		return 0, false
+	}
+	return h*60 + m, true
+}
+
+func entryView(e cadence.Entry) map[string]any {
+	v := map[string]any{
+		"id":      e.ID,
+		"intent":  e.Intent,
+		"cadence": e.Cadence(),
+		"enabled": e.Enabled,
+		"source":  e.Source,
+	}
+	if e.NextRunUnix > 0 {
+		v["next_run"] = time.Unix(e.NextRunUnix, 0).Format(time.RFC3339)
+	}
+	return v
+}
+
+func okEntry(msg string, e cadence.Entry) agent.Result {
+	view := entryView(e)
+	view["message"] = msg
+	return okJSON(view)
+}
+
+func okJSON(v any) agent.Result {
+	enc, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return errResult("marshal: " + err.Error())
+	}
+	return agent.Result{Output: string(enc)}
+}
+
+func errResult(msg string) agent.Result {
+	return agent.Result{Output: "schedule: " + msg, IsError: true}
+}

--- a/plugins/tools/schedule/schedule_test.go
+++ b/plugins/tools/schedule/schedule_test.go
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: MIT
+
+package schedule
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/agezt/agezt/kernel/cadence"
+)
+
+// fakeStore records calls so the tool's mapping (op → store method + args) is
+// asserted without a real on-disk schedule store.
+type fakeStore struct {
+	added    []cadence.Entry
+	lastOnce time.Time
+	lastIntv time.Duration
+	lastAtMin, lastDays int
+	removed  string
+	removeOK bool
+	entries  []cadence.Entry
+}
+
+func (f *fakeStore) Add(intent string, interval time.Duration, model, source string, now time.Time) (cadence.Entry, error) {
+	f.lastIntv = interval
+	e := cadence.Entry{ID: "ev1", Intent: intent, Mode: cadence.ModeInterval, IntervalSec: int64(interval / time.Second), Source: source, Enabled: true, NextRunUnix: now.Add(interval).Unix()}
+	f.added = append(f.added, e)
+	return e, nil
+}
+func (f *fakeStore) AddDaily(intent string, atMinutes, days int, tz, model, source string, now time.Time) (cadence.Entry, error) {
+	f.lastAtMin, f.lastDays = atMinutes, days
+	e := cadence.Entry{ID: "day1", Intent: intent, Mode: cadence.ModeDaily, AtMinutes: atMinutes, Days: days, Source: source, Enabled: true}
+	f.added = append(f.added, e)
+	return e, nil
+}
+func (f *fakeStore) AddOnce(intent string, at time.Time, model, source string, now time.Time) (cadence.Entry, error) {
+	f.lastOnce = at
+	e := cadence.Entry{ID: "once1", Intent: intent, Mode: cadence.ModeOnce, Source: source, Enabled: true, NextRunUnix: at.Unix()}
+	f.added = append(f.added, e)
+	return e, nil
+}
+func (f *fakeStore) Remove(id string) (bool, error) { f.removed = id; return f.removeOK, nil }
+func (f *fakeStore) List() []cadence.Entry          { return f.entries }
+
+// fixedNow pins the clock so the one-shot's absolute fire time is assertable.
+var fixedNow = time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+
+func newTool(f *fakeStore) *Tool {
+	t := New()
+	t.store = f
+	t.now = func() time.Time { return fixedNow }
+	return t
+}
+
+func invoke(t *testing.T, tool *Tool, in map[string]any) (map[string]any, bool) {
+	t.Helper()
+	raw, _ := json.Marshal(in)
+	res, err := tool.Invoke(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("Invoke error: %v", err)
+	}
+	var out map[string]any
+	_ = json.Unmarshal([]byte(res.Output), &out)
+	return out, res.IsError
+}
+
+func TestDefinitionValid(t *testing.T) {
+	d := New().Definition()
+	if d.Name != "schedule" {
+		t.Fatalf("name = %q", d.Name)
+	}
+	if !json.Valid(d.InputSchema) {
+		t.Fatal("schema invalid")
+	}
+}
+
+func TestOpIn_OneShotAtDelay(t *testing.T) {
+	f := &fakeStore{}
+	out, isErr := invoke(t, newTool(f), map[string]any{"op": "in", "delay": "30m", "intent": "check the deploy"})
+	if isErr {
+		t.Fatalf("unexpected error: %v", out)
+	}
+	if len(f.added) != 1 || f.added[0].Intent != "check the deploy" {
+		t.Fatalf("AddOnce not called as expected: %+v", f.added)
+	}
+	if f.added[0].Source != "agent" {
+		t.Errorf("source = %q, want agent", f.added[0].Source)
+	}
+	if want := fixedNow.Add(30 * time.Minute); !f.lastOnce.Equal(want) {
+		t.Errorf("fire time = %v, want now+30m = %v", f.lastOnce, want)
+	}
+}
+
+func TestOpEvery_Interval(t *testing.T) {
+	f := &fakeStore{}
+	_, isErr := invoke(t, newTool(f), map[string]any{"op": "every", "interval": "1h", "intent": "hourly digest"})
+	if isErr {
+		t.Fatal("unexpected error")
+	}
+	if f.lastIntv != time.Hour {
+		t.Errorf("interval = %v, want 1h", f.lastIntv)
+	}
+}
+
+func TestOpDaily_ParsesTimeAndDays(t *testing.T) {
+	f := &fakeStore{}
+	_, isErr := invoke(t, newTool(f), map[string]any{"op": "daily", "at": "09:30", "days": "mon-fri", "intent": "standup"})
+	if isErr {
+		t.Fatal("unexpected error")
+	}
+	if f.lastAtMin != 9*60+30 {
+		t.Errorf("atMinutes = %d, want %d", f.lastAtMin, 9*60+30)
+	}
+	if f.lastDays == 0 {
+		t.Error("days should be a non-zero weekday mask for mon-fri")
+	}
+}
+
+func TestOpRemove(t *testing.T) {
+	f := &fakeStore{removeOK: true}
+	out, isErr := invoke(t, newTool(f), map[string]any{"op": "remove", "id": "once1"})
+	if isErr {
+		t.Fatalf("unexpected error: %v", out)
+	}
+	if f.removed != "once1" {
+		t.Errorf("removed = %q, want once1", f.removed)
+	}
+}
+
+func TestOpRemove_NotFound(t *testing.T) {
+	f := &fakeStore{removeOK: false}
+	_, isErr := invoke(t, newTool(f), map[string]any{"op": "remove", "id": "nope"})
+	if !isErr {
+		t.Error("removing an unknown id should be an error result")
+	}
+}
+
+func TestOpList(t *testing.T) {
+	f := &fakeStore{entries: []cadence.Entry{
+		{ID: "a", Intent: "x", Mode: cadence.ModeInterval, IntervalSec: 3600, Enabled: true, Source: "agent"},
+	}}
+	out, _ := invoke(t, newTool(f), map[string]any{"op": "list"})
+	if out["count"].(float64) != 1 {
+		t.Fatalf("count = %v, want 1", out["count"])
+	}
+}
+
+func TestBadInputs(t *testing.T) {
+	f := &fakeStore{}
+	cases := []map[string]any{
+		{"op": "in", "delay": "nope", "intent": "x"},
+		{"op": "in", "delay": "-5m", "intent": "x"},
+		{"op": "every", "interval": "", "intent": "x"},
+		{"op": "daily", "at": "25:00", "intent": "x"},
+		{"op": "daily", "at": "notime", "intent": "x"},
+		{"op": "bogus"},
+		{"op": ""},
+	}
+	for _, c := range cases {
+		if _, isErr := invoke(t, newTool(f), c); !isErr {
+			t.Errorf("expected error result for %v", c)
+		}
+	}
+}
+
+func TestUnboundStoreIsSafe(t *testing.T) {
+	tool := New() // never Bound
+	res, err := tool.Invoke(context.Background(), json.RawMessage(`{"op":"list"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Error("an unbound tool should return an error result, not succeed")
+	}
+}


### PR DESCRIPTION
## What

A new in-process **`schedule`** tool lets the agent arrange its **own** future runs in the daemon's persistent cadence store: one-shot after a delay (`op=in`), recurring interval (`op=every`), daily at a wall-clock time (`op=daily`, optional weekday spec), plus `list` / `remove`.

A scheduled intent fires later as a fresh run through the full governed loop — the autonomy primitive that turns a reactive assistant proactive: *"I'll check back in an hour"* actually happens. **Tool count 14 → 15.**

## How

- Created unbound (like `notify`) and Bound to the live `cadence.Store` after the kernel opens — the same store the schedule engine ticks, so an agent-created schedule fires like any operator-added one.
- Schedules are tagged `source="agent"` so operators see/prune them (`agt schedule list`).
- Governed by a new ask-first **`schedule`** capability (in `DefaultLevels`, `AllCapabilities`, the tool→capability map); allowed under `AGEZT_ALLOW_ALL`. Boot banner shows `schedule tool: enabled`.

## Tested

- Unit tests (fake store): op→store-method mapping, one-shot fire time pinned via an injected clock, interval/daily parsing (incl `HH:MM` + days), remove, list, bad-input errors, unbound safety.
- Full `go test ./...` green.
- **Verified live** end-to-end with the real provider: the agent scheduled a one-shot (`source=agent` in `schedule list`), and ~40s later it **fired autonomously** (`schedule.fired` → a new governed run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)