### PR TITLE
Feat: continuous agents — a living, never-tiring loop (M646)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **Continuous agents — a living, never-tiring loop.** A new cadence mode,
+  `continuous`, is a completion-anchored loop: the agent runs, and once its run
+  COMPLETES it re-anchors to fire again `cooldown` later — so it runs forever,
+  one cycle after another, never overlapping (the engine's in-flight guard) and
+  carrying its memory + journal across cycles. The system can now keep a worker
+  perpetually alive ("watch the world and act"), not just fire on a fixed clock.
+  Exposed through the `schedule` tool (`op=continuous`, `cooldown`) so the agent
+  can start one itself; it shows in the Schedules cockpit as `continuous · Ns
+  cooldown` and is paused/removed like any schedule (the off-switch). The cooldown
+  is floored to 1s so it can't busy-loop the daemon; per-cycle cost rides the
+  daily budget ceiling. Verified live: the agent started a 15s-cooldown loop that
+  fired 3 times over ~50s, each cycle `last: completed` → `next` re-anchored.
+  (M646)
 - **`standing` tool — agents create their own event-triggered agents.** A new
   in-process tool lets the agent set up its OWN autonomous, trigger-driven agents
   (Chronos standing orders): `op=create_event` makes one that fires its plan

--- a/kernel/cadence/cadence.go
+++ b/kernel/cadence/cadence.go
@@ -49,6 +49,12 @@ const (
 	ModeDaily    = "daily"
 	ModeOnce     = "once"   // fire exactly once at NextRunUnix, then self-remove
 	ModeWindow   = "window" // fire every IntervalSec, but only within a daily time window
+	// ModeContinuous is a completion-anchored loop (M646): the entry fires, and
+	// once its run COMPLETES it re-anchors NextRunUnix to (completion + cooldown)
+	// — so it runs again `cooldown` after each cycle ends, never overlapping (the
+	// engine's in-flight guard), forever. A living, never-tiring agent. IntervalSec
+	// carries the cooldown.
+	ModeContinuous = "continuous"
 )
 
 // AllDays is the day-mask meaning "every day" (all seven bits set); the zero
@@ -83,7 +89,9 @@ func (e Entry) Interval() time.Duration { return time.Duration(e.IntervalSec) * 
 // usesInterval reports whether the entry's IntervalSec is load-bearing — true
 // for interval and windowed-interval modes, false for daily/once (which carry
 // IntervalSec == 0 legitimately).
-func (e Entry) usesInterval() bool { return e.Mode == ModeInterval || e.Mode == ModeWindow }
+func (e Entry) usesInterval() bool {
+	return e.Mode == ModeInterval || e.Mode == ModeWindow || e.Mode == ModeContinuous
+}
 
 // safeInterval is Interval clamped to MinInterval (M196). `advance` and the
 // window walker use it so a zero/negative IntervalSec — which Add rejects but a
@@ -115,6 +123,8 @@ func (e Entry) Cadence() string {
 		return out
 	case ModeOnce:
 		return "once at " + time.Unix(e.NextRunUnix, 0).Format("2006-01-02 15:04")
+	case ModeContinuous:
+		return "continuous · " + e.safeInterval().String() + " cooldown"
 	case ModeWindow:
 		w := fmt.Sprintf("every %s %02d:%02d-%02d:%02d", e.Interval(),
 			e.AtMinutes/60, e.AtMinutes%60, e.EndMinutes/60, e.EndMinutes%60)
@@ -515,6 +525,41 @@ func (s *Store) AddOnce(intent string, at time.Time, model, source string, now t
 	return *e, nil
 }
 
+// AddContinuous creates a completion-anchored continuous entry (M646): it fires
+// immediately, then re-fires `cooldown` after each run COMPLETES, forever, never
+// overlapping — a living, never-tiring agent. cooldown is clamped to MinInterval.
+func (s *Store) AddContinuous(intent string, cooldown time.Duration, model, source string, now time.Time) (Entry, error) {
+	intent = strings.TrimSpace(intent)
+	if intent == "" {
+		return Entry{}, fmt.Errorf("cadence: intent is required")
+	}
+	if cooldown < MinInterval {
+		cooldown = MinInterval
+	}
+	if source == "" {
+		source = SourceOperator
+	}
+	e := &Entry{
+		ID:          "sched-" + ulid.New(),
+		Intent:      intent,
+		Mode:        ModeContinuous,
+		IntervalSec: int64(cooldown / time.Second),
+		Model:       strings.TrimSpace(model),
+		Source:      source,
+		Enabled:     true,
+		CreatedUnix: now.Unix(),
+		NextRunUnix: now.Unix(), // due immediately — start living right away
+	}
+	s.mu.Lock()
+	s.entries = append(s.entries, e)
+	err := s.save()
+	s.mu.Unlock()
+	if err != nil {
+		return Entry{}, err
+	}
+	return *e, nil
+}
+
 // SetEnabled enables or disables an entry (pause/resume without deleting).
 // Returns whether the entry exists.
 func (s *Store) SetEnabled(id string, enabled bool) (bool, error) {
@@ -755,9 +800,11 @@ func (s *Store) Due(now time.Time) []Entry {
 		if now.Unix() < e.NextRunUnix {
 			continue
 		}
-		if e.Mode == ModeOnce {
-			// Crash-safe one-shot: leave it untouched; removal is deferred to
-			// CompleteFiring after the run finishes.
+		if e.Mode == ModeOnce || e.Mode == ModeContinuous {
+			// Crash-safe one-shot AND completion-anchored continuous: leave
+			// NextRunUnix untouched here. The engine's in-flight guard stops a
+			// second fire while the run is live, and CompleteFiring re-anchors a
+			// continuous entry forward (or removes a one-shot) once it finishes.
 			due = append(due, *e)
 			continue
 		}
@@ -780,18 +827,27 @@ func (s *Store) Due(now time.Time) []Entry {
 // (whether it succeeded or errored, so a permanently-failing one-shot cannot
 // retry-storm). For recurring entries this is a no-op: Due already advanced them.
 // Returns whether an entry was removed.
-func (s *Store) CompleteFiring(id string) (bool, error) {
+func (s *Store) CompleteFiring(id string, now time.Time) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for i, e := range s.entries {
 		if e.ID != id {
 			continue
 		}
-		if e.Mode != ModeOnce {
+		switch e.Mode {
+		case ModeOnce:
+			s.entries = append(s.entries[:i], s.entries[i+1:]...)
+			return true, s.save()
+		case ModeContinuous:
+			// Completion-anchored loop: schedule the next cycle `cooldown` after
+			// this run finished, so cycles never overlap and the agent runs
+			// forever with a steady breather between cycles (M646).
+			s.entries[i].LastRunUnix = now.Unix()
+			s.entries[i].NextRunUnix = now.Add(e.safeInterval()).Unix()
+			return false, s.save()
+		default:
 			return false, nil
 		}
-		s.entries = append(s.entries[:i], s.entries[i+1:]...)
-		return true, s.save()
 	}
 	return false, nil
 }
@@ -955,7 +1011,7 @@ func (e *Engine) fireOne(ctx context.Context, ent Entry) {
 	// it in the store to re-fire on restart (M199). This runs before the deferred
 	// running.Delete, so no tick can re-fire it in the gap between removal and
 	// clearing the in-flight guard.
-	if _, err := e.store.CompleteFiring(ent.ID); err != nil {
+	if _, err := e.store.CompleteFiring(ent.ID, time.Now()); err != nil {
 		fmt.Fprintf(e.log, "schedule: completing %q failed: %v\n", short(ent.Intent), err)
 	}
 }

--- a/kernel/cadence/cadence_test.go
+++ b/kernel/cadence/cadence_test.go
@@ -527,7 +527,7 @@ func TestStore_Once_FiresAndCompletes(t *testing.T) {
 		t.Error("one-shot must stay due until CompleteFiring removes it")
 	}
 	// Completing the firing removes it.
-	if ok, err := s.CompleteFiring(e.ID); err != nil || !ok {
+	if ok, err := s.CompleteFiring(e.ID, time.Now()); err != nil || !ok {
 		t.Fatalf("CompleteFiring: ok=%v err=%v", ok, err)
 	}
 	if s.Count() != 0 {

--- a/kernel/cadence/continuous_test.go
+++ b/kernel/cadence/continuous_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+
+package cadence
+
+import (
+	"testing"
+	"time"
+)
+
+// TestContinuous_CompletionAnchoredLoop proves a continuous entry fires
+// immediately, stays due until its run completes (no advance in Due), then
+// re-anchors `cooldown` after completion — a non-overlapping perpetual loop.
+func TestContinuous_CompletionAnchoredLoop(t *testing.T) {
+	s := mustStore(t)
+	now := time.Unix(1_000_000, 0)
+
+	e, err := s.AddContinuous("watch the world", 30*time.Second, SourceOperator, "", now)
+	if err != nil {
+		t.Fatalf("AddContinuous: %v", err)
+	}
+	if e.Mode != ModeContinuous || e.IntervalSec != 30 {
+		t.Fatalf("entry shape wrong: %+v", e)
+	}
+
+	// Due immediately (NextRun == now), and Due must NOT advance it (stays due
+	// until the run completes — the engine's in-flight guard prevents overlap).
+	if due := s.Due(now); len(due) != 1 {
+		t.Fatalf("want 1 due at creation, got %d", len(due))
+	}
+	if again := s.Due(now); len(again) != 1 {
+		t.Fatal("continuous entry must stay due until CompleteFiring re-anchors it")
+	}
+
+	// The run completes 5s later → next cycle is anchored at completion+cooldown.
+	complete := now.Add(5 * time.Second)
+	if removed, err := s.CompleteFiring(e.ID, complete); err != nil || removed {
+		t.Fatalf("CompleteFiring: removed=%v err=%v (continuous must NOT be removed)", removed, err)
+	}
+	got, _ := s.Get(e.ID)
+	wantNext := complete.Add(30 * time.Second).Unix()
+	if got.NextRunUnix != wantNext {
+		t.Errorf("next run = %d, want completion+cooldown = %d", got.NextRunUnix, wantNext)
+	}
+
+	// Not due during the cooldown; due again once it elapses → the loop continues.
+	if len(s.Due(complete.Add(10*time.Second))) != 0 {
+		t.Error("must not be due during the cooldown")
+	}
+	if len(s.Due(complete.Add(31*time.Second))) != 1 {
+		t.Error("must be due again after the cooldown — the loop never tires")
+	}
+}
+
+// TestContinuous_CooldownFloored: a sub-second cooldown is clamped to MinInterval
+// so a continuous agent can't busy-loop the daemon.
+func TestContinuous_CooldownFloored(t *testing.T) {
+	s := mustStore(t)
+	e, err := s.AddContinuous("tight", 100*time.Millisecond, SourceOperator, "", time.Unix(1, 0))
+	if err != nil {
+		t.Fatalf("AddContinuous: %v", err)
+	}
+	if e.IntervalSec != int64(MinInterval/time.Second) {
+		t.Errorf("cooldown not floored to MinInterval: %ds", e.IntervalSec)
+	}
+}

--- a/kernel/cadence/once_crashsafe_test.go
+++ b/kernel/cadence/once_crashsafe_test.go
@@ -29,7 +29,7 @@ func TestStore_CompleteFiring_RecurringIsNoOp(t *testing.T) {
 	now := time.Date(2026, 5, 31, 8, 0, 0, 0, time.UTC)
 	e, _ := s.Add("hourly", time.Hour, "", SourceOperator, now)
 
-	ok, err := s.CompleteFiring(e.ID)
+	ok, err := s.CompleteFiring(e.ID, time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,7 +39,7 @@ func TestStore_CompleteFiring_RecurringIsNoOp(t *testing.T) {
 	if s.Count() != 1 {
 		t.Errorf("recurring entry must remain, count = %d", s.Count())
 	}
-	if ok, _ := s.CompleteFiring("does-not-exist"); ok {
+	if ok, _ := s.CompleteFiring("does-not-exist", time.Now()); ok {
 		t.Error("CompleteFiring on an unknown id must return false")
 	}
 }

--- a/plugins/tools/schedule/schedule.go
+++ b/plugins/tools/schedule/schedule.go
@@ -32,6 +32,7 @@ type store interface {
 	Add(intent string, interval time.Duration, model, source string, now time.Time) (cadence.Entry, error)
 	AddDaily(intent string, atMinutes, days int, tz, model, source string, now time.Time) (cadence.Entry, error)
 	AddOnce(intent string, at time.Time, model, source string, now time.Time) (cadence.Entry, error)
+	AddContinuous(intent string, cooldown time.Duration, model, source string, now time.Time) (cadence.Entry, error)
 	Remove(id string) (bool, error)
 	List() []cadence.Entry
 }
@@ -77,10 +78,11 @@ func (t *Tool) Definition() agent.ToolDef {
   "type": "object",
   "required": ["op"],
   "properties": {
-    "op":       {"type":"string", "enum":["in","every","daily","list","remove"], "description":"in=one-shot after a delay; every=recurring interval; daily=at a wall-clock time; list; remove."},
-    "intent":   {"type":"string", "description":"The task to run at the scheduled time (for in/every/daily)."},
+    "op":       {"type":"string", "enum":["in","every","daily","continuous","list","remove"], "description":"in=one-shot after a delay; every=recurring interval; daily=at a wall-clock time; continuous=a never-ending loop that re-runs after each run finishes; list; remove."},
+    "intent":   {"type":"string", "description":"The task to run at the scheduled time (for in/every/daily/continuous)."},
     "delay":    {"type":"string", "description":"For op=in: how far out, e.g. \"30m\", \"2h\", \"24h\"."},
     "interval": {"type":"string", "description":"For op=every: the firing period, e.g. \"1h\", \"15m\"."},
+    "cooldown": {"type":"string", "description":"For op=continuous: the breather between cycles, e.g. \"30s\", \"5m\". The loop runs forever; pause/remove it to stop."},
     "at":       {"type":"string", "description":"For op=daily: wall-clock time \"HH:MM\" (24h, daemon local time)."},
     "days":     {"type":"string", "description":"For op=daily (optional): which days, e.g. \"mon-fri\", \"weekends\". Default every day."},
     "model":    {"type":"string", "description":"Optional model override for the scheduled run."},
@@ -95,6 +97,7 @@ type input struct {
 	Intent   string `json:"intent"`
 	Delay    string `json:"delay"`
 	Interval string `json:"interval"`
+	Cooldown string `json:"cooldown"`
 	At       string `json:"at"`
 	Days     string `json:"days"`
 	Model    string `json:"model"`
@@ -137,6 +140,17 @@ func (t *Tool) Invoke(_ context.Context, raw json.RawMessage) (agent.Result, err
 			return errResult(err.Error()), nil
 		}
 		return okEntry("scheduled recurring", e), nil
+
+	case "continuous":
+		d, err := time.ParseDuration(in.Cooldown)
+		if err != nil || d <= 0 {
+			return errResult(`op=continuous needs a positive "cooldown" like "30s" or "5m"`), nil
+		}
+		e, err := st.AddContinuous(in.Intent, d, in.Model, source, now)
+		if err != nil {
+			return errResult(err.Error()), nil
+		}
+		return okEntry("started a continuous loop (runs forever; pause/remove to stop)", e), nil
 
 	case "daily":
 		mins, ok := parseHHMM(in.At)

--- a/plugins/tools/schedule/schedule_test.go
+++ b/plugins/tools/schedule/schedule_test.go
@@ -41,6 +41,12 @@ func (f *fakeStore) AddOnce(intent string, at time.Time, model, source string, n
 	f.added = append(f.added, e)
 	return e, nil
 }
+func (f *fakeStore) AddContinuous(intent string, cooldown time.Duration, model, source string, now time.Time) (cadence.Entry, error) {
+	f.lastIntv = cooldown
+	e := cadence.Entry{ID: "cont1", Intent: intent, Mode: cadence.ModeContinuous, IntervalSec: int64(cooldown / time.Second), Source: source, Enabled: true, NextRunUnix: now.Unix()}
+	f.added = append(f.added, e)
+	return e, nil
+}
 func (f *fakeStore) Remove(id string) (bool, error) { f.removed = id; return f.removeOK, nil }
 func (f *fakeStore) List() []cadence.Entry          { return f.entries }
 
@@ -101,6 +107,30 @@ func TestOpEvery_Interval(t *testing.T) {
 	}
 	if f.lastIntv != time.Hour {
 		t.Errorf("interval = %v, want 1h", f.lastIntv)
+	}
+}
+
+func TestOpContinuous_Loop(t *testing.T) {
+	f := &fakeStore{}
+	out, isErr := invoke(t, newTool(f), map[string]any{"op": "continuous", "cooldown": "30s", "intent": "watch the world"})
+	if isErr {
+		t.Fatalf("unexpected error: %v", out)
+	}
+	if len(f.added) != 1 || f.added[0].Mode != cadence.ModeContinuous {
+		t.Fatalf("AddContinuous not called: %+v", f.added)
+	}
+	if f.lastIntv != 30*time.Second {
+		t.Errorf("cooldown = %v, want 30s", f.lastIntv)
+	}
+	if f.added[0].Source != "agent" {
+		t.Errorf("source = %q, want agent", f.added[0].Source)
+	}
+}
+
+func TestOpContinuous_BadCooldown(t *testing.T) {
+	f := &fakeStore{}
+	if _, isErr := invoke(t, newTool(f), map[string]any{"op": "continuous", "cooldown": "nope", "intent": "x"}); !isErr {
+		t.Error("a bad cooldown should be an error")
 	}
 }
 


### PR DESCRIPTION
## What

A new cadence **`continuous`** mode: a **completion-anchored loop**. The entry fires, and once its run **completes**, the store re-anchors `NextRun = completion + cooldown` — so it runs again `cooldown` after each cycle ends, **forever**, never overlapping (the engine's existing in-flight guard), carrying memory + journal across cycles. The "living organism that never tires."

## How

- **cadence**: `ModeContinuous`; `Due()` leaves it un-advanced (like `ModeOnce`) so the in-flight guard owns non-overlap; `CompleteFiring(id, now)` re-anchors a continuous entry forward (signature now takes `now`, updated at its 3 callers); `AddContinuous(cooldown)` with the cooldown floored to `MinInterval` so it can't busy-loop; `Cadence()` renders `continuous · Ns cooldown`.
- **schedule tool**: `op=continuous {cooldown}` → `AddContinuous`, so the agent can start a perpetual worker itself. It appears in the Schedules cockpit and is paused/removed like any schedule (the off-switch). Per-cycle cost rides the daily budget ceiling.

## Tested

- cadence unit tests prove the completion-anchored loop (fires → stays due until `CompleteFiring` re-anchors → not due during cooldown → due again after) and the cooldown floor; schedule-tool test covers `op=continuous` + bad cooldown.
- **Verified live** with the real provider: the agent started a 15s-cooldown loop that **fired 3 times over ~50s**, each cycle `last:completed → next` re-anchored, non-overlapping.
- Full `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)