### PR TITLE
Feat: "do-it-for-sure" — run/verify/retry until actually done (M651)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **"Do-it-for-sure" — run, verify, retry until actually done (`agt run --assure`).**
+  A new reliability loop: instead of a single pass, an assured run executes the
+  task, asks a strict verifier whether it was FULLY accomplished (a plan or a
+  promise doesn't count), and if not, retries with the verifier's gap fed back —
+  up to N attempts (default 3, max 10), stopping the moment it's judged complete.
+  This is the "when I write something, definitely do it, and repeat as needed"
+  primitive. The loop core is a pure, fully-tested `kernel/assure` package (run +
+  verify closures); the kernel supplies a governed `RunWith` and a provider-backed
+  completion judge. Every attempt reuses one correlation id (sequential, never
+  overlapping) so the whole objective streams and journals as one run, and each
+  completion check emits a `assure.verdict` event ({complete, gap}) so `agt why`
+  shows exactly why it retried or stopped. Exposed as `agt run --assure[=<n>]`;
+  available to any run surface through the `assure` arg on the run command.
+  Verified live with the real provider: an assured run completed and journaled a
+  `complete:true` verdict; the retry/exhaust/clamp/parse paths are covered by the
+  pure package's unit tests. (M651)
 - **Continuous-loop heartbeat — see the living organism breathe.** Every cadence
   entry now carries a `Fires` counter, incremented once per completed firing at
   the universal `CompleteFiring` hook (so it never double-counts an in-flight

--- a/cmd/agt/main.go
+++ b/cmd/agt/main.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/agezt/agezt/internal/brand"
 	"github.com/agezt/agezt/internal/paths"
+	"github.com/agezt/agezt/kernel/assure"
 	"github.com/agezt/agezt/kernel/controlplane"
 	"github.com/agezt/agezt/kernel/event"
 )
@@ -168,6 +169,7 @@ func printHelp(w io.Writer) {
 	fmt.Fprintf(w, "  run \"<intent>\" | run - | run --file <path>   run an intent (read from arg, stdin via -, or a file)\n")
 	fmt.Fprintf(w, "      [--json|-q] [--tenant <id>] [--model <id>] [--system <prompt>] [--timeout <dur>]   per-run overrides; -q/--quiet = only the answer; JSON = ndjson stream\n")
 	fmt.Fprintf(w, "      [--tools <csv>|--no-tools] [--dry-run] [--max-cost <usd>]   restrict tools / preview the plan / cap this run's spend\n")
+	fmt.Fprintf(w, "      [--assure[=<n>]]   do-it-for-sure: run, verify it's actually done, retry the gap up to n attempts (default 3)\n")
 	fmt.Fprintf(w, "  halt [--reason \"...\"] [--json]  freeze all in-flight runs (reason is journaled)\n")
 	fmt.Fprintf(w, "  resume [--reason \"...\"] [--json] clear the halt flag (reason is journaled)\n")
 	fmt.Fprintf(w, "  why <event_id> [--json|--payload]  list events sharing an event's correlation\n")
@@ -341,6 +343,7 @@ func cmdRun(args []string, stdout, stderr io.Writer) int {
 	var toolsList []any
 	dryRun := false
 	maxCostMicrocents := int64(0)
+	assureAttempts := int64(0) // 0 = single pass; >0 = "do-it-for-sure" retry budget
 	var images []string
 	var intentParts []string
 	for i := 0; i < len(args); i++ {
@@ -386,6 +389,16 @@ func cmdRun(args []string, stdout, stderr io.Writer) int {
 			timeout = strings.TrimPrefix(a, "--timeout=")
 		case a == "--dry-run":
 			dryRun = true
+		case a == "--assure":
+			assureAttempts = int64(assure.DefaultMaxAttempts)
+		case strings.HasPrefix(a, "--assure="):
+			v := strings.TrimPrefix(a, "--assure=")
+			n, perr := strconv.Atoi(v)
+			if perr != nil || n < 1 {
+				fmt.Fprintf(stderr, "%s run: invalid --assure %q (want a positive integer of attempts)\n", brand.CLI, v)
+				return 2
+			}
+			assureAttempts = int64(n)
 		case a == "--max-cost" || strings.HasPrefix(a, "--max-cost="):
 			var v string
 			if a == "--max-cost" {
@@ -521,6 +534,11 @@ func cmdRun(args []string, stdout, stderr io.Writer) int {
 	// Per-run cost cap (M166): bound this run's spend. Sent in microcents.
 	if maxCostMicrocents > 0 {
 		runArgs["max_cost"] = float64(maxCostMicrocents)
+	}
+	// "Do-it-for-sure" (M651): run, verify completion, retry the gap — up to this
+	// many attempts. The daemon runs the loop and streams every attempt's events.
+	if assureAttempts > 0 {
+		runArgs["assure"] = float64(assureAttempts)
 	}
 
 	c := dial(stderr)

--- a/kernel/assure/assure.go
+++ b/kernel/assure/assure.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MIT
+
+// Package assure is the "do-it-for-sure" loop: run a task, verify it was
+// actually accomplished, and retry with the verifier's gap fed back — up to a
+// bounded number of attempts, stopping the moment a verdict reports the task
+// complete (M651).
+//
+// This is the reliability primitive the owner asked for: "when I write something,
+// definitely do it, and repeat as many times as needed until it's done." The loop
+// itself is pure and side-effect-free — it takes a run closure and a verify
+// closure — so it is trivially testable; the kernel supplies the real closures
+// (a governed run + a provider-backed completion judge).
+package assure
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+)
+
+// DefaultMaxAttempts / MaxMaxAttempts bound the retry loop. The ceiling stops a
+// pathological task (one a verifier never deems complete) from looping forever
+// and burning budget.
+const (
+	DefaultMaxAttempts = 3
+	MaxMaxAttempts     = 10
+)
+
+// Verdict is the completion judgement for one attempt.
+type Verdict struct {
+	// Complete reports whether the answer fully accomplishes the task.
+	Complete bool `json:"complete"`
+	// Gap describes what is still missing when not complete — fed back into the
+	// next attempt so the agent knows exactly what to finish.
+	Gap string `json:"gap,omitempty"`
+}
+
+// RunFn executes one attempt of the task and returns the answer. attempt is
+// 1-based; task is the (possibly gap-augmented) instruction for this attempt.
+type RunFn func(ctx context.Context, attempt int, task string) (string, error)
+
+// VerifyFn judges whether answer fully accomplishes the ORIGINAL task.
+type VerifyFn func(ctx context.Context, task, answer string) (Verdict, error)
+
+// Attempt records one run+verify cycle.
+type Attempt struct {
+	N       int     `json:"n"`
+	Answer  string  `json:"answer"`
+	Verdict Verdict `json:"verdict"`
+}
+
+// Result is the outcome of an assured run.
+type Result struct {
+	// Answer is the last attempt's answer (the best the loop produced).
+	Answer string `json:"answer"`
+	// Complete reports whether a verdict deemed the task done within the budget.
+	Complete bool `json:"complete"`
+	// Attempts is how many run+verify cycles actually ran.
+	Attempts int `json:"attempts"`
+	// Gap is the last unmet gap when the loop exhausted without completing.
+	Gap string `json:"gap,omitempty"`
+	// History is the per-attempt trail (useful for `agt why` / debugging).
+	History []Attempt `json:"history,omitempty"`
+}
+
+// clampAttempts normalizes the requested attempt budget into [1, MaxMaxAttempts],
+// defaulting a non-positive request to DefaultMaxAttempts.
+func clampAttempts(n int) int {
+	if n < 1 {
+		return DefaultMaxAttempts
+	}
+	if n > MaxMaxAttempts {
+		return MaxMaxAttempts
+	}
+	return n
+}
+
+// Until runs the task, verifies completion, and retries with the verifier's gap
+// fed back, up to maxAttempts — stopping as soon as a verdict reports complete.
+// Verification is always against the ORIGINAL task, never the gap-augmented
+// instruction, so "complete" means the real goal was met. A run error aborts the
+// loop (it is typically persistent — a down provider — and retrying would only
+// burn the budget); a verify error likewise returns what was produced so far.
+func Until(ctx context.Context, task string, maxAttempts int, run RunFn, verify VerifyFn) (Result, error) {
+	maxAttempts = clampAttempts(maxAttempts)
+	var res Result
+	cur := task
+	for i := 1; i <= maxAttempts; i++ {
+		ans, err := run(ctx, i, cur)
+		if err != nil {
+			return res, err
+		}
+		res.Answer = ans
+		res.Attempts = i
+
+		v, err := verify(ctx, task, ans)
+		if err != nil {
+			return res, err
+		}
+		res.History = append(res.History, Attempt{N: i, Answer: ans, Verdict: v})
+		if v.Complete {
+			res.Complete = true
+			res.Gap = ""
+			return res, nil
+		}
+		res.Gap = v.Gap
+		cur = retryInstruction(task, v.Gap)
+	}
+	return res, nil
+}
+
+// retryInstruction augments the original task with the verifier's gap so the next
+// attempt knows exactly what remained unfinished.
+func retryInstruction(task, gap string) string {
+	var b strings.Builder
+	b.WriteString(task)
+	b.WriteString("\n\nYour previous attempt did NOT fully complete this task.")
+	if strings.TrimSpace(gap) != "" {
+		b.WriteString(" What is still missing: ")
+		b.WriteString(strings.TrimSpace(gap))
+	}
+	b.WriteString("\nFinish the task completely this time.")
+	return b.String()
+}
+
+// ParseVerdict extracts a Verdict from a model reply that SHOULD be strict JSON
+// {"complete":bool,"gap":"..."} but in practice may arrive wrapped in prose or a
+// ```json fence. It isolates the first balanced-looking {...} span and unmarshals
+// it. The bool is false when no JSON object could be parsed — the caller decides
+// how to treat an unparseable verdict (the kernel treats it as "not complete" so
+// the bounded loop tries again rather than declaring a false success).
+func ParseVerdict(reply string) (Verdict, bool) {
+	s := strings.TrimSpace(reply)
+	// Drop a leading ```json / ``` fence and trailing fence if present.
+	s = strings.TrimPrefix(s, "```json")
+	s = strings.TrimPrefix(s, "```")
+	s = strings.TrimSuffix(s, "```")
+	start := strings.IndexByte(s, '{')
+	end := strings.LastIndexByte(s, '}')
+	if start < 0 || end <= start {
+		return Verdict{}, false
+	}
+	var v Verdict
+	if err := json.Unmarshal([]byte(s[start:end+1]), &v); err != nil {
+		return Verdict{}, false
+	}
+	return v, true
+}

--- a/kernel/assure/assure_test.go
+++ b/kernel/assure/assure_test.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: MIT
+
+package assure
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// completeAfter returns a VerifyFn that reports the task incomplete for the first
+// (n-1) calls and complete on the nth — modelling a task that takes n tries.
+func completeAfter(n int) VerifyFn {
+	calls := 0
+	return func(_ context.Context, _, _ string) (Verdict, error) {
+		calls++
+		if calls >= n {
+			return Verdict{Complete: true}, nil
+		}
+		return Verdict{Complete: false, Gap: "still missing step"}, nil
+	}
+}
+
+func TestUntil_CompletesFirstTry(t *testing.T) {
+	runs := 0
+	res, err := Until(context.Background(), "do it", 3,
+		func(_ context.Context, _ int, _ string) (string, error) { runs++; return "done", nil },
+		completeAfter(1))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !res.Complete || res.Attempts != 1 || runs != 1 {
+		t.Fatalf("want complete in 1 attempt, got %+v (runs=%d)", res, runs)
+	}
+}
+
+func TestUntil_RetriesThenCompletes(t *testing.T) {
+	var lastTask string
+	res, err := Until(context.Background(), "ship the feature", 5,
+		func(_ context.Context, attempt int, task string) (string, error) {
+			lastTask = task
+			return "attempt-output", nil
+		},
+		completeAfter(3))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !res.Complete || res.Attempts != 3 {
+		t.Fatalf("want complete on 3rd attempt, got %+v", res)
+	}
+	if len(res.History) != 3 {
+		t.Errorf("history should record all 3 attempts, got %d", len(res.History))
+	}
+	// The retry instruction must carry the original task AND the gap feedback.
+	if !strings.Contains(lastTask, "ship the feature") || !strings.Contains(lastTask, "still missing step") {
+		t.Errorf("retry instruction missing task or gap: %q", lastTask)
+	}
+}
+
+func TestUntil_ExhaustsWithoutCompleting(t *testing.T) {
+	res, err := Until(context.Background(), "impossible", 2,
+		func(_ context.Context, _ int, _ string) (string, error) { return "partial", nil },
+		func(_ context.Context, _, _ string) (Verdict, error) {
+			return Verdict{Complete: false, Gap: "everything"}, nil
+		})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if res.Complete {
+		t.Fatal("should not be complete")
+	}
+	if res.Attempts != 2 {
+		t.Errorf("attempts = %d, want 2 (the budget)", res.Attempts)
+	}
+	if res.Gap != "everything" {
+		t.Errorf("final gap = %q, want the last unmet gap", res.Gap)
+	}
+	if res.Answer != "partial" {
+		t.Errorf("answer = %q, want the last attempt's output", res.Answer)
+	}
+}
+
+func TestUntil_RunErrorAborts(t *testing.T) {
+	boom := errors.New("provider down")
+	_, err := Until(context.Background(), "x", 3,
+		func(_ context.Context, _ int, _ string) (string, error) { return "", boom },
+		completeAfter(1))
+	if !errors.Is(err, boom) {
+		t.Fatalf("run error should abort the loop, got %v", err)
+	}
+}
+
+func TestUntil_VerifyErrorReturnsProgress(t *testing.T) {
+	boom := errors.New("judge unavailable")
+	res, err := Until(context.Background(), "x", 3,
+		func(_ context.Context, _ int, _ string) (string, error) { return "ans", nil },
+		func(_ context.Context, _, _ string) (Verdict, error) { return Verdict{}, boom })
+	if !errors.Is(err, boom) {
+		t.Fatalf("verify error should surface, got %v", err)
+	}
+	if res.Answer != "ans" {
+		t.Errorf("should still return the produced answer, got %q", res.Answer)
+	}
+}
+
+func TestUntil_ClampsAttempts(t *testing.T) {
+	// 0 → DefaultMaxAttempts; a huge value → MaxMaxAttempts.
+	for _, tc := range []struct{ in, want int }{{0, DefaultMaxAttempts}, {-5, DefaultMaxAttempts}, {999, MaxMaxAttempts}} {
+		runs := 0
+		Until(context.Background(), "x", tc.in,
+			func(_ context.Context, _ int, _ string) (string, error) { runs++; return "p", nil },
+			func(_ context.Context, _, _ string) (Verdict, error) { return Verdict{Complete: false, Gap: "g"}, nil })
+		if runs != tc.want {
+			t.Errorf("maxAttempts %d → ran %d times, want %d", tc.in, runs, tc.want)
+		}
+	}
+}
+
+func TestVerifyAgainstOriginalTask(t *testing.T) {
+	// The verifier must always receive the ORIGINAL task, not the gap-augmented one.
+	var seen []string
+	Until(context.Background(), "ORIGINAL", 3,
+		func(_ context.Context, _ int, _ string) (string, error) { return "a", nil },
+		func(_ context.Context, task, _ string) (Verdict, error) {
+			seen = append(seen, task)
+			return Verdict{Complete: false, Gap: "more"}, nil
+		})
+	for i, task := range seen {
+		if task != "ORIGINAL" {
+			t.Errorf("verify call %d saw task %q, want ORIGINAL every time", i, task)
+		}
+	}
+}
+
+func TestParseVerdict(t *testing.T) {
+	cases := []struct {
+		name      string
+		in        string
+		wantOK    bool
+		wantDone  bool
+		wantGap   string
+	}{
+		{"strict", `{"complete":true}`, true, true, ""},
+		{"with gap", `{"complete":false,"gap":"no tests"}`, true, false, "no tests"},
+		{"fenced", "```json\n{\"complete\": true, \"gap\": \"\"}\n```", true, true, ""},
+		{"prose wrapped", `Sure! Here is my verdict: {"complete": false, "gap": "x"} hope that helps`, true, false, "x"},
+		{"garbage", `I think it is done.`, false, false, ""},
+		{"empty", ``, false, false, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			v, ok := ParseVerdict(c.in)
+			if ok != c.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, c.wantOK)
+			}
+			if ok && (v.Complete != c.wantDone || v.Gap != c.wantGap) {
+				t.Errorf("verdict = %+v, want complete=%v gap=%q", v, c.wantDone, c.wantGap)
+			}
+		})
+	}
+}

--- a/kernel/controlplane/server.go
+++ b/kernel/controlplane/server.go
@@ -1196,6 +1196,15 @@ func (s *Server) handleRun(ctx context.Context, conn net.Conn, req Request) {
 		ctx = runtime.WithMaxCost(ctx, maxCost)
 	}
 
+	// Assured run (M651): when assure > 0, run the "do-it-for-sure" loop — run,
+	// verify completion, retry with the gap fed back — up to that many attempts,
+	// instead of a single pass. A malformed value is a usage error.
+	assureN, _, acerr := argInt64(req.Args, "assure")
+	if acerr != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: acerr.Error()})
+		return
+	}
+
 	// Dry-run (M159): resolve exactly what this run WOULD do — effective model
 	// (and its catalog capabilities), the system-prompt source, the effective
 	// wall-clock timeout, and the precise tool set the agent loop would see after
@@ -1271,6 +1280,11 @@ func (s *Server) handleRun(ctx context.Context, conn net.Conn, req Request) {
 	}
 	resultCh := make(chan runResult, 1)
 	go func() {
+		if assureN > 0 {
+			ans, _, err := k.RunAssured(ctx, corr, intent, int(assureN))
+			resultCh <- runResult{ans, err}
+			return
+		}
 		ans, err := k.RunWith(ctx, corr, intent)
 		resultCh <- runResult{ans, err}
 	}()

--- a/kernel/event/kinds.go
+++ b/kernel/event/kinds.go
@@ -250,6 +250,12 @@ const (
 	// firing is journaled so `agt journal grep schedule` shows what the system
 	// did on its own and `agt why` links the firing to the resulting run.
 	KindScheduleFired Kind = "schedule.fired"
+
+	// KindAssureVerdict is journaled by the "do-it-for-sure" loop after each
+	// attempt's completion check (M651): it carries the attempt number, whether
+	// the verifier judged the task complete, and the remaining gap if not — so
+	// `agt why` can show why an assured run retried (or stopped).
+	KindAssureVerdict Kind = "assure.verdict"
 )
 
 // IsKnown reports whether k is one of the kinds defined in this file. Useful
@@ -352,4 +358,5 @@ var knownKinds = map[Kind]struct{}{
 	KindWebhookDelivered:          {},
 	KindWebhookFailed:             {},
 	KindScheduleFired:             {},
+	KindAssureVerdict:             {},
 }

--- a/kernel/runtime/runtime.go
+++ b/kernel/runtime/runtime.go
@@ -25,6 +25,7 @@ import (
 	"github.com/agezt/agezt/kernel/agent"
 	"github.com/agezt/agezt/kernel/approval"
 	"github.com/agezt/agezt/kernel/artifact"
+	"github.com/agezt/agezt/kernel/assure"
 	"github.com/agezt/agezt/kernel/bus"
 	"github.com/agezt/agezt/kernel/cadence"
 	"github.com/agezt/agezt/kernel/catalog"
@@ -1211,6 +1212,61 @@ func (k *Kernel) Run(ctx context.Context, intent string) (string, string, error)
 	corr := k.NewCorrelation()
 	ans, err := k.RunWith(ctx, corr, intent)
 	return ans, corr, err
+}
+
+// assureVerifyMaxTokens bounds the verifier completion — it only emits a tiny
+// JSON verdict, so a small cap keeps the completion check cheap.
+const assureVerifyMaxTokens = 400
+
+// RunAssured is the "do-it-for-sure" loop (M651): it runs the intent, asks a
+// verifier whether the task was actually accomplished, and retries with the gap
+// fed back — up to maxAttempts, stopping the moment the task is judged complete.
+// Every attempt reuses corr (they run sequentially and never overlap), so the
+// whole objective streams and journals under one correlation id. Returns the
+// final answer and the loop result (attempts, completion, per-attempt history).
+func (k *Kernel) RunAssured(ctx context.Context, corr, intent string, maxAttempts int) (string, assure.Result, error) {
+	res, err := assure.Until(ctx, intent, maxAttempts,
+		func(ctx context.Context, _ int, task string) (string, error) {
+			return k.RunWith(ctx, corr, task)
+		},
+		func(ctx context.Context, task, answer string) (assure.Verdict, error) {
+			return k.verifyCompletion(ctx, corr, task, answer)
+		},
+	)
+	return res.Answer, res, err
+}
+
+// verifyCompletion asks the provider whether answer fully accomplishes task,
+// parsing a strict-JSON verdict and journaling it under corr so `agt why` shows
+// why an assured run retried or stopped. An unparseable verdict is treated as
+// "not complete" (the bounded loop tries again rather than declaring a false
+// success).
+func (k *Kernel) verifyCompletion(ctx context.Context, corr, task, answer string) (assure.Verdict, error) {
+	prompt := "You are a strict completion checker. Given a TASK and the ANSWER an agent produced, decide whether the answer FULLY accomplishes the task with nothing important left undone. Be skeptical: a plan or a promise to do it is NOT completion.\n\n" +
+		"Reply with ONLY a JSON object and no other text: {\"complete\": true|false, \"gap\": \"<concise description of what is still missing; empty string if complete>\"}.\n\n" +
+		"TASK:\n" + task + "\n\nANSWER:\n" + answer
+	resp, err := k.cfg.Provider.Complete(ctx, agent.CompletionRequest{
+		Model:         k.cfg.Model,
+		CorrelationID: corr,
+		TaskType:      "verify",
+		MaxTokens:     assureVerifyMaxTokens,
+		Messages:      []agent.Message{{Role: agent.RoleUser, Content: prompt}},
+	})
+	if err != nil {
+		return assure.Verdict{}, err
+	}
+	v, ok := assure.ParseVerdict(resp.Message.Content)
+	if !ok {
+		v = assure.Verdict{Complete: false, Gap: "verifier reply was not valid JSON"}
+	}
+	_, _ = k.bus.Publish(event.Spec{
+		Subject:       "agent.agent-" + corr + ".assure",
+		Kind:          event.KindAssureVerdict,
+		Actor:         "assure",
+		CorrelationID: corr,
+		Payload:       map[string]any{"complete": v.Complete, "gap": v.Gap},
+	})
+	return v, nil
 }
 
 // RunWith executes one tool-loop using the supplied correlation ID.


### PR DESCRIPTION
## What

A reliability loop. Instead of a single pass, **`agt run --assure[=<n>]`** runs the task, asks a strict verifier whether it was **FULLY accomplished** (a plan or a promise doesn't count), and retries with the verifier's gap fed back — up to *n* attempts (default 3, max 10), stopping the moment it's judged complete.

This is the owner's *"when I write something, definitely do it, and repeat as needed until it's done"* primitive.

## Design
- **`kernel/assure`** — a pure, fully-tested loop over `run` + `verify` closures (`Until` / `ParseVerdict`). No side effects → trivially testable.
- The kernel supplies the real closures: a governed `RunWith` and a `provider.Complete` completion judge (`RunAssured` / `verifyCompletion`).
- All attempts **reuse one correlation id** (sequential, never overlapping) so the whole objective streams and journals as one run; each check emits a new **`assure.verdict`** event `{complete, gap}` for `agt why`.
- Wired through `CmdRun`'s `assure` arg (server-side → available to any run surface) and the `agt run --assure` flag.

## Verification
- Full `go test ./...` green. `kernel/assure` unit tests cover: first-try complete, retry-then-complete, exhaust-without-completing, run-error abort, verify-error returns progress, attempt clamping, verify-against-original-task, and lenient verdict parsing (strict / fenced / prose-wrapped / garbage).
- **Live with the real provider (deepseek-v4-pro):** an assured run completed and journaled a `complete:true` verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)