### PR TITLE
Feat: persist live heartbeat cadence/dial across restart (M760)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 
 ## [Unreleased]
 
+### Changed
+- **Live heartbeat tuning now survives restart.** The cadence (M757) and dial (M758) changes made from
+  the Autonomy view were runtime-only — they reset to the `AGEZT_PULSE_*` defaults whenever the daemon
+  restarted. They're now **persisted to the config store** (the same mechanism behind the Config
+  Center and routing chains): when you change the cadence or dial, the new value is written as
+  `AGEZT_PULSE_CADENCE` / `AGEZT_PULSE_DIAL`, and since the config store is overlaid onto the
+  environment at startup before `buildPulse` reads it, the change becomes the new default. So "check
+  in every 5 minutes, stay chatty" sticks across restarts — set it once. Persistence is best-effort
+  (a store write failure never fails the live change, which already took effect). Asserted in the
+  control-plane test (cadence + dial land in the store), and verified live with a real restart: set
+  cadence 300s + dial chatty via the API, killed and restarted the daemon with no env overrides, and
+  it came back up at **cadence 300s / dial chatty**. (M760)
+
 ### Added
 - **Verify the journal's tamper-evident hash chain from the console.** The Journal-search view gains a
   **verify integrity** button: one click walks the append-only journal server-side and confirms its

--- a/kernel/controlplane/pulse_control.go
+++ b/kernel/controlplane/pulse_control.go
@@ -13,7 +13,22 @@ import (
 	"net"
 	"strconv"
 	"time"
+
+	"github.com/agezt/agezt/kernel/settings"
 )
+
+// persistPulseSetting writes a live pulse setting to the config store (M760) so it
+// survives restart: buildPulse reads these env vars at startup, and the config store
+// is overlaid onto the environment first, so a persisted value becomes the new default.
+// Best-effort — a store failure never fails the live change, which already took effect.
+func (s *Server) persistPulseSetting(name, value string) {
+	store := settings.NewStore(s.baseDir)
+	if err := store.Load(); err != nil {
+		return
+	}
+	store.Set(name, value)
+	_ = store.Save()
+}
 
 // PulseController is the slice of the Pulse engine the control plane needs.
 // kernel/pulse.Engine satisfies it (StatusMap/Pause/Resume/Beat/SetCadence); the
@@ -91,6 +106,7 @@ func (s *Server) handlePulseCadence(conn net.Conn, req Request) {
 		return
 	}
 	applied := s.pulse.SetCadence(time.Duration(secs * float64(time.Second)))
+	s.persistPulseSetting("AGEZT_PULSE_CADENCE", applied.String())
 	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{"cadence_ms": applied.Milliseconds()}})
 }
 
@@ -103,5 +119,6 @@ func (s *Server) handlePulseDial(conn net.Conn, req Request) {
 	}
 	dial, _ := req.Args["dial"].(string)
 	applied := s.pulse.SetDial(dial)
+	s.persistPulseSetting("AGEZT_PULSE_DIAL", applied)
 	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{"dial": applied}})
 }

--- a/kernel/controlplane/pulse_control_test.go
+++ b/kernel/controlplane/pulse_control_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/agezt/agezt/kernel/controlplane"
+	"github.com/agezt/agezt/kernel/settings"
 	"github.com/agezt/agezt/plugins/providers/mock"
 )
 
@@ -62,7 +63,7 @@ func TestPulsePauseDisabledErrors(t *testing.T) {
 }
 
 func TestPulseStatusPauseResumeWithEngine(t *testing.T) {
-	_, srv, c, _ := startPair(t, mock.New(mock.FinalText("ok")))
+	_, srv, c, baseDir := startPair(t, mock.New(mock.FinalText("ok")))
 	fp := &fakePulse{}
 	srv.SetPulse(fp)
 	ctx := context.Background()
@@ -122,5 +123,18 @@ func TestPulseStatusPauseResumeWithEngine(t *testing.T) {
 	}
 	if fp.dial != "chatty" {
 		t.Fatalf("expected engine dial chatty, got %q", fp.dial)
+	}
+
+	// Persistence (M760): cadence + dial are written to the config store so they
+	// survive restart (buildPulse reads these env vars, overlaid from the store).
+	store := settings.NewStore(baseDir)
+	if err := store.Load(); err != nil {
+		t.Fatalf("load store: %v", err)
+	}
+	if v, ok := store.Get("AGEZT_PULSE_CADENCE"); !ok || v != (45 * time.Second).String() {
+		t.Fatalf("cadence not persisted: %q (ok=%v)", v, ok)
+	}
+	if v, ok := store.Get("AGEZT_PULSE_DIAL"); !ok || v != "chatty" {
+		t.Fatalf("dial not persisted: %q (ok=%v)", v, ok)
 	}
 }


### PR DESCRIPTION
## What

The cadence (M757) and dial (M758) changes made from the Autonomy view were **runtime-only** — they reset to the `AGEZT_PULSE_*` defaults whenever the daemon restarted. They're now **persisted to the config store** (the same mechanism behind the Config Center and routing chains).

When you change the cadence or dial, the new value is written as `AGEZT_PULSE_CADENCE` / `AGEZT_PULSE_DIAL`; since the config store is overlaid onto the environment at startup before `buildPulse` reads it, the change becomes the new default. So "check in every 5 minutes, stay chatty" sticks across restarts — set it once.

Both env vars were already in `configEnvVars`. Persistence is best-effort (a store write failure never fails the live change, which already took effect). Backend-only — the UI already calls these routes.

## Tests

Control-plane test asserts cadence + dial land in the `settings.Store` after the calls. `go test ./kernel/controlplane/ ./kernel/pulse/ ./kernel/webui/ ./kernel/settings/` green.

## Live verification (isolated daemon, real restart)

Boot 1 came up at the 60s/balanced default. Set **cadence 300s + dial chatty** via the API. **Killed and restarted** the daemon (same `AGEZT_HOME`, no env overrides) → it came back up at **cadence 300s / dial chatty** — the settings survived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)