### PR TITLE
Feat: code_exec installs Python packages — real scraping & data work (M691)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **`code_exec` can install Python packages — real scraping & data work.** Pass
+  `packages` (e.g. `["requests","beautifulsoup4"]`) and the tool pip-installs them
+  before running your code, so `import requests` / `pandas` / `bs4` just work. In a
+  **project** the deps install into a persistent `.deps` dir and stay available
+  across calls (a second call needn't reinstall); in an ephemeral run they're
+  discarded with it. Installs run through the same warden isolation (scrubbed env,
+  confined to the work dir, time-bounded) with network, and a failed install
+  short-circuits so code never runs against a half-installed environment. Package
+  names are validated to block pip-flag injection (no leading `-`, no whitespace).
+  Python-only — for Deno/JS, import npm packages inline (`import x from "npm:…"`).
+  Verified live (isolated daemon, real PyPI): installed `six` into a project and
+  imported it (1.17.0); a second call with no packages still imported it (43 ms, no
+  reinstall); and `import requests; requests.get("https://example.com")` returned
+  `RESULT 200 528`. (M691)
 - **The agent can talk back — voice output in the chat.** The other half of the
   voice loop (M689 was the mic): a **speak** toggle in the composer reads each
   completed answer aloud, and every answer has its own **Speak / Stop** button to

--- a/plugins/tools/codeexec/codeexec.go
+++ b/plugins/tools/codeexec/codeexec.go
@@ -121,7 +121,8 @@ func (t *Tool) Definition() agent.ToolDef {
 	desc := "Write and run code, then read its output. Languages: " + strings.Join(langs, ", ") +
 		". Each call runs in its own scratch directory; pass a `project` name to keep a " +
 		"persistent directory you can revisit and extend across calls (write more files, re-run). " +
-		"Use `files` to drop extra source files alongside the entrypoint. " + netLine +
+		"Use `files` to drop extra source files alongside the entrypoint, and `packages` to pip-install " +
+		"Python dependencies (they persist in a project). " + netLine +
 		". The daemon's secrets are never visible to your code. Good for computation, scraping, " +
 		"data processing, and building small programs. Returns combined stdout+stderr (truncated to 256 KiB)."
 
@@ -134,6 +135,7 @@ func (t *Tool) Definition() agent.ToolDef {
     "stdin": {"type":"string", "description":"Optional input; written to stdin.txt in the working dir for your code to read."},
     "project": {"type":"string", "description":"Optional persistent project name. Reuse the same name across calls to keep and extend a working directory."},
     "files": {"type":"object", "description":"Optional extra files to write before running, as {\"relative/name\": \"content\"}."},
+    "packages": {"type":"array", "items":{"type":"string"}, "description":"Python only: pip packages to install before running, e.g. [\"requests\",\"beautifulsoup4\"]. In a project they persist across calls. For Deno/JS import npm packages inline instead: import x from \"npm:cheerio\"."},
     "timeout_ms": {"type":"integer", "description":"Per-call timeout in ms (default 120000, max 600000)."},
     "allow_net": {"type":"boolean", "description":"Deno only: grant network (default true). Ignored if the daemon has network disabled."}
   }
@@ -152,6 +154,7 @@ type input struct {
 	Stdin     string            `json:"stdin,omitempty"`
 	Project   string            `json:"project,omitempty"`
 	Files     map[string]string `json:"files,omitempty"`
+	Packages  []string          `json:"packages,omitempty"`
 	TimeoutMS int64             `json:"timeout_ms,omitempty"`
 	AllowNet  *bool             `json:"allow_net,omitempty"`
 }
@@ -213,14 +216,6 @@ func (t *Tool) Invoke(ctx context.Context, raw json.RawMessage) (agent.Result, e
 		_ = os.WriteFile(filepath.Join(dir, "stdin.txt"), []byte(in.Stdin), 0o600)
 	}
 
-	timeout := DefaultTimeout
-	if in.TimeoutMS > 0 {
-		timeout = time.Duration(in.TimeoutMS) * time.Millisecond
-	}
-	if timeout > MaxTimeout {
-		timeout = MaxTimeout
-	}
-
 	profile := t.Profile
 	if profile == "" {
 		profile = warden.ProfileNamespace
@@ -230,11 +225,56 @@ func (t *Tool) Invoke(ctx context.Context, raw json.RawMessage) (agent.Result, e
 		w = warden.New(nil)
 	}
 
+	// Install dependencies before running (Python only). They land in <dir>/.deps,
+	// so a project's installs persist across calls and an ephemeral run's are
+	// discarded with it. A failed install short-circuits — we never run code
+	// against a half-installed environment.
+	depsDir := filepath.Join(dir, pyDepsName)
+	if len(in.Packages) > 0 {
+		if lang != LangPython {
+			return errResult(`packages are only supported for python; for deno/JS, import npm packages inline instead, e.g. import x from "npm:cheerio"`), nil
+		}
+		if !t.NetEnabled {
+			return errResult("cannot install packages: network is disabled on this daemon (AGEZT_SANDBOX_NO_NET=1)"), nil
+		}
+		pkgs, perr := validatePackages(in.Packages)
+		if perr != nil {
+			return errResult(perr.Error()), nil
+		}
+		if len(pkgs) > 0 {
+			ires, ierr := pipInstall(ctx, w, interp, dir, depsDir, pkgs, profile)
+			if ierr != nil {
+				return errResult("pip install failed: " + ierr.Error()), nil
+			}
+			if ires.ExitCode != 0 {
+				return errResult(fmt.Sprintf("pip install failed (exit %d):\n%s", ires.ExitCode, installTail(ires))), nil
+			}
+		}
+	}
+
+	timeout := DefaultTimeout
+	if in.TimeoutMS > 0 {
+		timeout = time.Duration(in.TimeoutMS) * time.Millisecond
+	}
+	if timeout > MaxTimeout {
+		timeout = MaxTimeout
+	}
+
+	// The program's environment: scrubbed, plus PYTHONPATH pointing at any
+	// installed deps (present whenever a project — or this call — installed
+	// packages), so `import requests` resolves.
+	env := scrubEnv(dir)
+	if lang == LangPython {
+		if _, serr := os.Stat(depsDir); serr == nil {
+			env = append(env, "PYTHONPATH="+depsDir)
+		}
+	}
+
 	res, err := w.Run(ctx, warden.Spec{
 		Profile: profile,
 		Argv:    buildArgv(interp, lang, entry, dir, allowNet),
 		WorkDir: dir,
-		Env:     scrubEnv(dir),
+		Env:     env,
 		Limits: warden.Limits{
 			Timeout:           timeout,
 			MaxOutputBytes:    MaxOutputBytes,

--- a/plugins/tools/codeexec/codeexec_test.go
+++ b/plugins/tools/codeexec/codeexec_test.go
@@ -14,17 +14,34 @@ import (
 	"github.com/agezt/agezt/kernel/warden"
 )
 
-// fakeWarden captures the Spec it was handed and returns a scripted Result, so
+// fakeWarden captures every Spec it was handed and returns scripted Results, so
 // the tool's argv/env/workdir building and result rendering are testable without
 // actually running an interpreter. Satisfies warden.Engine.
 type fakeWarden struct {
-	last   warden.Spec
-	result warden.Result
+	last    warden.Spec
+	all     []warden.Spec
+	result  warden.Result   // default result
+	results []warden.Result // consumed in order (per call), then falls back to result
+	calls   int
 }
 
 func (f *fakeWarden) Run(_ context.Context, s warden.Spec) (*warden.Result, error) {
 	f.last = s
-	r := f.result
+	f.all = append(f.all, s)
+	// Simulate `pip install --target <dir>` creating its target dir, so the
+	// PYTHONPATH wiring (which keys on the dir existing) is exercised.
+	for i, a := range s.Argv {
+		if a == "--target" && i+1 < len(s.Argv) {
+			_ = os.MkdirAll(s.Argv[i+1], 0o755)
+		}
+	}
+	var r warden.Result
+	if f.calls < len(f.results) {
+		r = f.results[f.calls]
+	} else {
+		r = f.result
+	}
+	f.calls++
 	r.RequestedProfile = s.Profile
 	if r.EffectiveProfile == "" {
 		r.EffectiveProfile = warden.ProfileNone
@@ -198,6 +215,96 @@ func TestRendering_NonZeroAndTimeout(t *testing.T) {
 	out2, isErr2 := run(t, tl2, map[string]any{"language": "node", "code": "while(true){}"})
 	if !isErr2 || !strings.Contains(out2, "timed out") {
 		t.Errorf("timeout render wrong: isErr=%v out=%q", isErr2, out2)
+	}
+}
+
+func TestPackages_InstallThenRunWithPythonpath(t *testing.T) {
+	tl, fw := newTool(t, map[string]string{LangPython: "/usr/bin/python3"}, true)
+	out, isErr := run(t, tl, map[string]any{
+		"language": "python", "code": "import requests", "packages": []any{"requests", "beautifulsoup4"},
+	})
+	if isErr {
+		t.Fatalf("unexpected error: %s", out)
+	}
+	if len(fw.all) != 2 {
+		t.Fatalf("want 2 warden runs (install + program), got %d", len(fw.all))
+	}
+	// First run is the pip install into <dir>/.deps with both packages.
+	inst := strings.Join(fw.all[0].Argv, " ")
+	for _, want := range []string{"/usr/bin/python3", "-m pip install", "--target", ".deps", "requests", "beautifulsoup4"} {
+		if !strings.Contains(inst, want) {
+			t.Errorf("install argv missing %q: %s", want, inst)
+		}
+	}
+	// Second run is the program, with PYTHONPATH pointing at the deps dir.
+	prog := fw.all[1]
+	if prog.Argv[len(prog.Argv)-1] != "main.py" {
+		t.Errorf("second run should be the program: %v", prog.Argv)
+	}
+	if !strings.Contains(strings.Join(prog.Env, "\n"), "PYTHONPATH=") {
+		t.Errorf("program env should carry PYTHONPATH:\n%s", strings.Join(prog.Env, "\n"))
+	}
+}
+
+func TestPackages_RejectedForNonPython(t *testing.T) {
+	tl, fw := newTool(t, map[string]string{LangDeno: "/usr/bin/deno"}, true)
+	out, isErr := run(t, tl, map[string]any{"language": "deno", "code": "x", "packages": []any{"cheerio"}})
+	if !isErr || !strings.Contains(out, "only supported for python") {
+		t.Errorf("packages on deno should be rejected: isErr=%v out=%q", isErr, out)
+	}
+	if len(fw.all) != 0 {
+		t.Errorf("nothing should run when packages are rejected, got %d runs", len(fw.all))
+	}
+}
+
+func TestPackages_InstallFailureShortCircuits(t *testing.T) {
+	tl, fw := newTool(t, map[string]string{LangPython: "/usr/bin/python3"}, true)
+	// First run (install) fails; the program must NOT run.
+	fw.results = []warden.Result{{ExitCode: 1, Stderr: []byte("No matching distribution found for nope")}}
+	out, isErr := run(t, tl, map[string]any{"language": "python", "code": "print(1)", "packages": []any{"nope"}})
+	if !isErr || !strings.Contains(out, "pip install failed") {
+		t.Errorf("install failure should surface: isErr=%v out=%q", isErr, out)
+	}
+	if len(fw.all) != 1 {
+		t.Errorf("program must not run after a failed install; got %d runs", len(fw.all))
+	}
+}
+
+func TestPackages_RejectsFlagInjection(t *testing.T) {
+	tl, fw := newTool(t, map[string]string{LangPython: "/usr/bin/python3"}, true)
+	for _, bad := range []any{"--index-url=http://evil", "-rrequirements.txt", "foo bar"} {
+		out, isErr := run(t, tl, map[string]any{"language": "python", "code": "x", "packages": []any{bad}})
+		if !isErr || !strings.Contains(out, "illegal package") {
+			t.Errorf("package %v should be rejected: isErr=%v out=%q", bad, isErr, out)
+		}
+	}
+	if len(fw.all) != 0 {
+		t.Errorf("a rejected package list must run nothing, got %d", len(fw.all))
+	}
+}
+
+func TestPackages_NetDisabledBlocksInstall(t *testing.T) {
+	tl, _ := newTool(t, map[string]string{LangPython: "/usr/bin/python3"}, false) // NetEnabled=false
+	out, isErr := run(t, tl, map[string]any{"language": "python", "code": "x", "packages": []any{"requests"}})
+	if !isErr || !strings.Contains(out, "network is disabled") {
+		t.Errorf("install with net disabled should error: isErr=%v out=%q", isErr, out)
+	}
+}
+
+func TestProject_DepsPersistAcrossCalls(t *testing.T) {
+	tl, fw := newTool(t, map[string]string{LangPython: "/usr/bin/python3"}, true)
+	// Pre-create the project's .deps (as a prior install would have).
+	depsDir := filepath.Join(tl.SandboxRoot, "projects", "scraper", pyDepsName)
+	if err := os.MkdirAll(depsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A later call with NO packages still gets PYTHONPATH for the persisted deps.
+	run(t, tl, map[string]any{"language": "python", "code": "import requests", "project": "scraper"})
+	if len(fw.all) != 1 {
+		t.Fatalf("want 1 run (no install), got %d", len(fw.all))
+	}
+	if !strings.Contains(strings.Join(fw.all[0].Env, "\n"), "PYTHONPATH="+depsDir) {
+		t.Errorf("persisted project deps should be on PYTHONPATH:\n%s", strings.Join(fw.all[0].Env, "\n"))
 	}
 }
 

--- a/plugins/tools/codeexec/packages.go
+++ b/plugins/tools/codeexec/packages.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+
+package codeexec
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/agezt/agezt/kernel/warden"
+)
+
+// pyDepsName is the per-workspace directory pip installs into (a `pip install
+// --target` site). Under a project dir it persists across calls; under an
+// ephemeral run dir it's discarded with the run.
+const pyDepsName = ".deps"
+
+// pipInstallTimeout bounds dependency installation — generous, since fetching and
+// building wheels over the network can be slow.
+const pipInstallTimeout = MaxTimeout
+
+// validatePackages cleans and checks a pip requirement list. The warden runs pip
+// via exec (no shell), so the only real hazard is a "package" that's actually a
+// pip FLAG (e.g. "--index-url=evil"); we reject anything starting with "-" or
+// carrying whitespace/NUL. Normal requirement specs — name, version pins
+// (requests==2.31.0, pandas>=2), and extras (requests[security]) — are allowed.
+func validatePackages(pkgs []string) ([]string, error) {
+	out := make([]string, 0, len(pkgs))
+	for _, p := range pkgs {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if strings.HasPrefix(p, "-") {
+			return nil, fmt.Errorf("illegal package %q (looks like a pip flag, not a package)", p)
+		}
+		if strings.ContainsAny(p, " \t\r\n\x00") {
+			return nil, fmt.Errorf("illegal package name %q (whitespace not allowed)", p)
+		}
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+// pipInstall installs pkgs into depsDir via `python -m pip install --target`.
+// Network-using, time-bounded, scrubbed env, confined to the work dir — the same
+// isolation envelope as the program run.
+func pipInstall(ctx context.Context, w warden.Engine, interp, dir, depsDir string, pkgs []string, profile warden.Profile) (*warden.Result, error) {
+	argv := append([]string{
+		interp, "-m", "pip", "install",
+		"--target", depsDir,
+		"--no-input",
+		"--disable-pip-version-check",
+		"--no-warn-script-location",
+	}, pkgs...)
+	return w.Run(ctx, warden.Spec{
+		Profile: profile,
+		Argv:    argv,
+		WorkDir: dir,
+		Env:     scrubEnv(dir),
+		Limits: warden.Limits{
+			Timeout:           pipInstallTimeout,
+			MaxOutputBytes:    MaxOutputBytes,
+			CPUSeconds:        limitCPUSeconds,
+			AddressSpaceBytes: limitAddressSpaceByte,
+			MaxOpenFiles:      4096, // pip opens many files unpacking wheels
+			MaxFileSizeBytes:  limitMaxFileSizeBytes,
+		},
+		Actor:         "tool.code_exec",
+		CorrelationID: warden.CorrelationFrom(ctx),
+	})
+}
+
+// installTail returns the last chunk of a failed install's output for the error
+// message — the tail is where pip prints what actually went wrong.
+func installTail(res *warden.Result) string {
+	out := string(res.Stdout)
+	if len(res.Stderr) > 0 {
+		out += "\n" + string(res.Stderr)
+	}
+	out = strings.TrimSpace(out)
+	const max = 2000
+	if len(out) > max {
+		out = "…" + out[len(out)-max:]
+	}
+	return out
+}


### PR DESCRIPTION
## What

Agents could run Python but not **install dependencies**, so `import requests` / `pandas` / `bs4` failed — blocking the scraping and data work central to the *"ne lazımsa inşa edebilirler / infinite resources"* vision. Now a **`packages`** field pip-installs deps before running:

```json
{ "language": "python", "packages": ["requests", "beautifulsoup4"],
  "code": "import requests; print(requests.get('https://example.com').status_code)" }
```

## How

- **`packages`** is a pip requirement list. Installed via `python -m pip install --target <dir>/.deps` **before** the program run; the program then runs with `PYTHONPATH=<dir>/.deps` so the deps import.
- **Project persistence:** in a `project`, `.deps` persists — a later call reuses it (PYTHONPATH is set whenever `.deps` exists, even with no new packages). In an ephemeral run it's discarded with the dir.
- **Same isolation envelope** as the program: scrubbed env (no secrets), confined to the work dir, time-bounded (generous install timeout), network via the master `NetEnabled` switch. A **non-zero install exit short-circuits** — code never runs against a half-installed environment.
- **Safety:** `validatePackages` blocks pip-flag injection (leading `-`) and whitespace; the warden runs pip via `exec` (no shell), so shell-meta isn't a hazard. Python-only — Deno/JS use inline `npm:` imports (rejected with a helpful message otherwise).

## Tests

Fake warden now records **all** runs. New cases: install-then-run-with-PYTHONPATH, rejected-for-non-python, install-failure-short-circuits (program doesn't run), flag-injection rejected, net-disabled blocks install, project-deps-persist. Plus the existing real-interpreter parity test still passes.

## Verification

- `go build ./...` / `go vet` / `go test ./plugins/tools/codeexec/` — green.
- **Live (isolated daemon, real PyPI):**
  - Installed `six` into a project → `import six` → **1.17.0**; `.deps/` persisted on disk.
  - A **second** call to the same project with **no packages** still imported six in **43 ms** (no reinstall).
  - The headline: `import requests; requests.get("https://example.com")` → **`RESULT 200 528`**.
  - Owner's real `~/.agezt` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)