### PR TITLE
Feat: runs tool — the agent recalls its own past work (M644)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,19 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
   state renders cleanly, 0 console errors. (M640)
 
 ### Added
+- **`runs` tool — the agent recalls its OWN past work.** A new in-process tool
+  lets the agent introspect its own run history by folding the daemon's journal:
+  `op=recent` lists recent top-level runs (intent, status, cost, when), `op=stats`
+  gives aggregate totals (completed/failed/success-rate/spend), `op=search` finds
+  past runs whose intent matches a query. The self-knowledge primitive that
+  complements `memory` (deliberate facts) and `world` (entities): the agent can
+  see what it has actually *done*, not just what it chose to remember — so it can
+  check "have I looked into this already?" or report on its activity. Sub-agent
+  runs are folded out (operator-facing leads only); governed by a low-risk
+  `runs.read` capability (Allow by default). Verified live: asked to report its
+  history, the agent called `runs` and returned its real stats (18 completed,
+  100% success) and correctly listed its 3 most recent runs by intent. Tool count
+  15 → 16. (M644)
 - **Global alert bell — proactive signals visible from every view.** The header
   now carries an alert indicator (on every panel) that counts the daemon's
   warning/critical signals as they stream — self-health degradations, run

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -90,6 +90,7 @@ import (
 	httptool "github.com/agezt/agezt/plugins/tools/http"
 	"github.com/agezt/agezt/plugins/tools/notify"
 	"github.com/agezt/agezt/plugins/tools/peer"
+	"github.com/agezt/agezt/plugins/tools/runstool"
 	scheduletool "github.com/agezt/agezt/plugins/tools/schedule"
 	"github.com/agezt/agezt/plugins/tools/shell"
 	"github.com/agezt/agezt/plugins/tools/websearch"
@@ -290,6 +291,12 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// Always available — the schedule store is the kernel's and always exists.
 	scheduleTool := scheduletool.New()
 	tools["schedule"] = scheduleTool
+
+	// Run-introspection tool (`runs`, M644): the agent recalls its OWN past runs
+	// from the journal. Registered now, Bound to the live journal after the kernel
+	// opens. Always available — the journal is the kernel's and always exists.
+	runsTool := runstool.New()
+	tools["runs"] = runsTool
 
 	// OnReload is invoked by the control plane's `provider_reload`
 	// command (and `agt provider reload`). It re-reads the vault,
@@ -1082,6 +1089,11 @@ func runDaemon(stdout, stderr io.Writer) int {
 	if sched := k.Schedules(); sched != nil {
 		scheduleTool.Bind(sched)
 		fmt.Fprintf(stdout, "  schedule tool    : enabled (the agent can schedule its own future runs)\n")
+	}
+
+	// Bind the run-introspection tool to the live journal (M644).
+	if j := k.Journal(); j != nil {
+		runsTool.Bind(j)
 	}
 
 	// Scheduled intents (autonomy) — fire operator-configured intents on a timer

--- a/kernel/edict/edict.go
+++ b/kernel/edict/edict.go
@@ -105,6 +105,10 @@ const (
 	// genuine autonomy grant — a scheduled intent fires later through the full
 	// governed loop — so it is ask-first by default (M634).
 	CapSchedule Capability = "schedule"
+	// CapRunsRead gates the `runs` tool: the agent reading its OWN past runs from
+	// the journal (recent runs / stats / search). A read of local activity the
+	// operator already owns — low risk, Allow by default (M644).
+	CapRunsRead Capability = "runs.read"
 )
 
 // TrustLevel encodes the trust ladder (DECISIONS F3).
@@ -526,6 +530,7 @@ func DefaultLevels() map[Capability]TrustLevel {
 		CapWorld:       LevelAllow,    // local world-model graph; low risk
 		CapWebSearch:   LevelAskFirst, // L2 network read; engine host is fixed, query is the only operator input
 		CapSchedule:    LevelAskFirst, // L2 autonomy grant; a scheduled intent runs later through the governed loop
+		CapRunsRead:    LevelAllow,    // local read of the agent's own run history; low risk
 	}
 }
 
@@ -564,7 +569,7 @@ func AllCapabilities() []Capability {
 		CapHTTPGet, CapHTTPPost, CapProviderCall, CapDelegate, CapCoding,
 		CapACPAgent, CapRemoteRun, CapNotify,
 		CapHomeAssistantRead, CapHomeAssistantCall,
-		CapBrowserRead, CapMemory, CapWorld, CapWebSearch, CapSchedule,
+		CapBrowserRead, CapMemory, CapWorld, CapWebSearch, CapSchedule, CapRunsRead,
 	}
 	slices.Sort(caps)
 	return caps

--- a/kernel/edict/toolmap.go
+++ b/kernel/edict/toolmap.go
@@ -43,6 +43,8 @@ func CapabilityForToolCall(toolName string, input json.RawMessage) Capability {
 		return CapWebSearch
 	case "schedule":
 		return CapSchedule
+	case "runs":
+		return CapRunsRead
 	case "memory":
 		return CapMemory
 	case "world":

--- a/plugins/tools/runstool/runs.go
+++ b/plugins/tools/runstool/runs.go
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: MIT
+
+// Package runstool is the in-process run-introspection tool. It lets the agent
+// recall its OWN past work — "have I looked into this before?", "how many runs
+// have I done today and how did they go?" — by folding the daemon's own journal
+// into recent top-level runs and aggregate stats (M644).
+//
+// This is the self-knowledge primitive that complements memory (deliberate
+// facts) and world (entities): the agent can see what it has actually DONE, not
+// just what it chose to remember. Read-only; sub-agent runs are folded out so
+// the view is the operator-facing leads.
+package runstool
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/event"
+)
+
+// window caps how many recent journal events the tool folds — recent history is
+// what matters and it bounds the scan on a long-lived daemon.
+const window = 5000
+
+// DefaultLimit / MaxLimit bound how many runs op=recent/search returns.
+const (
+	DefaultLimit = 10
+	MaxLimit     = 50
+)
+
+// history is the journal subset the tool needs — an interface so tests inject a
+// fake without a real on-disk journal.
+type history interface {
+	Tail(n int) ([]*event.Event, error)
+}
+
+// Tool implements agent.Tool. Created unbound via New(); Bind wires the journal.
+type Tool struct {
+	hist history
+}
+
+// New returns an unbound runs tool (no journal until Bind).
+func New() *Tool { return &Tool{} }
+
+// Bind wires the live journal. Called once after the kernel opens.
+func (t *Tool) Bind(h history) {
+	if h != nil {
+		t.hist = h
+	}
+}
+
+// Definition implements agent.Tool.
+func (t *Tool) Definition() agent.ToolDef {
+	return agent.ToolDef{
+		Name: "runs",
+		Description: "Recall your OWN past runs from the journal: op=recent lists recent " +
+			"runs (intent, status, cost, when); op=stats gives aggregate totals " +
+			"(completed/failed/success-rate/spend); op=search finds past runs whose intent " +
+			"matches a query. Use this to check whether you've already worked on something, " +
+			"or to report on your recent activity.",
+		InputSchema: json.RawMessage(`{
+  "type": "object",
+  "required": ["op"],
+  "properties": {
+    "op":    {"type":"string", "enum":["recent","stats","search"]},
+    "limit": {"type":"integer", "description":"For recent/search: max runs to return (default 10, max 50)."},
+    "query": {"type":"string", "description":"For search: case-insensitive substring to match against run intents."}
+  }
+}`),
+	}
+}
+
+type input struct {
+	Op    string `json:"op"`
+	Limit int    `json:"limit,omitempty"`
+	Query string `json:"query,omitempty"`
+}
+
+// runRec is one folded run.
+type runRec struct {
+	Corr    string `json:"id"`
+	Intent  string `json:"intent"`
+	Status  string `json:"status"` // running | completed | failed
+	Reason  string `json:"reason,omitempty"`
+	SpentMC int64  `json:"spent_microcents"`
+	TSMS    int64  `json:"last_ts_unix_ms"`
+}
+
+// Invoke implements agent.Tool.
+func (t *Tool) Invoke(_ context.Context, raw json.RawMessage) (agent.Result, error) {
+	var in input
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return agent.Result{}, fmt.Errorf("runs: parse input: %w", err)
+	}
+	if t.hist == nil {
+		return errResult("run history is not available on this daemon"), nil
+	}
+	evs, err := t.hist.Tail(window)
+	if err != nil {
+		return errResult("read journal: " + err.Error()), nil
+	}
+	runs := fold(evs)
+	// Newest activity first.
+	sort.Slice(runs, func(i, j int) bool { return runs[i].TSMS > runs[j].TSMS })
+
+	switch in.Op {
+	case "recent":
+		return okJSON(map[string]any{"runs": clip(runs, limitOf(in.Limit))}), nil
+	case "search":
+		q := strings.ToLower(strings.TrimSpace(in.Query))
+		if q == "" {
+			return errResult(`op=search needs a "query"`), nil
+		}
+		var hits []runRec
+		for _, r := range runs {
+			if strings.Contains(strings.ToLower(r.Intent), q) {
+				hits = append(hits, r)
+			}
+		}
+		return okJSON(map[string]any{"query": in.Query, "matches": len(hits), "runs": clip(hits, limitOf(in.Limit))}), nil
+	case "stats":
+		return okJSON(statsOf(runs)), nil
+	case "":
+		return errResult("op required (recent|stats|search)"), nil
+	default:
+		return errResult("unknown op " + in.Op + " (recent|stats|search)"), nil
+	}
+}
+
+// fold reduces journal events into top-level runs, excluding sub-agent runs (a
+// sub-agent's correlation appears as a subagent.spawned child_correlation).
+func fold(evs []*event.Event) []runRec {
+	subAgents := map[string]bool{}
+	for _, e := range evs {
+		if e.Kind == event.KindSubAgentSpawned {
+			var p struct {
+				Child string `json:"child_correlation"`
+			}
+			_ = json.Unmarshal(e.Payload, &p)
+			if p.Child != "" {
+				subAgents[p.Child] = true
+			}
+		}
+	}
+
+	byCorr := map[string]*runRec{}
+	get := func(corr string) *runRec {
+		r := byCorr[corr]
+		if r == nil {
+			r = &runRec{Corr: corr, Status: "running"}
+			byCorr[corr] = r
+		}
+		return r
+	}
+	for _, e := range evs {
+		if e.CorrelationID == "" {
+			continue
+		}
+		switch e.Kind {
+		case event.KindTaskReceived:
+			var p struct {
+				Intent string `json:"intent"`
+			}
+			_ = json.Unmarshal(e.Payload, &p)
+			r := get(e.CorrelationID)
+			r.Intent = p.Intent
+			if e.TSUnixMS > r.TSMS {
+				r.TSMS = e.TSUnixMS
+			}
+		case event.KindTaskCompleted:
+			r := get(e.CorrelationID)
+			r.Status = "completed"
+			if e.TSUnixMS > r.TSMS {
+				r.TSMS = e.TSUnixMS
+			}
+		case event.KindTaskFailed:
+			var p struct {
+				Reason string `json:"reason"`
+			}
+			_ = json.Unmarshal(e.Payload, &p)
+			r := get(e.CorrelationID)
+			r.Status = "failed"
+			r.Reason = p.Reason
+			if e.TSUnixMS > r.TSMS {
+				r.TSMS = e.TSUnixMS
+			}
+		case event.KindBudgetConsumed:
+			var p struct {
+				CostMC int64 `json:"cost_microcents"`
+			}
+			_ = json.Unmarshal(e.Payload, &p)
+			get(e.CorrelationID).SpentMC += p.CostMC
+		}
+	}
+
+	out := make([]runRec, 0, len(byCorr))
+	for corr, r := range byCorr {
+		if subAgents[corr] || r.Intent == "" {
+			continue // skip sub-agents and entries that never saw a task.received
+		}
+		out = append(out, *r)
+	}
+	return out
+}
+
+func statsOf(runs []runRec) map[string]any {
+	var completed, failed, running int
+	var spent int64
+	for _, r := range runs {
+		switch r.Status {
+		case "completed":
+			completed++
+		case "failed":
+			failed++
+		default:
+			running++
+		}
+		spent += r.SpentMC
+	}
+	total := len(runs)
+	rate := 0.0
+	if done := completed + failed; done > 0 {
+		rate = float64(completed) / float64(done)
+	}
+	return map[string]any{
+		"total": total, "completed": completed, "failed": failed, "running": running,
+		"success_rate": rate, "total_spent_microcents": spent,
+	}
+}
+
+func limitOf(n int) int {
+	if n <= 0 {
+		return DefaultLimit
+	}
+	if n > MaxLimit {
+		return MaxLimit
+	}
+	return n
+}
+
+func clip(runs []runRec, n int) []runRec {
+	if runs == nil {
+		return []runRec{}
+	}
+	if len(runs) > n {
+		return runs[:n]
+	}
+	return runs
+}
+
+func okJSON(v any) agent.Result {
+	enc, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return errResult("marshal: " + err.Error())
+	}
+	return agent.Result{Output: string(enc)}
+}
+
+func errResult(msg string) agent.Result {
+	return agent.Result{Output: "runs: " + msg, IsError: true}
+}

--- a/plugins/tools/runstool/runs_test.go
+++ b/plugins/tools/runstool/runs_test.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+
+package runstool
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/agezt/agezt/kernel/event"
+)
+
+type fakeJournal struct{ evs []*event.Event }
+
+func (f *fakeJournal) Tail(n int) ([]*event.Event, error) { return f.evs, nil }
+
+func ev(kind event.Kind, corr string, ts int64, payload any) *event.Event {
+	b, _ := json.Marshal(payload)
+	return &event.Event{Kind: kind, CorrelationID: corr, TSUnixMS: ts, Payload: b}
+}
+
+// sample journal: lead-1 completed ($0.002), lead-2 failed, lead-3 running,
+// plus a sub-agent (child of lead-1) that must be folded OUT.
+func sampleJournal() *fakeJournal {
+	return &fakeJournal{evs: []*event.Event{
+		ev(event.KindTaskReceived, "lead-1", 100, map[string]any{"intent": "research the Go website"}),
+		ev(event.KindSubAgentSpawned, "lead-1", 101, map[string]any{"child_correlation": "sub-1"}),
+		ev(event.KindTaskReceived, "sub-1", 102, map[string]any{"intent": "confirm the URL"}),
+		ev(event.KindBudgetConsumed, "lead-1", 103, map[string]any{"cost_microcents": 2_000_000}),
+		ev(event.KindTaskCompleted, "sub-1", 104, nil),
+		ev(event.KindTaskCompleted, "lead-1", 105, nil),
+		ev(event.KindTaskReceived, "lead-2", 200, map[string]any{"intent": "deploy the service"}),
+		ev(event.KindTaskFailed, "lead-2", 201, map[string]any{"reason": "max_iters"}),
+		ev(event.KindTaskReceived, "lead-3", 300, map[string]any{"intent": "ongoing analysis"}),
+	}}
+}
+
+func newTool() *Tool {
+	t := New()
+	t.hist = sampleJournal()
+	return t
+}
+
+func invoke(t *testing.T, tool *Tool, in map[string]any) (map[string]any, bool) {
+	t.Helper()
+	raw, _ := json.Marshal(in)
+	res, err := tool.Invoke(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("Invoke error: %v", err)
+	}
+	var out map[string]any
+	_ = json.Unmarshal([]byte(res.Output), &out)
+	return out, res.IsError
+}
+
+func TestDefinitionValid(t *testing.T) {
+	d := New().Definition()
+	if d.Name != "runs" || !json.Valid(d.InputSchema) {
+		t.Fatalf("bad definition: %+v", d)
+	}
+}
+
+func TestRecent_ExcludesSubAgents_NewestFirst(t *testing.T) {
+	out, isErr := invoke(t, newTool(), map[string]any{"op": "recent"})
+	if isErr {
+		t.Fatalf("unexpected error: %v", out)
+	}
+	runs := out["runs"].([]any)
+	if len(runs) != 3 {
+		t.Fatalf("want 3 top-level runs (sub-agent folded out), got %d", len(runs))
+	}
+	// Newest first → lead-3 (ts 300), lead-2 (201), lead-1 (105).
+	first := runs[0].(map[string]any)
+	if first["id"] != "lead-3" {
+		t.Errorf("newest run id = %v, want lead-3", first["id"])
+	}
+	// No sub-agent in the results.
+	for _, r := range runs {
+		if r.(map[string]any)["id"] == "sub-1" {
+			t.Error("sub-agent run must be folded out")
+		}
+	}
+}
+
+func TestRecent_FoldsIntentStatusSpend(t *testing.T) {
+	out, _ := invoke(t, newTool(), map[string]any{"op": "recent"})
+	runs := out["runs"].([]any)
+	byID := map[string]map[string]any{}
+	for _, r := range runs {
+		m := r.(map[string]any)
+		byID[m["id"].(string)] = m
+	}
+	if byID["lead-1"]["status"] != "completed" || byID["lead-1"]["intent"] != "research the Go website" {
+		t.Errorf("lead-1 folded wrong: %+v", byID["lead-1"])
+	}
+	if byID["lead-1"]["spent_microcents"].(float64) != 2_000_000 {
+		t.Errorf("lead-1 spend = %v, want 2000000", byID["lead-1"]["spent_microcents"])
+	}
+	if byID["lead-2"]["status"] != "failed" || byID["lead-2"]["reason"] != "max_iters" {
+		t.Errorf("lead-2 folded wrong: %+v", byID["lead-2"])
+	}
+	if byID["lead-3"]["status"] != "running" {
+		t.Errorf("lead-3 status = %v, want running", byID["lead-3"]["status"])
+	}
+}
+
+func TestStats(t *testing.T) {
+	out, _ := invoke(t, newTool(), map[string]any{"op": "stats"})
+	if out["total"].(float64) != 3 || out["completed"].(float64) != 1 || out["failed"].(float64) != 1 || out["running"].(float64) != 1 {
+		t.Fatalf("stats wrong: %+v", out)
+	}
+	// success_rate = completed / (completed+failed) = 1/2.
+	if out["success_rate"].(float64) != 0.5 {
+		t.Errorf("success_rate = %v, want 0.5", out["success_rate"])
+	}
+	if out["total_spent_microcents"].(float64) != 2_000_000 {
+		t.Errorf("spend = %v", out["total_spent_microcents"])
+	}
+}
+
+func TestSearch(t *testing.T) {
+	out, _ := invoke(t, newTool(), map[string]any{"op": "search", "query": "DEPLOY"})
+	if out["matches"].(float64) != 1 {
+		t.Fatalf("want 1 match for 'deploy', got %v", out["matches"])
+	}
+	runs := out["runs"].([]any)
+	if runs[0].(map[string]any)["id"] != "lead-2" {
+		t.Errorf("match id = %v, want lead-2", runs[0].(map[string]any)["id"])
+	}
+}
+
+func TestSearch_EmptyQueryErrors(t *testing.T) {
+	if _, isErr := invoke(t, newTool(), map[string]any{"op": "search"}); !isErr {
+		t.Error("empty query should be an error")
+	}
+}
+
+func TestBadOps(t *testing.T) {
+	for _, op := range []string{"", "bogus"} {
+		if _, isErr := invoke(t, newTool(), map[string]any{"op": op}); !isErr {
+			t.Errorf("op %q should be an error", op)
+		}
+	}
+}
+
+func TestUnboundIsSafe(t *testing.T) {
+	res, err := New().Invoke(context.Background(), json.RawMessage(`{"op":"stats"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Error("an unbound tool should return an error result")
+	}
+}


### PR DESCRIPTION
## What

A new in-process **`runs`** tool lets the agent introspect its **own** run history by folding the daemon's journal:
- `op=recent` — recent top-level runs (intent, status, cost, when)
- `op=stats` — aggregate totals (completed / failed / success-rate / spend)
- `op=search` — past runs whose intent matches a query

The **self-knowledge** primitive that complements `memory` (deliberate facts) and `world` (entities): the agent can see what it has actually *done*, so it can check *"have I looked into this already?"* or report on its activity. **Tool count 15 → 16.**

## How

- Self-contained journal fold (`Tail(5000)`) via a small `history` interface — decoupled and unit-testable; **sub-agent runs are folded out** (a `subagent.spawned` child_correlation), leaving the operator-facing leads.
- Created unbound (like notify/schedule), Bound to `k.Journal()` after the kernel opens. Governed by a new low-risk `runs.read` capability (Allow by default).

## Tested

- Unit tests: the fold (intent/status/spend, sub-agent exclusion, newest-first), stats (success_rate 1/2, spend sum), search (case-insensitive), bad-input + unbound safety, against a fake journal.
- **Verified live** with the real provider: asked to report its history, the agent called `runs` and returned its **real** stats (18 completed, 100% success) and listed its 3 most recent runs by intent.
- Full `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)