### PR TITLE
Feat: per-agent memory scope — shared brain, private notes (M652)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **Per-agent memory scope — shared brain, private notes.** The `memory` tool now
+  takes an optional `scope` (e.g. an agent's role): a remembered note tagged with
+  a scope stays private to it, and recall surfaces shared records (no scope) PLUS
+  the requested scope's own — never another scope's private notes. Memory is
+  shared by default, so agents keep using one common brain; the scope is the
+  per-agent layer the vision called for ("each agent has SOME of its own data but
+  shares the main memory"). The daemon's automatic pre-run recall uses the empty
+  (shared-only) view, so a run can never inherit an unrelated agent's private
+  notes. Implemented as a tag (`scope=<name>`) over the existing store — no new
+  store, fully backward-compatible — via a new `Manager.RecallScoped`; recalled
+  private records are annotated `(scope: …)` and the Memory view already shows the
+  tag as a chip. Verified live with the real provider: an agent stored a note
+  scoped to `researcher`; recall under `researcher` returned it, recall under
+  `writer` returned nothing; the visibility rules are covered by unit tests. (M652)
 - **"Do-it-for-sure" — run, verify, retry until actually done (`agt run --assure`).**
   A new reliability loop: instead of a single pass, an assured run executes the
   task, asks a strict verifier whether it was FULLY accomplished (a plan or a

--- a/kernel/memory/manager.go
+++ b/kernel/memory/manager.go
@@ -144,10 +144,22 @@ func (m *Manager) Remember(corr string, spec RememberSpec) (Record, bool, error)
 // knowledge was surfaced for a task. Returns the ranked results (possibly
 // empty).
 func (m *Manager) Recall(corr, query string, limit int) ([]Scored, error) {
+	return m.RecallScoped(corr, query, limit, "")
+}
+
+// RecallScoped is Recall restricted to a caller's visibility: shared records
+// (no scope tag) are ALWAYS surfaced; a record private to some scope is surfaced
+// only when that same scope is requested. An empty scope therefore sees shared
+// memory only — which is what the daemon's automatic pre-run recall uses, so a
+// run never inherits another agent's private notes (M652). This is the per-agent
+// layer over the one shared brain: agents share most knowledge but can keep some
+// notes to themselves by naming a scope.
+func (m *Manager) RecallScoped(corr, query string, limit int, scope string) ([]Scored, error) {
 	all, err := m.store.All()
 	if err != nil {
 		return nil, err
 	}
+	all = filterScope(all, scope)
 	hits := Search(all, query, limit, m.now().UnixMilli())
 	if len(hits) > 0 {
 		ids := make([]string, 0, len(hits))
@@ -323,7 +335,8 @@ const toolInputSchema = `{
     "type":    {"type": "string", "enum": ["FACT","SUMMARY","RELATION","PREFERENCE","OBSERVATION"], "description": "memory type (remember; default FACT)"},
     "query":   {"type": "string", "description": "search text (recall)"},
     "limit":   {"type": "integer", "description": "max results (recall; default 5)"},
-    "id":      {"type": "string", "description": "record id (forget)"}
+    "id":      {"type": "string", "description": "record id (forget)"},
+    "scope":   {"type": "string", "description": "optional private namespace, e.g. your role like \"researcher\". On remember: keep this note private to that scope. On recall: also surface that scope's private notes. Shared memory (no scope) is ALWAYS visible; another scope's private notes never are. Omit for shared memory."}
   },
   "required": ["action"]
 }`
@@ -336,6 +349,7 @@ type toolInput struct {
 	Query   string `json:"query"`
 	Limit   int    `json:"limit"`
 	ID      string `json:"id"`
+	Scope   string `json:"scope"`
 }
 
 // memoryTool is the in-process agent.Tool that lets the agent remember,
@@ -353,7 +367,9 @@ func (t memoryTool) Definition() agent.ToolDef {
 		Description: "Persist and retrieve durable knowledge across tasks. " +
 			"action=remember stores a fact (subject, content); " +
 			"action=recall searches stored memory (query); " +
-			"action=forget tombstones a record (id).",
+			"action=forget tombstones a record (id). " +
+			"Memory is shared with every agent by default; pass an optional scope " +
+			"(e.g. your role) to keep a note private to that scope and to recall it.",
 		InputSchema: json.RawMessage(toolInputSchema),
 	}
 }
@@ -382,7 +398,7 @@ func (t memoryTool) Invoke(ctx context.Context, input json.RawMessage) (agent.Re
 		if limit <= 0 {
 			limit = 5
 		}
-		hits, err := t.mgr.Recall(corr, in.Query, limit)
+		hits, err := t.mgr.RecallScoped(corr, in.Query, limit, strings.TrimSpace(in.Scope))
 		if err != nil {
 			return agent.Result{Output: "recall failed: " + err.Error(), IsError: true}, nil
 		}
@@ -401,10 +417,34 @@ func (t memoryTool) Invoke(ctx context.Context, input json.RawMessage) (agent.Re
 	}
 }
 
-// Tags adapts the tool input to a tag map. The schema doesn't expose tags to
-// the model (keeps the surface small); tool writes are tagged source=agent so
-// they are distinguishable from operator and distilled writes.
-func (in toolInput) Tags() map[string]string { return map[string]string{"source": "agent"} }
+// Tags adapts the tool input to a tag map. Tool writes are tagged source=agent so
+// they are distinguishable from operator and distilled writes; an optional scope
+// tag makes the note private to that namespace (recall only surfaces it when the
+// same scope is requested) — the per-agent layer over shared memory (M652).
+func (in toolInput) Tags() map[string]string {
+	t := map[string]string{"source": "agent"}
+	if s := strings.TrimSpace(in.Scope); s != "" {
+		t["scope"] = s
+	}
+	return t
+}
+
+// filterScope drops records private to a scope other than the requested one.
+// A record is visible when it carries no scope tag (shared) or its scope equals
+// the caller's. Returns a new slice; the input is not mutated.
+func filterScope(recs []Record, scope string) []Record {
+	out := make([]Record, 0, len(recs))
+	for _, r := range recs {
+		rs := ""
+		if r.Tags != nil {
+			rs = r.Tags["scope"]
+		}
+		if rs == "" || rs == scope {
+			out = append(out, r)
+		}
+	}
+	return out
+}
 
 func renderHits(hits []Scored) string {
 	if len(hits) == 0 {
@@ -413,7 +453,11 @@ func renderHits(hits []Scored) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "%d relevant memor%s:\n", len(hits), plural(len(hits)))
 	for _, h := range hits {
-		fmt.Fprintf(&b, "- [%s] %s: %s\n", h.Record.Type, h.Record.Subject, h.Record.Content)
+		scope := ""
+		if h.Record.Tags != nil && h.Record.Tags["scope"] != "" {
+			scope = " (scope: " + h.Record.Tags["scope"] + ")"
+		}
+		fmt.Fprintf(&b, "- [%s] %s: %s%s\n", h.Record.Type, h.Record.Subject, h.Record.Content, scope)
 	}
 	return strings.TrimRight(b.String(), "\n")
 }

--- a/kernel/memory/scope_test.go
+++ b/kernel/memory/scope_test.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+
+package memory
+
+import (
+	"strings"
+	"testing"
+)
+
+// rememberScoped stores a record tagged with the given scope (empty = shared),
+// mirroring what the memory tool does for an agent-provided scope.
+func rememberScoped(t *testing.T, m *Manager, subject, content, scope string) {
+	t.Helper()
+	tags := map[string]string{"source": "agent"}
+	if scope != "" {
+		tags["scope"] = scope
+	}
+	if _, _, err := m.Remember("corr", RememberSpec{Type: TypeFact, Subject: subject, Content: content, Tags: tags}); err != nil {
+		t.Fatalf("Remember(%q): %v", scope, err)
+	}
+}
+
+func recallSubjects(t *testing.T, m *Manager, query, scope string) map[string]bool {
+	t.Helper()
+	hits, err := m.RecallScoped("corr", query, 50, scope)
+	if err != nil {
+		t.Fatalf("RecallScoped(%q): %v", scope, err)
+	}
+	got := map[string]bool{}
+	for _, h := range hits {
+		got[h.Record.Subject] = true
+	}
+	return got
+}
+
+// TestRecallScoped_VisibilityRules is the core contract: shared records are
+// always visible; a scope's private record is visible only to that scope; and an
+// empty-scope (shared / auto-recall) view never sees any private record.
+func TestRecallScoped_VisibilityRules(t *testing.T) {
+	m, _ := newTestManager(t)
+	// All three share the queryable term "project" so Search returns every record;
+	// only the scope filter decides visibility.
+	rememberScoped(t, m, "deploy-url", "project deploy URL is example.com", "")        // shared
+	rememberScoped(t, m, "researcher-draft", "project research draft notes", "researcher") // private
+	rememberScoped(t, m, "writer-style", "project writing style preference", "writer")     // private
+
+	// The researcher sees shared + its own, never the writer's.
+	r := recallSubjects(t, m, "project", "researcher")
+	if !r["deploy-url"] || !r["researcher-draft"] {
+		t.Errorf("researcher should see shared + own scope, got %v", r)
+	}
+	if r["writer-style"] {
+		t.Errorf("researcher must NOT see the writer's private note, got %v", r)
+	}
+
+	// The writer sees shared + its own, never the researcher's.
+	w := recallSubjects(t, m, "project", "writer")
+	if !w["deploy-url"] || !w["writer-style"] {
+		t.Errorf("writer should see shared + own scope, got %v", w)
+	}
+	if w["researcher-draft"] {
+		t.Errorf("writer must NOT see the researcher's private note, got %v", w)
+	}
+
+	// The shared/auto-recall view (empty scope) sees ONLY shared records.
+	s := recallSubjects(t, m, "project", "")
+	if !s["deploy-url"] {
+		t.Errorf("shared view should see shared records, got %v", s)
+	}
+	if s["researcher-draft"] || s["writer-style"] {
+		t.Errorf("shared view must NOT see any private note, got %v", s)
+	}
+}
+
+// TestRecall_DefaultIsSharedOnly: the legacy Recall (no scope) behaves like the
+// shared view, so the daemon's automatic pre-run recall can never leak private
+// notes into an unrelated run.
+func TestRecall_DefaultIsSharedOnly(t *testing.T) {
+	m, _ := newTestManager(t)
+	rememberScoped(t, m, "shared-fact", "project everyone can see this", "")
+	rememberScoped(t, m, "secret", "project only mine", "agent-x")
+
+	hits, err := m.Recall("corr", "project", 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, h := range hits {
+		if h.Record.Subject == "secret" {
+			t.Fatal("Recall (no scope) leaked a private record")
+		}
+	}
+}
+
+// TestToolInputTags_Scope: the tool maps an input scope onto a scope tag, and
+// omits it when absent.
+func TestToolInputTags_Scope(t *testing.T) {
+	if tags := (toolInput{}).Tags(); tags["scope"] != "" {
+		t.Errorf("no scope → no scope tag, got %v", tags)
+	}
+	tags := (toolInput{Scope: " researcher "}).Tags()
+	if tags["scope"] != "researcher" {
+		t.Errorf("scope tag = %q, want researcher (trimmed)", tags["scope"])
+	}
+	if tags["source"] != "agent" {
+		t.Errorf("source tag should still be agent, got %v", tags)
+	}
+}
+
+// TestRenderHits_AnnotatesScope: a recalled private record is labelled so the
+// agent can tell shared from scoped knowledge.
+func TestRenderHits_AnnotatesScope(t *testing.T) {
+	hits := []Scored{
+		{Record: Record{Type: TypeFact, Subject: "s", Content: "c", Tags: map[string]string{"scope": "researcher"}}},
+	}
+	if out := renderHits(hits); !strings.Contains(out, "scope: researcher") {
+		t.Errorf("render should annotate the scope, got %q", out)
+	}
+}


### PR DESCRIPTION
## What

The `memory` tool now takes an optional **`scope`** (e.g. an agent's role). A note tagged with a scope stays **private** to it; recall surfaces **shared** records (no scope) **plus** the requested scope's own — never another scope's private notes.

This is the per-agent layer the vision asked for — *"each agent has SOME of its own data but shares the main memory"* — kept minimal: a `scope=<name>` tag over the existing store, **no new store**, fully backward-compatible. (The tag-based shape was the owner's chosen approach.)

## How
- New `Manager.RecallScoped(corr, query, limit, scope)` with a `filterScope` pass. Legacy `Recall` delegates with an empty scope, so the daemon's **automatic pre-run recall stays shared-only** — a run can never inherit another agent's private notes.
- The tool maps an input scope onto the scope tag (trimmed); recalled private records are annotated `(scope: …)`; the schema + description document it.
- The Memory view already renders tags as chips → scope is observable with **no frontend change**.

## Verification
- Full `go test ./...` green — `scope_test.go` covers the visibility rules (shared always visible; own scope visible; other scopes hidden; empty scope = shared-only), the tag mapping, and the render annotation.
- **Live with the real provider (deepseek-v4-pro):** an agent stored a note scoped to `researcher`; recall under `researcher` returned it, recall under `writer` returned **nothing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)