### PR TITLE
Feat: `introspect` agent tool — read the daemon's own live state (M682)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **The agent can introspect the daemon's OWN live state.** A new read-only
+  `introspect` tool gives the agent everything it needs to report on AGEZT itself in
+  one call: `op=overview` (default) returns the at-a-glance health snapshot —
+  version, model, uptime, halted, active runs, registered tools, memory/world/skill
+  counts, journal head, schedule & standing-order & pending-approval counts,
+  provider-fallback health, and delegation ceilings (the same shape `agt status`
+  assembles); `op=schedules` and `op=standing` list the time- and event/cron-driven
+  autonomy in detail. Before this, the granular tools (memory/world/runs/skill) each
+  read one slice, so "give me AGEZT's health report every morning at 9" had nowhere
+  to see the whole system and the agent would resort to guessing. Governed by a new
+  `introspect` capability, Allow by default (local, no mutation, no network).
+  Verified live (isolated daemon, real DeepSeek): a "health report" task invoked
+  `introspect` across all three ops in ~1ms each and produced an accurate report —
+  version, model, the exact seeded standing order, delegation — with the policy
+  allowing it at L4 without a prompt. (M682)
 - **Chat answers read as a timeline.** A turn's tool calls are no longer bunched
   above the text — the fold now records a chronological `timeline` of text runs and
   tool calls, and the bubble renders them in the order they happened: *"Let me

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -89,6 +89,7 @@ import (
 	filetool "github.com/agezt/agezt/plugins/tools/file"
 	hatool "github.com/agezt/agezt/plugins/tools/homeassistant"
 	httptool "github.com/agezt/agezt/plugins/tools/http"
+	"github.com/agezt/agezt/plugins/tools/introspecttool"
 	"github.com/agezt/agezt/plugins/tools/notify"
 	"github.com/agezt/agezt/plugins/tools/peer"
 	"github.com/agezt/agezt/plugins/tools/runstool"
@@ -319,6 +320,13 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// to the kernel's Forge after it opens.
 	skillToolInst := skilltool.New()
 	tools["skill"] = skillToolInst
+
+	// Introspection tool (`introspect`, M682): the agent reads the daemon's OWN
+	// live state — a real health overview plus schedule/standing detail — in one
+	// call, so a "summarise AGEZT's health" task can see everything instead of
+	// guessing. Registered now, Bound to the live kernel after it opens.
+	introspectToolInst := introspecttool.New()
+	tools["introspect"] = introspectToolInst
 
 	// OnReload is invoked by the control plane's `provider_reload`
 	// command (and `agt provider reload`). It re-reads the vault,
@@ -1152,6 +1160,11 @@ func runDaemon(stdout, stderr io.Writer) int {
 		skillToolInst.Bind(fg)
 		fmt.Fprintf(stdout, "  skill tool       : enabled (the agent can author and manage its own skills)\n")
 	}
+
+	// Bind the introspection tool to the live kernel (M682), so the agent can read
+	// the daemon's own health/schedules/standing-orders in one call.
+	introspectToolInst.Bind(introspecttool.NewKernelSource(k))
+	fmt.Fprintf(stdout, "  introspect tool  : enabled (the agent can read the daemon's own live state)\n")
 
 	// Scheduled intents (autonomy) — fire operator-configured intents on a timer
 	// through the governed loop. Runs on the daemon ctx (halt/shutdown stop it).

--- a/kernel/edict/edict.go
+++ b/kernel/edict/edict.go
@@ -126,6 +126,13 @@ const (
 	// skill starts as a draft outside the retrieval pool — so ask-first by
 	// default (M648).
 	CapSkill Capability = "skill"
+	// CapIntrospect gates the `introspect` tool: the agent reading the daemon's
+	// OWN live state in one call — health overview (uptime, halted, active runs,
+	// counts), plus detailed listings of schedules and standing orders. A
+	// read-only reflection of state the operator already owns, no mutation and no
+	// network — low risk, Allow by default (M682), so a "summarise AGEZT's health"
+	// task can actually see everything instead of guessing.
+	CapIntrospect Capability = "introspect"
 )
 
 // TrustLevel encodes the trust ladder (DECISIONS F3).
@@ -551,6 +558,7 @@ func DefaultLevels() map[Capability]TrustLevel {
 		CapStanding:    LevelAskFirst, // L2 strongest autonomy grant; the agent sets up unattended trigger-driven behaviour
 		CapBoard:       LevelAllow,    // local shared message board between agents; low risk
 		CapSkill:       LevelAskFirst, // self-modification: the agent authoring/promoting its own skills
+		CapIntrospect:  LevelAllow,    // local read of the daemon's own live state; no mutation, no network — low risk
 	}
 }
 
@@ -590,6 +598,7 @@ func AllCapabilities() []Capability {
 		CapACPAgent, CapRemoteRun, CapNotify,
 		CapHomeAssistantRead, CapHomeAssistantCall,
 		CapBrowserRead, CapMemory, CapWorld, CapWebSearch, CapSchedule, CapRunsRead, CapStanding, CapBoard, CapSkill,
+		CapIntrospect,
 	}
 	slices.Sort(caps)
 	return caps

--- a/kernel/edict/toolmap.go
+++ b/kernel/edict/toolmap.go
@@ -51,6 +51,8 @@ func CapabilityForToolCall(toolName string, input json.RawMessage) Capability {
 		return CapBoard
 	case "skill":
 		return CapSkill
+	case "introspect":
+		return CapIntrospect
 	case "memory":
 		return CapMemory
 	case "world":

--- a/plugins/tools/introspecttool/introspect.go
+++ b/plugins/tools/introspecttool/introspect.go
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: MIT
+
+// Package introspecttool is the in-process self-introspection tool: it lets the
+// agent read the DAEMON's OWN live state in one call — a real health overview
+// (uptime, halted, active runs, memory/world/skill counts, journal head,
+// schedule/standing/approval posture, provider-fallback health, delegation
+// ceilings), plus detailed listings of the schedules and standing orders that
+// drive its autonomy (M682).
+//
+// This closes the introspection gap: the granular tools (memory, world, runs,
+// skill) each read ONE slice, so a "summarise AGEZT's health every morning at 9"
+// task had no single place to see the whole system and would resort to guessing
+// (or web-searching "AGEZT"). `introspect` is that place — the agent can actually
+// see everything that's running before it reports. Read-only; no mutation, no
+// network.
+package introspecttool
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/cadence"
+	"github.com/agezt/agezt/kernel/standing"
+)
+
+// Delegation mirrors the active sub-agent governance ceilings (M46–M48) for the
+// overview. 0 fan-out / spend / total = unbounded.
+type Delegation struct {
+	Enabled            bool  `json:"enabled"`
+	MaxDepth           int   `json:"max_depth"`
+	MaxFanout          int   `json:"max_fanout"`
+	MaxSpendMicrocents int64 `json:"max_spend_microcents"`
+	MaxTotal           int   `json:"max_total"`
+}
+
+// Overview is the daemon's at-a-glance health snapshot — the same shape `agt
+// status` assembles, minus the server-level (HTTP/channel) extras the kernel
+// doesn't own. Assembled by the Source (the kernel adapter); the tool just
+// formats it.
+type Overview struct {
+	Daemon                 string     `json:"daemon"`
+	Protocol               int        `json:"protocol"`
+	Model                  string     `json:"model"`
+	UptimeSeconds          int64      `json:"uptime_seconds"`
+	Halted                 bool       `json:"halted"`
+	ActiveRuns             int        `json:"active_runs"`
+	Tools                  []string   `json:"tools"`
+	MemoryRecords          int        `json:"memory_records"`
+	WorldEntities          int        `json:"world_entities"`
+	ActiveSkills           int        `json:"active_skills"`
+	JournalHead            int64      `json:"journal_head"`
+	SchedulesTotal         int        `json:"schedules_total"`
+	SchedulesEnabled       int        `json:"schedules_enabled"`
+	PendingApprovals       int        `json:"pending_approvals"`
+	ProviderFallbacks      int        `json:"provider_fallbacks"`
+	ProviderFallbackReason string     `json:"provider_fallback_reason,omitempty"`
+	Delegation             Delegation `json:"delegation"`
+}
+
+// Source is the narrow live-state surface the tool reads. The kernel adapter
+// (NewKernelSource) implements it against the real *runtime.Kernel; tests inject
+// a fake without standing up a daemon.
+type Source interface {
+	// Overview returns the daemon's at-a-glance health snapshot.
+	Overview() Overview
+	// Schedules returns every cadence entry (operator- and agent-created).
+	Schedules() []cadence.Entry
+	// Standing returns every standing order on this daemon.
+	Standing() []standing.Order
+}
+
+// Tool implements agent.Tool. Created unbound via New(); Bind wires the Source.
+type Tool struct {
+	src Source
+}
+
+// New returns an unbound introspect tool (no Source until Bind).
+func New() *Tool { return &Tool{} }
+
+// Bind wires the live state source. Called once after the kernel opens.
+func (t *Tool) Bind(s Source) {
+	if s != nil {
+		t.src = s
+	}
+}
+
+// Definition implements agent.Tool.
+func (t *Tool) Definition() agent.ToolDef {
+	return agent.ToolDef{
+		Name: "introspect",
+		Description: "Read THIS daemon's OWN live state — use this to report on AGEZT's health " +
+			"instead of guessing. op=overview (default) gives the at-a-glance snapshot: version, " +
+			"model, uptime, halted, active runs, registered tools, memory/world/skill counts, " +
+			"journal head, schedule & standing-order & pending-approval counts, provider-fallback " +
+			"health, and delegation ceilings. op=schedules lists the scheduled (time-driven) runs " +
+			"in detail; op=standing lists the standing orders (event/cron-triggered autonomous " +
+			"agents) in detail. For deeper drill-down combine with the runs, memory, world and " +
+			"skill tools.",
+		InputSchema: json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "op": {"type":"string", "enum":["overview","schedules","standing"], "description":"What to read (default overview)."}
+  }
+}`),
+	}
+}
+
+type input struct {
+	Op string `json:"op"`
+}
+
+// Invoke implements agent.Tool.
+func (t *Tool) Invoke(_ context.Context, raw json.RawMessage) (agent.Result, error) {
+	var in input
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &in); err != nil {
+			return agent.Result{}, fmt.Errorf("introspect: parse input: %w", err)
+		}
+	}
+	if t.src == nil {
+		return errResult("introspection is not available on this daemon"), nil
+	}
+
+	switch in.Op {
+	case "", "overview":
+		return okJSON(t.src.Overview()), nil
+	case "schedules":
+		entries := t.src.Schedules()
+		out := make([]map[string]any, 0, len(entries))
+		for _, e := range entries {
+			out = append(out, scheduleView(e))
+		}
+		// Soonest next run first so the most imminent autonomy is at the top.
+		sort.SliceStable(out, func(i, j int) bool {
+			return next(out[i]) < next(out[j])
+		})
+		return okJSON(map[string]any{"count": len(out), "schedules": out}), nil
+	case "standing":
+		orders := t.src.Standing()
+		out := make([]map[string]any, 0, len(orders))
+		for _, o := range orders {
+			out = append(out, standingView(o))
+		}
+		return okJSON(map[string]any{"count": len(out), "orders": out}), nil
+	default:
+		return errResult("unknown op " + in.Op + " (overview|schedules|standing)"), nil
+	}
+}
+
+// scheduleView renders one cadence entry for the agent — the human-readable
+// cadence string plus the load-bearing fields, omitting zero/empty noise.
+func scheduleView(e cadence.Entry) map[string]any {
+	v := map[string]any{
+		"id":            e.ID,
+		"intent":        e.Intent,
+		"cadence":       e.Cadence(),
+		"mode":          e.Mode,
+		"source":        e.Source,
+		"enabled":       e.Enabled,
+		"next_run_unix": e.NextRunUnix,
+	}
+	if e.LastRunUnix > 0 {
+		v["last_run_unix"] = e.LastRunUnix
+	}
+	if e.Fires > 0 {
+		v["fires"] = e.Fires
+	}
+	if e.Model != "" {
+		v["model"] = e.Model
+	}
+	if e.Assure > 0 {
+		v["assure"] = e.Assure
+	}
+	return v
+}
+
+func next(v map[string]any) int64 {
+	if n, ok := v["next_run_unix"].(int64); ok {
+		return n
+	}
+	return 0
+}
+
+// standingView renders one standing order — mirrors the standing tool's view so
+// the two read identically.
+func standingView(o standing.Order) map[string]any {
+	trigs := make([]map[string]any, 0, len(o.Triggers))
+	for _, tr := range o.Triggers {
+		m := map[string]any{"type": string(tr.Type)}
+		if tr.Schedule != "" {
+			m["schedule"] = tr.Schedule
+		}
+		if tr.Subject != "" {
+			m["subject"] = tr.Subject
+		}
+		trigs = append(trigs, m)
+	}
+	v := map[string]any{
+		"id": o.ID, "name": o.Name, "enabled": o.Enabled,
+		"mode": string(o.Initiative.Mode), "triggers": trigs, "plan": o.Plan,
+	}
+	if o.Assure > 0 {
+		v["assure"] = o.Assure
+	}
+	return v
+}
+
+func okJSON(v any) agent.Result {
+	enc, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return errResult("marshal: " + err.Error())
+	}
+	return agent.Result{Output: string(enc)}
+}
+
+func errResult(msg string) agent.Result {
+	return agent.Result{Output: "introspect: " + msg, IsError: true}
+}

--- a/plugins/tools/introspecttool/introspect_test.go
+++ b/plugins/tools/introspecttool/introspect_test.go
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MIT
+
+package introspecttool
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/agezt/agezt/kernel/cadence"
+	"github.com/agezt/agezt/kernel/standing"
+)
+
+// fakeSource is an in-memory Source so the tool's formatting/dispatch is testable
+// without standing up a kernel.
+type fakeSource struct {
+	ov   Overview
+	sch  []cadence.Entry
+	stnd []standing.Order
+}
+
+func (f *fakeSource) Overview() Overview         { return f.ov }
+func (f *fakeSource) Schedules() []cadence.Entry { return f.sch }
+func (f *fakeSource) Standing() []standing.Order { return f.stnd }
+
+func newBound() (*Tool, *fakeSource) {
+	src := &fakeSource{
+		ov: Overview{
+			Daemon: "1.0.0", Protocol: 1, Model: "deepseek-chat",
+			UptimeSeconds: 42, Halted: false, ActiveRuns: 1,
+			Tools:         []string{"introspect", "memory", "shell"},
+			MemoryRecords: 7, WorldEntities: 3, ActiveSkills: 2,
+			JournalHead: 99, SchedulesTotal: 2, SchedulesEnabled: 1,
+			PendingApprovals:  1,
+			ProviderFallbacks: 0,
+			Delegation:        Delegation{Enabled: true, MaxDepth: 1},
+		},
+		sch: []cadence.Entry{
+			{ID: "s-late", Intent: "weekly report", Mode: cadence.ModeOnce, Source: "operator", Enabled: true, NextRunUnix: 5000},
+			{ID: "s-soon", Intent: "morning brief", Mode: cadence.ModeOnce, Source: "operator", Enabled: true, NextRunUnix: 1000, Fires: 3, Model: "deepseek-chat"},
+		},
+		stnd: []standing.Order{
+			{
+				ID: "o1", Name: "error-watch", Enabled: true,
+				Triggers:   []standing.Trigger{{Type: standing.TriggerEvent, Subject: "task.failed"}},
+				Initiative: standing.Initiative{Mode: standing.InitiativeAsk},
+				Plan:       "investigate the failure", Assure: 2,
+			},
+		},
+	}
+	tl := New()
+	tl.Bind(src)
+	return tl, src
+}
+
+func invoke(t *testing.T, tl *Tool, raw string) (string, bool) {
+	t.Helper()
+	res, err := tl.Invoke(context.Background(), json.RawMessage(raw))
+	if err != nil {
+		t.Fatalf("Invoke(%s) returned a hard error: %v", raw, err)
+	}
+	return res.Output, res.IsError
+}
+
+func TestOverview_DefaultAndExplicit(t *testing.T) {
+	tl, _ := newBound()
+	for _, raw := range []string{`{}`, ``, `{"op":"overview"}`} {
+		out, isErr := invoke(t, tl, raw)
+		if isErr {
+			t.Fatalf("overview(%q) was an error result: %s", raw, out)
+		}
+		var ov Overview
+		if err := json.Unmarshal([]byte(out), &ov); err != nil {
+			t.Fatalf("overview(%q) is not valid Overview JSON: %v\n%s", raw, err, out)
+		}
+		if ov.Model != "deepseek-chat" || ov.MemoryRecords != 7 || ov.ActiveRuns != 1 {
+			t.Errorf("overview(%q) lost fields: %+v", raw, ov)
+		}
+		if !ov.Delegation.Enabled || ov.Delegation.MaxDepth != 1 {
+			t.Errorf("overview(%q) delegation wrong: %+v", raw, ov.Delegation)
+		}
+		// The agent must see its own capability surface.
+		if !strings.Contains(out, "introspect") || !strings.Contains(out, "memory") {
+			t.Errorf("overview(%q) should list registered tools, got:\n%s", raw, out)
+		}
+	}
+}
+
+func TestSchedules_ListedAndSortedBySoonest(t *testing.T) {
+	tl, _ := newBound()
+	out, isErr := invoke(t, tl, `{"op":"schedules"}`)
+	if isErr {
+		t.Fatalf("schedules error: %s", out)
+	}
+	var got struct {
+		Count     int `json:"count"`
+		Schedules []struct {
+			ID          string `json:"id"`
+			Cadence     string `json:"cadence"`
+			NextRunUnix int64  `json:"next_run_unix"`
+			Fires       int64  `json:"fires"`
+		} `json:"schedules"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("schedules not JSON: %v\n%s", err, out)
+	}
+	if got.Count != 2 {
+		t.Fatalf("count = %d, want 2", got.Count)
+	}
+	// Soonest next run first.
+	if got.Schedules[0].ID != "s-soon" || got.Schedules[1].ID != "s-late" {
+		t.Errorf("schedules not sorted by soonest next run: %+v", got.Schedules)
+	}
+	if got.Schedules[0].Cadence == "" {
+		t.Error("schedule should carry a human-readable cadence string")
+	}
+}
+
+func TestStanding_Listed(t *testing.T) {
+	tl, _ := newBound()
+	out, isErr := invoke(t, tl, `{"op":"standing"}`)
+	if isErr {
+		t.Fatalf("standing error: %s", out)
+	}
+	var got struct {
+		Count  int `json:"count"`
+		Orders []struct {
+			Name     string `json:"name"`
+			Mode     string `json:"mode"`
+			Plan     string `json:"plan"`
+			Assure   int    `json:"assure"`
+			Triggers []struct {
+				Type    string `json:"type"`
+				Subject string `json:"subject"`
+			} `json:"triggers"`
+		} `json:"orders"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("standing not JSON: %v\n%s", err, out)
+	}
+	if got.Count != 1 || got.Orders[0].Name != "error-watch" {
+		t.Fatalf("standing orders wrong: %+v", got)
+	}
+	o := got.Orders[0]
+	if o.Mode != "ask" || o.Assure != 2 || o.Triggers[0].Subject != "task.failed" {
+		t.Errorf("standing order detail lost: %+v", o)
+	}
+}
+
+func TestUnboundAndUnknownOp(t *testing.T) {
+	// Unbound: no Source wired.
+	if out, isErr := invoke(t, New(), `{"op":"overview"}`); !isErr || !strings.Contains(out, "not available") {
+		t.Errorf("unbound tool should error gracefully, got isErr=%v out=%q", isErr, out)
+	}
+	// Unknown op on a bound tool.
+	tl, _ := newBound()
+	if out, isErr := invoke(t, tl, `{"op":"frobnicate"}`); !isErr || !strings.Contains(out, "unknown op") {
+		t.Errorf("unknown op should error, got isErr=%v out=%q", isErr, out)
+	}
+}

--- a/plugins/tools/introspecttool/kernelsource.go
+++ b/plugins/tools/introspecttool/kernelsource.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: MIT
+
+package introspecttool
+
+import (
+	"encoding/json"
+	"sort"
+	"time"
+
+	"github.com/agezt/agezt/internal/brand"
+	"github.com/agezt/agezt/internal/strutil"
+	"github.com/agezt/agezt/kernel/cadence"
+	"github.com/agezt/agezt/kernel/event"
+	kernelruntime "github.com/agezt/agezt/kernel/runtime"
+	"github.com/agezt/agezt/kernel/standing"
+)
+
+// fallbackWindow bounds the journal scan for provider.fallback events — recent
+// history is what a health check cares about, and it keeps the cost flat on a
+// long-lived daemon (mirrors runstool's window).
+const fallbackWindow = 5000
+
+// kernelSource adapts the live *runtime.Kernel to the tool's narrow Source. The
+// kernel owns every slice the overview reports, so this is a thin gather — the
+// same data `agt status` (handleStatus) assembles, minus the server-level
+// HTTP/channel extras the kernel doesn't own.
+type kernelSource struct {
+	k *kernelruntime.Kernel
+}
+
+// NewKernelSource binds the introspect tool to the live kernel. Wired in
+// cmd/agezt once the kernel opens, exactly like the other self-knowledge tools.
+func NewKernelSource(k *kernelruntime.Kernel) Source { return &kernelSource{k: k} }
+
+func (s *kernelSource) Overview() Overview {
+	k := s.k
+
+	headSeq, _ := k.Journal().Head() // (seq, hash); hash unused here
+	if headSeq < 0 {
+		headSeq = 0 // empty journal returns -1; render 0 for a fresh install
+	}
+
+	// Floor uptime to whole seconds — sub-second precision is noise.
+	uptimeSecs := int64(time.Since(k.StartTime()) / time.Second)
+
+	schedTotal, schedEnabled := 0, 0
+	if sched := k.Schedules(); sched != nil {
+		for _, e := range sched.List() {
+			schedTotal++
+			if e.Enabled {
+				schedEnabled++
+			}
+		}
+	}
+
+	pendingApprovals := 0
+	if ap := k.Approvals(); ap != nil {
+		pendingApprovals = ap.PendingCount()
+	}
+
+	fbCount, fbReason := s.providerFallbacks()
+
+	dl := k.SubAgentLimits()
+
+	// Registered tool names, sorted, so the agent sees its own capability surface
+	// (and the list is stable across calls).
+	names := make([]string, 0, len(k.Tools()))
+	for name := range k.Tools() {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	return Overview{
+		Daemon:                 brand.Version,
+		Protocol:               brand.ProtocolVersion,
+		Model:                  k.Model(),
+		UptimeSeconds:          uptimeSecs,
+		Halted:                 k.IsHalted(),
+		ActiveRuns:             k.ActiveRuns(),
+		Tools:                  names,
+		MemoryRecords:          k.Memory().Count(),
+		WorldEntities:          k.World().Count(),
+		ActiveSkills:           k.Forge().Count(),
+		JournalHead:            headSeq,
+		SchedulesTotal:         schedTotal,
+		SchedulesEnabled:       schedEnabled,
+		PendingApprovals:       pendingApprovals,
+		ProviderFallbacks:      fbCount,
+		ProviderFallbackReason: fbReason,
+		Delegation: Delegation{
+			Enabled:            dl.Enabled,
+			MaxDepth:           dl.MaxDepth,
+			MaxFanout:          dl.MaxFanout,
+			MaxSpendMicrocents: dl.MaxSpendMicrocents,
+			MaxTotal:           dl.MaxTotal,
+		},
+	}
+}
+
+func (s *kernelSource) Schedules() []cadence.Entry {
+	if sched := s.k.Schedules(); sched != nil {
+		return sched.List()
+	}
+	return nil
+}
+
+func (s *kernelSource) Standing() []standing.Order {
+	if st := s.k.Standing(); st != nil {
+		return st.List()
+	}
+	return nil
+}
+
+// providerFallbacks folds recent journal events for provider.fallback (M280):
+// how many times the governor fell back from a primary provider to a backup,
+// plus the most recent reason. A silent primary that errors every request — and
+// gets masked by the always-on mock fallback — is otherwise invisible in a
+// health report.
+func (s *kernelSource) providerFallbacks() (int, string) {
+	j := s.k.Journal()
+	if j == nil {
+		return 0, ""
+	}
+	evs, err := j.Tail(fallbackWindow)
+	if err != nil {
+		return 0, ""
+	}
+	count := 0
+	last := ""
+	for _, e := range evs {
+		if e.Kind != event.KindProviderFallback {
+			continue
+		}
+		count++
+		var p struct {
+			Reason string `json:"reason"`
+		}
+		if e.Payload != nil {
+			_ = json.Unmarshal(e.Payload, &p)
+			if p.Reason != "" {
+				last = strutil.Ellipsis(p.Reason, 160, "…")
+			}
+		}
+	}
+	return count, last
+}


### PR DESCRIPTION
## What

A new read-only **`introspect`** agent tool that lets the agent read **the daemon's own live state** in one call — so a *"give me AGEZT's health report every morning at 9"* task can actually see everything instead of guessing.

Until now the granular self-knowledge tools (`memory`, `world`, `runs`, `skill`) each read **one** slice, and there was no single comprehensive view. A health-report task had nowhere to look — in practice the agent would web-search *"AGEZT"* rather than introspect itself. This is that missing place.

## Ops

- **`op=overview`** (default) — the at-a-glance health snapshot: version, model, uptime, halted, active runs, registered tools, memory/world/skill counts, journal head, schedule & standing-order & pending-approval counts, provider-fallback health, and delegation ceilings. The same shape `agt status` (`handleStatus`) assembles, minus the server-level HTTP/channel extras the kernel doesn't own.
- **`op=schedules`** — the time-driven scheduled runs in detail (id, intent, human-readable cadence, next/last run, fires), sorted soonest-first.
- **`op=standing`** — the event/cron-triggered standing orders in detail (mirrors the `standing` tool's view).

## How

- Mirrors the `runstool`/`standingtool` pattern: created unbound in `cmd/agezt`, **Bound to the live kernel** after it opens via a co-located adapter (`NewKernelSource`), behind a narrow `Source` interface so the formatter is unit-testable without a daemon.
- New **`introspect` edict capability**, **Allow by default** (local read, no mutation, no network — symmetric with `runs.read`). Wired into `toolmap.go` + `AllCapabilities()`.

## Verification

- `go build ./...`, `go vet`, `go test` for `introspecttool` + `edict` + `controlplane`/`runtime`/`webui`/`plugin` — all green.
- **Live (isolated `AGEZT_HOME`, real DeepSeek):** a health-report task invoked `introspect` across all three ops in ~1ms each; policy allowed it at **L4 without a prompt**; the agent produced an accurate report (version, model, the exact seeded standing order, delegation). The owner's real `~/.agezt` was untouched (test ran in an isolated base dir per the isolate-test-daemon rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)