### PR TITLE
Feat: delegate to a named agent — sub-agents run as roster identities (M784)

### DIFF
--- a/.project/PHASE-M784-DELEGATE-BY-SLUG-REPORT.md
+++ b/.project/PHASE-M784-DELEGATE-BY-SLUG-REPORT.md
@@ -1,0 +1,41 @@
+# Phase M784 — delegate(agent="slug"): sub-agents as named roster agents
+
+**Date:** 2026-06-10 · **Status:** DONE · **Arc:** multi-agent identity, step 2
+(builds on M783 roster).
+
+## What
+
+The `delegate` tool gains an optional `agent` param (roster slug). The
+sub-agent runs AS that identity: soul → child persona (replaces the daemon
+persona layer; sub-agent preamble stays on top), model + task_type as defaults
+(explicit args win), MaxCostMc → child's `MaxRunCostMicrocents` (on top of the
+M46/M48/M629 tree caps). `subagent.spawned` payload records `agent: <slug>`.
+Unknown/paused agent → tool error the lead adapts to; zero spawns.
+
+## Changes
+
+- `kernel/runtime/subagent.go`: tool schema + Invoke + runner signature
+  (`run(ctx, task, model, taskType, agentRef)`); profile resolution up front;
+  soul/model/task-type/cost application; spawn payload `agent` field.
+- No control-plane/CLI/webui changes (the tool is the surface).
+
+## Tests (3 new, 4 cases, on a REAL kernel — journal+bus+loop, mock provider)
+
+- `TestDelegate_AsNamedAgent`: child completion request carries profile model
+  AND soul in System; spawn event payload has agent+model.
+- `TestDelegate_ExplicitModelWinsOverProfile`: profile fills gaps only.
+- `TestDelegate_UnknownOrPausedAgentRefused` (2 subtests): tool error, lead
+  adapts, 0 subagent.spawned events.
+
+## Gate
+
+Full suite `-p 2 ./...` green; vet + staticcheck clean; linux cross-build OK;
+go.mod unchanged. Isolated-daemon boot smoke with the extended schema: 0
+panics, clean shutdown. CI org-billing still blocked → local battery +
+arc-authority merge.
+
+## Next in the arc
+
+Agents console view (webui CRUD; routes live since M783) · memory_scope/
+workdir wiring into runs · Fallbacks → per-agent routing chain · A2A
+ask/reply on the board.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **Delegate to a named agent — `delegate(agent="researcher")`.** The lead agent can now spawn
+  sub-agents AS named roster identities (M783): the `delegate` tool takes an optional **`agent`**
+  (roster slug), and the sub-agent runs with that profile's **soul** as its persona (replacing the
+  daemon persona layer; the sub-agent preamble stays on top), its **model** and **task type** as
+  defaults (explicit `model`/`task_type` args still win), and its **per-run spend ceiling** bounding
+  the child's own run — on top of the existing delegation-tree depth/fan-out/total/spend caps. The
+  `subagent.spawned` journal event now records who the child ran as (`agent: researcher`), so the
+  delegation graph and `agt why` show the fleet by name. An unknown or paused agent is a clear tool
+  error the lead adapts to — never a sub-agent silently running as the default identity. This turns
+  the roster into a real **fleet**: define "researcher", "coder", "ops-watcher" once, and the lead
+  (or a standing order's plan) staffs work to them by name. Unit-tested on a real kernel (the
+  provider sees the profile's model + soul in the child's completion request; the spawn event
+  carries the agent slug; explicit model wins over the profile; unknown and paused agents are
+  refused with zero spawns). Daemon boots clean with the extended tool schema; 0 panics. (M784)
 - **Named, durable agents — the roster.** Until now an "agent" was a run: it existed for the length
   of one task and vanished. The new **agent roster** (`kernel/roster`) makes agents *durable named
   identities*: `agt agent add researcher --soul "You research deeply…" --model … --max-cost 0.50`

--- a/kernel/runtime/subagent.go
+++ b/kernel/runtime/subagent.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/agezt/agezt/kernel/agent"
 	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/roster"
 )
 
 // ctxKeyDepth carries the current sub-agent nesting depth so runSubAgent can
@@ -38,7 +39,7 @@ const subAgentSystem = "You are a focused sub-agent spawned to complete ONE dele
 // wired to k.runSubAgent after the kernel is constructed (the tool is built
 // during Open before *Kernel exists).
 type subAgentTool struct {
-	run func(ctx context.Context, task, model, taskType string) (string, error)
+	run func(ctx context.Context, task, model, taskType, agentRef string) (string, error)
 }
 
 func newSubAgentTool() *subAgentTool { return &subAgentTool{} }
@@ -67,6 +68,10 @@ func (t *subAgentTool) Definition() agent.ToolDef {
     "task_type": {
       "type": "string",
       "description": "Optional routing task type for the sub-agent (e.g. \"code\", \"plan\"); its configured model chain supplies the fallbacks. Defaults to \"delegate\"."
+    },
+    "agent": {
+      "type": "string",
+      "description": "Optional named agent (roster slug) to run the sub-agent AS: its soul becomes the sub-agent's persona and its model/task type/cost ceiling apply as defaults. Explicit model/task_type here still win."
     }
   },
   "required": ["task"]
@@ -79,6 +84,7 @@ func (t *subAgentTool) Invoke(ctx context.Context, input json.RawMessage) (agent
 		Task     string `json:"task"`
 		Model    string `json:"model"`
 		TaskType string `json:"task_type"`
+		Agent    string `json:"agent"`
 	}
 	if err := json.Unmarshal(input, &in); err != nil {
 		return agent.Result{Output: "invalid input: " + err.Error(), IsError: true}, nil
@@ -86,7 +92,7 @@ func (t *subAgentTool) Invoke(ctx context.Context, input json.RawMessage) (agent
 	if t.run == nil {
 		return agent.Result{Output: "sub-agent runner not wired", IsError: true}, nil
 	}
-	out, err := t.run(ctx, in.Task, in.Model, in.TaskType)
+	out, err := t.run(ctx, in.Task, in.Model, in.TaskType, in.Agent)
 	if err != nil {
 		// Surface as a tool error so the lead agent can adapt, not crash.
 		return agent.Result{Output: "delegation failed: " + err.Error(), IsError: true}, nil
@@ -98,10 +104,25 @@ func (t *subAgentTool) Invoke(ctx context.Context, input json.RawMessage) (agent
 // child correlation, bounded by SubAgentMaxDepth. The spawn is journaled under
 // the PARENT correlation (carrying the child correlation) so `agt why <parent>`
 // shows the delegation; the child's own steps live under the child correlation.
-func (k *Kernel) runSubAgent(ctx context.Context, task, model, taskType string) (string, error) {
+func (k *Kernel) runSubAgent(ctx context.Context, task, model, taskType, agentRef string) (string, error) {
 	task = strings.TrimSpace(task)
 	if task == "" {
 		return "", errors.New("task required")
+	}
+	// Delegate AS a named agent (M784): resolve the roster profile up front so
+	// an unknown or paused agent is a clear tool error the lead adapts to, not
+	// a sub-agent silently running as the default identity. The profile's
+	// model/task type/cost ceiling apply as DEFAULTS; explicit call args win.
+	var prof *roster.Profile
+	if agentRef = strings.TrimSpace(agentRef); agentRef != "" {
+		p, ok := k.roster.Get(agentRef)
+		if !ok {
+			return "", fmt.Errorf("unknown agent %q (agt agent list)", agentRef)
+		}
+		if !p.Enabled {
+			return "", fmt.Errorf("agent %q is paused (agt agent resume %s)", p.Slug, p.Slug)
+		}
+		prof = &p
 	}
 	// Per-sub-agent model (M705): an explicit model overrides the daemon default
 	// for this delegation; an explicit task_type selects the routing chain whose
@@ -109,6 +130,14 @@ func (k *Kernel) runSubAgent(ctx context.Context, task, model, taskType string) 
 	// a bare delegate behaves exactly as before.
 	model = strings.TrimSpace(model)
 	taskType = strings.TrimSpace(taskType)
+	if prof != nil {
+		if model == "" {
+			model = strings.TrimSpace(prof.Model)
+		}
+		if taskType == "" {
+			taskType = strings.TrimSpace(prof.TaskType)
+		}
+	}
 	if taskType == "" {
 		taskType = "delegate"
 	}
@@ -216,19 +245,23 @@ func (k *Kernel) runSubAgent(ctx context.Context, task, model, taskType string) 
 	if linkCorr == "" {
 		linkCorr = childCorr
 	}
+	spawnPayload := map[string]any{
+		"task":              task,
+		"child_correlation": childCorr,
+		"depth":             depth + 1,
+		"parent":            parentCorr,
+		"model":             subModel,
+		"task_type":         taskType,
+	}
+	if prof != nil {
+		spawnPayload["agent"] = prof.Slug // who the sub-agent ran AS (M784)
+	}
 	_, _ = k.bus.Publish(event.Spec{
 		Subject:       "agent." + actor + ".subagent",
 		Kind:          event.KindSubAgentSpawned,
 		Actor:         actor,
 		CorrelationID: linkCorr,
-		Payload: map[string]any{
-			"task":              task,
-			"child_correlation": childCorr,
-			"depth":             depth + 1,
-			"parent":            parentCorr,
-			"model":             subModel,
-			"task_type":         taskType,
-		},
+		Payload:       spawnPayload,
 	})
 
 	// Child context: bump depth, retarget actor/correlation so the policy hook
@@ -240,24 +273,37 @@ func (k *Kernel) runSubAgent(ctx context.Context, task, model, taskType string) 
 	// to the whole tree, not re-seeded at each level.
 	childCtx = context.WithValue(childCtx, ctxKeyRoot, rootCorr)
 
+	// A named agent's soul REPLACES the daemon persona layer (it IS this
+	// sub-agent's identity); the sub-agent preamble always stays on top.
 	system := subAgentSystem
-	if k.cfg.System != "" {
+	switch {
+	case prof != nil && strings.TrimSpace(prof.Soul) != "":
+		system += "\n\n" + strings.TrimSpace(prof.Soul)
+	case k.cfg.System != "":
 		system += "\n\n" + k.cfg.System
 	}
 
+	// The profile's per-run spend ceiling bounds this sub-agent's own run
+	// (M784) — the delegation-tree spend cap above still applies on top.
+	var maxRunCost int64
+	if prof != nil {
+		maxRunCost = prof.MaxCostMc
+	}
+
 	answer, err := agent.Run(childCtx, agent.LoopConfig{
-		Provider:      k.cfg.Provider,
-		Tools:         k.tools,
-		Bus:           k.bus,
-		Model:         subModel,
-		TaskType:      taskType, // M705: route the sub-agent (chain supplies fallbacks)
-		System:        system,
-		MaxIter:       k.cfg.MaxIter,
-		ToolTimeout:   k.cfg.ToolTimeout,
-		Actor:         actor,
-		CorrelationID: childCorr,
-		Policy:        k.policyHook,
-		Steer:         rc, // M631: individual sub-agent steering
+		Provider:             k.cfg.Provider,
+		Tools:                k.tools,
+		Bus:                  k.bus,
+		Model:                subModel,
+		TaskType:             taskType, // M705: route the sub-agent (chain supplies fallbacks)
+		System:               system,
+		MaxIter:              k.cfg.MaxIter,
+		ToolTimeout:          k.cfg.ToolTimeout,
+		MaxRunCostMicrocents: maxRunCost,
+		Actor:                actor,
+		CorrelationID:        childCorr,
+		Policy:               k.policyHook,
+		Steer:                rc, // M631: individual sub-agent steering
 	}, task)
 	if err != nil {
 		return "", fmt.Errorf("sub-agent %s: %w", childCorr, err)

--- a/kernel/runtime/subagent_roster_test.go
+++ b/kernel/runtime/subagent_roster_test.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+
+package runtime_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/roster"
+	"github.com/agezt/agezt/plugins/providers/mock"
+)
+
+// TestDelegate_AsNamedAgent: delegate(agent="researcher") runs the sub-agent AS
+// that roster profile — the provider sees the profile's model and its soul in
+// the system prompt, and the spawn event records who the child ran as (M784).
+func TestDelegate_AsNamedAgent(t *testing.T) {
+	prov := mock.New(
+		mock.ToolUse("c1", "delegate", map[string]any{"task": "dig deep", "agent": "researcher"}),
+		mock.FinalText("found it"), // child's run
+		mock.FinalText("done"),     // lead's final
+	)
+	var reqs []agent.CompletionRequest
+	prov.OnRequest = func(req agent.CompletionRequest) { reqs = append(reqs, req) }
+	k := openSubAgentKernel(t, prov, 1)
+
+	if _, err := k.AddProfile(roster.Profile{
+		Slug: "researcher", Soul: "You are Researcher. Cite sources.", Model: "agent-model",
+	}); err != nil {
+		t.Fatalf("AddProfile: %v", err)
+	}
+
+	col := &collector{}
+	col.watch(k)
+
+	ans, _, err := k.Run(context.Background(), "lead task")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if ans != "done" {
+		t.Errorf("final answer = %q", ans)
+	}
+
+	// The child's completion request carried the profile's model + soul.
+	var child *agent.CompletionRequest
+	for i := range reqs {
+		if reqs[i].Model == "agent-model" {
+			child = &reqs[i]
+			break
+		}
+	}
+	if child == nil {
+		t.Fatalf("no provider request used the profile model; models seen: %v",
+			func() []string {
+				var m []string
+				for _, r := range reqs {
+					m = append(m, r.Model)
+				}
+				return m
+			}())
+	}
+	if !strings.Contains(child.System, "You are Researcher. Cite sources.") {
+		t.Errorf("child system prompt missing the soul: %q", child.System)
+	}
+
+	// The spawn event records the agent the child ran AS.
+	time.Sleep(50 * time.Millisecond)
+	spawns := col.ofKind(event.KindSubAgentSpawned)
+	if len(spawns) != 1 {
+		t.Fatalf("expected 1 spawn, got %d", len(spawns))
+	}
+	var pl struct {
+		Agent string `json:"agent"`
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal(spawns[0].Payload, &pl); err != nil {
+		t.Fatal(err)
+	}
+	if pl.Agent != "researcher" || pl.Model != "agent-model" {
+		t.Errorf("spawn payload agent=%q model=%q, want researcher/agent-model", pl.Agent, pl.Model)
+	}
+}
+
+// TestDelegate_ExplicitModelWinsOverProfile: an explicit delegate model beats
+// the profile's — the profile only fills gaps.
+func TestDelegate_ExplicitModelWinsOverProfile(t *testing.T) {
+	prov := mock.New(
+		mock.ToolUse("c1", "delegate", map[string]any{
+			"task": "t", "agent": "researcher", "model": "explicit-model"}),
+		mock.FinalText("child"),
+		mock.FinalText("lead"),
+	)
+	var models []string
+	prov.OnRequest = func(req agent.CompletionRequest) { models = append(models, req.Model) }
+	k := openSubAgentKernel(t, prov, 1)
+	if _, err := k.AddProfile(roster.Profile{Slug: "researcher", Model: "agent-model"}); err != nil {
+		t.Fatalf("AddProfile: %v", err)
+	}
+	if _, _, err := k.Run(context.Background(), "lead task"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for _, m := range models {
+		if m == "agent-model" {
+			t.Fatalf("profile model used despite explicit override; models: %v", models)
+		}
+	}
+	found := false
+	for _, m := range models {
+		if m == "explicit-model" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("explicit model never reached the provider; models: %v", models)
+	}
+}
+
+// TestDelegate_UnknownOrPausedAgentRefused: a bad agent ref is a tool error the
+// lead adapts to — no sub-agent is ever spawned.
+func TestDelegate_UnknownOrPausedAgentRefused(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(t *testing.T, k interface {
+			AddProfile(roster.Profile) (roster.Profile, error)
+			SetProfileEnabled(string, bool) (roster.Profile, error)
+		})
+	}{
+		{"unknown agent", nil},
+		{"paused agent", func(t *testing.T, k interface {
+			AddProfile(roster.Profile) (roster.Profile, error)
+			SetProfileEnabled(string, bool) (roster.Profile, error)
+		}) {
+			if _, err := k.AddProfile(roster.Profile{Slug: "ghost"}); err != nil {
+				t.Fatalf("AddProfile: %v", err)
+			}
+			if _, err := k.SetProfileEnabled("ghost", false); err != nil {
+				t.Fatalf("SetProfileEnabled: %v", err)
+			}
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prov := mock.New(
+				mock.ToolUse("c1", "delegate", map[string]any{"task": "t", "agent": "ghost"}),
+				mock.FinalText("lead adapted"), // the lead's next turn after the tool error
+			)
+			k := openSubAgentKernel(t, prov, 1)
+			if tc.setup != nil {
+				tc.setup(t, k)
+			}
+			col := &collector{}
+			col.watch(k)
+			ans, _, err := k.Run(context.Background(), "lead task")
+			if err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+			if ans != "lead adapted" {
+				t.Errorf("answer = %q", ans)
+			}
+			time.Sleep(50 * time.Millisecond)
+			if n := len(col.ofKind(event.KindSubAgentSpawned)); n != 0 {
+				t.Errorf("%d sub-agent(s) spawned for a refused agent ref", n)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

`delegate(agent="researcher")` — the lead spawns sub-agents AS named roster identities (M783). The profile's **soul** becomes the child's persona, **model/task type** apply as defaults (explicit args win), **per-run spend ceiling** bounds the child's run (on top of depth/fan-out/total/spend tree caps). `subagent.spawned` records `agent: <slug>` so the delegation graph shows the fleet by name. Unknown/paused agent → tool error, zero spawns.

## Validation

- 3 new tests (4 cases) on a **real kernel** (journal+bus+loop, mock provider): child completion request carries profile model + soul in System; spawn payload has the slug; explicit model wins; unknown/paused refused with no spawn.
- Full suite green, vet + staticcheck clean, linux cross-build OK, go.mod unchanged. Isolated-daemon boot smoke: 0 panics.
- CI org-billing still blocked (jobs die at startup) — local battery, arc-authority merge (PRs #136+ pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)