### PR TITLE
Feat: push warning/critical alerts to channels (M782)

### DIFF
--- a/.project/PHASE-M782-ALERT-NOTIFY-REPORT.md
+++ b/.project/PHASE-M782-ALERT-NOTIFY-REPORT.md
@@ -1,0 +1,91 @@
+# Phase M782 — Alert → Channel Notifications
+
+**Date:** 2026-06-10 · **Status:** DONE · **PR:** feat-m782-alert-notify
+
+## What
+
+Push warning/critical alerts — the exact set the console's Alerts view classifies
+(run failures, blocked egress, budget ceiling trips, provider rate limits, daemon
+halts) — to the configured channels (Telegram, Slack, Discord, email, Signal, …)
+the moment they happen. Completes the M777–M781 alert arc: badge and cockpit strip
+inform you *in* the console; this informs you when you're *away from it*.
+
+## Design
+
+- **`kernel/alerter`** (new, ~270 LOC): a bus subscriber in the `kernel/anomaly`
+  pattern (subscribe `">"`, panic-recovered goroutine, ctx-scoped).
+  - `Classify` mirrors `frontend/src/lib/alerts.ts` kind-for-kind:
+    `task.failed`/`netguard.blocked`/`rate.limited` → warning,
+    `budget.exceeded`/`halt` → critical. Pulse-originated kinds
+    (`observer.delta`, `briefing.sent`) are **deliberately excluded** — the Pulse
+    engine already delivers its own briefs through the same sinks; handling them
+    here would double every heartbeat signal.
+  - Delivery reuses the existing **Pulse sink infrastructure**: a
+    `pulse.Brief` with `DispAlert` (send-now, high-priority — the disposition
+    that breaks through digests/quiet hours), correlation threaded for `agt why`,
+    `IssueKey = alert/<kind>`. Kernel never imports plugins; the daemon injects
+    the same combined `MultiSink` it builds for Pulse.
+  - **Spam-safe by construction**: per-alert (kind+correlation) cooldown
+    (default 5m) suppresses repeats; a global sliding-window flood cap
+    (default 12 per 10m) bounds cascading failures. Dedup map is size-bounded
+    (prune at 4096) for long daemon lives.
+- **Wiring** (`cmd/agezt/main.go`): the per-channel sink list at the Pulse build
+  site is factored into `channelSinks` and shared; `buildAlertNotify` reads the
+  env knobs and starts the watcher; a boot-banner status line reports
+  on/disabled/no-channel.
+- **Config**: opt-in `AGEZT_ALERT_NOTIFY=1`; `AGEZT_ALERT_NOTIFY_LEVEL`
+  (`critical` narrows; default warning+), `AGEZT_ALERT_NOTIFY_COOLDOWN`,
+  `AGEZT_ALERT_NOTIFY_MAX`. All four registered in `controlplane.configEnvVars`
+  (M127 guard test) and as a new built-in **Alert Notifications** section in the
+  Config Center schema (`kernel/settings/schema.go`).
+
+## Tests (8 new, all green)
+
+- `TestClassify_MirrorsConsoleAlertRules` — 10-case table: five notify kinds with
+  payload field extraction (reason/error fallback, ip—reason join, tool→egress
+  source default); tool.invoked / observer.delta / briefing.sent are NOT alerts.
+- `TestHandle_MinLevelGate` — critical-only mode drops warnings.
+- `TestHandle_DedupCooldown` — same kind+run suppressed inside the cooldown;
+  different run and elapsed cooldown deliver (injected clock, deterministic).
+- `TestHandle_RateCap` — 8 distinct alerts at cap 3 → exactly 3; cap frees after
+  the window slides.
+- `TestBrief_RendersSeverityAndDisposition` — 🚨/⚠ titles, DispAlert, correlation,
+  IssueKey, body with source line.
+- `TestStart_DeliversFromRealBus` — end-to-end over a real journal-backed bus:
+  published task.failed reaches the sink; tool.invoked doesn't.
+- `TestStart_NilGuards` — no bus / no sink → nothing starts.
+
+Also: `gofmt` drift in `kernel/settings/schema.go` (pre-existing on main, struct
+tag alignment) fixed while touching the file.
+
+## Runtime smoke (isolated daemon — never the real ~/.agezt)
+
+Isolated `AGEZT_HOME` + demo-echo provider + webhook channel (outbound-only)
+pointed at a local capture listener, `AGEZT_WEBHOOK_ALLOW_PRIVATE=1`:
+
+1. **Enabled** (`AGEZT_ALERT_NOTIFY=1`): boot banner
+   `alert notify : on (level≥warning → channels; repeats suppressed; flood-capped)`.
+   Real `agt halt` → listener captured
+   `{"channel_id":"ops","priority":"notify","text":"📣 🚨 daemon halted\nsource: kernel",…}`. ✅
+2. **Cooldown live**: `agt resume` + immediate second `agt halt` → no second POST. ✅
+3. **Negative control** (notify unset): banner
+   `alert notify : disabled (set AGEZT_ALERT_NOTIFY=1 …)`; `agt halt` → POST count
+   still 1. ✅
+4. 0 panics; clean `agt shutdown`; smoke dir removed.
+
+## Gate
+
+- Full suite: `GOMAXPROCS=3 go test -p 2 ./...` — **all green** (84 pkgs).
+- `go vet ./...` clean; `go build ./...` clean.
+- gofmt verified on the **staged LF blobs** (Windows CRLF working-copy noise
+  ignored per protocol).
+- `go.mod`/`go.sum` unchanged (stdlib only). No frontend change (dist untouched).
+- CI: org Actions billing still exhausted (every job fails at startup, steps=0)
+  → full local CI-equivalent battery run + documented on the PR, merged under
+  arc authority (same as PRs #136–#225).
+
+## Follow-ups (optional)
+
+- Per-channel alert routing (e.g. criticals → SMS, warnings → Slack).
+- Live (no-restart) toggle via the mu-guarded-kernel-field pattern (M710 recipe).
+- Mute window / per-kind opt-out.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,25 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **Hear about problems without the console open — alerts push to your channels.** The same
+  warning/critical signals the console's Alerts view surfaces — a run failure, blocked egress, a
+  budget ceiling or provider rate trip, a daemon halt — can now be **pushed to the configured
+  channels** (Telegram, Slack, Discord, email, Signal, …) the moment they happen. It completes the
+  alert arc (M777–M781): the badge and cockpit strip tell you *in* the console; this tells you when
+  you're *away from it*. A new `kernel/alerter` watcher classifies bus events with the very same
+  rules as the console (Pulse's own signals are deliberately excluded — Pulse already delivers its
+  briefs through these sinks, and double-pinging every heartbeat would be noise) and delivers a short
+  high-priority brief through the existing Pulse channel sinks, with the run's correlation threaded
+  for `agt why`. Spam-safe by construction: the same alert (kind + run) repeats at most once per
+  cooldown (default 5m), and a global flood cap (default 12 per 10m) keeps a cascading failure from
+  turning a channel into a siren. **Opt-in** via `AGEZT_ALERT_NOTIFY=1` (plus `_LEVEL` to restrict to
+  criticals, `_COOLDOWN`, `_MAX`), editable in the Config Center under **Alert Notifications**.
+  Unit-tested (classification mirrors the console's rules kind-for-kind; min-level gate; dedup
+  cooldown; flood cap window slide; severity/disposition/correlation on the brief; end-to-end
+  delivery from a real bus; nil guards). Verified live on an isolated daemon: a real `agt halt`
+  pushed `🚨 daemon halted` through the webhook channel to a local listener; a repeat halt inside the
+  cooldown was suppressed; the negative control (notify off) pushed nothing and reported `disabled`
+  in the boot banner. (M782)
 - **Jump from an alert to the run that caused it.** Alerts tied to a run — a failure, a budget/rate
   trip, blocked egress — now carry the run's id, so both the **Alerts** view (an *open run →* link on
   the row) and the Cockpit's **Needs attention** strip (the whole row is clickable) take you straight to

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/agezt/agezt/internal/brand"
 	"github.com/agezt/agezt/internal/paths"
 	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/alerter"
 	"github.com/agezt/agezt/kernel/anomaly"
 	"github.com/agezt/agezt/kernel/bus"
 	"github.com/agezt/agezt/kernel/cadence"
@@ -966,11 +967,15 @@ func runDaemon(stdout, stderr io.Writer) int {
 		fmt.Fprintf(stdout, "  signal channel   : disabled (set AGEZT_SIGNAL_API_URL + AGEZT_SIGNAL_NUMBER)\n")
 	}
 
+	// Every configured channel's brief sink, teed: Pulse briefs and (M782)
+	// alert notifications share the same delivery surface.
+	channelSinks := combineSinks(tgSink, slSink, dcSink, whSink, emSink, mxSink, smSink, waSink, haSink, tmSink, sgSink)
+
 	// Pulse — the proactive heart (SPEC-03). On by default; the resident
 	// engine runs on the daemon ctx so `agt halt`/SIGTERM/`agt shutdown`
 	// stop it with everything else. AGEZT_PULSE=off disables it. When a channel
 	// is configured, briefs tee to it (closes the Jarvis loop).
-	if eng, pulseDesc := buildPulse(k, ward, model, stdout, combineSinks(tgSink, slSink, dcSink, whSink, emSink, mxSink, smSink, waSink, haSink, tmSink, sgSink)); eng != nil {
+	if eng, pulseDesc := buildPulse(k, ward, model, stdout, channelSinks); eng != nil {
 		eng.Start(ctx)
 		srv.SetPulse(eng)
 		// Runtime disk watches (M767): build the observer here (the daemon owns the
@@ -1040,6 +1045,12 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// that auto-halts the kernel if a runaway/looping agent floods tool calls.
 	// On by default; AGEZT_ANOMALY_MAX_TOOLCALLS=0 disables.
 	fmt.Fprintf(stdout, "  anomaly halt     : %s\n", buildAnomaly(ctx, k, stdout))
+
+	// Alert notifications (M782): push warning/critical alerts — run failures,
+	// blocked egress, budget/rate trips, halts — to the configured channels, so
+	// the operator hears about problems without the console open. Opt-in via
+	// AGEZT_ALERT_NOTIFY=1; uses the same sinks Pulse briefs go through.
+	fmt.Fprintf(stdout, "  alert notify     : %s\n", buildAlertNotify(ctx, k, channelSinks))
 
 	// draining flips true at shutdown so /readyz reports not-ready and the daemon
 	// drains in-flight runs before exiting (M136). Shared with buildRESTAPI's
@@ -2940,6 +2951,39 @@ func buildAnomaly(ctx context.Context, k *kernelruntime.Kernel, stdout io.Writer
 		return "disabled"
 	}
 	return fmt.Sprintf("on (halt if >%d tool calls / %s; set AGEZT_ANOMALY_MAX_TOOLCALLS=0 to disable)", max, window)
+}
+
+// buildAlertNotify starts the alert → channel notifier (M782) when
+// AGEZT_ALERT_NOTIFY is on and at least one channel is configured. Knobs:
+//
+//	AGEZT_ALERT_NOTIFY           1/on/true enables (default off — opt-in)
+//	AGEZT_ALERT_NOTIFY_LEVEL     "critical" = criticals only; default warning+
+//	AGEZT_ALERT_NOTIFY_COOLDOWN  per-alert (kind+run) repeat suppression, default 5m
+//	AGEZT_ALERT_NOTIFY_MAX       global cap per 10-minute window, default 12
+func buildAlertNotify(ctx context.Context, k *kernelruntime.Kernel, sink pulse.BriefSink) string {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(brand.EnvPrefix + "ALERT_NOTIFY"))) {
+	case "1", "on", "true", "yes":
+	default:
+		return "disabled (set AGEZT_ALERT_NOTIFY=1 to push warning/critical alerts to channels)"
+	}
+	if sink == nil {
+		return "enabled but NO channel configured — configure Telegram/Slack/… first"
+	}
+	cfg := alerter.Config{MinLevel: alerter.ParseLevel(os.Getenv(brand.EnvPrefix + "ALERT_NOTIFY_LEVEL"))}
+	if v := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "ALERT_NOTIFY_COOLDOWN")); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			cfg.Cooldown = d
+		}
+	}
+	if v := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "ALERT_NOTIFY_MAX")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.MaxPerWindow = n
+		}
+	}
+	if !alerter.Start(ctx, k.Bus(), sink, cfg) {
+		return "disabled"
+	}
+	return fmt.Sprintf("on (level≥%s → channels; repeats suppressed; flood-capped)", cfg.MinLevel)
 }
 
 // buildStandingRunner starts the event-trigger half of Chronos (SPEC-16 §4): when

--- a/kernel/alerter/alerter.go
+++ b/kernel/alerter/alerter.go
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: MIT
+
+// Package alerter pushes warning/critical alerts to the configured channels
+// (M782). It watches the bus for the same proactive-signal event kinds the
+// console's Alerts view classifies (run failures, blocked egress, budget/rate
+// trips, halts) and delivers a short brief through the existing Pulse channel
+// sinks — so the operator hears about problems without the console open.
+//
+// Pulse-originated kinds (observer.delta, briefing.sent) are deliberately NOT
+// handled here: the Pulse engine already delivers its own briefs through the
+// same sinks, and notifying them twice would double every heartbeat signal.
+package alerter
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/agezt/agezt/kernel/bus"
+	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/pulse"
+)
+
+// Level ranks alert severity. Mirrors the console's classifier
+// (frontend/src/lib/alerts.ts): info signals exist but never notify.
+type Level int
+
+const (
+	LevelInfo Level = iota
+	LevelWarning
+	LevelCritical
+)
+
+// String renders the level for status lines and tests.
+func (l Level) String() string {
+	switch l {
+	case LevelCritical:
+		return "critical"
+	case LevelWarning:
+		return "warning"
+	default:
+		return "info"
+	}
+}
+
+// ParseLevel reads a minimum-level config value. Only "critical" narrows the
+// gate; anything else (including empty) means warning-and-up, the default.
+func ParseLevel(s string) Level {
+	if strings.EqualFold(strings.TrimSpace(s), "critical") {
+		return LevelCritical
+	}
+	return LevelWarning
+}
+
+// Alert is one classified proactive signal.
+type Alert struct {
+	Kind   event.Kind
+	Level  Level
+	Title  string
+	Detail string
+	Source string
+}
+
+// Classify maps an event to an Alert, or ok=false when the event is not a
+// notify-worthy proactive signal. The kinds and severities mirror the console's
+// Alerts view exactly (warning/critical only — the badge-worthy set).
+func Classify(ev *event.Event) (Alert, bool) {
+	if ev == nil {
+		return Alert{}, false
+	}
+	p := payloadMap(ev.Payload)
+	switch ev.Kind {
+	case event.KindTaskFailed:
+		return Alert{Kind: ev.Kind, Level: LevelWarning, Title: "run failed",
+			Detail: firstStr(p, "reason", "error"), Source: "run"}, true
+	case event.KindNetguardBlocked:
+		src := str(p, "tool")
+		if src == "" {
+			src = "egress"
+		}
+		return Alert{Kind: ev.Kind, Level: LevelWarning, Title: "egress blocked",
+			Detail: joinNonEmpty(" — ", str(p, "ip"), str(p, "reason")), Source: src}, true
+	case event.KindBudgetExceeded:
+		return Alert{Kind: ev.Kind, Level: LevelCritical, Title: "budget ceiling exceeded",
+			Source: "budget"}, true
+	case event.KindRateLimited:
+		return Alert{Kind: ev.Kind, Level: LevelWarning, Title: "provider rate-limited",
+			Detail: str(p, "provider"), Source: "provider"}, true
+	case event.KindHalt:
+		return Alert{Kind: ev.Kind, Level: LevelCritical, Title: "daemon halted",
+			Detail: str(p, "reason"), Source: "kernel"}, true
+	}
+	return Alert{}, false
+}
+
+// Config tunes the notifier. Zero values get safe defaults (see normalize).
+type Config struct {
+	// MinLevel gates delivery: LevelWarning (default) sends warnings and
+	// criticals; LevelCritical sends criticals only.
+	MinLevel Level
+	// Cooldown suppresses repeats of the same alert (kind + correlation)
+	// within the window. Default 5m.
+	Cooldown time.Duration
+	// MaxPerWindow caps total deliveries inside Window — a flood of distinct
+	// failures must not turn a channel into a siren. Default 12.
+	MaxPerWindow int
+	// Window is the trailing window MaxPerWindow is measured over. Default 10m.
+	Window time.Duration
+}
+
+func (c Config) normalize() Config {
+	if c.Cooldown <= 0 {
+		c.Cooldown = 5 * time.Minute
+	}
+	if c.MaxPerWindow <= 0 {
+		c.MaxPerWindow = 12
+	}
+	if c.Window <= 0 {
+		c.Window = 10 * time.Minute
+	}
+	if c.MinLevel < LevelWarning {
+		c.MinLevel = LevelWarning
+	}
+	return c
+}
+
+// Notifier classifies events and delivers gated briefs to a sink. Safe for
+// concurrent use; Start runs one goroutine but tests drive Handle directly.
+type Notifier struct {
+	cfg  Config
+	sink pulse.BriefSink
+	now  func() time.Time
+
+	mu       sync.Mutex
+	lastSent map[string]time.Time // dedup: kind+correlation → last delivery
+	recent   []time.Time          // rate cap: deliveries inside the window
+}
+
+// New builds a Notifier. sink must be non-nil.
+func New(sink pulse.BriefSink, cfg Config) *Notifier {
+	return &Notifier{cfg: cfg.normalize(), sink: sink, now: time.Now,
+		lastSent: map[string]time.Time{}}
+}
+
+// Handle classifies one event and, when it passes the level/dedup/rate gates,
+// delivers it. Returns true when a brief was delivered.
+func (n *Notifier) Handle(ev *event.Event) bool {
+	a, ok := Classify(ev)
+	if !ok || a.Level < n.cfg.MinLevel {
+		return false
+	}
+	now := n.now()
+	key := string(a.Kind) + "/" + ev.CorrelationID
+	n.mu.Lock()
+	if last, seen := n.lastSent[key]; seen && now.Sub(last) < n.cfg.Cooldown {
+		n.mu.Unlock()
+		return false
+	}
+	// Prune the rate window, then check the cap.
+	cut := now.Add(-n.cfg.Window)
+	kept := n.recent[:0]
+	for _, t := range n.recent {
+		if t.After(cut) {
+			kept = append(kept, t)
+		}
+	}
+	n.recent = kept
+	if len(n.recent) >= n.cfg.MaxPerWindow {
+		n.mu.Unlock()
+		return false
+	}
+	n.recent = append(n.recent, now)
+	n.lastSent[key] = now
+	if len(n.lastSent) > 4096 { // bound the dedup map across a long daemon life
+		for k, t := range n.lastSent {
+			if now.Sub(t) >= n.cfg.Cooldown {
+				delete(n.lastSent, k)
+			}
+		}
+	}
+	n.mu.Unlock()
+	_ = n.sink.Deliver(brief(a, ev.CorrelationID)) // a channel outage must not wedge the watcher
+	return true
+}
+
+// brief renders an Alert as a Pulse brief. DispAlert is the "send now, high
+// priority" disposition — these are exactly the signals that should break
+// through digests and quiet hours.
+func brief(a Alert, corr string) pulse.Brief {
+	title := "⚠ " + a.Title
+	if a.Level == LevelCritical {
+		title = "🚨 " + a.Title
+	}
+	body := a.Detail
+	if a.Source != "" {
+		body = joinNonEmpty("\n", body, "source: "+a.Source)
+	}
+	return pulse.Brief{
+		Title:         title,
+		Body:          body,
+		Disposition:   pulse.DispAlert,
+		IssueKey:      "alert/" + string(a.Kind),
+		CorrelationID: corr,
+		Items:         1,
+	}
+}
+
+// Start wires the notifier onto the bus: subscribe to everything, classify,
+// gate, deliver. Returns false (nothing started) when bus or sink is missing.
+// The goroutine stops on ctx cancellation or bus close; a panic in the loop is
+// recovered so a notifier bug can never crash the daemon (anomaly pattern).
+func Start(ctx context.Context, b *bus.Bus, sink pulse.BriefSink, cfg Config) bool {
+	if b == nil || sink == nil {
+		return false
+	}
+	sub, err := b.Subscribe(">", 256)
+	if err != nil {
+		return false
+	}
+	n := New(sink, cfg)
+	go func() {
+		defer func() {
+			sub.Cancel()
+			_ = recover() // a watcher panic must never take down the daemon
+		}()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case ev, ok := <-sub.C:
+				if !ok {
+					return
+				}
+				n.Handle(ev)
+			}
+		}
+	}()
+	return true
+}
+
+// payloadMap decodes an event payload object, tolerating nil/non-object
+// payloads (→ nil map, so every field lookup just comes back empty).
+func payloadMap(raw json.RawMessage) map[string]any {
+	if len(raw) == 0 {
+		return nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil
+	}
+	return m
+}
+
+func str(p map[string]any, key string) string {
+	if p == nil {
+		return ""
+	}
+	if v, ok := p[key]; ok && v != nil {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+func firstStr(p map[string]any, keys ...string) string {
+	for _, k := range keys {
+		if s := str(p, k); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func joinNonEmpty(sep string, parts ...string) string {
+	var out []string
+	for _, p := range parts {
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return strings.Join(out, sep)
+}

--- a/kernel/alerter/alerter_test.go
+++ b/kernel/alerter/alerter_test.go
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: MIT
+
+package alerter
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/agezt/agezt/kernel/bus"
+	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/journal"
+	"github.com/agezt/agezt/kernel/pulse"
+)
+
+// captureSink records delivered briefs, safely across goroutines.
+type captureSink struct {
+	mu     sync.Mutex
+	briefs []pulse.Brief
+}
+
+func (c *captureSink) Deliver(b pulse.Brief) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.briefs = append(c.briefs, b)
+	return nil
+}
+
+func (c *captureSink) all() []pulse.Brief {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]pulse.Brief(nil), c.briefs...)
+}
+
+func ev(kind event.Kind, corr string, payload map[string]any) *event.Event {
+	e := &event.Event{Kind: kind, CorrelationID: corr}
+	if payload != nil {
+		raw, err := json.Marshal(payload)
+		if err != nil {
+			panic(err)
+		}
+		e.Payload = raw
+	}
+	return e
+}
+
+// TestClassify_MirrorsConsoleAlertRules: the five notify-worthy kinds map to
+// the console's titles/levels/sources; everything else is not an alert.
+func TestClassify_MirrorsConsoleAlertRules(t *testing.T) {
+	cases := []struct {
+		name   string
+		ev     *event.Event
+		want   Alert
+		wantOK bool
+	}{
+		{"task.failed", ev(event.KindTaskFailed, "c1", map[string]any{"reason": "boom"}),
+			Alert{Kind: event.KindTaskFailed, Level: LevelWarning, Title: "run failed", Detail: "boom", Source: "run"}, true},
+		{"task.failed error fallback", ev(event.KindTaskFailed, "c1", map[string]any{"error": "exploded"}),
+			Alert{Kind: event.KindTaskFailed, Level: LevelWarning, Title: "run failed", Detail: "exploded", Source: "run"}, true},
+		{"netguard.blocked", ev(event.KindNetguardBlocked, "c2", map[string]any{"ip": "10.0.0.1", "reason": "private", "tool": "http"}),
+			Alert{Kind: event.KindNetguardBlocked, Level: LevelWarning, Title: "egress blocked", Detail: "10.0.0.1 — private", Source: "http"}, true},
+		{"netguard.blocked no tool", ev(event.KindNetguardBlocked, "", nil),
+			Alert{Kind: event.KindNetguardBlocked, Level: LevelWarning, Title: "egress blocked", Source: "egress"}, true},
+		{"budget.exceeded", ev(event.KindBudgetExceeded, "c3", nil),
+			Alert{Kind: event.KindBudgetExceeded, Level: LevelCritical, Title: "budget ceiling exceeded", Source: "budget"}, true},
+		{"rate.limited", ev(event.KindRateLimited, "", map[string]any{"provider": "openai"}),
+			Alert{Kind: event.KindRateLimited, Level: LevelWarning, Title: "provider rate-limited", Detail: "openai", Source: "provider"}, true},
+		{"halt", ev(event.KindHalt, "", map[string]any{"reason": "operator"}),
+			Alert{Kind: event.KindHalt, Level: LevelCritical, Title: "daemon halted", Detail: "operator", Source: "kernel"}, true},
+		{"tool.invoked is not an alert", ev(event.KindToolInvoked, "", nil), Alert{}, false},
+		{"pulse observer.delta NOT handled here (pulse delivers its own)",
+			&event.Event{Kind: event.Kind("observer.delta")}, Alert{}, false},
+		{"briefing.sent NOT handled here", &event.Event{Kind: event.Kind("briefing.sent")}, Alert{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := Classify(tc.ev)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok && got != tc.want {
+				t.Fatalf("got %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestHandle_MinLevelGate: MinLevel=critical drops warnings, passes criticals.
+func TestHandle_MinLevelGate(t *testing.T) {
+	sink := &captureSink{}
+	n := New(sink, Config{MinLevel: LevelCritical})
+	if n.Handle(ev(event.KindTaskFailed, "c1", nil)) {
+		t.Fatal("warning delivered despite MinLevel=critical")
+	}
+	if !n.Handle(ev(event.KindBudgetExceeded, "c1", nil)) {
+		t.Fatal("critical not delivered")
+	}
+	if got := len(sink.all()); got != 1 {
+		t.Fatalf("delivered %d briefs, want 1", got)
+	}
+}
+
+// TestHandle_DedupCooldown: the same kind+correlation inside the cooldown is
+// sent once; a different correlation or an elapsed cooldown sends again.
+func TestHandle_DedupCooldown(t *testing.T) {
+	sink := &captureSink{}
+	n := New(sink, Config{Cooldown: time.Minute})
+	clock := time.Unix(1000, 0)
+	n.now = func() time.Time { return clock }
+
+	if !n.Handle(ev(event.KindTaskFailed, "run-1", nil)) {
+		t.Fatal("first alert not delivered")
+	}
+	if n.Handle(ev(event.KindTaskFailed, "run-1", nil)) {
+		t.Fatal("duplicate inside cooldown delivered")
+	}
+	if !n.Handle(ev(event.KindTaskFailed, "run-2", nil)) {
+		t.Fatal("different correlation suppressed")
+	}
+	clock = clock.Add(61 * time.Second)
+	if !n.Handle(ev(event.KindTaskFailed, "run-1", nil)) {
+		t.Fatal("alert after cooldown elapsed suppressed")
+	}
+	if got := len(sink.all()); got != 3 {
+		t.Fatalf("delivered %d briefs, want 3", got)
+	}
+}
+
+// TestHandle_RateCap: a flood of DISTINCT alerts is capped per window, and the
+// cap frees up once the window slides past the burst.
+func TestHandle_RateCap(t *testing.T) {
+	sink := &captureSink{}
+	n := New(sink, Config{MaxPerWindow: 3, Window: 10 * time.Minute})
+	clock := time.Unix(1000, 0)
+	n.now = func() time.Time { return clock }
+
+	delivered := 0
+	for i := range 8 {
+		clock = clock.Add(time.Second)
+		if n.Handle(ev(event.KindTaskFailed, "run-"+string(rune('a'+i)), nil)) {
+			delivered++
+		}
+	}
+	if delivered != 3 {
+		t.Fatalf("delivered %d, want exactly the cap 3", delivered)
+	}
+	clock = clock.Add(11 * time.Minute) // burst slides out of the window
+	if !n.Handle(ev(event.KindTaskFailed, "run-z", nil)) {
+		t.Fatal("delivery after the window cleared was suppressed")
+	}
+}
+
+// TestBrief_RendersSeverityAndDisposition: criticals get the siren, warnings
+// the caution sign; every brief is DispAlert (breaks through digests/quiet
+// hours) with the correlation threaded for `agt why`.
+func TestBrief_RendersSeverityAndDisposition(t *testing.T) {
+	sink := &captureSink{}
+	n := New(sink, Config{})
+	n.Handle(ev(event.KindHalt, "corr-7", map[string]any{"reason": "operator"}))
+	n.Handle(ev(event.KindTaskFailed, "corr-8", map[string]any{"reason": "boom"}))
+	briefs := sink.all()
+	if len(briefs) != 2 {
+		t.Fatalf("delivered %d briefs, want 2", len(briefs))
+	}
+	crit, warn := briefs[0], briefs[1]
+	if crit.Title != "🚨 daemon halted" {
+		t.Fatalf("critical title = %q", crit.Title)
+	}
+	if warn.Title != "⚠ run failed" {
+		t.Fatalf("warning title = %q", warn.Title)
+	}
+	for _, b := range briefs {
+		if b.Disposition != pulse.DispAlert {
+			t.Fatalf("disposition = %q, want %q", b.Disposition, pulse.DispAlert)
+		}
+	}
+	if crit.CorrelationID != "corr-7" || crit.IssueKey != "alert/halt" {
+		t.Fatalf("correlation/issue = %q/%q", crit.CorrelationID, crit.IssueKey)
+	}
+	if crit.Body != "operator\nsource: kernel" {
+		t.Fatalf("critical body = %q", crit.Body)
+	}
+}
+
+func newBus(t *testing.T) *bus.Bus {
+	t.Helper()
+	j, err := journal.Open(t.TempDir(), journal.Options{})
+	if err != nil {
+		t.Fatalf("journal.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = j.Close() })
+	return bus.New(j)
+}
+
+// TestStart_DeliversFromRealBus: end to end on a real bus — a published
+// task.failed reaches the sink; non-alert events do not.
+func TestStart_DeliversFromRealBus(t *testing.T) {
+	b := newBus(t)
+	sink := &captureSink{}
+	if !Start(t.Context(), b, sink, Config{}) {
+		t.Fatal("Start returned false")
+	}
+
+	if _, err := b.Publish(event.Spec{Subject: "agent.run-1.task", Kind: event.KindToolInvoked,
+		Actor: "agent", Payload: map[string]any{"name": "shell"}}); err != nil {
+		t.Fatalf("publish tool.invoked: %v", err)
+	}
+	if _, err := b.Publish(event.Spec{Subject: "agent.run-1.task", Kind: event.KindTaskFailed,
+		Actor: "agent", CorrelationID: "run-1", Payload: map[string]any{"reason": "boom"}}); err != nil {
+		t.Fatalf("publish task.failed: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if briefs := sink.all(); len(briefs) >= 1 {
+			if briefs[0].Title != "⚠ run failed" || briefs[0].CorrelationID != "run-1" {
+				t.Fatalf("unexpected brief: %+v", briefs[0])
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("alert never reached the sink")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := len(sink.all()); got != 1 {
+		t.Fatalf("delivered %d briefs, want 1 (tool.invoked must not notify)", got)
+	}
+}
+
+// TestStart_NilGuards: nothing starts without a bus or a sink.
+func TestStart_NilGuards(t *testing.T) {
+	if Start(context.Background(), nil, &captureSink{}, Config{}) {
+		t.Fatal("started without a bus")
+	}
+	if Start(context.Background(), newBus(t), nil, Config{}) {
+		t.Fatal("started without a sink")
+	}
+}

--- a/kernel/controlplane/config.go
+++ b/kernel/controlplane/config.go
@@ -34,6 +34,10 @@ import (
 // so the inventory can no longer silently rot.
 var configEnvVars = []string{
 	"AGEZT_ACP_AGENT_CMD",
+	"AGEZT_ALERT_NOTIFY",
+	"AGEZT_ALERT_NOTIFY_COOLDOWN",
+	"AGEZT_ALERT_NOTIFY_LEVEL",
+	"AGEZT_ALERT_NOTIFY_MAX",
 	"AGEZT_ALLOW_ALL",
 	"AGEZT_ANOMALY_MAX_TOOLCALLS",
 	"AGEZT_ANOMALY_WINDOW",

--- a/kernel/settings/schema.go
+++ b/kernel/settings/schema.go
@@ -53,10 +53,10 @@ type Field struct {
 // the section came from — "builtin" for the compiled-in core config, or the
 // registered schema's id for a skill/plugin-contributed section (see registry.go).
 type Section struct {
-	ID     string  `json:"id"`
-	Name   string  `json:"name"`
-	Help   string  `json:"help,omitempty"`
-	Source string  `json:"source,omitempty"`
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Help   string `json:"help,omitempty"`
+	Source string `json:"source,omitempty"`
 	// Locked: a system-approved section that cannot be unregistered through the
 	// normal path (config_schema_unregister / the `config` tool) — only with an
 	// explicit operator force, or by deleting the file. Built-in sections are
@@ -150,6 +150,16 @@ func builtinSections() []Section {
 			Fields: []Field{
 				{Env: "AGEZT_RATE_PER_MIN", Label: "Max requests / minute", Type: TypeNumber, Apply: ApplyRestart},
 				{Env: "AGEZT_CONTEXT_BUDGET", Label: "Context budget (chars)", Type: TypeNumber, Apply: ApplyRestart},
+			},
+		},
+		{
+			ID: "alerts", Name: "Alert Notifications",
+			Help: "Push warning/critical alerts (run failures, blocked egress, budget/rate trips, halts) to the configured channels. Restart to apply.",
+			Fields: []Field{
+				{Env: "AGEZT_ALERT_NOTIFY", Label: "Enabled", Type: TypeBool, Apply: ApplyRestart, Help: "Needs at least one configured channel (Telegram, Slack, …)."},
+				{Env: "AGEZT_ALERT_NOTIFY_LEVEL", Label: "Minimum level", Type: TypeSelect, Apply: ApplyRestart, Options: []string{"", "warning", "critical"}, Help: "warning (default) sends warnings and criticals; critical sends criticals only."},
+				{Env: "AGEZT_ALERT_NOTIFY_COOLDOWN", Label: "Repeat cooldown", Type: TypeText, Apply: ApplyRestart, Help: "The same alert (kind + run) is sent at most once per this window, e.g. 5m."},
+				{Env: "AGEZT_ALERT_NOTIFY_MAX", Label: "Flood cap (per 10m)", Type: TypeNumber, Apply: ApplyRestart, Help: "Hard ceiling on notifications per 10-minute window; extra alerts are dropped."},
 			},
 		},
 		{


### PR DESCRIPTION
## What

The same warning/critical signals the console's Alerts view surfaces — **run failures, blocked egress, budget/rate trips, daemon halts** — can now be pushed to the configured channels (Telegram, Slack, Discord, email, Signal, …) the moment they happen. Completes the alert arc (M777–M781): the badge and cockpit strip tell you *in* the console; this tells you when you're *away from it*.

## How

- New `kernel/alerter` bus watcher (anomaly-monitor pattern: subscribe `>`, panic-recovered, ctx-scoped). `Classify` mirrors `frontend/src/lib/alerts.ts` kind-for-kind; Pulse-originated kinds are deliberately excluded (Pulse already delivers its own briefs through these sinks — double-pinging every heartbeat would be noise).
- Delivery reuses the existing **Pulse channel sinks** (`DispAlert` brief, correlation threaded for `agt why`). Kernel never imports plugins — the daemon injects the same combined MultiSink it builds for Pulse.
- **Spam-safe**: per-alert (kind+run) cooldown (default 5m) + global flood cap (default 12/10m), dedup map size-bounded.
- **Opt-in**: `AGEZT_ALERT_NOTIFY=1` (+`_LEVEL`/`_COOLDOWN`/`_MAX`); registered in `configEnvVars` (M127 guard) and as a new **Alert Notifications** Config Center section.
- Drive-by: fixed pre-existing gofmt drift in `kernel/settings/schema.go`.

## Validation

- **8 unit tests**: classification parity table, min-level gate, dedup cooldown (injected clock), flood-cap window slide, brief rendering (🚨/⚠, DispAlert, correlation, IssueKey), real-bus end-to-end, nil guards.
- **Isolated-daemon smoke** (never the real ~/.agezt): real `agt halt` → webhook channel POST `📣 🚨 daemon halted`; repeat halt inside cooldown suppressed; **negative control** (notify off) → banner `disabled`, no POST; 0 panics, clean shutdown.
- **Local CI battery** (org Actions billing still exhausted; jobs fail at startup steps=0 — same as PRs #136–#225): full `go test -p 2 ./...` green (84 pkgs), `go vet` clean, `staticcheck` clean, `GOOS=linux` cross-build OK, gofmt verified on staged LF blobs, `go.mod` unchanged, frontend dist untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)