### PR TITLE
Test: end-to-end browser coverage for this session's console controls (M764)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Tests
+- **End-to-end browser coverage for this session's console controls.** Extended the headless-browser
+  E2E gate (`scripts/webui-e2e.sh`, real daemon + go:embed-ded production SPA) — which previously
+  smoked the shell, Overview, Runs and World — to also drive the new control surfaces against a live
+  daemon: the **Autonomy** heartbeat controls render and **Beat now** fires; the **Policy** view's
+  *Capability policy* + *test a decision* + *Secret redaction* panels mount; and **Search**'s
+  **verify integrity** validates the journal's hash chain to "chain intact". All under the same
+  zero-console-errors / strict-CSP guard. Validated by mirroring the exact spec selectors against a
+  real demo daemon (all assertions resolved; 0 console errors). This is the browser-level complement
+  to the HTTP route-wiring tests (M763) — together they cover the new surface from the DOM down to the
+  control-plane command. (M764)
 - **HTTP-layer route-wiring tests for this session's console controls.** Hardened the new Web UI
   routes with committed integration tests (run in the frontend/Go CI gate, no browser needed) that
   drive the actual HTTP handler and assert each path maps to the right control-plane command,

--- a/frontend/e2e/webui.spec.ts
+++ b/frontend/e2e/webui.spec.ts
@@ -60,6 +60,35 @@ test.describe("Agezt Web UI — embedded SPA against a real daemon", () => {
       page.getByRole("heading", { level: 2, name: "World" }),
     ).toBeVisible();
 
+    const nav = page.getByRole("navigation");
+
+    // --- Autonomy: the proactive-heartbeat controls render + work -------
+    // (M743 pause/resume, M756 beat-now, M757 cadence, M758 dial, M761 flush).
+    // Pulse is on by default in the demo daemon, so the steering controls render.
+    await nav.getByRole("button", { name: "Autonomy" }).click();
+    await expect(page.getByRole("heading", { level: 2, name: "Autonomy" })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Beat now/ })).toBeVisible();
+    await expect(page.getByLabel("Heartbeat cadence")).toBeVisible();
+    await expect(page.getByLabel("Proactivity dial")).toBeVisible();
+    // "Beat now" drives the on-demand-heartbeat route end to end (the zero-console-
+    // errors guard below also covers it).
+    await page.getByRole("button", { name: /Beat now/ }).click();
+
+    // --- Policy: the decision + secret-redaction testers mount ----------
+    // (M753 policy dry-run, M754 redaction check).
+    await nav.getByRole("button", { name: "Policy" }).click();
+    await expect(page.getByRole("heading", { level: 2, name: "Capability policy" })).toBeVisible();
+    await expect(page.getByText("test a decision")).toBeVisible();
+    await expect(page.getByRole("heading", { level: 2, name: "Secret redaction" })).toBeVisible();
+
+    // --- Search: the journal's tamper-evident hash chain verifies clean -
+    // (M759 integrity verify). The seeded run wrote hash-linked events.
+    await nav.getByRole("button", { name: "Search" }).click();
+    const verify = page.getByRole("button", { name: /verify integrity/ });
+    await expect(verify).toBeVisible();
+    await verify.click();
+    await expect(page.getByText("chain intact")).toBeVisible();
+
     expect(errors, `console errors:\n${errors.join("\n")}`).toEqual([]);
   });
 });


### PR DESCRIPTION
## What

Extend the headless-browser E2E gate (`scripts/webui-e2e.sh` — boots a real daemon and drives the go:embed-ded **production** SPA), which previously smoked the shell / Overview / Runs / World, to also exercise the control surfaces built this session against a live daemon:

- **Autonomy** — the heartbeat controls render (Beat now button, cadence + dial selectors) and **Beat now** fires (M743/M756–M761).
- **Policy** — the *Capability policy* + *test a decision* + *Secret redaction* panels mount (M753/M754).
- **Search** — **verify integrity** validates the journal's tamper-evident hash chain → "chain intact" (M759).

All under the same **zero-console-errors / strict-CSP** guard the existing spec uses.

## Validation

Mirrored the exact spec selectors against a real demo daemon (`AGEZT_DEMO_ECHO=1`, pulse on by default): every assertion resolved true, the Beat-now and verify clicks worked, and 0 console errors. `tsc` clean.

This is the browser-level complement to the HTTP route-wiring tests (M763) — together they cover the new surface from the DOM down to the control-plane command.

> Runs in the `webui-e2e` CI job (currently gated on the org's GitHub Actions billing) and locally via `make webui-e2e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)