### PR TITLE
Feat: skills read/write/register config — agt config CLI + config agent tool (M696)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **Skills can read/write/register config — `agt config` CLI + a `config` tool.**
+  The skill-facing half of the extensible Config Center (M695). The agent (and the
+  skills it runs) can now configure things directly: a built-in **`config` agent
+  tool** with ops `schema | get | set | register | unregister`, and matching
+  **`agt config`** subcommands (`ls`, `get <ENV>`, `set <ENV> <value>`,
+  `schema [register <file> | unregister <id>]`) on top of the existing
+  `/api/config/*` HTTP routes — three front-ends over the *same* `kernel/settings`
+  registry + `creds` vault, so namespacing, secret handling, and live-vs-restart are
+  identical everywhere. Secrets are always presence-only on read and go to the
+  encrypted vault on write; provider/model apply live (the tool holds a kernel ref
+  bound after boot and calls `Reload()`), everything else is restart-class. The tool
+  is capability-gated via edict: **`config.read` allows** (schema/get — no mutation,
+  secrets masked) and **`config.write` asks first** (set/register/unregister — a
+  write can reach built-in security fields, so confirm by default; lower it in the
+  policy center). Verified live (isolated daemon): registered a namespaced section
+  from a file via `agt config schema register`, then `ls`/`get`/`set` round-tripped
+  (secret → vault, value never shown; non-secret → `config.json`); a section
+  shadowing `AGEZT_ALLOW_ALL` was rejected; `unregister` removed it. (M696)
 - **Config Center schema is now extensible — skills/plugins register their own
   config.** The schema was hardcoded in `kernel/settings/schema.go`; it's now a
   **registry** (`kernel/settings/registry.go`) that merges the compiled-in built-in

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -88,6 +88,7 @@ import (
 	"github.com/agezt/agezt/plugins/tools/browser"
 	"github.com/agezt/agezt/plugins/tools/codeexec"
 	"github.com/agezt/agezt/plugins/tools/coding"
+	configtool "github.com/agezt/agezt/plugins/tools/config"
 	filetool "github.com/agezt/agezt/plugins/tools/file"
 	hatool "github.com/agezt/agezt/plugins/tools/homeassistant"
 	httptool "github.com/agezt/agezt/plugins/tools/http"
@@ -615,6 +616,12 @@ func runDaemon(stdout, stderr io.Writer) int {
 		return 1
 	}
 	defer k.Close()
+
+	// Bind the kernel into the config tool now that it exists, so live-apply
+	// fields (provider/model) rebuild the provider in place via Reload().
+	if ct, ok := tools["config"].(*configtool.Tool); ok {
+		ct.SetKernel(k)
+	}
 
 	// Wire the bus into the Governor and the Warden so their events
 	// land in the journal. MUST happen before any Run is dispatched.
@@ -3796,6 +3803,13 @@ func buildTools(baseDir string, stderr io.Writer, ward warden.Engine) (map[strin
 	}
 	out["file"] = ft
 	registered = append(registered, "file(root="+ft.Root()+")")
+
+	// config — the agent's window into the Config Center: read/write/register
+	// settings (same registry + vault as the `agt config` CLI and HTTP routes).
+	// The kernel is bound after runtime.Open (see bindConfigTool) so live-apply
+	// fields (provider/model) can rebuild the provider in place.
+	out["config"] = configtool.New(baseDir)
+	registered = append(registered, "config()")
 
 	// http — default-deny; allowed hosts via $AGEZT_HTTP_ALLOWED_HOSTS
 	// (comma-separated). $AGEZT_HTTP_ALLOW_ALL=1 bypasses (DANGEROUS).

--- a/cmd/agt/config.go
+++ b/cmd/agt/config.go
@@ -14,7 +14,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/agezt/agezt/internal/brand"
@@ -23,18 +25,32 @@ import (
 
 func cmdConfig(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
-		fmt.Fprintf(stderr, "%s config: subcommand required (show)\n", brand.CLI)
+		fmt.Fprintf(stderr, "%s config: subcommand required (show, ls, get, set, schema)\n", brand.CLI)
 		return 2
 	}
 	switch args[0] {
 	case "show":
 		return cmdConfigShow(args[1:], stdout, stderr)
+	case "ls":
+		return cmdConfigLs(args[1:], stdout, stderr)
+	case "get":
+		return cmdConfigGet(args[1:], stdout, stderr)
+	case "set":
+		return cmdConfigSet(args[1:], stdout, stderr)
+	case "schema":
+		return cmdConfigSchema(args[1:], stdout, stderr)
 	case "-h", "--help":
-		fmt.Fprintf(stdout, "usage: %s config show [--json]\n", brand.CLI)
-		fmt.Fprintf(stdout, "show the daemon's resolved config (paths, model, env presence)\n")
+		fmt.Fprintf(stdout, "usage: %s config <subcommand>\n\n", brand.CLI)
+		fmt.Fprintf(stdout, "  show [--json]            resolved config (paths, model, env presence)\n")
+		fmt.Fprintf(stdout, "  ls [--json]              every Config Center setting + its state\n")
+		fmt.Fprintf(stdout, "  get <ENV>                one setting's value (secrets: presence only)\n")
+		fmt.Fprintf(stdout, "  set <ENV> <value>        write a setting (live for provider/model, else restart)\n")
+		fmt.Fprintf(stdout, "  schema [--json]          list the editable schema (built-in + registered)\n")
+		fmt.Fprintf(stdout, "  schema register <file>   register a skill/plugin schema section (JSON)\n")
+		fmt.Fprintf(stdout, "  schema unregister <id>   remove a registered schema section\n")
 		return 0
 	default:
-		fmt.Fprintf(stderr, "%s config: unknown subcommand %q (show)\n", brand.CLI, args[0])
+		fmt.Fprintf(stderr, "%s config: unknown subcommand %q (show, ls, get, set, schema)\n", brand.CLI, args[0])
 		return 2
 	}
 }
@@ -163,6 +179,328 @@ func cmdConfigShow(args []string, stdout, stderr io.Writer) int {
 	fmt.Fprintf(stdout, "  env (AGEZT_*)   : %d set (values not shown)\n", len(keys))
 	for _, k := range keys {
 		fmt.Fprintf(stdout, "    %s\n", k)
+	}
+	return 0
+}
+
+// configValues fetches the Config Center field state (CmdConfigValues). Secrets
+// report presence only — the value never leaves the daemon.
+func configValues(c *controlplane.Client, stderr io.Writer, label string) ([]any, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := c.Call(ctx, controlplane.CmdConfigValues, nil)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s %s: %v\n", brand.CLI, label, err)
+		return nil, false
+	}
+	fields, _ := res["fields"].([]any)
+	return fields, true
+}
+
+// cmdConfigLs lists every Config Center setting and its current state — the
+// machine-friendly companion to `config show` that the `config` skill/tool and
+// operators use to see what's editable.
+func cmdConfigLs(args []string, stdout, stderr io.Writer) int {
+	asJSON := false
+	for _, a := range args {
+		switch a {
+		case "--json":
+			asJSON = true
+		case "-h", "--help":
+			fmt.Fprintf(stdout, "usage: %s config ls [--json]\n", brand.CLI)
+			return 0
+		default:
+			fmt.Fprintf(stderr, "%s config ls: unexpected arg %q\n", brand.CLI, a)
+			return 2
+		}
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	if asJSON {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		res, err := c.Call(ctx, controlplane.CmdConfigValues, nil)
+		if err != nil {
+			fmt.Fprintf(stderr, "%s config ls: %v\n", brand.CLI, err)
+			return 1
+		}
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(res)
+		return 0
+	}
+	fields, ok := configValues(c, stderr, "config ls")
+	if !ok {
+		return 1
+	}
+	fmt.Fprintf(stdout, "%s config (%d settings):\n", brand.CLI, len(fields))
+	for _, fi := range fields {
+		m, _ := fi.(map[string]any)
+		env, _ := m["env"].(string)
+		secret, _ := m["secret"].(bool)
+		set, _ := m["set"].(bool)
+		pinned, _ := m["env_pinned"].(bool)
+		state := "unset"
+		if secret {
+			if set {
+				state = "set (secret)"
+			} else {
+				state = "unset (secret)"
+			}
+		} else if val, _ := m["value"].(string); val != "" {
+			state = val
+		}
+		tag := ""
+		if pinned {
+			tag = " [env-pinned]"
+		}
+		fmt.Fprintf(stdout, "  %-34s %s%s\n", env, state, tag)
+	}
+	return 0
+}
+
+// cmdConfigGet prints one setting's value (secrets: presence only).
+func cmdConfigGet(args []string, stdout, stderr io.Writer) int {
+	var env string
+	for _, a := range args {
+		switch a {
+		case "-h", "--help":
+			fmt.Fprintf(stdout, "usage: %s config get <ENV>\n", brand.CLI)
+			return 0
+		default:
+			if env != "" {
+				fmt.Fprintf(stderr, "%s config get: unexpected arg %q\n", brand.CLI, a)
+				return 2
+			}
+			env = a
+		}
+	}
+	if env == "" {
+		fmt.Fprintf(stderr, "%s config get: ENV required\n", brand.CLI)
+		return 2
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	fields, ok := configValues(c, stderr, "config get")
+	if !ok {
+		return 1
+	}
+	for _, fi := range fields {
+		m, _ := fi.(map[string]any)
+		if m["env"] != env {
+			continue
+		}
+		secret, _ := m["secret"].(bool)
+		set, _ := m["set"].(bool)
+		if secret {
+			if set {
+				fmt.Fprintf(stdout, "%s: set (secret, value not shown)\n", env)
+			} else {
+				fmt.Fprintf(stdout, "%s: not set\n", env)
+			}
+		} else {
+			val, _ := m["value"].(string)
+			fmt.Fprintf(stdout, "%s=%s\n", env, val)
+		}
+		return 0
+	}
+	fmt.Fprintf(stderr, "%s config get: unknown setting %q\n", brand.CLI, env)
+	return 1
+}
+
+// cmdConfigSet writes one setting. An empty value clears it. Provider/model apply
+// live; everything else needs a restart (the response says which).
+func cmdConfigSet(args []string, stdout, stderr io.Writer) int {
+	if len(args) >= 1 && (args[0] == "-h" || args[0] == "--help") {
+		fmt.Fprintf(stdout, "usage: %s config set <ENV> [value]\n", brand.CLI)
+		fmt.Fprintf(stdout, "  omit value (or pass \"\") to clear the setting\n")
+		return 0
+	}
+	if len(args) < 1 {
+		fmt.Fprintf(stderr, "%s config set: ENV required (usage: config set <ENV> [value])\n", brand.CLI)
+		return 2
+	}
+	env := args[0]
+	value := strings.Join(args[1:], " ")
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	res, err := c.Call(ctx, controlplane.CmdConfigSet, map[string]any{"name": env, "value": value})
+	if err != nil {
+		fmt.Fprintf(stderr, "%s config set: %v\n", brand.CLI, err)
+		return 1
+	}
+	if pinned, _ := res["env_pinned"].(bool); pinned {
+		fmt.Fprintf(stdout, "%s saved, but pinned by the environment — unset it in .env to apply\n", env)
+		return 0
+	}
+	switch applied, _ := res["applied"].(string); applied {
+	case "live":
+		fmt.Fprintf(stdout, "%s applied live\n", env)
+	default:
+		fmt.Fprintf(stdout, "%s saved — restart to apply\n", env)
+	}
+	return 0
+}
+
+// cmdConfigSchema lists the editable schema, or dispatches register/unregister.
+func cmdConfigSchema(args []string, stdout, stderr io.Writer) int {
+	if len(args) >= 1 {
+		switch args[0] {
+		case "register":
+			return cmdConfigSchemaRegister(args[1:], stdout, stderr)
+		case "unregister":
+			return cmdConfigSchemaUnregister(args[1:], stdout, stderr)
+		}
+	}
+	asJSON := false
+	for _, a := range args {
+		switch a {
+		case "--json":
+			asJSON = true
+		case "-h", "--help":
+			fmt.Fprintf(stdout, "usage: %s config schema [--json | register <file> | unregister <id>]\n", brand.CLI)
+			return 0
+		default:
+			fmt.Fprintf(stderr, "%s config schema: unexpected arg %q\n", brand.CLI, a)
+			return 2
+		}
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := c.Call(ctx, controlplane.CmdConfigSchema, nil)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s config schema: %v\n", brand.CLI, err)
+		return 1
+	}
+	if asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(res)
+		return 0
+	}
+	sections, _ := res["sections"].([]any)
+	for _, si := range sections {
+		s, _ := si.(map[string]any)
+		id, _ := s["id"].(string)
+		name, _ := s["name"].(string)
+		source, _ := s["source"].(string)
+		tag := ""
+		if source != "" && source != "builtin" {
+			tag = " (registered)"
+		}
+		fmt.Fprintf(stdout, "[%s] %s%s\n", id, name, tag)
+		flds, _ := s["fields"].([]any)
+		for _, fld := range flds {
+			f, _ := fld.(map[string]any)
+			env, _ := f["env"].(string)
+			typ, _ := f["type"].(string)
+			label, _ := f["label"].(string)
+			sec := ""
+			if secret, _ := f["secret"].(bool); secret {
+				sec = " (secret)"
+			}
+			fmt.Fprintf(stdout, "  %-34s %-8s%s  %s\n", env, typ, sec, label)
+		}
+	}
+	return 0
+}
+
+// cmdConfigSchemaRegister reads a JSON schema section from a file and registers it
+// — the "a skill drops a schema into the Config Center" path. The daemon validates
+// it (slug id, namespaced AGEZT_* fields, no shadowing of a built-in).
+func cmdConfigSchemaRegister(args []string, stdout, stderr io.Writer) int {
+	var file string
+	for _, a := range args {
+		switch a {
+		case "-h", "--help":
+			fmt.Fprintf(stdout, "usage: %s config schema register <file.json>\n", brand.CLI)
+			return 0
+		default:
+			if file != "" {
+				fmt.Fprintf(stderr, "%s config schema register: unexpected arg %q\n", brand.CLI, a)
+				return 2
+			}
+			file = a
+		}
+	}
+	if file == "" {
+		fmt.Fprintf(stderr, "%s config schema register: FILE required\n", brand.CLI)
+		return 2
+	}
+	raw, err := os.ReadFile(file)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s config schema register: %v\n", brand.CLI, err)
+		return 1
+	}
+	var section map[string]any
+	if err := json.Unmarshal(raw, &section); err != nil {
+		fmt.Fprintf(stderr, "%s config schema register: invalid JSON: %v\n", brand.CLI, err)
+		return 1
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := c.Call(ctx, controlplane.CmdConfigSchemaRegister, map[string]any{"section": section})
+	if err != nil {
+		fmt.Fprintf(stderr, "%s config schema register: %v\n", brand.CLI, err)
+		return 1
+	}
+	id, _ := res["id"].(string)
+	fmt.Fprintf(stdout, "registered schema section %q\n", id)
+	return 0
+}
+
+// cmdConfigSchemaUnregister removes a registered schema section by id (stored
+// values are left untouched).
+func cmdConfigSchemaUnregister(args []string, stdout, stderr io.Writer) int {
+	var id string
+	for _, a := range args {
+		switch a {
+		case "-h", "--help":
+			fmt.Fprintf(stdout, "usage: %s config schema unregister <id>\n", brand.CLI)
+			return 0
+		default:
+			if id != "" {
+				fmt.Fprintf(stderr, "%s config schema unregister: unexpected arg %q\n", brand.CLI, a)
+				return 2
+			}
+			id = a
+		}
+	}
+	if id == "" {
+		fmt.Fprintf(stderr, "%s config schema unregister: ID required\n", brand.CLI)
+		return 2
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := c.Call(ctx, controlplane.CmdConfigSchemaUnregister, map[string]any{"id": id})
+	if err != nil {
+		fmt.Fprintf(stderr, "%s config schema unregister: %v\n", brand.CLI, err)
+		return 1
+	}
+	if removed, _ := res["removed"].(bool); removed {
+		fmt.Fprintf(stdout, "unregistered %q\n", id)
+	} else {
+		fmt.Fprintf(stdout, "%q was not registered\n", id)
 	}
 	return 0
 }

--- a/cmd/agt/config_test.go
+++ b/cmd/agt/config_test.go
@@ -15,8 +15,48 @@ func TestCmdConfig_HelpExitsCleanly(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit=%d want 0; stderr=%q", code, errOut.String())
 	}
-	if !strings.Contains(out.String(), "config show") {
-		t.Errorf("--help missing 'config show'; got %q", out.String())
+	for _, want := range []string{"show", "ls", "get", "set", "schema register", "schema unregister"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help missing %q; got %q", want, out.String())
+		}
+	}
+}
+
+// The new subcommands must validate their args BEFORE dialing the daemon, so
+// these run with no daemon and still exit 2 (usage) rather than hanging or 1.
+func TestCmdConfig_SubcommandArgValidation(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want int
+		errc string
+	}{
+		{"set needs env", []string{"set"}, 2, "ENV required"},
+		{"get needs env", []string{"get"}, 2, "ENV required"},
+		{"get rejects extra", []string{"get", "AGEZT_MODEL", "extra"}, 2, "unexpected arg"},
+		{"schema register needs file", []string{"schema", "register"}, 2, "FILE required"},
+		{"schema unregister needs id", []string{"schema", "unregister"}, 2, "ID required"},
+		{"schema rejects extra", []string{"schema", "bogus"}, 2, "unexpected arg"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var out, errOut bytes.Buffer
+			if code := cmdConfig(c.args, &out, &errOut); code != c.want {
+				t.Errorf("exit=%d want %d; stderr=%q", code, c.want, errOut.String())
+			}
+			if !strings.Contains(errOut.String(), c.errc) {
+				t.Errorf("stderr=%q want contains %q", errOut.String(), c.errc)
+			}
+		})
+	}
+}
+
+// schema register with a missing file fails (exit 1) at ReadFile, before dialing.
+func TestCmdConfigSchemaRegister_MissingFile(t *testing.T) {
+	var out, errOut bytes.Buffer
+	code := cmdConfig([]string{"schema", "register", "does-not-exist.json"}, &out, &errOut)
+	if code != 1 {
+		t.Errorf("exit=%d want 1; stderr=%q", code, errOut.String())
 	}
 }
 

--- a/kernel/edict/edict.go
+++ b/kernel/edict/edict.go
@@ -142,6 +142,15 @@ const (
 	// warden.exec). The owner runs it Allow by default for full autonomy; operators
 	// who want confirmation set it to ask/deny in the policy center.
 	CapCodeExec Capability = "code.exec"
+
+	// CapConfigRead / CapConfigWrite gate the `config` tool (M696): the agent
+	// reading vs mutating Config Center settings. Reads (schema/get) are low-risk
+	// and Allow by default. Writes (set/register/unregister) are Ask by default —
+	// a write can reach built-in security fields (e.g. AGEZT_ALLOW_ALL) and a
+	// register adds a new editable surface — so a confirmation is warranted;
+	// operators can lower it in the policy center.
+	CapConfigRead  Capability = "config.read"
+	CapConfigWrite Capability = "config.write"
 )
 
 // TrustLevel encodes the trust ladder (DECISIONS F3).
@@ -569,6 +578,8 @@ func DefaultLevels() map[Capability]TrustLevel {
 		CapSkill:       LevelAskFirst, // self-modification: the agent authoring/promoting its own skills
 		CapIntrospect:  LevelAllow,    // local read of the daemon's own live state; no mutation, no network — low risk
 		CapCodeExec:    LevelAllow,    // write+run code; sandboxed (scrubbed env, confined dir, capped) and journaled — owner's choice for full autonomy
+		CapConfigRead:  LevelAllow,    // read Config Center schema/values; no mutation, secrets presence-only
+		CapConfigWrite: LevelAskFirst, // mutate settings / register schema; can reach built-in security fields — confirm first
 	}
 }
 
@@ -608,7 +619,7 @@ func AllCapabilities() []Capability {
 		CapACPAgent, CapRemoteRun, CapNotify,
 		CapHomeAssistantRead, CapHomeAssistantCall,
 		CapBrowserRead, CapMemory, CapWorld, CapWebSearch, CapSchedule, CapRunsRead, CapStanding, CapBoard, CapSkill,
-		CapIntrospect, CapCodeExec,
+		CapIntrospect, CapCodeExec, CapConfigRead, CapConfigWrite,
 	}
 	slices.Sort(caps)
 	return caps

--- a/kernel/edict/toolmap.go
+++ b/kernel/edict/toolmap.go
@@ -69,6 +69,18 @@ func CapabilityForToolCall(toolName string, input json.RawMessage) Capability {
 		return CapRemoteRun
 	case "notify":
 		return CapNotify
+	case "config":
+		var p struct {
+			Op string `json:"op"`
+		}
+		_ = json.Unmarshal(input, &p)
+		switch strings.ToLower(strings.TrimSpace(p.Op)) {
+		case "set", "register", "unregister":
+			return CapConfigWrite
+		}
+		// schema/get (and anything unrecognised) is the read axis — the low-risk
+		// default, so a garbled call lands on read rather than silently gaining write.
+		return CapConfigRead
 	case "homeassistant":
 		var p struct {
 			Operation string `json:"operation"`

--- a/plugins/tools/config/config.go
+++ b/plugins/tools/config/config.go
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: MIT
+
+// Package config is the in-process `config` agent tool: it lets the agent (and
+// the skills it runs) read, write, and register Config Center settings directly,
+// without shelling out. It is the tool half of the Config Center's skill-facing
+// surface (the other halves are the `agt config` CLI and the /api/config/* HTTP
+// routes). All three go through the same kernel/settings Registry + creds vault,
+// so behaviour — namespacing, secret handling, live-vs-restart — is identical.
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/creds"
+	kernelruntime "github.com/agezt/agezt/kernel/runtime"
+	"github.com/agezt/agezt/kernel/settings"
+)
+
+// Tool implements agent.Tool. It is constructed in buildTools() before the kernel
+// exists; SetKernel binds the kernel afterwards so live-apply fields (provider /
+// model) can rebuild the provider in place via Reload().
+type Tool struct {
+	baseDir string
+	kernel  *kernelruntime.Kernel
+}
+
+// New returns a config Tool scoped to baseDir.
+func New(baseDir string) *Tool { return &Tool{baseDir: baseDir} }
+
+// SetKernel binds the kernel for live reloads (called once the kernel is open).
+func (t *Tool) SetKernel(k *kernelruntime.Kernel) { t.kernel = k }
+
+// Definition implements agent.Tool.
+func (t *Tool) Definition() agent.ToolDef {
+	return agent.ToolDef{
+		Name: "config",
+		Description: "Read, write, and register configuration in the Config Center. " +
+			"Ops: schema (list editable settings), get (read one — secrets report presence only), " +
+			"set (write one; empty value clears it; provider/model apply live, the rest need a restart), " +
+			"register (add your own schema section — fields must be namespaced AGEZT_* and cannot shadow a built-in), " +
+			"unregister (remove a registered section). Use this to let a skill configure itself.",
+		InputSchema: json.RawMessage(`{
+  "type": "object",
+  "required": ["op"],
+  "properties": {
+    "op": {"type": "string", "enum": ["schema", "get", "set", "register", "unregister"], "description": "The operation to perform."},
+    "name": {"type": "string", "description": "For get/set: the AGEZT_* env-var name (e.g. AGEZT_X_WEATHER_API_KEY)."},
+    "value": {"type": "string", "description": "For set: the value to store (empty string clears the setting)."},
+    "section": {"type": "object", "description": "For register: a schema section {id, name, help?, fields:[{env, label, type, secret?, required?, help?, options?}]}. Field env names must match AGEZT_[A-Z0-9_]+."},
+    "id": {"type": "string", "description": "For unregister: the registered section id."}
+  }
+}`),
+	}
+}
+
+type input struct {
+	Op      string          `json:"op"`
+	Name    string          `json:"name,omitempty"`
+	Value   string          `json:"value,omitempty"`
+	Section json.RawMessage `json:"section,omitempty"`
+	ID      string          `json:"id,omitempty"`
+}
+
+// Invoke implements agent.Tool.
+func (t *Tool) Invoke(_ context.Context, raw json.RawMessage) (agent.Result, error) {
+	var in input
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return agent.Result{}, fmt.Errorf("config: parse input: %w", err)
+	}
+	switch in.Op {
+	case "schema":
+		return t.doSchema()
+	case "get":
+		return t.doGet(in)
+	case "set":
+		return t.doSet(in)
+	case "register":
+		return t.doRegister(in)
+	case "unregister":
+		return t.doUnregister(in)
+	default:
+		return errf("unknown op %q (schema|get|set|register|unregister)", in.Op), nil
+	}
+}
+
+func (t *Tool) registry() *settings.Registry { return settings.NewRegistry(t.baseDir) }
+
+func (t *Tool) doSchema() (agent.Result, error) {
+	var b strings.Builder
+	for _, sec := range t.registry().Sections() {
+		tag := ""
+		if sec.Source != "" && sec.Source != settings.SourceBuiltin {
+			tag = " (registered)"
+		}
+		fmt.Fprintf(&b, "[%s] %s%s\n", sec.ID, sec.Name, tag)
+		for _, f := range sec.Fields {
+			secret := ""
+			if f.Secret {
+				secret = " (secret)"
+			}
+			typ := string(f.Type)
+			if len(f.Options) > 0 {
+				typ += ":" + strings.Join(f.Options, "|")
+			}
+			fmt.Fprintf(&b, "  %s (%s)%s — %s\n", f.Env, typ, secret, f.Label)
+		}
+	}
+	return agent.Result{Output: strings.TrimRight(b.String(), "\n")}, nil
+}
+
+func (t *Tool) doGet(in input) (agent.Result, error) {
+	name := strings.TrimSpace(in.Name)
+	if name == "" {
+		return errf("name required"), nil
+	}
+	field, ok := t.registry().FieldByEnv(name)
+	if !ok {
+		return errf("unknown setting %q", name), nil
+	}
+	if field.Secret {
+		vault := creds.NewStore(t.baseDir)
+		_ = vault.Load()
+		if vault.Has(name) {
+			return agent.Result{Output: name + ": set (secret, value not shown)"}, nil
+		}
+		return agent.Result{Output: name + ": not set"}, nil
+	}
+	val := os.Getenv(name)
+	if val == "" {
+		store := settings.NewStore(t.baseDir)
+		_ = store.Load()
+		val, _ = store.Get(name)
+	}
+	return agent.Result{Output: fmt.Sprintf("%s=%s", name, val)}, nil
+}
+
+func (t *Tool) doSet(in input) (agent.Result, error) {
+	name := strings.TrimSpace(in.Name)
+	if name == "" {
+		return errf("name required"), nil
+	}
+	field, ok := t.registry().FieldByEnv(name)
+	if !ok {
+		return errf("unknown setting %q", name), nil
+	}
+	value := strings.TrimSpace(in.Value)
+	if err := settings.Validate(field, value); err != nil {
+		return errf("%s", err.Error()), nil
+	}
+	if field.Secret {
+		vault := creds.NewStore(t.baseDir)
+		if err := vault.Load(); err != nil {
+			return errf("load vault: %v", err), nil
+		}
+		if value == "" {
+			vault.Remove(name)
+		} else {
+			vault.Set(name, value)
+		}
+		if err := vault.Save(); err != nil {
+			return errf("save vault: %v", err), nil
+		}
+	} else {
+		store := settings.NewStore(t.baseDir)
+		if err := store.Load(); err != nil {
+			return errf("load config: %v", err), nil
+		}
+		if value == "" {
+			store.Remove(name)
+		} else {
+			store.Set(name, value)
+		}
+		if err := store.Save(); err != nil {
+			return errf("save config: %v", err), nil
+		}
+	}
+	// Live-apply provider/model in place; everything else takes effect on restart.
+	if field.Apply == settings.ApplyLive && !field.Secret && t.kernel != nil {
+		_ = os.Setenv(name, value)
+		if _, _, err := t.kernel.Reload(); err != nil {
+			return agent.Result{Output: fmt.Sprintf("%s saved, but live reload failed: %v", name, err), IsError: true}, nil
+		}
+		return agent.Result{Output: name + " applied live"}, nil
+	}
+	return agent.Result{Output: name + " saved — restart to apply"}, nil
+}
+
+func (t *Tool) doRegister(in input) (agent.Result, error) {
+	if len(in.Section) == 0 {
+		return errf("section required"), nil
+	}
+	var sec settings.Section
+	if err := json.Unmarshal(in.Section, &sec); err != nil {
+		return errf("decode section: %v", err), nil
+	}
+	if err := t.registry().Register(sec); err != nil {
+		return errf("%s", err.Error()), nil
+	}
+	return agent.Result{Output: fmt.Sprintf("registered schema section %q (restart to apply its values)", sec.ID)}, nil
+}
+
+func (t *Tool) doUnregister(in input) (agent.Result, error) {
+	id := strings.TrimSpace(in.ID)
+	if id == "" {
+		return errf("id required"), nil
+	}
+	removed, err := t.registry().Unregister(id)
+	if err != nil {
+		return errf("%s", err.Error()), nil
+	}
+	if removed {
+		return agent.Result{Output: "unregistered " + id}, nil
+	}
+	return agent.Result{Output: id + " was not registered"}, nil
+}
+
+func errf(format string, a ...any) agent.Result {
+	return agent.Result{Output: fmt.Sprintf(format, a...), IsError: true}
+}

--- a/plugins/tools/config/config_test.go
+++ b/plugins/tools/config/config_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func invoke(t *testing.T, tool *Tool, args map[string]any) (string, bool) {
+	t.Helper()
+	raw, _ := json.Marshal(args)
+	res, err := tool.Invoke(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("invoke %v: %v", args, err)
+	}
+	return res.Output, res.IsError
+}
+
+func TestConfigTool_RegisterSchemaSetGet(t *testing.T) {
+	t.Setenv("AGEZT_VAULT_PASSPHRASE", "test-pass")
+	dir := t.TempDir()
+	tool := New(dir)
+
+	// register a namespaced section with a secret + a plain field
+	section := map[string]any{
+		"id":   "weather",
+		"name": "Weather Skill",
+		"fields": []map[string]any{
+			{"env": "AGEZT_X_WEATHER_API_KEY", "label": "API key", "type": "password", "secret": true},
+			{"env": "AGEZT_X_WEATHER_UNITS", "label": "Units", "type": "text"},
+		},
+	}
+	if out, isErr := invoke(t, tool, map[string]any{"op": "register", "section": section}); isErr {
+		t.Fatalf("register failed: %s", out)
+	}
+
+	// schema lists it as registered
+	out, _ := invoke(t, tool, map[string]any{"op": "schema"})
+	if !strings.Contains(out, "weather") || !strings.Contains(out, "(registered)") {
+		t.Fatalf("schema missing registered section:\n%s", out)
+	}
+
+	// set the plain field → restart-class
+	out, isErr := invoke(t, tool, map[string]any{"op": "set", "name": "AGEZT_X_WEATHER_UNITS", "value": "metric"})
+	if isErr || !strings.Contains(out, "restart to apply") {
+		t.Fatalf("set units: out=%q isErr=%v", out, isErr)
+	}
+	if out, _ := invoke(t, tool, map[string]any{"op": "get", "name": "AGEZT_X_WEATHER_UNITS"}); out != "AGEZT_X_WEATHER_UNITS=metric" {
+		t.Fatalf("get units: %q", out)
+	}
+
+	// set the secret → vault; get reports presence only (never the value)
+	if _, isErr := invoke(t, tool, map[string]any{"op": "set", "name": "AGEZT_X_WEATHER_API_KEY", "value": "FAKE-KEY"}); isErr {
+		t.Fatal("set secret failed")
+	}
+	out, _ = invoke(t, tool, map[string]any{"op": "get", "name": "AGEZT_X_WEATHER_API_KEY"})
+	if strings.Contains(out, "FAKE-KEY") {
+		t.Fatalf("secret value leaked via get: %q", out)
+	}
+	if !strings.Contains(out, "set (secret") {
+		t.Fatalf("secret presence not reported: %q", out)
+	}
+
+	// unregister
+	if out, isErr := invoke(t, tool, map[string]any{"op": "unregister", "id": "weather"}); isErr || !strings.Contains(out, "unregistered") {
+		t.Fatalf("unregister: out=%q isErr=%v", out, isErr)
+	}
+}
+
+func TestConfigTool_RejectsBadOps(t *testing.T) {
+	tool := New(t.TempDir())
+	cases := []map[string]any{
+		{"op": "wat"},
+		{"op": "get", "name": "AGEZT_NOPE"},               // unknown setting
+		{"op": "set", "name": "AGEZT_NOPE", "value": "x"}, // unknown setting
+		{"op": "register", "section": map[string]any{"id": "evil", "name": "e", "fields": []map[string]any{{"env": "AGEZT_ALLOW_ALL", "type": "bool"}}}}, // shadows built-in
+		{"op": "register", "section": map[string]any{"id": "ns", "name": "n", "fields": []map[string]any{{"env": "OPENAI_KEY", "type": "text"}}}},        // not namespaced
+	}
+	for _, c := range cases {
+		out, isErr := invoke(t, tool, c)
+		if !isErr {
+			t.Errorf("expected error for %v, got %q", c, out)
+		}
+	}
+}
+
+func TestConfigTool_GetSetBuiltin(t *testing.T) {
+	t.Setenv("AGEZT_MODEL", "") // ignore any ambient env so get reads the store
+	dir := t.TempDir()
+	tool := New(dir)
+	// A built-in non-secret field round-trips through the store (no kernel bound,
+	// so even a live field reports restart rather than reloading).
+	if out, isErr := invoke(t, tool, map[string]any{"op": "set", "name": "AGEZT_MODEL", "value": "deepseek-chat"}); isErr {
+		t.Fatalf("set builtin model: %s", out)
+	}
+	if out, _ := invoke(t, tool, map[string]any{"op": "get", "name": "AGEZT_MODEL"}); out != "AGEZT_MODEL=deepseek-chat" {
+		t.Fatalf("get builtin model: %q", out)
+	}
+}


### PR DESCRIPTION
## What

The **skill-facing half** of the extensible Config Center (M695 was the registry). The agent and the skills it runs can now configure things directly — read, write, and register their own schema — three ways over **one** backend (`kernel/settings` registry + `creds` vault), so behaviour is identical everywhere.

## How

- **`plugins/tools/config`** — a built-in **`config` agent tool**: ops `schema | get | set | register | unregister`. Built in `buildTools()` before the kernel exists; `SetKernel(k)` after `runtime.Open` lets live-apply fields (provider/model) rebuild the provider via `Reload()`. Secrets presence-only on read, vault on write.
- **`cmd/agt/config.go`** — new `agt config` subcommands: `ls`, `get <ENV>`, `set <ENV> <value>`, `schema [register <file.json> | unregister <id>]`.
- **`kernel/edict`** — `config.read` (**Allow**) and `config.write` (**AskFirst** — a write can reach built-in security fields), mapped by the tool's `op`.

## Verification

- Tool tests (register/schema/set/get/unregister + shadowing/non-namespaced/bad-op rejection + built-in round-trip); CLI arg-validation (dial-free) + missing-file; edict capability guards green; full build.
- **Live (isolated daemon):** `agt config schema register` a namespaced section from a file → schema shows it `(registered)`; `ls`/`get`/`set` round-tripped (secret → encrypted vault, value never shown; non-secret → `config.json`); a section shadowing `AGEZT_ALLOW_ALL` rejected; `unregister` removed it; `config()` shows in the tool banner. Owner `~/.agezt` untouched.

> CI note: org GitHub Actions blocked on billing (not this PR); verified locally + live before admin-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)