### PR TITLE
Fix: clean code_exec Python output on Windows (M685)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 
 ## [Unreleased]
 
+### Fixed
+- **`code_exec` Python output is clean on Windows.** The sandbox resolved the
+  Python interpreter via `python3` first, which on Windows is usually the Microsoft
+  Store shim (`…\WindowsApps\python3.exe`) — it could trigger the Store auto-
+  installer mid-run and wrap the program's real output in "Installing Python…" /
+  "Extracting…" chatter (and made a trivial run take ~5 s). Detection now prefers a
+  real `python.exe` on Windows (the usual `python3`-first order is kept elsewhere),
+  and the scrubbed env sets `PYLAUNCHER_ALLOW_INSTALL=0` as a backstop. A trivial
+  Python run is now clean output in ~30 ms. (M685)
+
 ### Added
 - **Every run's tool calls are now fully inspectable in the Runs view.** A tool-call
   row in a run's detail used to show only a clipped snippet of the result; it now

--- a/plugins/tools/codeexec/codeexec_test.go
+++ b/plugins/tools/codeexec/codeexec_test.go
@@ -103,6 +103,27 @@ func TestDeno_PermissionFlags_NetOnOff(t *testing.T) {
 	}
 }
 
+func TestPythonCandidates_PrefersRealPythonOnWindows(t *testing.T) {
+	// On Windows, `python` (a real install) must be tried before `python3` (the
+	// Store shim that can trigger the auto-installer and pollute output).
+	if got := pythonCandidates("windows"); len(got) != 2 || got[0] != "python" || got[1] != "python3" {
+		t.Errorf("windows candidates = %v, want [python python3]", got)
+	}
+	// Elsewhere `python3` is canonical and tried first.
+	if got := pythonCandidates("linux"); len(got) != 2 || got[0] != "python3" {
+		t.Errorf("linux candidates = %v, want [python3 python]", got)
+	}
+}
+
+func TestEnv_DisablesPyLauncherAutoInstall(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin")
+	tl, fw := newTool(t, map[string]string{LangPython: "/usr/bin/python3"}, true)
+	run(t, tl, map[string]any{"language": "python", "code": "x"})
+	if !strings.Contains(strings.Join(fw.last.Env, "\n"), "PYLAUNCHER_ALLOW_INSTALL=0") {
+		t.Errorf("env should disable the py-launcher auto-installer:\n%s", strings.Join(fw.last.Env, "\n"))
+	}
+}
+
 func TestEnv_ScrubsSecrets(t *testing.T) {
 	t.Setenv("AGEZT_API_KEY", "super-secret")
 	t.Setenv("DEEPSEEK_API_KEY", "sk-leak")

--- a/plugins/tools/codeexec/runtimes.go
+++ b/plugins/tools/codeexec/runtimes.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 )
@@ -22,7 +23,7 @@ const (
 // interpreter resolves are returned — the tool exposes exactly what can run.
 func DetectRuntimes() map[string]string {
 	out := map[string]string{}
-	if p := lookAny("python3", "python"); p != "" {
+	if p := lookAny(pythonCandidates(runtime.GOOS)...); p != "" {
 		out[LangPython] = p
 	}
 	if p := lookAny("node"); p != "" {
@@ -32,6 +33,20 @@ func DetectRuntimes() map[string]string {
 		out[LangDeno] = p
 	}
 	return out
+}
+
+// pythonCandidates is the interpreter-name preference order for the host OS. On
+// Windows we try `python` (a real install, e.g. C:\PythonXX\python.exe) BEFORE
+// `python3`, because `python3` there is usually the Microsoft Store shim
+// (…\WindowsApps\python3.exe) which can trigger the Store auto-installer mid-run
+// and pollute the program's output with "Installing Python…" chatter. Elsewhere
+// `python3` is the canonical name and `python` may be absent or python2, so we
+// keep the usual order.
+func pythonCandidates(goos string) []string {
+	if goos == "windows" {
+		return []string{"python", "python3"}
+	}
+	return []string{"python3", "python"}
 }
 
 func lookAny(names ...string) string {
@@ -125,7 +140,8 @@ func scrubEnv(dir string) []string {
 		"TMPDIR="+dir,
 		"TEMP="+dir,
 		"TMP="+dir,
-		"PYTHONDONTWRITEBYTECODE=1", // no __pycache__ litter in the work dir
+		"PYTHONDONTWRITEBYTECODE=1",  // no __pycache__ litter in the work dir
+		"PYLAUNCHER_ALLOW_INSTALL=0", // never let the Windows py launcher auto-install Python mid-run
 	)
 	return out
 }


### PR DESCRIPTION
## What

`code_exec` Python runs on Windows could be polluted by the Microsoft Store **auto-installer**. `DetectRuntimes` resolved Python via `python3` first, which on Windows is usually the Store shim (`…\WindowsApps\python3.exe`) — it can trigger "Installing Python… / Extracting…" chatter that wraps the program's real output (and made a trivial run take ~5 s). Witnessed in the M684 live test.

## Fix

- **`pythonCandidates(goos)`** — prefer `python` (a real install, e.g. `C:\Python314\python.exe`) **before** `python3` on Windows; keep `python3`-first elsewhere (it's canonical there, and `python` may be absent or python2).
- **`scrubEnv`** — set `PYLAUNCHER_ALLOW_INSTALL=0` as a backstop so even the shim can't auto-install mid-run.
- **Tests** — `pythonCandidates` returns the right per-OS order; `scrubEnv` carries the guard var.

## Verification

- `gofmt`/`go vet`/`go test ./plugins/tools/codeexec/`/`go build ./...` — green.
- **Live (isolated daemon, real DeepSeek):** a trivial python run now produces **clean output** (just the printed line) in **~32 ms** — down from ~5.1 s with the install noise. Owner's real `~/.agezt` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)