### PR TITLE
Feat: standing tool — agents create their own event-triggered agents (M645)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 
 ## [Unreleased]
 
+### Added
+- **`standing` tool — agents create their own event-triggered agents.** A new
+  in-process tool lets the agent set up its OWN autonomous, trigger-driven agents
+  (Chronos standing orders): `op=create_event` makes one that fires its plan
+  whenever a matching journal event is published (e.g. trigger on `task.failed`);
+  `op=create_cron` on a cron schedule; plus `list` / `remove`. This is the
+  agents-create-agents primitive for the EVENT/cron axis, symmetric with the
+  `schedule` tool (the time axis) — so the agent can now arrange reactive
+  ("when X happens, do Y") *and* recurring unattended behaviour itself, each
+  firing through the full governed loop and visible in the Standing cockpit.
+  Conservative `ask` initiative by default; governed by a new ask-first
+  `standing` capability. Verified live: the agent created a `task.failed` →
+  "investigate the failure" order that persisted in the store. Tool count
+  16 → 17. (M645)
+
 ### Fixed
 - **Inbox view never rendered conversations.** The unified Inbox read the wrong
   payload key (`items`) while the control plane returns `threads`, so it always

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -93,6 +93,7 @@ import (
 	"github.com/agezt/agezt/plugins/tools/runstool"
 	scheduletool "github.com/agezt/agezt/plugins/tools/schedule"
 	"github.com/agezt/agezt/plugins/tools/shell"
+	standingtool "github.com/agezt/agezt/plugins/tools/standingtool"
 	"github.com/agezt/agezt/plugins/tools/websearch"
 )
 
@@ -297,6 +298,12 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// opens. Always available — the journal is the kernel's and always exists.
 	runsTool := runstool.New()
 	tools["runs"] = runsTool
+
+	// Standing-order tool (`standing`, M645): the agent creates its OWN autonomous,
+	// trigger-driven agents (event/cron). Registered now, Bound to the kernel after
+	// it opens (the kernel satisfies the tool's journaled standing-CRUD surface).
+	standingToolInst := standingtool.New()
+	tools["standing"] = standingToolInst
 
 	// OnReload is invoked by the control plane's `provider_reload`
 	// command (and `agt provider reload`). It re-reads the vault,
@@ -1095,6 +1102,10 @@ func runDaemon(stdout, stderr io.Writer) int {
 	if j := k.Journal(); j != nil {
 		runsTool.Bind(j)
 	}
+
+	// Bind the standing-order tool to the kernel (M645) — it satisfies the tool's
+	// journaled AddStanding / RemoveStanding / Standing() surface.
+	standingToolInst.Bind(k)
 
 	// Scheduled intents (autonomy) — fire operator-configured intents on a timer
 	// through the governed loop. Runs on the daemon ctx (halt/shutdown stop it).

--- a/kernel/edict/edict.go
+++ b/kernel/edict/edict.go
@@ -109,6 +109,11 @@ const (
 	// the journal (recent runs / stats / search). A read of local activity the
 	// operator already owns — low risk, Allow by default (M644).
 	CapRunsRead Capability = "runs.read"
+	// CapStanding gates the `standing` tool: the agent creating its OWN autonomous,
+	// trigger-driven agents (Chronos standing orders that fire a plan on a cron
+	// schedule or a matching event). The strongest autonomy grant — it sets up
+	// unattended behaviour — so ask-first by default (M645).
+	CapStanding Capability = "standing"
 )
 
 // TrustLevel encodes the trust ladder (DECISIONS F3).
@@ -531,6 +536,7 @@ func DefaultLevels() map[Capability]TrustLevel {
 		CapWebSearch:   LevelAskFirst, // L2 network read; engine host is fixed, query is the only operator input
 		CapSchedule:    LevelAskFirst, // L2 autonomy grant; a scheduled intent runs later through the governed loop
 		CapRunsRead:    LevelAllow,    // local read of the agent's own run history; low risk
+		CapStanding:    LevelAskFirst, // L2 strongest autonomy grant; the agent sets up unattended trigger-driven behaviour
 	}
 }
 
@@ -569,7 +575,7 @@ func AllCapabilities() []Capability {
 		CapHTTPGet, CapHTTPPost, CapProviderCall, CapDelegate, CapCoding,
 		CapACPAgent, CapRemoteRun, CapNotify,
 		CapHomeAssistantRead, CapHomeAssistantCall,
-		CapBrowserRead, CapMemory, CapWorld, CapWebSearch, CapSchedule, CapRunsRead,
+		CapBrowserRead, CapMemory, CapWorld, CapWebSearch, CapSchedule, CapRunsRead, CapStanding,
 	}
 	slices.Sort(caps)
 	return caps

--- a/kernel/edict/toolmap.go
+++ b/kernel/edict/toolmap.go
@@ -45,6 +45,8 @@ func CapabilityForToolCall(toolName string, input json.RawMessage) Capability {
 		return CapSchedule
 	case "runs":
 		return CapRunsRead
+	case "standing":
+		return CapStanding
 	case "memory":
 		return CapMemory
 	case "world":

--- a/plugins/tools/standingtool/standing.go
+++ b/plugins/tools/standingtool/standing.go
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: MIT
+
+// Package standingtool is the in-process standing-order tool: it lets the agent
+// create its OWN autonomous, trigger-driven agents (Chronos standing orders) —
+// "when event X happens, run plan Y" or "on this cron schedule, do Z" — plus
+// list and remove them (M645).
+//
+// This is the agents-create-agents primitive for the EVENT/cron axis, symmetric
+// with the `schedule` tool (which covers the time axis). A standing order the
+// agent creates fires later through the full governed loop; the operator sees
+// and governs them in the Standing cockpit (pause/remove). Tagged via name so
+// it's clear which were set up autonomously.
+package standingtool
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/standing"
+)
+
+// host is the kernel surface the tool needs — journaled standing CRUD. An
+// interface so tests inject a fake (or a real store adapter) without a kernel.
+type host interface {
+	AddStanding(o standing.Order) (standing.Order, error)
+	RemoveStanding(id string) (bool, error)
+	Standing() *standing.Store
+}
+
+// Tool implements agent.Tool. Created unbound via New(); Bind wires the kernel.
+type Tool struct {
+	host host
+}
+
+// New returns an unbound standing tool.
+func New() *Tool { return &Tool{} }
+
+// Bind wires the live kernel standing surface. Called once after the kernel opens.
+func (t *Tool) Bind(h host) {
+	if h != nil {
+		t.host = h
+	}
+}
+
+// Definition implements agent.Tool.
+func (t *Tool) Definition() agent.ToolDef {
+	return agent.ToolDef{
+		Name: "standing",
+		Description: "Create your OWN autonomous, trigger-driven agents (standing orders): " +
+			"op=create_event makes one that fires its plan whenever a matching journal event " +
+			"is published (trigger on a subject like \"task.failed\"); op=create_cron makes one " +
+			"that fires on a cron schedule. op=list / op=remove manage them. A standing order " +
+			"runs its plan later through the full governed loop. Use this to set up reactive or " +
+			"recurring behaviour that should happen without the user asking again.",
+		InputSchema: json.RawMessage(`{
+  "type": "object",
+  "required": ["op"],
+  "properties": {
+    "op":       {"type":"string", "enum":["create_event","create_cron","list","remove"]},
+    "name":     {"type":"string", "description":"A short name for the standing order."},
+    "plan":     {"type":"string", "description":"The intent/task to run when the order fires."},
+    "subject":  {"type":"string", "description":"For create_event: the journal event subject to trigger on (e.g. \"task.failed\", \"observer.delta\")."},
+    "schedule": {"type":"string", "description":"For create_cron: a 5-field cron expression (e.g. \"0 9 * * *\")."},
+    "mode":     {"type":"string", "enum":["inform_only","ask","act_or_ask"], "description":"Autonomy when it fires. Default ask (confirm before acting)."},
+    "id":       {"type":"string", "description":"For remove: the standing order id."}
+  }
+}`),
+	}
+}
+
+type input struct {
+	Op       string `json:"op"`
+	Name     string `json:"name"`
+	Plan     string `json:"plan"`
+	Subject  string `json:"subject"`
+	Schedule string `json:"schedule"`
+	Mode     string `json:"mode"`
+	ID       string `json:"id"`
+}
+
+// Invoke implements agent.Tool.
+func (t *Tool) Invoke(_ context.Context, raw json.RawMessage) (agent.Result, error) {
+	var in input
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return agent.Result{}, fmt.Errorf("standing: parse input: %w", err)
+	}
+	if t.host == nil {
+		return errResult("standing orders are not available on this daemon"), nil
+	}
+
+	switch in.Op {
+	case "create_event":
+		if strings.TrimSpace(in.Subject) == "" {
+			return errResult(`op=create_event needs a "subject" (the event to trigger on)`), nil
+		}
+		return t.create(in, standing.Trigger{Type: standing.TriggerEvent, Subject: strings.TrimSpace(in.Subject)})
+
+	case "create_cron":
+		if strings.TrimSpace(in.Schedule) == "" {
+			return errResult(`op=create_cron needs a "schedule" (a cron expression)`), nil
+		}
+		return t.create(in, standing.Trigger{Type: standing.TriggerCron, Schedule: strings.TrimSpace(in.Schedule)})
+
+	case "remove":
+		if in.ID == "" {
+			return errResult(`op=remove needs an "id"`), nil
+		}
+		removed, err := t.host.RemoveStanding(in.ID)
+		if err != nil {
+			return errResult(err.Error()), nil
+		}
+		if !removed {
+			return errResult("no standing order with id " + in.ID), nil
+		}
+		return okJSON(map[string]any{"removed": in.ID}), nil
+
+	case "list":
+		orders := t.host.Standing().List()
+		out := make([]map[string]any, 0, len(orders))
+		for _, o := range orders {
+			out = append(out, orderView(o))
+		}
+		return okJSON(map[string]any{"count": len(out), "orders": out}), nil
+
+	case "":
+		return errResult("op required (create_event|create_cron|list|remove)"), nil
+	default:
+		return errResult("unknown op " + in.Op), nil
+	}
+}
+
+func (t *Tool) create(in input, trig standing.Trigger) (agent.Result, error) {
+	name := strings.TrimSpace(in.Name)
+	if name == "" {
+		return errResult(`a "name" is required`), nil
+	}
+	if strings.TrimSpace(in.Plan) == "" {
+		return errResult(`a "plan" is required (what to run when it fires)`), nil
+	}
+	mode := standing.InitiativeMode(strings.TrimSpace(in.Mode))
+	if mode == "" {
+		mode = standing.InitiativeAsk // conservative default: confirm before acting
+	}
+	o := standing.Order{
+		Name:       name,
+		Enabled:    true,
+		Triggers:   []standing.Trigger{trig},
+		Initiative: standing.Initiative{Mode: mode},
+		Plan:       strings.TrimSpace(in.Plan),
+	}
+	saved, err := t.host.AddStanding(o)
+	if err != nil {
+		return errResult(err.Error()), nil
+	}
+	v := orderView(saved)
+	v["message"] = "standing order created"
+	return okJSON(v), nil
+}
+
+func orderView(o standing.Order) map[string]any {
+	trigs := make([]map[string]any, 0, len(o.Triggers))
+	for _, tr := range o.Triggers {
+		m := map[string]any{"type": string(tr.Type)}
+		if tr.Schedule != "" {
+			m["schedule"] = tr.Schedule
+		}
+		if tr.Subject != "" {
+			m["subject"] = tr.Subject
+		}
+		trigs = append(trigs, m)
+	}
+	return map[string]any{
+		"id": o.ID, "name": o.Name, "enabled": o.Enabled,
+		"mode": string(o.Initiative.Mode), "triggers": trigs, "plan": o.Plan,
+	}
+}
+
+func okJSON(v any) agent.Result {
+	enc, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return errResult("marshal: " + err.Error())
+	}
+	return agent.Result{Output: string(enc)}
+}
+
+func errResult(msg string) agent.Result {
+	return agent.Result{Output: "standing: " + msg, IsError: true}
+}

--- a/plugins/tools/standingtool/standing_test.go
+++ b/plugins/tools/standingtool/standing_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MIT
+
+package standingtool
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/agezt/agezt/kernel/standing"
+)
+
+// testHost wraps a real standing.Store so the tool's Order construction is
+// validated end-to-end against the real standing.Validate.
+type testHost struct{ store *standing.Store }
+
+func (h testHost) AddStanding(o standing.Order) (standing.Order, error) { return h.store.Add(o) }
+func (h testHost) RemoveStanding(id string) (bool, error)               { return h.store.Remove(id) }
+func (h testHost) Standing() *standing.Store                            { return h.store }
+
+func newTool(t *testing.T) (*Tool, *standing.Store) {
+	t.Helper()
+	st, err := standing.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	tool := New()
+	tool.Bind(testHost{st})
+	return tool, st
+}
+
+func invoke(t *testing.T, tool *Tool, in map[string]any) (map[string]any, bool) {
+	t.Helper()
+	raw, _ := json.Marshal(in)
+	res, err := tool.Invoke(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("Invoke error: %v", err)
+	}
+	var out map[string]any
+	_ = json.Unmarshal([]byte(res.Output), &out)
+	return out, res.IsError
+}
+
+func TestDefinitionValid(t *testing.T) {
+	d := New().Definition()
+	if d.Name != "standing" || !json.Valid(d.InputSchema) {
+		t.Fatalf("bad definition: %+v", d)
+	}
+}
+
+func TestCreateEvent_PassesValidationAndPersists(t *testing.T) {
+	tool, st := newTool(t)
+	out, isErr := invoke(t, tool, map[string]any{
+		"op": "create_event", "name": "health-watch", "subject": "observer.delta",
+		"plan": "Investigate the health degradation.",
+	})
+	if isErr {
+		t.Fatalf("unexpected error: %v", out)
+	}
+	if st.Count() != 1 {
+		t.Fatalf("order not persisted, count=%d", st.Count())
+	}
+	// Default mode is the conservative "ask".
+	if out["mode"] != string(standing.InitiativeAsk) {
+		t.Errorf("mode = %v, want ask", out["mode"])
+	}
+	trigs := out["triggers"].([]any)
+	if trigs[0].(map[string]any)["subject"] != "observer.delta" {
+		t.Errorf("event subject wrong: %+v", trigs[0])
+	}
+}
+
+func TestCreateCron_PassesValidation(t *testing.T) {
+	tool, st := newTool(t)
+	out, isErr := invoke(t, tool, map[string]any{
+		"op": "create_cron", "name": "nightly", "schedule": "0 9 * * *",
+		"plan": "Produce a morning digest.", "mode": "inform_only",
+	})
+	if isErr {
+		t.Fatalf("unexpected error: %v", out)
+	}
+	if st.Count() != 1 {
+		t.Fatalf("not persisted")
+	}
+	if out["mode"] != "inform_only" {
+		t.Errorf("mode override not applied: %v", out["mode"])
+	}
+}
+
+func TestListAndRemove(t *testing.T) {
+	tool, _ := newTool(t)
+	create, _ := invoke(t, tool, map[string]any{
+		"op": "create_event", "name": "x", "subject": "task.failed", "plan": "look into it",
+	})
+	id := create["id"].(string)
+
+	list, _ := invoke(t, tool, map[string]any{"op": "list"})
+	if list["count"].(float64) != 1 {
+		t.Fatalf("list count = %v, want 1", list["count"])
+	}
+
+	rm, isErr := invoke(t, tool, map[string]any{"op": "remove", "id": id})
+	if isErr || rm["removed"] != id {
+		t.Fatalf("remove failed: %+v", rm)
+	}
+	list2, _ := invoke(t, tool, map[string]any{"op": "list"})
+	if list2["count"].(float64) != 0 {
+		t.Errorf("order not removed, count = %v", list2["count"])
+	}
+}
+
+func TestValidationErrors(t *testing.T) {
+	tool, _ := newTool(t)
+	cases := []map[string]any{
+		{"op": "create_event", "subject": "x", "plan": "y"},                 // missing name
+		{"op": "create_event", "name": "n", "plan": "y"},                    // missing subject
+		{"op": "create_event", "name": "n", "subject": "x"},                 // missing plan
+		{"op": "create_cron", "name": "n", "plan": "y"},                     // missing schedule
+		{"op": "remove"},                                                    // missing id
+		{"op": "bogus"},
+		{"op": ""},
+	}
+	for _, c := range cases {
+		if _, isErr := invoke(t, tool, c); !isErr {
+			t.Errorf("expected error for %v", c)
+		}
+	}
+}
+
+func TestUnboundIsSafe(t *testing.T) {
+	res, err := New().Invoke(context.Background(), json.RawMessage(`{"op":"list"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Error("an unbound tool should return an error result")
+	}
+}


### PR DESCRIPTION
## What

A new in-process **`standing`** tool lets the agent set up its **own** autonomous, trigger-driven agents (Chronos standing orders):
- `op=create_event` — fires a plan whenever a matching journal event is published (e.g. trigger on `task.failed`)
- `op=create_cron` — fires on a cron schedule
- `op=list` / `op=remove`

This is the **agents-create-agents** primitive for the EVENT/cron axis, symmetric with the `schedule` tool (the time axis). The agent can now arrange reactive (*"when X happens, do Y"*) **and** recurring unattended behaviour itself — each firing through the full governed loop and visible/governable in the Standing cockpit (M638). **Tool count 16 → 17.**

## How

- Conservative `ask` initiative by default (confirm before acting); overridable.
- Uses the kernel's **journaled** `AddStanding` / `RemoveStanding` / `Standing()` surface (the kernel satisfies the tool's host interface directly). Created unbound like notify/schedule/runs, Bound after the kernel opens. Governed by a new ask-first `standing` capability.

## Tested

- Unit tests build orders that pass the **real** `standing.Validate` (event + cron triggers, default vs override mode, list/remove round-trip, validation errors, unbound safety) against a real `standing.Store`.
- **Verified live** with the real provider: the agent created a `task.failed` → *"investigate the failure"* standing order that persisted in the store.
- Full `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)