### PR TITLE
Feat: Config Center schema registry — skills/plugins register their own config (M695)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **Config Center schema is now extensible — skills/plugins register their own
+  config.** The schema was hardcoded in `kernel/settings/schema.go`; it's now a
+  **registry** (`kernel/settings/registry.go`) that merges the compiled-in built-in
+  sections with on-disk sections dropped into `<baseDir>/schemas/*.json` — the same
+  disk-merge pattern as the model catalog. A skill or plugin can "drop" a schema
+  section (id, name, typed fields) and it appears in the Config Center immediately,
+  reading/writing through the existing store (non-secret) + vault (secret) plumbing.
+  **Safety by construction:** registered fields must be namespaced (`AGEZT_*`) and
+  may **not** shadow a built-in env (e.g. `AGEZT_ALLOW_ALL`) — collisions are
+  rejected on write and defensively dropped on read, so a skill can only configure
+  *its own* namespace and built-in always wins. New control-plane commands
+  `config_schema_register` (validates + persists a section) and
+  `config_schema_unregister` (removes the schema, leaves stored values untouched),
+  surfaced as `POST /api/config/schema/{register,unregister}`. Registered fields are
+  restart-class (read at the plugin's own startup); only built-in provider/model
+  stay live. Verified live (isolated daemon): a namespaced section registered and
+  appeared in `/api/config/schema` with its `source`; a section shadowing
+  `AGEZT_ALLOW_ALL` and a non-namespaced `OPENAI_KEY` were both rejected; a
+  registered non-secret wrote to `config.json` and a registered secret went to the
+  vault with the value never returned. (M695)
 - **Config Center UI — edit settings from the console, no `.env` by hand.** The
   visible half of M693: a new **Config Center** view (under *System*) renders
   schema-driven forms section by section (Provider & Model, Telegram, Email/SMTP,

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -3718,7 +3718,9 @@ func sttTranscriberFromEnv() *stt.Client {
 // show read-only. AGEZT_CONFIG=off disables the bridge entirely.
 func injectConfig(baseDir string, vault *creds.Store, stdout io.Writer) map[string]bool {
 	pinned := map[string]bool{}
-	for _, sec := range settings.Schema() {
+	// Pin across the FULL merged surface (built-in + registered) so a skill's
+	// registered field is also marked read-only when the operator pins it in .env.
+	for _, sec := range settings.NewRegistry(baseDir).Sections() {
 		for _, f := range sec.Fields {
 			if os.Getenv(f.Env) != "" {
 				pinned[f.Env] = true

--- a/kernel/controlplane/protocol.go
+++ b/kernel/controlplane/protocol.go
@@ -845,6 +845,10 @@ const (
 	CmdConfigSchema = "config_schema"
 	CmdConfigValues = "config_values"
 	CmdConfigSet    = "config_set"
+	// Schema registry (M695): skills/plugins register their own config sections
+	// into <baseDir>/schemas/*.json. Register: args{section}; Unregister: args{id}.
+	CmdConfigSchemaRegister   = "config_schema_register"
+	CmdConfigSchemaUnregister = "config_schema_unregister"
 
 	// Reflection — meta-cognition (SPEC-05 §6).
 	//

--- a/kernel/controlplane/server.go
+++ b/kernel/controlplane/server.go
@@ -667,6 +667,10 @@ func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
 		s.handleConfigValues(conn, req)
 	case CmdConfigSet:
 		s.handleConfigSet(conn, req)
+	case CmdConfigSchemaRegister:
+		s.handleConfigSchemaRegister(conn, req)
+	case CmdConfigSchemaUnregister:
+		s.handleConfigSchemaUnregister(conn, req)
 	case CmdStandingWhy:
 		s.handleStandingWhy(conn, req)
 	case CmdReflectRun:

--- a/kernel/controlplane/settings.go
+++ b/kernel/controlplane/settings.go
@@ -11,6 +11,7 @@ package controlplane
 // read at startup, so the response says "restart to apply".
 
 import (
+	"encoding/json"
 	"net"
 	"os"
 	"strings"
@@ -20,10 +21,12 @@ import (
 )
 
 // handleConfigSchema returns the editable configuration surface (sections +
-// fields) the Config Center renders forms from.
+// fields) the Config Center renders forms from — the built-in schema merged with
+// any skill/plugin-registered sections from <baseDir>/schemas/*.json.
 func (s *Server) handleConfigSchema(conn net.Conn, req Request) {
+	reg := settings.NewRegistry(s.baseDir)
 	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{
-		"sections": settings.Schema(),
+		"sections": reg.Sections(),
 	}})
 }
 
@@ -36,9 +39,10 @@ func (s *Server) handleConfigValues(conn net.Conn, req Request) {
 	_ = store.Load() // missing file = empty; not fatal
 	vault := creds.NewStore(s.baseDir)
 	_ = vault.Load()
+	reg := settings.NewRegistry(s.baseDir)
 
 	out := make([]map[string]any, 0, 32)
-	for _, sec := range settings.Schema() {
+	for _, sec := range reg.Sections() {
 		for _, f := range sec.Fields {
 			pinned := s.configEnvPinned[f.Env]
 			entry := map[string]any{
@@ -77,7 +81,7 @@ func (s *Server) handleConfigSet(conn net.Conn, req Request) {
 		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.name required"})
 		return
 	}
-	field, ok := settings.FieldByEnv(name)
+	field, ok := settings.NewRegistry(s.baseDir).FieldByEnv(name)
 	if !ok {
 		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "unknown setting " + name})
 		return
@@ -145,4 +149,55 @@ func (s *Server) handleConfigSet(conn net.Conn, req Request) {
 		result["applied"] = "restart"
 	}
 	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: result})
+}
+
+// handleConfigSchemaRegister persists a skill/plugin-contributed schema section to
+// <baseDir>/schemas/<id>.json. The section is validated (slug id, namespaced
+// AGEZT_* fields, no shadowing of a built-in setting); on success it appears in
+// the Config Center immediately. The arg `section` is the JSON section object.
+func (s *Server) handleConfigSchemaRegister(conn net.Conn, req Request) {
+	raw, ok := req.Args["section"]
+	if !ok {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.section required"})
+		return
+	}
+	// The section arrives as decoded JSON (map[string]any); round-trip it into the
+	// typed Section so validation sees the real shape.
+	blob, err := json.Marshal(raw)
+	if err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "encode section: " + err.Error()})
+		return
+	}
+	var sec settings.Section
+	if err := json.Unmarshal(blob, &sec); err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "decode section: " + err.Error()})
+		return
+	}
+	if err := settings.NewRegistry(s.baseDir).Register(sec); err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
+		return
+	}
+	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{
+		"id": sec.ID, "registered": true, "applied": "restart",
+	}})
+}
+
+// handleConfigSchemaUnregister removes a registered schema section by id. The
+// section's stored VALUES (config.json / vault) are left untouched; only the
+// schema is removed, so the Config Center stops showing the section.
+func (s *Server) handleConfigSchemaUnregister(conn net.Conn, req Request) {
+	id, _ := req.Args["id"].(string)
+	id = strings.TrimSpace(id)
+	if id == "" {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.id required"})
+		return
+	}
+	existed, err := settings.NewRegistry(s.baseDir).Unregister(id)
+	if err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
+		return
+	}
+	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{
+		"id": id, "removed": existed,
+	}})
 }

--- a/kernel/settings/registry.go
+++ b/kernel/settings/registry.go
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: MIT
+
+package settings
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// SchemaDir is the subdirectory under <baseDir> holding registered schema
+// sections — one JSON file per section (<id>.json). Skills/plugins "drop" a
+// section here (via the control plane, `agt config schema register`, or the
+// `config` tool) and the Config Center merges it with the built-in schema. This
+// is the disk-merge pattern from kernel/catalog applied to config schema.
+const SchemaDir = "schemas"
+
+// envNamePattern constrains registered field env-var names: an AGEZT_ prefix,
+// then uppercase / digits / underscore. Keeps registered keys namespaced and
+// shell-safe, and (together with the built-in reserved set) prevents a skill
+// from shadowing a core setting.
+var envNamePattern = regexp.MustCompile(`^AGEZT_[A-Z0-9_]+$`)
+
+// slugPattern constrains a section id to a filesystem- and URL-safe slug.
+var slugPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{0,63}$`)
+
+// Registry is the single source of truth for the editable configuration surface:
+// the compiled-in built-in sections merged with on-disk registered sections from
+// <baseDir>/schemas/*.json. Built-in always wins on collision. The registry holds
+// no state — it reads the directory on each call, so a newly-registered section
+// is visible immediately (the dir is tiny). Safe for concurrent use.
+type Registry struct {
+	dir string
+}
+
+// NewRegistry returns a Registry rooted at <baseDir>/schemas.
+func NewRegistry(baseDir string) *Registry {
+	return &Registry{dir: filepath.Join(baseDir, SchemaDir)}
+}
+
+// Dir is the schemas directory (it may not exist yet).
+func (r *Registry) Dir() string { return r.dir }
+
+// builtinEnvSet returns the set of env-var names owned by the built-in schema.
+// Registered fields may not shadow these.
+func builtinEnvSet() map[string]bool {
+	set := map[string]bool{}
+	for _, sec := range builtinSections() {
+		for _, f := range sec.Fields {
+			set[f.Env] = true
+		}
+	}
+	return set
+}
+
+// Sections returns the merged configuration surface: built-in sections first,
+// then registered sections sorted by id. As a safety net (even against a
+// hand-edited schema file), any registered field that is not namespaced
+// (AGEZT_*) or that collides with a built-in env name is dropped — built-in
+// always wins — and a registered section left with no usable fields is omitted.
+func (r *Registry) Sections() []Section {
+	out := builtinSections()
+	reserved := builtinEnvSet()
+	for _, sec := range r.Registered() {
+		kept := make([]Field, 0, len(sec.Fields))
+		for _, f := range sec.Fields {
+			if reserved[f.Env] || !envNamePattern.MatchString(f.Env) {
+				continue // never let a registered field shadow or escape its namespace
+			}
+			kept = append(kept, f)
+		}
+		if len(kept) == 0 {
+			continue
+		}
+		sec.Fields = kept
+		out = append(out, sec)
+	}
+	return out
+}
+
+// Registered returns the on-disk registered sections (sorted by id), each tagged
+// with Source = its id and every field normalised to ApplyRestart (only the
+// built-in provider/model hot-reload; skill/plugin config is read at the plugin's
+// own startup). Structurally broken files (unparseable, no slug id, no fields)
+// are skipped silently so one bad file can't break the whole Config Center;
+// per-field safety (namespacing, no shadowing) is enforced in Sections(), and
+// Register() validates strictly on write.
+func (r *Registry) Registered() []Section {
+	entries, err := os.ReadDir(r.dir)
+	if err != nil {
+		return nil // missing dir = nothing registered
+	}
+	var out []Section
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		raw, err := os.ReadFile(filepath.Join(r.dir, e.Name()))
+		if err != nil {
+			continue
+		}
+		var sec Section
+		if err := json.Unmarshal(raw, &sec); err != nil {
+			continue
+		}
+		if sec.ID == "" {
+			sec.ID = strings.TrimSuffix(e.Name(), ".json")
+		}
+		if !slugPattern.MatchString(sec.ID) || len(sec.Fields) == 0 {
+			continue
+		}
+		for i := range sec.Fields {
+			sec.Fields[i].Apply = ApplyRestart
+		}
+		sec.Source = sec.ID
+		out = append(out, sec)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// FieldByEnv finds a field by its env name across the merged surface.
+func (r *Registry) FieldByEnv(env string) (Field, bool) {
+	for _, sec := range r.Sections() {
+		for _, f := range sec.Fields {
+			if f.Env == env {
+				return f, true
+			}
+		}
+	}
+	return Field{}, false
+}
+
+// Register validates a section and persists it to <dir>/<id>.json (atomic, 0600),
+// replacing any existing section with the same id. Returns a descriptive error if
+// the section violates the registered-schema contract (slug id, namespaced fields,
+// no shadowing of built-ins).
+func (r *Registry) Register(sec Section) error {
+	if err := validateSection(sec, builtinEnvSet()); err != nil {
+		return err
+	}
+	for i := range sec.Fields {
+		sec.Fields[i].Apply = ApplyRestart
+	}
+	sec.Source = sec.ID
+	if err := os.MkdirAll(r.dir, 0755); err != nil {
+		return fmt.Errorf("settings: ensure schemas dir: %w", err)
+	}
+	raw, err := json.MarshalIndent(sec, "", "  ")
+	if err != nil {
+		return fmt.Errorf("settings: marshal section: %w", err)
+	}
+	return atomicWrite(filepath.Join(r.dir, sec.ID+".json"), raw)
+}
+
+// Unregister removes a registered section by id; reports whether it existed.
+func (r *Registry) Unregister(id string) (bool, error) {
+	if !slugPattern.MatchString(id) {
+		return false, fmt.Errorf("settings: invalid section id %q", id)
+	}
+	path := filepath.Join(r.dir, id+".json")
+	if _, err := os.Stat(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	if err := os.Remove(path); err != nil {
+		return false, fmt.Errorf("settings: remove %s: %w", id, err)
+	}
+	return true, nil
+}
+
+// validateSection enforces the registered-schema contract: a slug id, a name, at
+// least one field, and every field namespaced (AGEZT_*), typed, and NOT shadowing
+// a built-in env. reserved is the built-in env set.
+func validateSection(sec Section, reserved map[string]bool) error {
+	if !slugPattern.MatchString(sec.ID) {
+		return fmt.Errorf("section id %q must be a slug (lowercase letters, digits, '-', '_')", sec.ID)
+	}
+	if strings.TrimSpace(sec.Name) == "" {
+		return fmt.Errorf("section %q: name required", sec.ID)
+	}
+	if len(sec.Fields) == 0 {
+		return fmt.Errorf("section %q: at least one field required", sec.ID)
+	}
+	seen := map[string]bool{}
+	for _, f := range sec.Fields {
+		if !envNamePattern.MatchString(f.Env) {
+			return fmt.Errorf("field %q: env must match AGEZT_[A-Z0-9_]+ (registered settings are namespaced)", f.Env)
+		}
+		if reserved[f.Env] {
+			return fmt.Errorf("field %q: shadows a built-in setting and is reserved", f.Env)
+		}
+		if seen[f.Env] {
+			return fmt.Errorf("field %q: duplicated in section", f.Env)
+		}
+		seen[f.Env] = true
+		if !validType(f.Type) {
+			return fmt.Errorf("field %q: unknown type %q", f.Env, f.Type)
+		}
+		if f.Type == TypeSelect && len(f.Options) == 0 {
+			return fmt.Errorf("field %q: select type requires options", f.Env)
+		}
+	}
+	return nil
+}
+
+func validType(t FieldType) bool {
+	switch t {
+	case TypeText, TypePassword, TypeNumber, TypeBool, TypeCSV, TypeSelect:
+		return true
+	}
+	return false
+}

--- a/kernel/settings/registry_test.go
+++ b/kernel/settings/registry_test.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: MIT
+
+package settings
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func sampleSection() Section {
+	return Section{
+		ID:   "weather-skill",
+		Name: "Weather Skill",
+		Help: "API access for the weather skill.",
+		Fields: []Field{
+			{Env: "AGEZT_X_WEATHER_API_KEY", Label: "API key", Type: TypePassword, Secret: true},
+			{Env: "AGEZT_X_WEATHER_UNITS", Label: "Units", Type: TypeSelect, Options: []string{"metric", "imperial"}},
+		},
+	}
+}
+
+func TestRegistry_RegisterAndMerge(t *testing.T) {
+	dir := t.TempDir()
+	r := NewRegistry(dir)
+
+	// Built-in only to start.
+	if got := len(r.Registered()); got != 0 {
+		t.Fatalf("expected 0 registered, got %d", got)
+	}
+	base := len(r.Sections())
+	if base == 0 {
+		t.Fatal("expected built-in sections")
+	}
+
+	if err := r.Register(sampleSection()); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	// File landed under schemas/<id>.json.
+	if _, err := os.Stat(filepath.Join(dir, SchemaDir, "weather-skill.json")); err != nil {
+		t.Fatalf("schema file not written: %v", err)
+	}
+
+	secs := r.Sections()
+	if len(secs) != base+1 {
+		t.Fatalf("expected %d sections, got %d", base+1, len(secs))
+	}
+	last := secs[len(secs)-1]
+	if last.ID != "weather-skill" || last.Source != "weather-skill" {
+		t.Fatalf("registered section not tagged: id=%q source=%q", last.ID, last.Source)
+	}
+	// Registered fields are forced to restart-apply.
+	for _, f := range last.Fields {
+		if f.Apply != ApplyRestart {
+			t.Errorf("field %s apply=%q, want restart", f.Env, f.Apply)
+		}
+	}
+	// FieldByEnv finds a registered field.
+	if f, ok := r.FieldByEnv("AGEZT_X_WEATHER_API_KEY"); !ok || !f.Secret {
+		t.Errorf("FieldByEnv registered secret: ok=%v secret=%v", ok, f.Secret)
+	}
+}
+
+func TestRegistry_Unregister(t *testing.T) {
+	dir := t.TempDir()
+	r := NewRegistry(dir)
+	if err := r.Register(sampleSection()); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	removed, err := r.Unregister("weather-skill")
+	if err != nil || !removed {
+		t.Fatalf("unregister: removed=%v err=%v", removed, err)
+	}
+	if got := len(r.Registered()); got != 0 {
+		t.Fatalf("expected 0 after unregister, got %d", got)
+	}
+	// Unregistering a missing id is not an error.
+	removed, err = r.Unregister("nope")
+	if err != nil || removed {
+		t.Fatalf("unregister missing: removed=%v err=%v", removed, err)
+	}
+}
+
+func TestRegistry_RejectsShadowingBuiltin(t *testing.T) {
+	r := NewRegistry(t.TempDir())
+	sec := sampleSection()
+	sec.Fields = append(sec.Fields, Field{Env: "AGEZT_ALLOW_ALL", Label: "pwn", Type: TypeBool})
+	if err := r.Register(sec); err == nil {
+		t.Fatal("expected register to reject a field shadowing AGEZT_ALLOW_ALL")
+	}
+}
+
+func TestRegistry_RejectsBadInput(t *testing.T) {
+	r := NewRegistry(t.TempDir())
+	cases := map[string]Section{
+		"bad id":            {ID: "Bad Id", Name: "x", Fields: []Field{{Env: "AGEZT_X_A", Type: TypeText}}},
+		"no fields":         {ID: "empty", Name: "x"},
+		"non-namespaced":    {ID: "ns", Name: "x", Fields: []Field{{Env: "OPENAI_KEY", Type: TypeText}}},
+		"not agezt prefix":  {ID: "ns2", Name: "x", Fields: []Field{{Env: "AGEZTX", Type: TypeText}}},
+		"unknown type":      {ID: "ty", Name: "x", Fields: []Field{{Env: "AGEZT_X_A", Type: "wat"}}},
+		"select no options": {ID: "se", Name: "x", Fields: []Field{{Env: "AGEZT_X_A", Type: TypeSelect}}},
+		"dup env":           {ID: "dup", Name: "x", Fields: []Field{{Env: "AGEZT_X_A", Type: TypeText}, {Env: "AGEZT_X_A", Type: TypeText}}},
+	}
+	for name, sec := range cases {
+		if err := r.Register(sec); err == nil {
+			t.Errorf("%s: expected rejection", name)
+		}
+	}
+}
+
+// A hand-edited file that sneaks a colliding/non-namespaced field past Register
+// must still have that field dropped at read time (built-in wins).
+func TestRegistry_SectionsDropsColliding(t *testing.T) {
+	dir := t.TempDir()
+	schemas := filepath.Join(dir, SchemaDir)
+	if err := os.MkdirAll(schemas, 0755); err != nil {
+		t.Fatal(err)
+	}
+	sec := Section{
+		ID:   "sneaky",
+		Name: "Sneaky",
+		Fields: []Field{
+			{Env: "AGEZT_X_OK", Label: "ok", Type: TypeText},
+			{Env: "AGEZT_ALLOW_ALL", Label: "pwn", Type: TypeBool}, // collides with built-in
+			{Env: "OPENAI_KEY", Label: "escape", Type: TypeText},   // not namespaced
+		},
+	}
+	raw, _ := json.MarshalIndent(sec, "", "  ")
+	if err := os.WriteFile(filepath.Join(schemas, "sneaky.json"), raw, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewRegistry(dir)
+	var found *Section
+	for _, s := range r.Sections() {
+		if s.ID == "sneaky" {
+			cp := s
+			found = &cp
+		}
+	}
+	if found == nil {
+		t.Fatal("sneaky section missing")
+	}
+	if len(found.Fields) != 1 || found.Fields[0].Env != "AGEZT_X_OK" {
+		t.Fatalf("expected only AGEZT_X_OK to survive, got %+v", found.Fields)
+	}
+	// And it never shadowed the real built-in: AGEZT_ALLOW_ALL still resolves to
+	// the built-in bool field, not the sneaky registered one.
+	if f, ok := r.FieldByEnv("AGEZT_ALLOW_ALL"); !ok || f.Type != TypeBool {
+		t.Errorf("AGEZT_ALLOW_ALL did not resolve to the built-in: ok=%v field=%+v", ok, f)
+	}
+}

--- a/kernel/settings/schema.go
+++ b/kernel/settings/schema.go
@@ -43,24 +43,38 @@ type Field struct {
 	Options  []string  `json:"options,omitempty"` // for TypeSelect
 }
 
-// Section groups related fields for the Config Center UI.
+// Section groups related fields for the Config Center UI. Source records where
+// the section came from — "builtin" for the compiled-in core config, or the
+// registered schema's id for a skill/plugin-contributed section (see registry.go).
 type Section struct {
 	ID     string  `json:"id"`
 	Name   string  `json:"name"`
 	Help   string  `json:"help,omitempty"`
+	Source string  `json:"source,omitempty"`
 	Fields []Field `json:"fields"`
 }
 
-// Schema returns the editable configuration surface — the typed, grouped,
-// secret-flagged description the Config Center renders forms from and the server
-// validates against. Every Env here is an existing AGEZT_* var already consumed
-// at startup, so editing it (via the config store / vault + startup injection)
-// changes real behaviour.
+// SourceBuiltin marks the compiled-in core configuration sections.
+const SourceBuiltin = "builtin"
+
+// Schema returns the built-in editable configuration surface. Kept for
+// back-compat and as the seed for the Registry (registry.go), which merges
+// these compiled-in sections with on-disk skill/plugin-registered ones.
 func Schema() []Section {
+	return builtinSections()
+}
+
+// builtinSections is the typed, grouped, secret-flagged description the Config
+// Center renders forms from and the server validates against. Every Env here is
+// an existing AGEZT_* var already consumed at startup, so editing it (via the
+// config store / vault + startup injection) changes real behaviour. Each section
+// is tagged Source = SourceBuiltin so the UI can tell core config apart from
+// skill/plugin-registered sections.
+func builtinSections() []Section {
 	pw := func(env, label, help string) Field {
 		return Field{Env: env, Label: label, Type: TypePassword, Secret: true, Apply: ApplyRestart, Help: help}
 	}
-	return []Section{
+	secs := []Section{
 		{
 			ID: "provider", Name: "Provider & Model",
 			Help: "The active LLM provider and model. Applies live (the provider is rebuilt without a restart).",
@@ -136,6 +150,10 @@ func Schema() []Section {
 			},
 		},
 	}
+	for i := range secs {
+		secs[i].Source = SourceBuiltin
+	}
+	return secs
 }
 
 // FieldByEnv returns the schema field for an env-var name, and whether it's known.

--- a/kernel/webui/settings_route_test.go
+++ b/kernel/webui/settings_route_test.go
@@ -63,3 +63,52 @@ func TestConfigSetRoute_RejectsGET(t *testing.T) {
 		t.Errorf("GET must not issue a write, got %v", fc.calls)
 	}
 }
+
+func TestConfigSchemaRegisterRoute_ForwardsSection(t *testing.T) {
+	fc := &fakeCaller{result: map[string]any{"id": "weather", "registered": true}}
+	s, _ := newServer(t, fc, "secret")
+	body := `{"section":{"id":"weather","name":"Weather","fields":[{"env":"AGEZT_X_W","type":"text"}]},"evil":"x"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/config/schema/register?token=secret", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK || len(fc.calls) != 1 || fc.calls[0] != "config_schema_register" {
+		t.Fatalf("register route: code=%d calls=%v body=%s", rec.Code, fc.calls, rec.Body.String())
+	}
+	sec, ok := fc.lastArgs["section"].(map[string]any)
+	if !ok || sec["id"] != "weather" {
+		t.Errorf("section not forwarded as object: %v", fc.lastArgs)
+	}
+	if _, leaked := fc.lastArgs["evil"]; leaked {
+		t.Error("non-allowlisted body key leaked into config_schema_register")
+	}
+}
+
+func TestConfigSchemaUnregisterRoute_ForwardsID(t *testing.T) {
+	fc := &fakeCaller{result: map[string]any{"id": "weather", "removed": true}}
+	s, _ := newServer(t, fc, "secret")
+	req := httptest.NewRequest(http.MethodPost, "/api/config/schema/unregister?token=secret", strings.NewReader(`{"id":"weather"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK || len(fc.calls) != 1 || fc.calls[0] != "config_schema_unregister" {
+		t.Fatalf("unregister route: code=%d calls=%v", rec.Code, fc.calls)
+	}
+	if fc.lastArgs["id"] != "weather" {
+		t.Errorf("id not forwarded: %v", fc.lastArgs)
+	}
+}
+
+func TestConfigSchemaRegisterRoute_RejectsGET(t *testing.T) {
+	fc := &fakeCaller{result: map[string]any{"ok": true}}
+	s, _ := newServer(t, fc, "secret")
+	req := httptest.NewRequest(http.MethodGet, "/api/config/schema/register?token=secret", nil)
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("GET config/schema/register = %d want 405", rec.Code)
+	}
+	if len(fc.calls) != 0 {
+		t.Errorf("GET must not issue a write, got %v", fc.calls)
+	}
+}

--- a/kernel/webui/webui.go
+++ b/kernel/webui/webui.go
@@ -191,6 +191,10 @@ var jsonRoutes = map[string]writeRoute{
 	// Config Center write (M693): set one setting (non-secret → config store,
 	// secret → vault). POST-only; only name+value are forwarded.
 	"/api/config/set": {controlplane.CmdConfigSet, []string{"name", "value"}},
+	// Schema registry write (M695): register/unregister a skill/plugin-contributed
+	// schema section. Register forwards the whole `section` object; unregister an id.
+	"/api/config/schema/register":   {controlplane.CmdConfigSchemaRegister, []string{"section"}},
+	"/api/config/schema/unregister": {controlplane.CmdConfigSchemaUnregister, []string{"id"}},
 }
 
 // planRoute is the streaming "run this plan" action (Flow Studio's Run button).


### PR DESCRIPTION
## What

The Config Center schema was **hardcoded** (`kernel/settings/schema.go`). It's now a **registry** that merges the compiled-in built-in sections with on-disk sections dropped into `<baseDir>/schemas/*.json`. A skill or plugin can **register its own config schema** and it appears in the Config Center immediately, reading/writing through the existing store (non-secret) + vault (secret) plumbing. First of three increments (CLI + `config` tool, then UI redesign follow).

## How

- **`kernel/settings/registry.go`** — `Registry{Sections, Registered, FieldByEnv, Register, Unregister}`. Built-in first (`Source="builtin"`), then registered sections by id (`Source=<id>`). Loads the dir per call → newly-registered sections are visible without a restart (catalog disk-merge pattern).
- **Safety by construction** — registered fields must be `AGEZT_*` and may **not** shadow a built-in env (e.g. `AGEZT_ALLOW_ALL`). Rejected on write; defensively dropped on read (built-in wins). A skill can only configure its own namespace.
- Registered fields are restart-class (read at the plugin's own startup); only built-in provider/model stay live.
- **Control plane** — `config_schema_register` / `config_schema_unregister`; **routes** `POST /api/config/schema/{register,unregister}`.
- `injectConfig` pins across the full merged surface.

## Verification

- `go build`/`vet`; new registry tests (merge, builtin-wins collision-drop, namespacing + bad-input rejection, register/unregister round-trip) + webui route tests; full `kernel/settings` + `controlplane` + `webui` suites green (incl. `TestAPIReadOnly` + `configEnvVars` guard).
- **Live (isolated daemon):** a namespaced section registered → surfaced in `/api/config/schema` with its `source`; a section shadowing `AGEZT_ALLOW_ALL` and a non-namespaced `OPENAI_KEY` both rejected; a registered non-secret wrote to `config.json`, a registered secret went to the **vault** with the value never returned; unregister removed the schema. Owner `~/.agezt` untouched.

> CI note: org GitHub Actions is blocked on a billing issue (not this PR); verified locally + live before admin-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)