### PR TITLE
Feat: code_exec JS/TS packages via Deno, clean output (--quiet) (M692)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **`code_exec` JS/TS packages via Deno — clean, no install step.** Deno resolves
+  `import x from "npm:pkg"` itself (caching under the sandbox's scrubbed HOME), so
+  agents can use any npm package in TypeScript/JavaScript with no install phase —
+  the JS counterpart to M691's pip support. The Deno run now passes `--quiet`, so
+  Deno's own `Download`/`Check` progress no longer pollutes the program's output
+  (real errors and program stdout still show). With this, the package story is
+  complete across all three runtimes: Python via `packages` (pip), JS/TS via Deno
+  `npm:` imports, and the tool description points agents to each. Verified live
+  (isolated daemon): an agent imported `lodash-es` via `npm:` in Deno and printed a
+  clean result with no download noise. (M692)
 - **`code_exec` can install Python packages — real scraping & data work.** Pass
   `packages` (e.g. `["requests","beautifulsoup4"]`) and the tool pip-installs them
   before running your code, so `import requests` / `pandas` / `bs4` just work. In a

--- a/plugins/tools/codeexec/codeexec_test.go
+++ b/plugins/tools/codeexec/codeexec_test.go
@@ -95,7 +95,7 @@ func TestDeno_PermissionFlags_NetOnOff(t *testing.T) {
 	tl, fw := newTool(t, map[string]string{LangDeno: "/usr/bin/deno"}, true)
 	run(t, tl, map[string]any{"language": "deno", "code": "console.log(1)"})
 	argv := strings.Join(fw.last.Argv, " ")
-	for _, want := range []string{"run", "--no-prompt", "--allow-read=", "--allow-write=", "--allow-env", "--allow-net", "main.ts"} {
+	for _, want := range []string{"run", "--quiet", "--no-prompt", "--allow-read=", "--allow-write=", "--allow-env", "--allow-net", "main.ts"} {
 		if !strings.Contains(argv, want) {
 			t.Errorf("deno argv missing %q: %s", want, argv)
 		}

--- a/plugins/tools/codeexec/runtimes.go
+++ b/plugins/tools/codeexec/runtimes.go
@@ -87,13 +87,18 @@ func entryName(lang string) string {
 // and env access (env is already scrubbed), plus network only when granted —
 // this is a real OS-level jail on every platform, including Windows. We
 // deliberately do NOT pass --allow-run, so a Deno script can't shell out to
-// escape the fs confinement. Python/Node take no such flags (their isolation is
-// whatever the warden profile provides — real on Linux+namespace, workdir/env/
-// limits only elsewhere).
+// escape the fs confinement. --quiet suppresses Deno's own progress output so a
+// program's stdout stays clean even when it imports npm packages inline (Deno
+// resolves `import x from "npm:pkg"` itself, caching under the scrubbed HOME — no
+// install step needed; that is the JS/TS package path). Python/Node take no such
+// flags (their isolation is whatever the warden profile provides — real on
+// Linux+namespace, workdir/env/limits only elsewhere).
 func buildArgv(interp, lang, entry string, dir string, allowNet bool) []string {
 	if lang == LangDeno {
 		args := []string{
-			interp, "run", "--no-prompt",
+			interp, "run",
+			"--quiet", // suppress Deno's own Download/Check progress so npm: imports don't pollute the program's output (real errors still show)
+			"--no-prompt",
 			"--allow-read=" + dir,
 			"--allow-write=" + dir,
 			"--allow-env",


### PR DESCRIPTION
## What

Completes the package story started in M691 (pip for Python): the JS/TS side. **Deno resolves `import x from "npm:pkg"` itself** — caching under the sandbox's scrubbed `HOME`, confined by the existing `--allow-read/write=<dir>` flags — so agents can use **any npm package in TypeScript/JavaScript with no install step**. I verified empirically that this works inside the sandbox permission set.

The fix: add **`--quiet`** to the Deno argv so Deno's own `Download`/`Check` progress lines don't pollute the program's stdout when it imports npm packages. Real errors and program output still show (verified). Consistent with the M685 clean-output goal.

Also clarified `buildArgv`'s doc + the tool description so the agent knows the JS/TS package path is Deno `npm:` imports (Python uses `packages` → pip). **No Node `npm install`** — it would be redundant (Deno covers JS packages) and `npm` is a shell script with Windows `.cmd` exec complications.

## Verification

- `go vet` / `go test ./plugins/tools/codeexec/` — green (the deno-argv assertion now includes `--quiet`).
- Empirical (local): `deno run --quiet … npm:lodash-es` → clean `CLEAN hello-world`; a thrown error still prints `error: Uncaught … boom-visible`.
- **Live (isolated daemon, no browser):** an agent imported `lodash-es` via `npm:` in Deno → printed **`NPMDENO Jarvis`**, clean, **no `Download` noise**, 135 ms. Owner's real `~/.agezt` untouched.

The package story is now complete across all three runtimes: Python → `packages` (pip), JS/TS → Deno `npm:` imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)