### PR TITLE
Feat: `board` tool — agents talk to each other via a shared message board (M647)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **`board` tool — agents talk to each other.** A new in-process tool gives every
+  agent on the daemon a shared, persistent, topic-addressed message board:
+  `op=post` leaves a message on a topic (with an optional `from` role), `op=read`
+  returns recent messages newest-first (optionally filtered to one topic), and
+  `op=topics` lists the active topics. This is the inter-agent communication
+  primitive — one run can hand off findings, leave a note for its next cycle, or
+  coordinate with a peer, and any other agent (lead, sub-agent, scheduled,
+  standing-order, or continuous loop) reads it back. It is the shared common
+  ground that complements memory (durable facts) and world (entities): the board
+  carries shared *messages*. One JSON store under `<base>/board.json`, mutex-
+  guarded, atomic writes, capped at 1000 messages (oldest dropped). Gated by a new
+  `board` capability (Allow by default — a local shared note-store like memory).
+  Verified live with the real provider: one run posted an API base URL under topic
+  `handoff`, a separate run read it back verbatim. (M647)
 - **Continuous agents — a living, never-tiring loop.** A new cadence mode,
   `continuous`, is a completion-anchored loop: the agent runs, and once its run
   COMPLETES it re-anchors to fire again `cooldown` later — so it runs forever,

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -83,6 +83,7 @@ import (
 	"github.com/agezt/agezt/plugins/providers/compat"
 	"github.com/agezt/agezt/plugins/providers/mock"
 	"github.com/agezt/agezt/plugins/tools/acpagent"
+	boardtool "github.com/agezt/agezt/plugins/tools/boardtool"
 	"github.com/agezt/agezt/plugins/tools/browser"
 	"github.com/agezt/agezt/plugins/tools/coding"
 	filetool "github.com/agezt/agezt/plugins/tools/file"
@@ -304,6 +305,13 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// it opens (the kernel satisfies the tool's journaled standing-CRUD surface).
 	standingToolInst := standingtool.New()
 	tools["standing"] = standingToolInst
+
+	// Board tool (`board`, M647): the shared, persistent message board every agent
+	// can post to and read from, so they can coordinate and talk to each other.
+	// Registered now, Bound to its on-disk store under the daemon base dir after
+	// the kernel opens.
+	boardToolInst := boardtool.New()
+	tools["board"] = boardToolInst
 
 	// OnReload is invoked by the control plane's `provider_reload`
 	// command (and `agt provider reload`). It re-reads the vault,
@@ -1106,6 +1114,14 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// Bind the standing-order tool to the kernel (M645) — it satisfies the tool's
 	// journaled AddStanding / RemoveStanding / Standing() surface.
 	standingToolInst.Bind(k)
+
+	// Bind the shared message board to its on-disk store under the base dir (M647),
+	// so every agent on this daemon posts to and reads from one common board.
+	if err := boardToolInst.Bind(filepath.Join(baseDir, "board")); err != nil {
+		fmt.Fprintf(stderr, "%s: board tool unavailable: %v\n", brand.Binary, err)
+	} else {
+		fmt.Fprintf(stdout, "  board tool       : enabled (agents share a persistent message board)\n")
+	}
 
 	// Scheduled intents (autonomy) — fire operator-configured intents on a timer
 	// through the governed loop. Runs on the daemon ctx (halt/shutdown stop it).

--- a/kernel/edict/edict.go
+++ b/kernel/edict/edict.go
@@ -114,6 +114,11 @@ const (
 	// schedule or a matching event). The strongest autonomy grant — it sets up
 	// unattended behaviour — so ask-first by default (M645).
 	CapStanding Capability = "standing"
+	// CapBoard gates the `board` tool: agents posting to and reading from the
+	// shared, persistent message board so they can coordinate and talk to each
+	// other. A local shared note-store like memory — low risk, Allow by
+	// default (M647).
+	CapBoard Capability = "board"
 )
 
 // TrustLevel encodes the trust ladder (DECISIONS F3).
@@ -537,6 +542,7 @@ func DefaultLevels() map[Capability]TrustLevel {
 		CapSchedule:    LevelAskFirst, // L2 autonomy grant; a scheduled intent runs later through the governed loop
 		CapRunsRead:    LevelAllow,    // local read of the agent's own run history; low risk
 		CapStanding:    LevelAskFirst, // L2 strongest autonomy grant; the agent sets up unattended trigger-driven behaviour
+		CapBoard:       LevelAllow,    // local shared message board between agents; low risk
 	}
 }
 
@@ -575,7 +581,7 @@ func AllCapabilities() []Capability {
 		CapHTTPGet, CapHTTPPost, CapProviderCall, CapDelegate, CapCoding,
 		CapACPAgent, CapRemoteRun, CapNotify,
 		CapHomeAssistantRead, CapHomeAssistantCall,
-		CapBrowserRead, CapMemory, CapWorld, CapWebSearch, CapSchedule, CapRunsRead, CapStanding,
+		CapBrowserRead, CapMemory, CapWorld, CapWebSearch, CapSchedule, CapRunsRead, CapStanding, CapBoard,
 	}
 	slices.Sort(caps)
 	return caps

--- a/kernel/edict/toolmap.go
+++ b/kernel/edict/toolmap.go
@@ -47,6 +47,8 @@ func CapabilityForToolCall(toolName string, input json.RawMessage) Capability {
 		return CapRunsRead
 	case "standing":
 		return CapStanding
+	case "board":
+		return CapBoard
 	case "memory":
 		return CapMemory
 	case "world":

--- a/plugins/tools/boardtool/board.go
+++ b/plugins/tools/boardtool/board.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: MIT
+
+// Package boardtool is the in-process shared message board: a persistent,
+// topic-addressed space every agent — the lead, its sub-agents, scheduled and
+// standing-order agents, and the continuous loops — can post to and read from,
+// so they can coordinate and talk to each other (M647).
+//
+// It is the common ground that complements memory (shared durable FACTS) and
+// world (shared ENTITIES): the board carries shared MESSAGES — "I found X",
+// "needs follow-up", a note an agent leaves for its next cycle or for a peer.
+// One store, shared across every run on the daemon; survives restarts.
+package boardtool
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// maxMessages bounds the on-disk board so it can't grow without limit; the
+// oldest are dropped first.
+const maxMessages = 1000
+
+// DefaultReadLimit / MaxReadLimit bound op=read.
+const (
+	DefaultReadLimit = 20
+	MaxReadLimit     = 100
+)
+
+// Message is one board post.
+type Message struct {
+	Topic string `json:"topic"`
+	From  string `json:"from,omitempty"`
+	Text  string `json:"text"`
+	TSMS  int64  `json:"ts_ms"`
+}
+
+// Store is the persistent, concurrency-safe message board. Many agents (and
+// their goroutines) post concurrently, so every access is mutex-guarded.
+type Store struct {
+	mu   sync.Mutex
+	path string
+	msgs []Message
+}
+
+// Open loads (or creates) the board under dir/board.json.
+func Open(dir string) (*Store, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("board: mkdir: %w", err)
+	}
+	s := &Store{path: filepath.Join(dir, "board.json")}
+	b, err := os.ReadFile(s.path)
+	if err == nil {
+		_ = json.Unmarshal(b, &s.msgs)
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("board: read: %w", err)
+	}
+	return s, nil
+}
+
+// Post appends a message and persists, dropping the oldest past maxMessages.
+func (s *Store) Post(topic, from, text string, nowMS int64) (Message, error) {
+	m := Message{Topic: strings.TrimSpace(topic), From: strings.TrimSpace(from), Text: text, TSMS: nowMS}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.msgs = append(s.msgs, m)
+	if len(s.msgs) > maxMessages {
+		s.msgs = s.msgs[len(s.msgs)-maxMessages:]
+	}
+	return m, s.save()
+}
+
+// Read returns up to limit messages, newest first, optionally filtered to a
+// topic (case-insensitive exact match).
+func (s *Store) Read(topic string, limit int) []Message {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	topic = strings.ToLower(strings.TrimSpace(topic))
+	out := make([]Message, 0, len(s.msgs))
+	for _, m := range s.msgs {
+		if topic == "" || strings.ToLower(m.Topic) == topic {
+			out = append(out, m)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].TSMS > out[j].TSMS })
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+// Topics returns the distinct topics on the board with their message counts.
+func (s *Store) Topics() map[string]int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	counts := map[string]int{}
+	for _, m := range s.msgs {
+		counts[m.Topic]++
+	}
+	return counts
+}
+
+func (s *Store) save() error {
+	b, err := json.MarshalIndent(s.msgs, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, s.path)
+}
+
+// --- tool ---
+
+// board is the store subset the tool needs (an interface for tests).
+type board interface {
+	Post(topic, from, text string, nowMS int64) (Message, error)
+	Read(topic string, limit int) []Message
+	Topics() map[string]int
+}
+
+// Tool implements agent.Tool. Created unbound via New(); Bind opens the store.
+type Tool struct {
+	mu    sync.RWMutex
+	store board
+	now   func() int64
+}
+
+// New returns an unbound board tool.
+func New() *Tool { return &Tool{now: func() int64 { return time.Now().UnixMilli() }} }
+
+// Bind opens the shared board store under dir and wires it. Called once after
+// the daemon knows its base dir. Returns an error only if the store can't open.
+func (t *Tool) Bind(dir string) error {
+	st, err := Open(dir)
+	if err != nil {
+		return err
+	}
+	t.mu.Lock()
+	t.store = st
+	t.mu.Unlock()
+	return nil
+}
+
+// bindStore wires a pre-built store (used by tests).
+func (t *Tool) bindStore(b board) {
+	t.mu.Lock()
+	t.store = b
+	t.mu.Unlock()
+}
+
+func (t *Tool) current() (board, func() int64) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	now := t.now
+	if now == nil {
+		now = func() int64 { return time.Now().UnixMilli() }
+	}
+	return t.store, now
+}

--- a/plugins/tools/boardtool/board_test.go
+++ b/plugins/tools/boardtool/board_test.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+
+package boardtool
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func newTool(t *testing.T) *Tool {
+	t.Helper()
+	st, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	tool := New()
+	tool.bindStore(st)
+	var clock int64 = 1000
+	tool.now = func() int64 { clock += 10; return clock } // monotonically increasing
+	return tool
+}
+
+func invoke(t *testing.T, tool *Tool, in map[string]any) (map[string]any, bool) {
+	t.Helper()
+	raw, _ := json.Marshal(in)
+	res, err := tool.Invoke(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("Invoke error: %v", err)
+	}
+	var out map[string]any
+	_ = json.Unmarshal([]byte(res.Output), &out)
+	return out, res.IsError
+}
+
+func TestDefinitionValid(t *testing.T) {
+	d := New().Definition()
+	if d.Name != "board" || !json.Valid(d.InputSchema) {
+		t.Fatalf("bad definition: %+v", d)
+	}
+}
+
+func TestPostThenRead_SharedAcrossCalls(t *testing.T) {
+	tool := newTool(t)
+	// One "agent" posts...
+	if _, isErr := invoke(t, tool, map[string]any{"op": "post", "topic": "findings", "from": "researcher", "text": "Go site is go.dev"}); isErr {
+		t.Fatal("post errored")
+	}
+	// ...another reads it back (same shared store).
+	out, isErr := invoke(t, tool, map[string]any{"op": "read", "topic": "findings"})
+	if isErr {
+		t.Fatal("read errored")
+	}
+	if out["count"].(float64) != 1 {
+		t.Fatalf("read count = %v, want 1", out["count"])
+	}
+	msgs := out["messages"].([]any)
+	m := msgs[0].(map[string]any)
+	if m["text"] != "Go site is go.dev" || m["from"] != "researcher" || m["topic"] != "findings" {
+		t.Errorf("message folded wrong: %+v", m)
+	}
+}
+
+func TestRead_NewestFirst_AndTopicFilter(t *testing.T) {
+	tool := newTool(t)
+	invoke(t, tool, map[string]any{"op": "post", "topic": "a", "text": "first"})
+	invoke(t, tool, map[string]any{"op": "post", "topic": "b", "text": "other-topic"})
+	invoke(t, tool, map[string]any{"op": "post", "topic": "a", "text": "second"})
+
+	// Topic filter: only topic "a", newest first.
+	out, _ := invoke(t, tool, map[string]any{"op": "read", "topic": "a"})
+	msgs := out["messages"].([]any)
+	if len(msgs) != 2 {
+		t.Fatalf("topic 'a' count = %d, want 2", len(msgs))
+	}
+	if msgs[0].(map[string]any)["text"] != "second" {
+		t.Errorf("newest-first wrong: %v", msgs[0])
+	}
+
+	// No filter: all three.
+	all, _ := invoke(t, tool, map[string]any{"op": "read"})
+	if all["count"].(float64) != 3 {
+		t.Errorf("unfiltered count = %v, want 3", all["count"])
+	}
+}
+
+func TestTopics(t *testing.T) {
+	tool := newTool(t)
+	invoke(t, tool, map[string]any{"op": "post", "topic": "x", "text": "1"})
+	invoke(t, tool, map[string]any{"op": "post", "topic": "x", "text": "2"})
+	invoke(t, tool, map[string]any{"op": "post", "topic": "y", "text": "3"})
+	out, _ := invoke(t, tool, map[string]any{"op": "topics"})
+	topics := out["topics"].(map[string]any)
+	if topics["x"].(float64) != 2 || topics["y"].(float64) != 1 {
+		t.Errorf("topic counts wrong: %+v", topics)
+	}
+}
+
+func TestPersistence(t *testing.T) {
+	dir := t.TempDir()
+	st1, _ := Open(dir)
+	if _, err := st1.Post("t", "", "durable", 100); err != nil {
+		t.Fatal(err)
+	}
+	// Reopen → message survives.
+	st2, _ := Open(dir)
+	if got := st2.Read("t", 10); len(got) != 1 || got[0].Text != "durable" {
+		t.Fatalf("message did not persist: %+v", got)
+	}
+}
+
+func TestBadInputs(t *testing.T) {
+	tool := newTool(t)
+	for _, c := range []map[string]any{
+		{"op": "post", "text": "no topic"},
+		{"op": "post", "topic": "t"}, // no text
+		{"op": "bogus"},
+		{"op": ""},
+	} {
+		if _, isErr := invoke(t, tool, c); !isErr {
+			t.Errorf("expected error for %v", c)
+		}
+	}
+}
+
+func TestUnboundIsSafe(t *testing.T) {
+	res, err := New().Invoke(context.Background(), json.RawMessage(`{"op":"topics"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Error("an unbound tool should return an error result")
+	}
+}

--- a/plugins/tools/boardtool/tool.go
+++ b/plugins/tools/boardtool/tool.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MIT
+
+package boardtool
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/agezt/agezt/kernel/agent"
+)
+
+// Definition implements agent.Tool.
+func (t *Tool) Definition() agent.ToolDef {
+	return agent.ToolDef{
+		Name: "board",
+		Description: "A shared message board every agent on this daemon can use to coordinate: " +
+			"op=post leaves a message on a topic; op=read returns recent messages (optionally for " +
+			"one topic); op=topics lists the active topics. Use it to talk to other agents, hand off " +
+			"findings, or leave a note for your next cycle. The board is shared and persistent.",
+		InputSchema: json.RawMessage(`{
+  "type": "object",
+  "required": ["op"],
+  "properties": {
+    "op":    {"type":"string", "enum":["post","read","topics"]},
+    "topic": {"type":"string", "description":"The topic to post under, or to filter reads by (a short label)."},
+    "text":  {"type":"string", "description":"For op=post: the message body."},
+    "from":  {"type":"string", "description":"For op=post (optional): who is posting (e.g. a role like \"researcher\")."},
+    "limit": {"type":"integer", "description":"For op=read: max messages (default 20, max 100)."}
+  }
+}`),
+	}
+}
+
+type input struct {
+	Op    string `json:"op"`
+	Topic string `json:"topic"`
+	Text  string `json:"text"`
+	From  string `json:"from"`
+	Limit int    `json:"limit"`
+}
+
+// Invoke implements agent.Tool.
+func (t *Tool) Invoke(_ context.Context, raw json.RawMessage) (agent.Result, error) {
+	var in input
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return agent.Result{}, fmt.Errorf("board: parse input: %w", err)
+	}
+	st, nowFn := t.current()
+	if st == nil {
+		return errResult("the board is not available on this daemon"), nil
+	}
+
+	switch in.Op {
+	case "post":
+		if strings.TrimSpace(in.Topic) == "" {
+			return errResult(`op=post needs a "topic"`), nil
+		}
+		if strings.TrimSpace(in.Text) == "" {
+			return errResult(`op=post needs "text"`), nil
+		}
+		m, err := st.Post(in.Topic, in.From, in.Text, nowFn())
+		if err != nil {
+			return errResult(err.Error()), nil
+		}
+		return okJSON(map[string]any{"posted": msgView(m)}), nil
+
+	case "read":
+		limit := in.Limit
+		if limit <= 0 {
+			limit = DefaultReadLimit
+		}
+		if limit > MaxReadLimit {
+			limit = MaxReadLimit
+		}
+		msgs := st.Read(in.Topic, limit)
+		views := make([]map[string]any, 0, len(msgs))
+		for _, m := range msgs {
+			views = append(views, msgView(m))
+		}
+		out := map[string]any{"count": len(views), "messages": views}
+		if strings.TrimSpace(in.Topic) != "" {
+			out["topic"] = in.Topic
+		}
+		return okJSON(out), nil
+
+	case "topics":
+		return okJSON(map[string]any{"topics": st.Topics()}), nil
+
+	case "":
+		return errResult("op required (post|read|topics)"), nil
+	default:
+		return errResult("unknown op " + in.Op + " (post|read|topics)"), nil
+	}
+}
+
+func msgView(m Message) map[string]any {
+	v := map[string]any{"topic": m.Topic, "text": m.Text}
+	if m.From != "" {
+		v["from"] = m.From
+	}
+	if m.TSMS > 0 {
+		v["at"] = time.UnixMilli(m.TSMS).Format(time.RFC3339)
+	}
+	return v
+}
+
+func okJSON(v any) agent.Result {
+	enc, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return errResult("marshal: " + err.Error())
+	}
+	return agent.Result{Output: string(enc)}
+}
+
+func errResult(msg string) agent.Result {
+	return agent.Result{Output: "board: " + msg, IsError: true}
+}


### PR DESCRIPTION
## What

A new in-process **`board`** tool: a shared, persistent, topic-addressed message board every agent on the daemon can post to and read from. This is the **inter-agent communication primitive** the multi-agent vision calls for — agents can hand off findings, leave a note for their next cycle, or coordinate with a peer.

It is the shared common ground that complements **memory** (durable facts) and **world** (entities): the board carries shared **messages**.

## Ops
- `op=post` — leave a message on a topic (optional `from` role)
- `op=read` — recent messages newest-first (optional topic filter, default 20 / max 100)
- `op=topics` — active topics with counts

## Storage
One JSON store under `<base>/board.json`: mutex-guarded, atomic write via `.tmp`+rename, capped at 1000 messages (oldest dropped), survives restarts. The tool owns its store (`Bind(dir)` after the kernel opens), mirroring the schedule-tool lifecycle.

## Policy
New `board` edict capability — **Allow** by default (a local shared note-store like memory) — plus toolmap case.

## Verification
- `go build` / `go vet` + full `go test ./...` green.
- `board_test.go` covers post/read (newest-first + topic filter), topics, persistence, bad inputs, unbound safety.
- **Live with the real provider (deepseek-v4-pro):** one run posted an API base URL under topic `handoff`; a separate run read it back verbatim — inter-agent communication across independent runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)