### PR TITLE
Feat: agent roster — durable named agents with soul/model/budget (M783)

### DIFF
--- a/.project/PHASE-M783-AGENT-ROSTER-REPORT.md
+++ b/.project/PHASE-M783-AGENT-ROSTER-REPORT.md
@@ -1,0 +1,76 @@
+# Phase M783 — Agent Roster: durable named agents
+
+**Date:** 2026-06-10 · **Status:** DONE · **Arc:** multi-agent identity (gap #1
+of the 2026-06-10 vision gap analysis — the prerequisite for A2A messaging,
+per-agent budgets/tools, and the brain loop)
+
+## What
+
+Agents stop being ephemeral runs. `kernel/roster` is a durable registry of
+named agent identities: slug (immutable address) + soul (system prompt) +
+model (+ ordered fallbacks, stored for the routing arc) + default task type +
+per-run spend ceiling (USD-microcents) + memory scope + workspace subdir +
+description + enabled. `agt run --agent <slug>` runs AS the agent.
+
+## Design
+
+- **Store** (`kernel/roster/roster.go`): atomic-JSON file store, the
+  kernel/standing pattern verbatim (mutex, rollback-on-save-failure,
+  kernel-assigned id/timestamps, deterministic List). Lookup by id OR slug
+  everywhere. Validation: slug `^[a-z0-9][a-z0-9._-]{0,63}$`, soul ≤ 64KiB,
+  ≤ 8 fallbacks, non-negative cost, workdir must be relative and cannot
+  escape (`..`/absolute rejected).
+- **Kernel** (`kernel/runtime`): `roster` field + `Roster()` accessor +
+  `AddProfile/UpdateProfile/SetProfileEnabled/RemoveProfile` publishing
+  `roster.created/updated/removed` (new append-only event kinds).
+- **Control plane**: `agent_list/add/edit/set_enabled/remove` commands
+  (`kernel/controlplane/roster.go`), standing-handler shapes; edit applies
+  mutable fields wholesale, identity/lifecycle protected by the store;
+  `enabled` accepts bool or string (webui query transport).
+- **Run seam** (`handleRun`): new `agent` arg resolved BEFORE the vision gate
+  (so the gate judges the model the run actually uses). Profile fills the
+  gaps — model when `--model` absent, soul when `--system` absent, cost
+  ceiling when `--max-cost` absent; explicit flags always win. Unknown agent
+  → usage error; paused agent → refused with `agt agent resume` hint.
+- **CLI** (`cmd/agt/agent.go`): `agt agent list/add/show/set/pause/resume/
+  remove` + `agt run --agent <slug>`. `set` is a partial edit: reads the
+  current profile, overlays only the provided flags.
+- **Web UI routes** (`kernel/webui`): GET `/api/agents`; POST
+  `/api/agents/{add,edit}` (JSON body), `/api/agents/{enable,remove}`
+  (query args). Console view = next milestone.
+
+## Tests (10 new, all green)
+
+- roster: slug rules (8 good/8 bad), bounds + workdir-escape table, identity
+  defaults + duplicate-slug refusal, id/slug lookup, Update protects
+  id/slug/created/enabled + rolls back invalid mutations, pause/resume/remove,
+  persistence across reopen (all fields), deterministic order.
+- controlplane: `TestAgent_CRUDRoundTrip` (add→list→edit→pause→remove over the
+  wire + journal asserts roster.created/updated/removed + duplicate slug and
+  unknown-ref errors); `TestRun_AsAgent` (dry-run plan proves profile model +
+  soul applied from the SAME locals the real run uses; explicit `--model`
+  wins; unknown/paused refused).
+- webui guard test (`TestAPIReadOnly`) extended: `agent_list` registered as a
+  read command.
+
+## Runtime smoke (isolated AGEZT_HOME, demo echo)
+
+add (with soul/desc/$0.50 ceiling) → list/show render → `run --agent
+researcher --dry-run` showed `system prompt: per-run` + `cost cap: $0.50` →
+real run completed → pause → run refused exit 1 with resume hint → resume →
+set (soul v2) → remove → empty-roster hint. Journal: `roster.created`
+seq=0. 0 panics, clean shutdown, smoke dir removed.
+
+## Gate
+
+Full suite `GOMAXPROCS=3 go test -p 2 ./...` green (85 pkgs incl. new roster);
+`go vet` + staticcheck clean; `GOOS=linux` cross-build OK; go.mod unchanged;
+frontend dist untouched. CI org-billing still blocked → local battery +
+arc-authority merge (PRs #136+ pattern).
+
+## Next in the arc
+
+- M784+: Agents console view (roster CRUD from the Web UI — jsonRoute +
+  `New<X>Form` recipe), delegate-tool `agent` param (sub-agents by slug),
+  per-agent memory-scope + workdir wiring into the run, A2A ask/reply on the
+  board, per-agent routing chains via Fallbacks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **Named, durable agents — the roster.** Until now an "agent" was a run: it existed for the length
+  of one task and vanished. The new **agent roster** (`kernel/roster`) makes agents *durable named
+  identities*: `agt agent add researcher --soul "You research deeply…" --model … --max-cost 0.50`
+  creates **researcher** — with its own **soul** (system prompt), model (+ ordered fallback list),
+  default task type, per-run spend ceiling, memory scope, and workspace subdirectory — and
+  `agt run --agent researcher "…"` runs AS it: the soul becomes the run's system prompt, the
+  profile's model and cost ceiling apply as defaults (explicit per-run flags still win), and a
+  paused or unknown agent is refused with a hint rather than silently running as the default
+  identity. Profiles persist across restarts (atomic JSON, the standing-orders pattern), every
+  create/edit/pause/resume/remove is journaled (`roster.*`) so `agt why` can explain how an agent
+  came to exist, and the slug is immutable — it's the agent's address. Full management surface:
+  `agt agent list/add/show/set/pause/resume/remove`, control-plane commands (`agent_*`), and Web UI
+  proxy routes (`/api/agents` + add/edit/enable/remove) ready for the console view. This is the
+  identity layer the multi-agent arc builds on: per-agent messaging, budgets, and tool grants all
+  get something durable to attach to. Unit-tested (slug rules, workdir-escape rejection, identity
+  protection on edit, persistence across reopen, CRUD round-trip over the control plane with
+  journal assertions, and the run seam: profile fills model/soul/cost gaps, explicit flags win,
+  paused/unknown refused). Verified live on an isolated daemon end-to-end: created an agent, ran as
+  it (dry-run showed the soul + $0.50 ceiling applied; the real run completed), pause refused the
+  run with a hint, edit/remove round-tripped, `roster.created` in the journal; 0 panics. (M783)
 - **Hear about problems without the console open — alerts push to your channels.** The same
   warning/critical signals the console's Alerts view surfaces — a run failure, blocked egress, a
   budget ceiling or provider rate trip, a daemon halt — can now be **pushed to the configured

--- a/cmd/agt/agent.go
+++ b/cmd/agt/agent.go
@@ -1,0 +1,441 @@
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/agezt/agezt/internal/brand"
+	"github.com/agezt/agezt/kernel/controlplane"
+)
+
+// cmdAgent dispatches `agt agent <subcommand>` — the management surface for the
+// durable agent roster (M783): named agent identities with their own soul
+// (system prompt), model, per-run cost ceiling, memory scope, and workdir.
+// `agt run --agent <slug>` runs AS one. Every mutation is journaled (roster.*).
+func cmdAgent(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		return agentUsage(stderr)
+	}
+	switch args[0] {
+	case "list":
+		return cmdAgentList(args[1:], stdout, stderr)
+	case "add", "create":
+		return cmdAgentAdd(args[1:], stdout, stderr)
+	case "show":
+		return cmdAgentShow(args[1:], stdout, stderr)
+	case "set", "edit":
+		return cmdAgentSet(args[1:], stdout, stderr)
+	case "pause":
+		return cmdAgentSetEnabled(args[1:], stdout, stderr, false)
+	case "resume":
+		return cmdAgentSetEnabled(args[1:], stdout, stderr, true)
+	case "remove", "rm":
+		return cmdAgentRemove(args[1:], stdout, stderr)
+	case "-h", "--help", "help":
+		return agentUsage(stdout)
+	default:
+		fmt.Fprintf(stderr, "%s agent: unknown subcommand %q\n", brand.CLI, args[0])
+		return agentUsage(stderr)
+	}
+}
+
+func agentUsage(w io.Writer) int {
+	fmt.Fprintf(w, "usage: %s agent <list|add|show|set|pause|resume|remove>\n", brand.CLI)
+	fmt.Fprintf(w, "  list [--json]                                  show the agent roster\n")
+	fmt.Fprintf(w, "  add <slug> [--name N] [--soul PROMPT] [--model M] [--fallbacks m1,m2]\n")
+	fmt.Fprintf(w, "      [--task TYPE] [--max-cost USD] [--memory-scope S] [--workdir DIR] [--desc TEXT]\n")
+	fmt.Fprintf(w, "  show <slug|id> [--json]                        one agent's full profile\n")
+	fmt.Fprintf(w, "  set <slug|id> [same flags as add]              edit an agent (slug is immutable)\n")
+	fmt.Fprintf(w, "  pause <slug|id>                                disable an agent (runs refused)\n")
+	fmt.Fprintf(w, "  resume <slug|id>                               re-enable an agent\n")
+	fmt.Fprintf(w, "  remove <slug|id>                               delete an agent\n")
+	fmt.Fprintf(w, "run as an agent:  %s run --agent <slug> \"intent\"\n", brand.CLI)
+	return 0
+}
+
+// agentFlags parses the shared add/set flag set. Returns the profile fields
+// that were explicitly provided (set tracks which, for partial edits).
+type agentFlags struct {
+	name, soul, model, task, memScope, workdir, desc string
+	fallbacks                                        []string
+	maxCostMc                                        int64
+	set                                              map[string]bool
+}
+
+func parseAgentFlags(args []string, stderr io.Writer, cmd string) (agentFlags, []string, bool) {
+	f := agentFlags{set: map[string]bool{}}
+	var rest []string
+	need := func(i int, flag string) bool {
+		if i+1 >= len(args) {
+			fmt.Fprintf(stderr, "%s agent %s: %s needs a value\n", brand.CLI, cmd, flag)
+			return false
+		}
+		return true
+	}
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch a {
+		case "--name":
+			if !need(i, a) {
+				return f, nil, false
+			}
+			i++
+			f.name, f.set["name"] = args[i], true
+		case "--soul":
+			if !need(i, a) {
+				return f, nil, false
+			}
+			i++
+			f.soul, f.set["soul"] = args[i], true
+		case "--model":
+			if !need(i, a) {
+				return f, nil, false
+			}
+			i++
+			f.model, f.set["model"] = args[i], true
+		case "--fallbacks":
+			if !need(i, a) {
+				return f, nil, false
+			}
+			i++
+			for m := range strings.SplitSeq(args[i], ",") {
+				if m = strings.TrimSpace(m); m != "" {
+					f.fallbacks = append(f.fallbacks, m)
+				}
+			}
+			f.set["fallbacks"] = true
+		case "--task":
+			if !need(i, a) {
+				return f, nil, false
+			}
+			i++
+			f.task, f.set["task"] = args[i], true
+		case "--max-cost":
+			if !need(i, a) {
+				return f, nil, false
+			}
+			i++
+			mc, err := parseUSDToMicrocents(args[i])
+			if err != nil {
+				fmt.Fprintf(stderr, "%s agent %s: invalid --max-cost %q (want a dollar amount like 0.50)\n", brand.CLI, cmd, args[i])
+				return f, nil, false
+			}
+			f.maxCostMc, f.set["max_cost"] = mc, true
+		case "--memory-scope":
+			if !need(i, a) {
+				return f, nil, false
+			}
+			i++
+			f.memScope, f.set["memory_scope"] = args[i], true
+		case "--workdir":
+			if !need(i, a) {
+				return f, nil, false
+			}
+			i++
+			f.workdir, f.set["workdir"] = args[i], true
+		case "--desc":
+			if !need(i, a) {
+				return f, nil, false
+			}
+			i++
+			f.desc, f.set["desc"] = args[i], true
+		default:
+			rest = append(rest, a)
+		}
+	}
+	return f, rest, true
+}
+
+func cmdAgentList(args []string, stdout, stderr io.Writer) int {
+	asJSON := false
+	for _, a := range args {
+		if a == "--json" {
+			asJSON = true
+		}
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := c.Call(ctx, controlplane.CmdAgentList, nil)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s agent list: %v\n", brand.CLI, err)
+		return 1
+	}
+	if asJSON {
+		return encodeJSON(stdout, res)
+	}
+	profiles, _ := res["profiles"].([]any)
+	if len(profiles) == 0 {
+		fmt.Fprintf(stdout, "no agents yet — create one with `%s agent add <slug> --soul \"...\"`\n", brand.CLI)
+		return 0
+	}
+	for _, raw := range profiles {
+		p, _ := raw.(map[string]any)
+		if p == nil {
+			continue
+		}
+		state := "enabled"
+		if en, _ := p["enabled"].(bool); !en {
+			state = "PAUSED"
+		}
+		model, _ := p["model"].(string)
+		if model == "" {
+			model = "(default)"
+		}
+		fmt.Fprintf(stdout, "%-20s %-9s model=%s", str(p["slug"]), state, model)
+		if tt, _ := p["task_type"].(string); tt != "" {
+			fmt.Fprintf(stdout, " task=%s", tt)
+		}
+		if mc, ok := p["max_cost_mc"].(float64); ok && mc > 0 {
+			fmt.Fprintf(stdout, " max-cost=%s", fmtUSD(int64(mc)))
+		}
+		fmt.Fprintln(stdout)
+	}
+	fmt.Fprintf(stdout, "%v agent(s)\n", res["count"])
+	return 0
+}
+
+func cmdAgentShow(args []string, stdout, stderr io.Writer) int {
+	asJSON := false
+	ref := ""
+	for _, a := range args {
+		if a == "--json" {
+			asJSON = true
+		} else if !strings.HasPrefix(a, "--") && ref == "" {
+			ref = a
+		}
+	}
+	if ref == "" {
+		fmt.Fprintf(stderr, "usage: %s agent show <slug|id> [--json]\n", brand.CLI)
+		return 2
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := c.Call(ctx, controlplane.CmdAgentList, nil)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s agent show: %v\n", brand.CLI, err)
+		return 1
+	}
+	profiles, _ := res["profiles"].([]any)
+	for _, raw := range profiles {
+		p, _ := raw.(map[string]any)
+		if p == nil || (str(p["slug"]) != ref && str(p["id"]) != ref) {
+			continue
+		}
+		if asJSON {
+			return encodeJSON(stdout, p)
+		}
+		fmt.Fprintf(stdout, "slug:         %s\n", str(p["slug"]))
+		fmt.Fprintf(stdout, "id:           %s\n", str(p["id"]))
+		fmt.Fprintf(stdout, "name:         %s\n", str(p["name"]))
+		state := "enabled"
+		if en, _ := p["enabled"].(bool); !en {
+			state = "PAUSED"
+		}
+		fmt.Fprintf(stdout, "state:        %s\n", state)
+		if v := str(p["model"]); v != "" {
+			fmt.Fprintf(stdout, "model:        %s\n", v)
+		}
+		if fb, _ := p["fallbacks"].([]any); len(fb) > 0 {
+			parts := make([]string, 0, len(fb))
+			for _, m := range fb {
+				parts = append(parts, str(m))
+			}
+			fmt.Fprintf(stdout, "fallbacks:    %s\n", strings.Join(parts, " → "))
+		}
+		if v := str(p["task_type"]); v != "" {
+			fmt.Fprintf(stdout, "task type:    %s\n", v)
+		}
+		if mc, ok := p["max_cost_mc"].(float64); ok && mc > 0 {
+			fmt.Fprintf(stdout, "max cost/run: %s\n", fmtUSD(int64(mc)))
+		}
+		if v := str(p["memory_scope"]); v != "" {
+			fmt.Fprintf(stdout, "memory scope: %s\n", v)
+		}
+		if v := str(p["workdir"]); v != "" {
+			fmt.Fprintf(stdout, "workdir:      %s\n", v)
+		}
+		if v := str(p["description"]); v != "" {
+			fmt.Fprintf(stdout, "description:  %s\n", v)
+		}
+		if v := str(p["soul"]); v != "" {
+			fmt.Fprintf(stdout, "soul:\n  %s\n", strings.ReplaceAll(v, "\n", "\n  "))
+		}
+		return 0
+	}
+	fmt.Fprintf(stderr, "%s agent show: unknown agent %q\n", brand.CLI, ref)
+	return 1
+}
+
+func cmdAgentAdd(args []string, stdout, stderr io.Writer) int {
+	f, rest, ok := parseAgentFlags(args, stderr, "add")
+	if !ok {
+		return 2
+	}
+	if len(rest) != 1 {
+		fmt.Fprintf(stderr, "usage: %s agent add <slug> [--soul PROMPT] [--model M] ...\n", brand.CLI)
+		return 2
+	}
+	profile := map[string]any{
+		"slug": rest[0], "name": f.name, "soul": f.soul, "model": f.model,
+		"task_type": f.task, "max_cost_mc": f.maxCostMc,
+		"memory_scope": f.memScope, "workdir": f.workdir, "description": f.desc,
+	}
+	if len(f.fallbacks) > 0 {
+		fb := make([]any, len(f.fallbacks))
+		for i, m := range f.fallbacks {
+			fb[i] = m
+		}
+		profile["fallbacks"] = fb
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := c.Call(ctx, controlplane.CmdAgentAdd, map[string]any{"profile": profile})
+	if err != nil {
+		fmt.Fprintf(stderr, "%s agent add: %v\n", brand.CLI, err)
+		return 1
+	}
+	p, _ := res["profile"].(map[string]any)
+	fmt.Fprintf(stdout, "agent %s created (run it: %s run --agent %s \"...\")\n", str(p["slug"]), brand.CLI, str(p["slug"]))
+	return 0
+}
+
+func cmdAgentSet(args []string, stdout, stderr io.Writer) int {
+	f, rest, ok := parseAgentFlags(args, stderr, "set")
+	if !ok {
+		return 2
+	}
+	if len(rest) != 1 || len(f.set) == 0 {
+		fmt.Fprintf(stderr, "usage: %s agent set <slug|id> --soul PROMPT|--model M|... (at least one flag)\n", brand.CLI)
+		return 2
+	}
+	ref := rest[0]
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	// agent_edit applies the mutable fields WHOLESALE, so a partial edit must
+	// start from the current profile and overlay only the provided flags.
+	cur, err := c.Call(ctx, controlplane.CmdAgentList, nil)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s agent set: %v\n", brand.CLI, err)
+		return 1
+	}
+	var base map[string]any
+	if profiles, _ := cur["profiles"].([]any); profiles != nil {
+		for _, raw := range profiles {
+			p, _ := raw.(map[string]any)
+			if p != nil && (str(p["slug"]) == ref || str(p["id"]) == ref) {
+				base = p
+				break
+			}
+		}
+	}
+	if base == nil {
+		fmt.Fprintf(stderr, "%s agent set: unknown agent %q\n", brand.CLI, ref)
+		return 1
+	}
+	overlay := func(key, flag, val string) {
+		if f.set[flag] {
+			base[key] = val
+		}
+	}
+	overlay("name", "name", f.name)
+	overlay("soul", "soul", f.soul)
+	overlay("model", "model", f.model)
+	overlay("task_type", "task", f.task)
+	overlay("memory_scope", "memory_scope", f.memScope)
+	overlay("workdir", "workdir", f.workdir)
+	overlay("description", "desc", f.desc)
+	if f.set["max_cost"] {
+		base["max_cost_mc"] = f.maxCostMc
+	}
+	if f.set["fallbacks"] {
+		fb := make([]any, len(f.fallbacks))
+		for i, m := range f.fallbacks {
+			fb[i] = m
+		}
+		base["fallbacks"] = fb
+	}
+	res, err := c.Call(ctx, controlplane.CmdAgentEdit, map[string]any{"ref": ref, "profile": base})
+	if err != nil {
+		fmt.Fprintf(stderr, "%s agent set: %v\n", brand.CLI, err)
+		return 1
+	}
+	p, _ := res["profile"].(map[string]any)
+	fmt.Fprintf(stdout, "agent %s updated\n", str(p["slug"]))
+	return 0
+}
+
+func cmdAgentSetEnabled(args []string, stdout, stderr io.Writer, enabled bool) int {
+	verb := "pause"
+	if enabled {
+		verb = "resume"
+	}
+	if len(args) != 1 {
+		fmt.Fprintf(stderr, "usage: %s agent %s <slug|id>\n", brand.CLI, verb)
+		return 2
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := c.Call(ctx, controlplane.CmdAgentSetEnabled, map[string]any{"ref": args[0], "enabled": enabled})
+	if err != nil {
+		fmt.Fprintf(stderr, "%s agent %s: %v\n", brand.CLI, verb, err)
+		return 1
+	}
+	p, _ := res["profile"].(map[string]any)
+	fmt.Fprintf(stdout, "agent %s %sd\n", str(p["slug"]), verb)
+	return 0
+}
+
+func cmdAgentRemove(args []string, stdout, stderr io.Writer) int {
+	if len(args) != 1 {
+		fmt.Fprintf(stderr, "usage: %s agent remove <slug|id>\n", brand.CLI)
+		return 2
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := c.Call(ctx, controlplane.CmdAgentRemove, map[string]any{"ref": args[0]})
+	if err != nil {
+		fmt.Fprintf(stderr, "%s agent remove: %v\n", brand.CLI, err)
+		return 1
+	}
+	if removed, _ := res["removed"].(bool); !removed {
+		fmt.Fprintf(stderr, "%s agent remove: unknown agent %q\n", brand.CLI, args[0])
+		return 1
+	}
+	fmt.Fprintf(stdout, "agent %s removed\n", args[0])
+	return 0
+}
+
+// str renders any JSON value as its string form ("" for nil/non-strings).
+func str(v any) string {
+	s, _ := v.(string)
+	return s
+}

--- a/cmd/agt/main.go
+++ b/cmd/agt/main.go
@@ -134,6 +134,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 		return cmdSkill(args[1:], stdout, stderr)
 	case "standing":
 		return cmdStanding(args[1:], stdout, stderr)
+	case "agent":
+		return cmdAgent(args[1:], stdout, stderr)
 	case "reflect":
 		return cmdReflect(args[1:], stdout, stderr)
 	case "inbox":
@@ -336,6 +338,7 @@ func cmdRun(args []string, stdout, stderr io.Writer) int {
 	quiet := false
 	tenant := ""
 	model := ""
+	agentRef := ""
 	system := ""
 	file := ""
 	timeout := ""
@@ -369,6 +372,15 @@ func cmdRun(args []string, stdout, stderr io.Writer) int {
 			model = args[i]
 		case strings.HasPrefix(a, "--model="):
 			model = strings.TrimPrefix(a, "--model=")
+		case a == "--agent":
+			if i+1 >= len(args) {
+				fmt.Fprintf(stderr, "%s run: --agent needs an agent slug (agt agent list)\n", brand.CLI)
+				return 2
+			}
+			i++
+			agentRef = args[i]
+		case strings.HasPrefix(a, "--agent="):
+			agentRef = strings.TrimPrefix(a, "--agent=")
 		case a == "--system":
 			if i+1 >= len(args) {
 				fmt.Fprintf(stderr, "%s run: --system needs a prompt\n", brand.CLI)
@@ -490,6 +502,11 @@ func cmdRun(args []string, stdout, stderr io.Writer) int {
 	}
 	if model = strings.TrimSpace(model); model != "" {
 		runArgs["model"] = model
+	}
+	// Run AS a named agent (M783): the daemon resolves the roster profile and
+	// applies its soul/model/cost ceiling as defaults (explicit flags win).
+	if agentRef = strings.TrimSpace(agentRef); agentRef != "" {
+		runArgs["agent"] = agentRef
 	}
 	if strings.TrimSpace(system) != "" {
 		runArgs["system"] = system

--- a/kernel/controlplane/protocol.go
+++ b/kernel/controlplane/protocol.go
@@ -866,6 +866,16 @@ const (
 	CmdStandingWhy        = "standing_why"  // fold the journal for one order's life story
 	CmdStandingFire       = "standing_fire" // fire an order now, ignoring its triggers (M765)
 
+	// Agent roster (M783) — durable named agent profiles behind `agt agent`.
+	// Add: args.profile (object). Edit: args{ref, profile}. SetEnabled:
+	// args{ref, enabled}. Remove: args.ref. List: no args. ref = id OR slug.
+	// Every mutation is journaled (roster.*).
+	CmdAgentList       = "agent_list"
+	CmdAgentAdd        = "agent_add"
+	CmdAgentEdit       = "agent_edit"
+	CmdAgentSetEnabled = "agent_set_enabled"
+	CmdAgentRemove     = "agent_remove"
+
 	// Sandbox projects (M686) — read-only inspection of what agents BUILT with the
 	// code_exec tool under <baseDir>/sandbox/projects. List: no args, returns each
 	// persistent project with its files (name, bytes, modified). File: args{project,

--- a/kernel/controlplane/roster.go
+++ b/kernel/controlplane/roster.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+
+package controlplane
+
+// Agent roster CRUD handlers (M783) — the management path behind `agt agent`.
+// Lifecycle changes go through the kernel so every create/edit/pause/resume/
+// remove is journaled (roster.*) and auditable via `agt why`. Profiles are
+// addressed by ref = id OR slug everywhere, so operators can say
+// `agt agent show researcher` without copying ULIDs.
+
+import (
+	"encoding/json"
+	"errors"
+	"net"
+	"strings"
+
+	"github.com/agezt/agezt/kernel/roster"
+)
+
+// profileView is the stable wire shape for one profile.
+func profileView(p roster.Profile) map[string]any {
+	b, _ := json.Marshal(p)
+	var m map[string]any
+	_ = json.Unmarshal(b, &m)
+	return m
+}
+
+func (s *Server) handleAgentList(conn net.Conn, req Request) {
+	profiles := s.k.Roster().List()
+	out := make([]any, 0, len(profiles))
+	enabled := 0
+	for _, p := range profiles {
+		out = append(out, profileView(p))
+		if p.Enabled {
+			enabled++
+		}
+	}
+	s.writeResp(conn, Response{
+		ID:     req.ID,
+		Type:   RespResult,
+		Result: map[string]any{"profiles": out, "count": len(out), "enabled_count": enabled},
+	})
+}
+
+func (s *Server) handleAgentAdd(conn net.Conn, req Request) {
+	raw, ok := req.Args["profile"]
+	if !ok {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.profile required"})
+		return
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.profile: " + err.Error()})
+		return
+	}
+	var p roster.Profile
+	if err := json.Unmarshal(b, &p); err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.profile: " + err.Error()})
+		return
+	}
+	saved, err := s.k.AddProfile(p)
+	if err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
+		return
+	}
+	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{"profile": profileView(saved)}})
+}
+
+// handleAgentEdit applies args.profile's MUTABLE fields wholesale to the
+// profile named by args.ref (identity/lifecycle fields are protected by the
+// store, so a stale client can't rename a slug or resurrect a paused agent).
+func (s *Server) handleAgentEdit(conn net.Conn, req Request) {
+	ref, _ := req.Args["ref"].(string)
+	if strings.TrimSpace(ref) == "" {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.ref required"})
+		return
+	}
+	raw, ok := req.Args["profile"]
+	if !ok {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.profile required"})
+		return
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.profile: " + err.Error()})
+		return
+	}
+	var in roster.Profile
+	if err := json.Unmarshal(b, &in); err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.profile: " + err.Error()})
+		return
+	}
+	p, found, err := s.k.UpdateProfile(ref, func(dst *roster.Profile) {
+		dst.Name = in.Name
+		dst.Soul = in.Soul
+		dst.Model = in.Model
+		dst.Fallbacks = in.Fallbacks
+		dst.TaskType = in.TaskType
+		dst.MaxCostMc = in.MaxCostMc
+		dst.MemoryScope = in.MemoryScope
+		dst.Workdir = in.Workdir
+		dst.Description = in.Description
+	})
+	if err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
+		return
+	}
+	if !found {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "unknown agent: " + ref})
+		return
+	}
+	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{"profile": profileView(p)}})
+}
+
+func (s *Server) handleAgentSetEnabled(conn net.Conn, req Request) {
+	ref, _ := req.Args["ref"].(string)
+	if strings.TrimSpace(ref) == "" {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.ref required"})
+		return
+	}
+	// Accept enabled as a bool (CLI/JSON) or a "true"/"false"/"1"/"0" string
+	// (the webui query-arg transport carries every value as a string).
+	enabled := false
+	switch v := req.Args["enabled"].(type) {
+	case bool:
+		enabled = v
+	case string:
+		enabled = strings.EqualFold(v, "true") || v == "1"
+	}
+	p, err := s.k.SetProfileEnabled(ref, enabled)
+	if err != nil {
+		if errors.Is(err, roster.ErrNotFound) {
+			s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "unknown agent: " + ref})
+			return
+		}
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
+		return
+	}
+	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{"profile": profileView(p)}})
+}
+
+func (s *Server) handleAgentRemove(conn net.Conn, req Request) {
+	ref, _ := req.Args["ref"].(string)
+	if strings.TrimSpace(ref) == "" {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.ref required"})
+		return
+	}
+	ok, err := s.k.RemoveProfile(ref)
+	if err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
+		return
+	}
+	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{"removed": ok}})
+}

--- a/kernel/controlplane/roster_test.go
+++ b/kernel/controlplane/roster_test.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: MIT
+
+package controlplane_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/agezt/agezt/kernel/controlplane"
+	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/plugins/providers/mock"
+)
+
+// TestAgent_CRUDRoundTrip drives the agent-roster management surface over the
+// control plane: add → list → edit → pause → remove (by slug), asserting each
+// step and that every mutation is journaled (roster.created/updated/removed).
+func TestAgent_CRUDRoundTrip(t *testing.T) {
+	k, _, c, _ := startPair(t, mock.New(mock.FinalText("ok")))
+	ctx := context.Background()
+
+	add, err := c.Call(ctx, controlplane.CmdAgentAdd, map[string]any{
+		"profile": map[string]any{
+			"slug":  "researcher",
+			"soul":  "You research deeply and cite sources.",
+			"model": "mock-model",
+		},
+	})
+	if err != nil {
+		t.Fatalf("agent add: %v", err)
+	}
+	prof, _ := add["profile"].(map[string]any)
+	if prof == nil || prof["slug"] != "researcher" || prof["enabled"] != true {
+		t.Fatalf("add returned %v", add)
+	}
+	if prof["name"] != "researcher" {
+		t.Errorf("name should default to slug, got %v", prof["name"])
+	}
+
+	// A duplicate slug is refused.
+	if _, err := c.Call(ctx, controlplane.CmdAgentAdd, map[string]any{
+		"profile": map[string]any{"slug": "researcher"},
+	}); err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("duplicate slug: err = %v, want already-exists", err)
+	}
+
+	list, err := c.Call(ctx, controlplane.CmdAgentList, nil)
+	if err != nil {
+		t.Fatalf("agent list: %v", err)
+	}
+	if n, _ := list["count"].(float64); n != 1 {
+		t.Fatalf("count = %v, want 1", list["count"])
+	}
+
+	// Edit by slug: the soul changes, the slug cannot.
+	edit, err := c.Call(ctx, controlplane.CmdAgentEdit, map[string]any{
+		"ref": "researcher",
+		"profile": map[string]any{
+			"slug": "hijacked", "name": "The Researcher", "soul": "v2 soul", "model": "mock-model",
+		},
+	})
+	if err != nil {
+		t.Fatalf("agent edit: %v", err)
+	}
+	ep, _ := edit["profile"].(map[string]any)
+	if ep["slug"] != "researcher" || ep["soul"] != "v2 soul" || ep["name"] != "The Researcher" {
+		t.Fatalf("edit result wrong: %v", ep)
+	}
+	if _, err := c.Call(ctx, controlplane.CmdAgentEdit, map[string]any{
+		"ref": "ghost", "profile": map[string]any{},
+	}); err == nil || !strings.Contains(err.Error(), "unknown agent") {
+		t.Fatalf("edit unknown: err = %v", err)
+	}
+
+	// Pause by slug; the webui string transport ("false") must also work.
+	pause, err := c.Call(ctx, controlplane.CmdAgentSetEnabled, map[string]any{"ref": "researcher", "enabled": "false"})
+	if err != nil {
+		t.Fatalf("agent pause: %v", err)
+	}
+	if pp, _ := pause["profile"].(map[string]any); pp["enabled"] != false {
+		t.Fatalf("pause result wrong: %v", pause)
+	}
+
+	rm, err := c.Call(ctx, controlplane.CmdAgentRemove, map[string]any{"ref": "researcher"})
+	if err != nil {
+		t.Fatalf("agent remove: %v", err)
+	}
+	if removed, _ := rm["removed"].(bool); !removed {
+		t.Error("remove should report removed=true")
+	}
+
+	// Every mutation is journaled.
+	for _, want := range []event.Kind{event.KindRosterCreated, event.KindRosterUpdated, event.KindRosterRemoved} {
+		n := 0
+		_ = k.Journal().Range(func(e *event.Event) error {
+			if e.Kind == want {
+				n++
+			}
+			return nil
+		})
+		if n == 0 {
+			t.Errorf("no %s event journaled", want)
+		}
+	}
+}
+
+// TestRun_AsAgent proves the run seam: --agent resolves the profile and applies
+// its model + soul as the run's defaults (visible in the dry-run plan, which is
+// built from the SAME locals the real run uses); explicit overrides still win;
+// unknown and paused agents are usage errors.
+func TestRun_AsAgent(t *testing.T) {
+	_, _, c, _ := startPair(t, mock.New(mock.FinalText("ok")))
+	ctx := context.Background()
+
+	if _, err := c.Call(ctx, controlplane.CmdAgentAdd, map[string]any{
+		"profile": map[string]any{
+			"slug":  "researcher",
+			"soul":  "You research deeply.",
+			"model": "agent-model",
+		},
+	}); err != nil {
+		t.Fatalf("agent add: %v", err)
+	}
+
+	// The profile fills the gaps: model + system come from the agent.
+	plan, err := c.Call(ctx, controlplane.CmdRun,
+		map[string]any{"intent": "x", "agent": "researcher", "dry_run": true})
+	if err != nil {
+		t.Fatalf("dry-run as agent: %v", err)
+	}
+	if plan["model"] != "agent-model" {
+		t.Errorf("model = %v, want agent-model", plan["model"])
+	}
+	if src, _ := plan["system_source"].(string); !strings.Contains(src, "per-run") {
+		t.Errorf("system_source = %v, want per-run (the soul was applied)", src)
+	}
+
+	// Explicit per-run flags still win over the profile.
+	plan2, err := c.Call(ctx, controlplane.CmdRun,
+		map[string]any{"intent": "x", "agent": "researcher", "model": "explicit-model", "dry_run": true})
+	if err != nil {
+		t.Fatalf("dry-run with explicit model: %v", err)
+	}
+	if plan2["model"] != "explicit-model" {
+		t.Errorf("model = %v, want explicit-model (explicit flag must win)", plan2["model"])
+	}
+
+	// Unknown agent → usage error, nothing runs.
+	if _, err := c.Call(ctx, controlplane.CmdRun,
+		map[string]any{"intent": "x", "agent": "ghost"}); err == nil ||
+		!strings.Contains(err.Error(), "unknown agent") {
+		t.Fatalf("unknown agent: err = %v", err)
+	}
+
+	// Paused agent → refused with a hint, nothing runs.
+	if _, err := c.Call(ctx, controlplane.CmdAgentSetEnabled,
+		map[string]any{"ref": "researcher", "enabled": false}); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+	if _, err := c.Call(ctx, controlplane.CmdRun,
+		map[string]any{"intent": "x", "agent": "researcher"}); err == nil ||
+		!strings.Contains(err.Error(), "paused") {
+		t.Fatalf("paused agent: err = %v", err)
+	}
+}

--- a/kernel/controlplane/server.go
+++ b/kernel/controlplane/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/agezt/agezt/internal/brand"
 	"github.com/agezt/agezt/kernel/approval"
 	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/roster"
 	"github.com/agezt/agezt/kernel/runtime"
 	"github.com/agezt/agezt/kernel/scheduler"
 	"github.com/agezt/agezt/kernel/tenant"
@@ -681,6 +682,16 @@ func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
 		s.handleStandingRemove(conn, req)
 	case CmdStandingFire:
 		s.handleStandingFire(conn, req)
+	case CmdAgentList:
+		s.handleAgentList(conn, req)
+	case CmdAgentAdd:
+		s.handleAgentAdd(conn, req)
+	case CmdAgentEdit:
+		s.handleAgentEdit(conn, req)
+	case CmdAgentSetEnabled:
+		s.handleAgentSetEnabled(conn, req)
+	case CmdAgentRemove:
+		s.handleAgentRemove(conn, req)
 	case CmdSandboxList:
 		s.handleSandboxList(conn, req)
 	case CmdSandboxFile:
@@ -1187,6 +1198,34 @@ func (s *Server) handleRun(ctx context.Context, conn net.Conn, req Request) {
 		return
 	}
 	modelOverride := strings.TrimSpace(modelRaw)
+
+	// Run AS a named agent (M783): `agt run --agent <slug>` resolves a roster
+	// profile and applies its soul / model / per-run cost ceiling as this run's
+	// DEFAULTS. Explicit per-run overrides still win; the profile fills the
+	// gaps. Resolved before the vision gate so the gate judges the model the
+	// run will actually use. An unknown or paused agent is a usage error —
+	// silently running as the default identity would be worse than failing.
+	agentRaw, _, agerr := argString(req.Args, "agent")
+	if agerr != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: agerr.Error()})
+		return
+	}
+	var agentProf *roster.Profile
+	if agentRef := strings.TrimSpace(agentRaw); agentRef != "" {
+		p, found := k.Roster().Get(agentRef)
+		if !found {
+			s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "unknown agent: " + agentRef})
+			return
+		}
+		if !p.Enabled {
+			s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "agent " + p.Slug + " is paused (agt agent resume " + p.Slug + ")"})
+			return
+		}
+		agentProf = &p
+		if modelOverride == "" {
+			modelOverride = strings.TrimSpace(p.Model)
+		}
+	}
 	effModel := k.Model()
 	if modelOverride != "" {
 		effModel = modelOverride
@@ -1245,6 +1284,9 @@ func (s *Server) handleRun(ctx context.Context, conn net.Conn, req Request) {
 		return
 	}
 	systemOverride := strings.TrimSpace(sysRaw)
+	if systemOverride == "" && agentProf != nil {
+		systemOverride = strings.TrimSpace(agentProf.Soul) // the agent's soul IS its system prompt
+	}
 	if systemOverride != "" {
 		ctx = runtime.WithSystem(ctx, systemOverride)
 	}
@@ -1283,6 +1325,9 @@ func (s *Server) handleRun(ctx context.Context, conn net.Conn, req Request) {
 	if mcerr != nil {
 		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: mcerr.Error()})
 		return
+	}
+	if maxCost <= 0 && agentProf != nil {
+		maxCost = agentProf.MaxCostMc // the agent's own per-run spend ceiling
 	}
 	if maxCost > 0 {
 		ctx = runtime.WithMaxCost(ctx, maxCost)

--- a/kernel/event/kinds.go
+++ b/kernel/event/kinds.go
@@ -229,6 +229,13 @@ const (
 	// diagnosable (`agt journal`) instead of taking down the whole daemon.
 	KindStandingError Kind = "standing.error"
 
+	// Agent roster (M783) — durable named agent profiles (slug + soul + model
+	// + budget + memory scope). Lifecycle is journaled so `agt why` and the
+	// changelog can explain how an agent came to exist.
+	KindRosterCreated Kind = "roster.created"
+	KindRosterUpdated Kind = "roster.updated" // edited/paused/resumed
+	KindRosterRemoved Kind = "roster.removed"
+
 	// Reflection — meta-cognition (SPEC-05 §6). The system reviews its own
 	// behaviour from the journal and recalibrates; the report (observations,
 	// adjustments applied, advisory proposals) is itself journaled.
@@ -367,6 +374,9 @@ var knownKinds = map[Kind]struct{}{
 	KindStandingRemoved:           {},
 	KindStandingFired:             {},
 	KindStandingError:             {},
+	KindRosterCreated:             {},
+	KindRosterUpdated:             {},
+	KindRosterRemoved:             {},
 	KindReflectionCompleted:       {},
 	KindJournalSegmentRotated:     {},
 	KindWebhookDelivered:          {},

--- a/kernel/roster/roster.go
+++ b/kernel/roster/roster.go
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: MIT
+
+// Package roster is the durable agent roster (M783): named, persistent agent
+// profiles — an identity ("researcher", "ops-watcher") with its own soul
+// (system prompt), model (+ ordered fallbacks), default task type, per-run
+// spend ceiling, memory scope, and workspace subdirectory. A profile is the
+// durable HOME for everything that until now lived per-run: `agt run --agent
+// researcher` runs AS that agent, and future arcs attach per-agent messaging,
+// budgets, and tool grants to the same identity.
+//
+// Storage mirrors kernel/standing: a single JSON file rewritten atomically on
+// change, safe for concurrent use; every lifecycle mutation is journaled by
+// the kernel (roster.created/updated/removed) so `agt why` can explain how an
+// agent came to exist.
+package roster
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/agezt/agezt/kernel/ulid"
+)
+
+// ErrNotFound is returned for an unknown profile id/slug.
+var ErrNotFound = errors.New("roster: profile not found")
+
+// Profile is one named agent identity. Slug is the address — unique,
+// immutable, what operators and (future) other agents refer to it by.
+type Profile struct {
+	ID   string `json:"id"`
+	Slug string `json:"slug"`           // unique handle, e.g. "researcher"
+	Name string `json:"name,omitempty"` // human label; defaults to the slug
+
+	// Soul is the agent's system prompt — who it IS. Applied as the run's
+	// system override; memory/world/skill injection still layers on top.
+	Soul string `json:"soul,omitempty"`
+
+	// Model is the primary model for this agent's runs (empty = kernel
+	// default); Fallbacks is its ordered per-agent fallback chain (reserved
+	// for the routing integration arc — stored and validated now so profiles
+	// are forward-complete).
+	Model     string   `json:"model,omitempty"`
+	Fallbacks []string `json:"fallbacks,omitempty"`
+
+	// TaskType is the governor task type this agent's runs default to
+	// (e.g. "coding", "research"); empty = unclassified.
+	TaskType string `json:"task_type,omitempty"`
+
+	// MaxCostMc is the per-run spend ceiling in USD-microcents (0 = none).
+	// Applied as the run's max_cost default; an explicit per-run cap wins.
+	MaxCostMc int64 `json:"max_cost_mc,omitempty"`
+
+	// MemoryScope is the agent's private memory scope (M652); empty = the
+	// slug, so every named agent gets its own notes by default.
+	MemoryScope string `json:"memory_scope,omitempty"`
+
+	// Workdir is a workspace-relative subdirectory this agent works in
+	// (reserved for the per-agent sandbox arc). Must be relative and must
+	// not escape the workspace.
+	Workdir string `json:"workdir,omitempty"`
+
+	Description string `json:"description,omitempty"`
+	Enabled     bool   `json:"enabled"`
+	CreatedMS   int64  `json:"created_ms"`
+	UpdatedMS   int64  `json:"updated_ms"`
+}
+
+// slugRe: lowercase, digit-or-letter first, then letters/digits/dot/dash/underscore.
+var slugRe = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,63}$`)
+
+const (
+	maxSoulBytes = 64 * 1024 // a soul is a prompt, not a novel
+	maxFallbacks = 8
+)
+
+// Validate checks a profile's user-supplied fields (identity/lifecycle fields
+// are kernel-assigned and not judged here).
+func Validate(p Profile) error {
+	if !slugRe.MatchString(p.Slug) {
+		return fmt.Errorf("roster: slug must match %s", slugRe)
+	}
+	if len(p.Soul) > maxSoulBytes {
+		return fmt.Errorf("roster: soul exceeds %d bytes", maxSoulBytes)
+	}
+	if len(p.Fallbacks) > maxFallbacks {
+		return fmt.Errorf("roster: at most %d fallback models", maxFallbacks)
+	}
+	for _, f := range p.Fallbacks {
+		if strings.TrimSpace(f) == "" {
+			return errors.New("roster: empty fallback model id")
+		}
+	}
+	if p.MaxCostMc < 0 {
+		return errors.New("roster: max_cost_mc must be >= 0")
+	}
+	if p.Workdir != "" {
+		w := filepath.ToSlash(p.Workdir)
+		if filepath.IsAbs(p.Workdir) || strings.HasPrefix(w, "/") ||
+			w == ".." || strings.HasPrefix(w, "../") || strings.Contains(w, "/../") || strings.HasSuffix(w, "/..") {
+			return errors.New("roster: workdir must be a relative path inside the workspace")
+		}
+	}
+	return nil
+}
+
+// Store is the persistent roster, a single JSON file rewritten atomically on
+// change. Safe for concurrent use. Mirrors kernel/standing.Store.
+type Store struct {
+	path     string
+	mu       sync.Mutex
+	now      func() time.Time
+	profiles []*Profile
+}
+
+// Open opens (or creates) the roster store under dir.
+func Open(dir string) (*Store, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("roster: mkdir %s: %w", dir, err)
+	}
+	s := &Store{path: filepath.Join(dir, "roster.json"), now: time.Now}
+	b, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return s, nil
+		}
+		return nil, fmt.Errorf("roster: read %s: %w", s.path, err)
+	}
+	if len(b) > 0 {
+		if err := json.Unmarshal(b, &s.profiles); err != nil {
+			return nil, fmt.Errorf("roster: parse %s: %w", s.path, err)
+		}
+	}
+	return s, nil
+}
+
+// Add validates and persists a new enabled profile, assigning an id +
+// timestamps. Caller-supplied ID/Enabled/timestamps are ignored
+// (kernel-assigned). The slug must be unique across the roster.
+func (s *Store) Add(p Profile) (Profile, error) {
+	p.Slug = strings.TrimSpace(p.Slug)
+	if err := Validate(p); err != nil {
+		return Profile{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, ex := range s.profiles {
+		if ex.Slug == p.Slug {
+			return Profile{}, fmt.Errorf("roster: slug %q already exists", p.Slug)
+		}
+	}
+	now := s.now().UnixMilli()
+	p.ID = ulid.New()
+	if strings.TrimSpace(p.Name) == "" {
+		p.Name = p.Slug
+	}
+	p.Enabled = true
+	p.CreatedMS = now
+	p.UpdatedMS = now
+	cp := p
+	s.profiles = append(s.profiles, &cp)
+	if err := s.save(); err != nil {
+		s.profiles = s.profiles[:len(s.profiles)-1]
+		return Profile{}, err
+	}
+	return cp, nil
+}
+
+// SetEnabled pauses (false) or resumes (true) a profile by id or slug.
+func (s *Store) SetEnabled(ref string, enabled bool) (Profile, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p := s.find(ref)
+	if p == nil {
+		return Profile{}, ErrNotFound
+	}
+	// Roll back the in-memory mutation if the durable write fails, so the
+	// running view never diverges from disk on a transient save error.
+	prevEnabled, prevUpdated := p.Enabled, p.UpdatedMS
+	p.Enabled = enabled
+	p.UpdatedMS = s.now().UnixMilli()
+	if err := s.save(); err != nil {
+		p.Enabled, p.UpdatedMS = prevEnabled, prevUpdated
+		return Profile{}, err
+	}
+	return *p, nil
+}
+
+// Update applies edits to a profile's mutable fields via mutate, re-validates,
+// and persists. Identity and lifecycle fields — ID, Slug, CreatedMS, Enabled
+// (which has its own setter) — are preserved regardless of what mutate does;
+// UpdatedMS is bumped. Rolled back in memory on validation/save failure.
+func (s *Store) Update(ref string, mutate func(*Profile)) (Profile, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p := s.find(ref)
+	if p == nil {
+		return Profile{}, ErrNotFound
+	}
+	snapshot := *p
+	mutate(p)
+	// Protect identity + lifecycle fields from the mutator. The slug is the
+	// agent's ADDRESS — renaming it would orphan every reference to it.
+	p.ID, p.Slug, p.CreatedMS, p.Enabled = snapshot.ID, snapshot.Slug, snapshot.CreatedMS, snapshot.Enabled
+	p.UpdatedMS = s.now().UnixMilli()
+	if err := Validate(*p); err != nil {
+		*p = snapshot
+		return Profile{}, err
+	}
+	if err := s.save(); err != nil {
+		*p = snapshot
+		return Profile{}, err
+	}
+	return *p, nil
+}
+
+// Remove deletes a profile by id or slug. Returns whether it existed.
+func (s *Store) Remove(ref string) (Profile, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, p := range s.profiles {
+		if p.ID == ref || p.Slug == ref {
+			removed := s.profiles
+			gone := *p
+			s.profiles = append(append([]*Profile{}, s.profiles[:i]...), s.profiles[i+1:]...)
+			if err := s.save(); err != nil {
+				s.profiles = removed // restore: disk write failed, keep the profile
+				return Profile{}, false, err
+			}
+			return gone, true, nil
+		}
+	}
+	return Profile{}, false, nil
+}
+
+// Get returns one profile by id or slug.
+func (s *Store) Get(ref string) (Profile, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if p := s.find(ref); p != nil {
+		return *p, true
+	}
+	return Profile{}, false
+}
+
+// find returns the live pointer for an id or slug. Caller holds s.mu.
+func (s *Store) find(ref string) *Profile {
+	for _, p := range s.profiles {
+		if p.ID == ref || p.Slug == ref {
+			return p
+		}
+	}
+	return nil
+}
+
+// List returns all profiles, sorted by creation time then id (deterministic).
+func (s *Store) List() []Profile {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]Profile, 0, len(s.profiles))
+	for _, p := range s.profiles {
+		out = append(out, *p)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].CreatedMS != out[j].CreatedMS {
+			return out[i].CreatedMS < out[j].CreatedMS
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out
+}
+
+// Count returns the number of profiles.
+func (s *Store) Count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.profiles)
+}
+
+func (s *Store) save() error {
+	b, err := json.MarshalIndent(s.profiles, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, s.path)
+}

--- a/kernel/roster/roster_test.go
+++ b/kernel/roster/roster_test.go
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: MIT
+
+package roster
+
+import (
+	"strings"
+	"testing"
+)
+
+func openStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	return s
+}
+
+// TestValidate_SlugRules: the slug is the agent's address — lowercase, no
+// spaces, bounded; bad shapes are rejected before anything persists.
+func TestValidate_SlugRules(t *testing.T) {
+	good := []string{"researcher", "ops-watcher", "a", "r2.d2", "x_1"}
+	for _, s := range good {
+		if err := Validate(Profile{Slug: s}); err != nil {
+			t.Fatalf("slug %q rejected: %v", s, err)
+		}
+	}
+	bad := []string{"", "Researcher", "has space", "-leading", ".leading", "_leading",
+		strings.Repeat("a", 65), "ünïcode"}
+	for _, s := range bad {
+		if err := Validate(Profile{Slug: s}); err == nil {
+			t.Fatalf("slug %q accepted, want rejection", s)
+		}
+	}
+}
+
+// TestValidate_Bounds: soul size, fallback count/emptiness, negative cost, and
+// workdir escape attempts are all rejected.
+func TestValidate_Bounds(t *testing.T) {
+	if err := Validate(Profile{Slug: "a", Soul: strings.Repeat("x", maxSoulBytes+1)}); err == nil {
+		t.Fatal("oversized soul accepted")
+	}
+	if err := Validate(Profile{Slug: "a", Fallbacks: make([]string, maxFallbacks+1)}); err == nil {
+		t.Fatal("too many fallbacks accepted")
+	}
+	if err := Validate(Profile{Slug: "a", Fallbacks: []string{"m1", " "}}); err == nil {
+		t.Fatal("blank fallback accepted")
+	}
+	if err := Validate(Profile{Slug: "a", MaxCostMc: -1}); err == nil {
+		t.Fatal("negative cost ceiling accepted")
+	}
+	for _, w := range []string{"/abs", "..", "../up", "a/../../b", "a/.."} {
+		if err := Validate(Profile{Slug: "a", Workdir: w}); err == nil {
+			t.Fatalf("escaping workdir %q accepted", w)
+		}
+	}
+	if err := Validate(Profile{Slug: "a", Workdir: "team/researcher"}); err != nil {
+		t.Fatalf("relative workdir rejected: %v", err)
+	}
+}
+
+// TestAdd_AssignsIdentityAndDefaults: kernel assigns id/enabled/timestamps,
+// name defaults to the slug, and the slug must be unique.
+func TestAdd_AssignsIdentityAndDefaults(t *testing.T) {
+	s := openStore(t)
+	p, err := s.Add(Profile{Slug: "researcher", Soul: "You research.", ID: "spoofed", Enabled: false})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if p.ID == "" || p.ID == "spoofed" {
+		t.Fatalf("ID not kernel-assigned: %q", p.ID)
+	}
+	if !p.Enabled || p.CreatedMS == 0 || p.UpdatedMS == 0 {
+		t.Fatalf("lifecycle defaults wrong: %+v", p)
+	}
+	if p.Name != "researcher" {
+		t.Fatalf("name should default to slug, got %q", p.Name)
+	}
+	if _, err := s.Add(Profile{Slug: "researcher"}); err == nil {
+		t.Fatal("duplicate slug accepted")
+	}
+}
+
+// TestGet_ByIdAndSlug: profiles resolve by either handle.
+func TestGet_ByIdAndSlug(t *testing.T) {
+	s := openStore(t)
+	p, _ := s.Add(Profile{Slug: "ops"})
+	if got, ok := s.Get(p.ID); !ok || got.Slug != "ops" {
+		t.Fatal("lookup by id failed")
+	}
+	if got, ok := s.Get("ops"); !ok || got.ID != p.ID {
+		t.Fatal("lookup by slug failed")
+	}
+	if _, ok := s.Get("ghost"); ok {
+		t.Fatal("unknown ref resolved")
+	}
+}
+
+// TestUpdate_ProtectsIdentity: mutate can change mutable fields but never the
+// id/slug/created/enabled, and a mutation into an invalid state rolls back.
+func TestUpdate_ProtectsIdentity(t *testing.T) {
+	s := openStore(t)
+	p, _ := s.Add(Profile{Slug: "ops", Soul: "v1"})
+	got, err := s.Update("ops", func(dst *Profile) {
+		dst.Soul = "v2"
+		dst.Slug = "hijacked"
+		dst.ID = "hijacked"
+		dst.Enabled = false
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if got.Soul != "v2" || got.Slug != "ops" || got.ID != p.ID || !got.Enabled {
+		t.Fatalf("identity not protected: %+v", got)
+	}
+	if _, err := s.Update("ops", func(dst *Profile) { dst.MaxCostMc = -5 }); err == nil {
+		t.Fatal("invalid mutation accepted")
+	}
+	if cur, _ := s.Get("ops"); cur.MaxCostMc != 0 || cur.Soul != "v2" {
+		t.Fatalf("failed mutation not rolled back: %+v", cur)
+	}
+	if _, err := s.Update("ghost", func(*Profile) {}); err != ErrNotFound {
+		t.Fatalf("unknown ref: err = %v, want ErrNotFound", err)
+	}
+}
+
+// TestSetEnabled_And_Remove: pause/resume round-trips; remove by slug works
+// and reports existence.
+func TestSetEnabled_And_Remove(t *testing.T) {
+	s := openStore(t)
+	_, _ = s.Add(Profile{Slug: "ops"})
+	if p, err := s.SetEnabled("ops", false); err != nil || p.Enabled {
+		t.Fatalf("pause failed: %+v %v", p, err)
+	}
+	if p, err := s.SetEnabled("ops", true); err != nil || !p.Enabled {
+		t.Fatalf("resume failed: %+v %v", p, err)
+	}
+	if _, err := s.SetEnabled("ghost", true); err != ErrNotFound {
+		t.Fatalf("unknown ref: err = %v, want ErrNotFound", err)
+	}
+	gone, ok, err := s.Remove("ops")
+	if err != nil || !ok || gone.Slug != "ops" {
+		t.Fatalf("remove failed: %+v %v %v", gone, ok, err)
+	}
+	if _, ok, _ := s.Remove("ops"); ok {
+		t.Fatal("second remove reported existence")
+	}
+	if s.Count() != 0 {
+		t.Fatalf("count = %d after remove", s.Count())
+	}
+}
+
+// TestPersistence_SurvivesReopen: the roster is durable — a second Open on the
+// same dir sees every profile with fields intact.
+func TestPersistence_SurvivesReopen(t *testing.T) {
+	dir := t.TempDir()
+	s1, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	want, _ := s1.Add(Profile{Slug: "researcher", Soul: "You research deeply.",
+		Model: "deepseek-v4-pro", Fallbacks: []string{"m2", "m3"}, MaxCostMc: 500_000,
+		MemoryScope: "research", Workdir: "research", Description: "the digger"})
+	_, _ = s1.Add(Profile{Slug: "ops"})
+
+	s2, err := Open(dir)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	if s2.Count() != 2 {
+		t.Fatalf("count after reopen = %d, want 2", s2.Count())
+	}
+	got, ok := s2.Get("researcher")
+	if !ok {
+		t.Fatal("researcher lost on reopen")
+	}
+	if got.ID != want.ID || got.Soul != want.Soul || got.Model != want.Model ||
+		got.MaxCostMc != want.MaxCostMc || got.MemoryScope != want.MemoryScope ||
+		got.Workdir != want.Workdir || len(got.Fallbacks) != 2 {
+		t.Fatalf("profile fields lost on reopen: %+v", got)
+	}
+}
+
+// TestList_DeterministicOrder: creation order, stable.
+func TestList_DeterministicOrder(t *testing.T) {
+	s := openStore(t)
+	for _, slug := range []string{"c", "a", "b"} {
+		if _, err := s.Add(Profile{Slug: slug}); err != nil {
+			t.Fatalf("Add %s: %v", slug, err)
+		}
+	}
+	got := s.List()
+	if len(got) != 3 || got[0].Slug != "c" || got[1].Slug != "a" || got[2].Slug != "b" {
+		t.Fatalf("order wrong: %+v", got)
+	}
+}

--- a/kernel/runtime/runtime.go
+++ b/kernel/runtime/runtime.go
@@ -37,6 +37,7 @@ import (
 	"github.com/agezt/agezt/kernel/reflect"
 	"github.com/agezt/agezt/kernel/scheduler"
 	"github.com/agezt/agezt/kernel/skill"
+	"github.com/agezt/agezt/kernel/roster"
 	"github.com/agezt/agezt/kernel/standing"
 	"github.com/agezt/agezt/kernel/state"
 	"github.com/agezt/agezt/kernel/tenantctx"
@@ -327,6 +328,7 @@ type Kernel struct {
 	forge     *skill.Forge
 	skillDir  *skill.FileStore
 	standing  *standing.Store
+	roster    *roster.Store
 	artifacts *artifact.Store
 	reflect   *reflect.Engine
 	schedules *cadence.Store        // persistent scheduled-intents store (autonomy)
@@ -446,6 +448,16 @@ func Open(cfg Config) (*Kernel, error) {
 		return nil, fmt.Errorf("runtime: standing: %w", err)
 	}
 
+	rstore, err := roster.Open(filepath.Join(cfg.BaseDir, "roster"))
+	if err != nil {
+		j.Close()
+		st.Close()
+		mstore.Close()
+		wstore.Close()
+		skstore.Close()
+		return nil, fmt.Errorf("runtime: roster: %w", err)
+	}
+
 	// Reflection holds no store of its own — it folds the journal and tunes
 	// the world graph, then journals its report (SPEC-05 §6). Default decay
 	// knobs; the daemon may override via the optional periodic trigger.
@@ -505,6 +517,7 @@ func Open(cfg Config) (*Kernel, error) {
 		forge:        forge,
 		skillDir:     skstore,
 		standing:     ststore,
+		roster:       rstore,
 		artifacts:    artStore,
 		reflect:      reflectEng,
 		schedules:    schedStore,
@@ -681,6 +694,74 @@ func (k *Kernel) RemoveStanding(id string) (bool, error) {
 		_, _ = k.bus.Publish(event.Spec{
 			Subject: "standing." + id, Kind: event.KindStandingRemoved, Actor: "standing",
 			Payload: map[string]any{"id": id, "name": o.Name},
+		})
+	}
+	return ok, nil
+}
+
+// Roster returns the durable agent-profile store (M783). Always non-nil after Open.
+func (k *Kernel) Roster() *roster.Store { return k.roster }
+
+// AddProfile validates and persists a named agent profile, journaling
+// roster.created so the agent's birth is auditable.
+func (k *Kernel) AddProfile(p roster.Profile) (roster.Profile, error) {
+	saved, err := k.roster.Add(p)
+	if err != nil {
+		return roster.Profile{}, err
+	}
+	_, _ = k.bus.Publish(event.Spec{
+		Subject: "roster." + saved.Slug, Kind: event.KindRosterCreated, Actor: "roster",
+		Payload: map[string]any{"id": saved.ID, "slug": saved.Slug, "name": saved.Name, "model": saved.Model},
+	})
+	return saved, nil
+}
+
+// SetProfileEnabled pauses/resumes an agent profile, journaling roster.updated.
+func (k *Kernel) SetProfileEnabled(ref string, enabled bool) (roster.Profile, error) {
+	p, err := k.roster.SetEnabled(ref, enabled)
+	if err != nil {
+		return roster.Profile{}, err
+	}
+	state := "paused"
+	if enabled {
+		state = "resumed"
+	}
+	_, _ = k.bus.Publish(event.Spec{
+		Subject: "roster." + p.Slug, Kind: event.KindRosterUpdated, Actor: "roster",
+		Payload: map[string]any{"id": p.ID, "slug": p.Slug, "enabled": enabled, "action": state},
+	})
+	return p, nil
+}
+
+// UpdateProfile edits a profile's mutable fields via mutate, journaling
+// roster.updated (action "edited"). Identity/lifecycle fields are protected by
+// the store. Returns false + nil error for an unknown ref (standing pattern).
+func (k *Kernel) UpdateProfile(ref string, mutate func(*roster.Profile)) (roster.Profile, bool, error) {
+	p, err := k.roster.Update(ref, mutate)
+	if errors.Is(err, roster.ErrNotFound) {
+		return roster.Profile{}, false, nil
+	}
+	if err != nil {
+		return roster.Profile{}, false, err
+	}
+	_, _ = k.bus.Publish(event.Spec{
+		Subject: "roster." + p.Slug, Kind: event.KindRosterUpdated, Actor: "roster",
+		Payload: map[string]any{"id": p.ID, "slug": p.Slug, "action": "edited"},
+	})
+	return p, true, nil
+}
+
+// RemoveProfile deletes an agent profile, journaling roster.removed when it
+// existed. Returns whether it existed.
+func (k *Kernel) RemoveProfile(ref string) (bool, error) {
+	gone, ok, err := k.roster.Remove(ref)
+	if err != nil {
+		return false, err
+	}
+	if ok {
+		_, _ = k.bus.Publish(event.Spec{
+			Subject: "roster." + gone.Slug, Kind: event.KindRosterRemoved, Actor: "roster",
+			Payload: map[string]any{"id": gone.ID, "slug": gone.Slug, "name": gone.Name},
 		})
 	}
 	return ok, nil

--- a/kernel/webui/webui.go
+++ b/kernel/webui/webui.go
@@ -110,6 +110,7 @@ var apiRoutes = map[string]string{
 	"/api/world":         controlplane.CmdWorldList,
 	"/api/skills":        controlplane.CmdSkillList,
 	"/api/standing":      controlplane.CmdStandingList,
+	"/api/agents":        controlplane.CmdAgentList,
 	"/api/inbox":         controlplane.CmdInbox,
 	"/api/board":         controlplane.CmdBoardRead,
 	"/api/autonomy":      controlplane.CmdAutonomyFeed,
@@ -234,6 +235,9 @@ var writeRoutes = map[string]writeRoute{
 	"/api/standing/remove":  {controlplane.CmdStandingRemove, []string{"id"}},
 	// Fire a standing order now (M765), ignoring its triggers — test or run on demand.
 	"/api/standing/fire": {controlplane.CmdStandingFire, []string{"id"}},
+	// Agent roster lifecycle (M783): pause/resume/remove a named agent (ref = id or slug).
+	"/api/agents/enable": {controlplane.CmdAgentSetEnabled, []string{"ref", "enabled"}},
+	"/api/agents/remove": {controlplane.CmdAgentRemove, []string{"ref"}},
 	"/api/reflect/run":      {controlplane.CmdReflectRun, nil},
 	// Provider keyring switch/remove (M700): activate or remove a key, reloading
 	// the provider in place. (Add is a jsonRoute — the value is a secret body.)
@@ -275,6 +279,10 @@ var jsonRoutes = map[string]writeRoute{
 	// Edit a standing order in place (M729): id + any subset of the human-tunable
 	// fields. assure is numeric, so the JSON body preserves its type.
 	"/api/standing/edit": {controlplane.CmdStandingEdit, []string{"id", "name", "plan", "mode", "max_trust", "briefing_min", "assure"}},
+	// Agent roster create/edit (M783): the profile is a structured object (soul
+	// text, fallback list, numeric cost ceiling) — a JSON body, not query args.
+	"/api/agents/add":  {controlplane.CmdAgentAdd, []string{"profile"}},
+	"/api/agents/edit": {controlplane.CmdAgentEdit, []string{"ref", "profile"}},
 	// Create a schedule (M715): intent + a timing mode. Numeric timing args (e.g.
 	// interval_sec, at_minutes, once_at_unix) ride the JSON body so they keep their
 	// types — a query arg would stringify them.

--- a/kernel/webui/webui_test.go
+++ b/kernel/webui/webui_test.go
@@ -554,7 +554,7 @@ func TestAPIReadOnly(t *testing.T) {
 	// never issues anything outside the known read set.
 	readOnly := map[string]bool{
 		"status": true, "config": true, "runs_list": true, "runs_stats": true, "budget": true, "cache_stats": true, "provider_stats": true, "tool_stats": true, "edict_stats": true, "schedule_list": true, "memory_list": true, "world_list": true,
-		"skill_list": true, "standing_list": true, "inbox": true, "reflect_show": true, "approvals": true,
+		"skill_list": true, "standing_list": true, "agent_list": true, "inbox": true, "reflect_show": true, "approvals": true,
 		"plan_stats": true, "edict_show": true, "tool_list": true, "board_read": true, "autonomy_feed": true,
 		"catalog_list": true, "sandbox_list": true,
 		"config_schema": true, "config_values": true, "routing_get": true, "persona_get": true, "prompts_get": true,


### PR DESCRIPTION
## What

Agents stop being ephemeral runs. **`kernel/roster`** is a durable registry of named agent identities: an immutable **slug** (the agent's address), a **soul** (system prompt), **model + ordered fallbacks**, default task type, **per-run spend ceiling**, **memory scope**, and **workspace subdir**. First milestone of the multi-agent identity arc (gap #1 of the vision gap analysis).

`agt run --agent researcher` **runs AS the agent**: soul → system prompt, profile model + cost ceiling as defaults (explicit flags win); paused/unknown agents are refused with a hint rather than silently running as the default identity.

## Surface

- `agt agent list/add/show/set/pause/resume/remove` + `agt run --agent <slug>`
- Control plane: `agent_list/add/edit/set_enabled/remove` (ref = id or slug)
- Web UI proxy routes: GET `/api/agents`, POST `/api/agents/{add,edit,enable,remove}` (console view = next milestone)
- Journaled lifecycle: `roster.created/updated/removed` (new append-only kinds)

## Validation

- **10 new tests**: slug rules, bounds + workdir-escape rejection, identity protection on edit (slug immutable, rollback on invalid mutation), persistence across reopen, control-plane CRUD round-trip with journal asserts, run seam via dry-run plan (profile fills model/soul/cost gaps; explicit `--model` wins; paused/unknown refused). webui read-only guard extended for `agent_list`.
- **Isolated-daemon smoke**: add (soul + $0.50 ceiling) → dry-run showed both applied → real run completed → pause refused the run (exit 1, resume hint) → set/remove round-trip → `roster.created` seq=0 in journal; 0 panics.
- **Local CI battery** (org Actions billing still exhausted, jobs die at startup — same as PRs #136–#226): full suite green (85 pkgs), vet + staticcheck clean, linux cross-build OK, gofmt verified on staged LF blobs, go.mod unchanged, dist untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)