### PR TITLE
Feat: a named agent's memory follows it — private notes, shared brain (M786)

### DIFF
--- a/.project/PHASE-M786-AGENT-MEMORY-SCOPE-REPORT.md
+++ b/.project/PHASE-M786-AGENT-MEMORY-SCOPE-REPORT.md
@@ -1,0 +1,53 @@
+# Phase M786 — agent memory scope: private notes follow the identity
+
+**Date:** 2026-06-10 · **Status:** DONE · **Arc:** multi-agent identity, step 4
+(M783 roster → M784 delegate-by-slug → M785 console → this).
+
+## What
+
+A roster profile's `MemoryScope` (default: the slug) now flows into runs:
+
+- **Context injection** (`RunWith`): `RecallScoped(corr, intent, topK,
+  memory.ScopeFrom(runCtx))` — the named agent's private notes inject
+  alongside shared memory; unscoped runs unchanged (scope "" ≡ old Recall).
+- **Memory tool**: recall's scope DEFAULTS to the ctx scope (explicit param
+  wins). Writes stay shared by default — M652's "shared brain, private
+  notes": private writes remain opt-in via the param.
+- **Run boundary**: `handleRun` sets `memory.WithScope(ctx, scope)` when an
+  `agent` resolves; **delegate** sets it on the child ctx, so a
+  `delegate(agent="researcher")` child reads researcher's notes too.
+
+## Changes
+
+- `kernel/memory/manager.go`: ctx key + `WithScope`/`ScopeFrom` (mirrors
+  `WithCorrelation`); tool recall ctx-default.
+- `kernel/runtime/runtime.go`: injection → `RecallScoped(..., ScopeFrom)`.
+- `kernel/runtime/subagent.go`: child ctx scope from the profile.
+- `kernel/controlplane/server.go`: run-as-agent ctx scope.
+
+## Tests (4 new, all layers)
+
+- memory: `TestTool_RecallDefaultsToCtxScope` (ctx scope sees shared+own,
+  never another scope; explicit param wins; unscoped = shared only) and
+  `TestTool_RememberStaysSharedByDefault` (scoped ctx does NOT privatise
+  writes).
+- runtime: `TestDelegate_AgentMemoryScopeFollowsChild` — real kernel, child's
+  memory recall (journaled tool.result) surfaces the profile-private note.
+- controlplane: `TestRun_AsAgent_MemoryScope` — end-to-end over the wire,
+  asserted on the actual provider requests: the agent run's injected system
+  contains the shared fact AND the private note; the plain run contains
+  shared only (no leak).
+
+## Gate
+
+Full suite `-p 2 ./...` green; vet + staticcheck clean; linux cross-build OK;
+go.mod unchanged; no frontend change. Isolated-daemon smoke: seeded shared +
+scope-tagged memories via `agt memory add --tag scope=…`, ran `--agent` and
+plain runs, clean, 0 panics (the behavioural proof lives in the wire-level
+e2e test, which asserts the injected provider context directly). CI
+org-billing still blocked → local battery + arc-authority merge.
+
+## Next in the arc
+
+Fallbacks → per-agent routing chain (governor) · workdir wiring · A2A
+ask/reply on the board · chat: converse AS a named agent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **A named agent's memory follows it — private notes, shared brain.** Running as a roster agent
+  (M783) now wires the profile's **memory scope** (default: its slug) into the whole run: the
+  **context injection** recalls the agent's private notes alongside shared memory (a plain run still
+  sees shared only — nothing leaks), and the **memory tool's recalls default to the agent's scope**,
+  so "researcher" surfaces its own notes without naming itself. The same follows **sub-agents**:
+  `delegate(agent="researcher")` gives the child the profile's scope. Writes deliberately stay
+  shared by default — the M652 philosophy is *shared brain, private notes*: an agent's learnings
+  benefit the fleet unless it explicitly scopes a note; the explicit tool `scope` param always wins
+  over the identity default, in both directions. Plumbed as a context value in `kernel/memory`
+  (`WithScope`/`ScopeFrom`), applied at the run boundary (`agt run --agent`) and the delegate spawn.
+  Tested at every layer: the memory tool's ctx-default/explicit-wins/unscoped matrix; writes staying
+  shared under a scoped ctx; the delegated child's recall surfacing the profile-private note on a
+  real kernel; and end-to-end over the control plane — the agent run's injected context contained
+  both the shared fact and the private note while the plain run got shared only, asserted on the
+  actual provider requests. Isolated-daemon smoke: scoped + plain runs clean, 0 panics. (M786)
 - **The Roster view — manage your named agents from the console.** The agent roster (M783) gets its
   console surface: a **Roster** view under the Agents group lists every named agent — slug, state,
   model, task type, per-run budget, memory scope, workdir, fallbacks, description, and its full

--- a/kernel/controlplane/roster_memory_test.go
+++ b/kernel/controlplane/roster_memory_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+
+package controlplane_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/controlplane"
+	"github.com/agezt/agezt/kernel/memory"
+	"github.com/agezt/agezt/kernel/runtime"
+	"github.com/agezt/agezt/plugins/providers/mock"
+	"github.com/agezt/agezt/plugins/tools/shell"
+)
+
+// TestRun_AsAgent_MemoryScope proves the M786 chain end to end over the wire:
+// a run AS a named agent recalls that agent's PRIVATE notes into its injected
+// context (plus shared memory), while a plain run sees shared memory only —
+// "shared brain, private notes" (M652) wired to the M783 identity.
+func TestRun_AsAgent_MemoryScope(t *testing.T) {
+	prov := mock.New(
+		mock.FinalText("run1"), // the agent run
+		mock.FinalText("run2"), // the plain run
+	)
+	var systems []string
+	prov.OnRequest = func(req agent.CompletionRequest) { systems = append(systems, req.System) }
+	k, _, c, _ := startPairWithConfig(t, runtime.Config{
+		Provider:     prov,
+		Tools:        map[string]agent.Tool{"shell": shell.New()},
+		MemoryInject: true,
+	})
+	ctx := context.Background()
+
+	// Shared fact + a note private to the researcher scope.
+	if _, _, err := k.Memory().Remember("", memory.RememberSpec{
+		Subject: "deploy target", Content: "the shared deploy target is prod-eu",
+	}); err != nil {
+		t.Fatalf("remember shared: %v", err)
+	}
+	if _, _, err := k.Memory().Remember("", memory.RememberSpec{
+		Subject: "deploy target notes", Content: "researcher-private: prefer the staging mirror",
+		Tags: map[string]string{"scope": "researcher"},
+	}); err != nil {
+		t.Fatalf("remember private: %v", err)
+	}
+
+	if _, err := c.Call(ctx, controlplane.CmdAgentAdd, map[string]any{
+		"profile": map[string]any{"slug": "researcher", "soul": "You research."},
+	}); err != nil {
+		t.Fatalf("agent add: %v", err)
+	}
+
+	// Run AS the agent: both the shared fact and the private note inject.
+	if _, err := c.Stream(ctx, controlplane.CmdRun,
+		map[string]any{"intent": "what is the deploy target?", "agent": "researcher"}, nil); err != nil {
+		t.Fatalf("run as agent: %v", err)
+	}
+	// Plain run: shared only.
+	if _, err := c.Stream(ctx, controlplane.CmdRun,
+		map[string]any{"intent": "what is the deploy target?"}, nil); err != nil {
+		t.Fatalf("plain run: %v", err)
+	}
+
+	if len(systems) < 2 {
+		t.Fatalf("saw %d provider requests, want 2", len(systems))
+	}
+	asAgent, plain := systems[0], systems[1]
+	if !strings.Contains(asAgent, "researcher-private") {
+		t.Errorf("agent run's injected context missing its private note:\n%s", asAgent)
+	}
+	if !strings.Contains(asAgent, "prod-eu") {
+		t.Errorf("agent run's injected context missing shared memory:\n%s", asAgent)
+	}
+	if strings.Contains(plain, "researcher-private") {
+		t.Errorf("plain run leaked a private note:\n%s", plain)
+	}
+	if !strings.Contains(plain, "prod-eu") {
+		t.Errorf("plain run's injected context missing shared memory:\n%s", plain)
+	}
+}

--- a/kernel/controlplane/server.go
+++ b/kernel/controlplane/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/agezt/agezt/internal/brand"
 	"github.com/agezt/agezt/kernel/approval"
 	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/memory"
 	"github.com/agezt/agezt/kernel/roster"
 	"github.com/agezt/agezt/kernel/runtime"
 	"github.com/agezt/agezt/kernel/scheduler"
@@ -1225,6 +1226,13 @@ func (s *Server) handleRun(ctx context.Context, conn net.Conn, req Request) {
 		if modelOverride == "" {
 			modelOverride = strings.TrimSpace(p.Model)
 		}
+		// The agent's memory follows it (M786): recalls — context injection
+		// and the memory tool — default to its scope (private notes + shared).
+		scope := strings.TrimSpace(p.MemoryScope)
+		if scope == "" {
+			scope = p.Slug
+		}
+		ctx = memory.WithScope(ctx, scope)
 	}
 	effModel := k.Model()
 	if modelOverride != "" {

--- a/kernel/memory/manager.go
+++ b/kernel/memory/manager.go
@@ -322,6 +322,29 @@ func CorrelationFrom(ctx context.Context) string {
 	return ""
 }
 
+const ctxKeyScope ctxKey = iota + 1
+
+// WithScope returns a child context carrying the run's per-agent memory scope
+// (M786): when a run executes AS a named agent (M783), its recalls — the
+// context injection and the memory tool — default to this scope, so the agent
+// sees its own private notes on top of shared memory without having to name
+// itself. Writes stay shared by default ("shared brain, private notes", M652);
+// the explicit tool scope param always wins over this default.
+func WithScope(ctx context.Context, scope string) context.Context {
+	if scope == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, ctxKeyScope, scope)
+}
+
+// ScopeFrom extracts the per-agent memory scope set by WithScope ("" = none).
+func ScopeFrom(ctx context.Context) string {
+	if v, ok := ctx.Value(ctxKeyScope).(string); ok {
+		return v
+	}
+	return ""
+}
+
 // --- agent tool -----------------------------------------------------------
 
 // toolInputSchema is the JSON Schema advertised to the model for the
@@ -398,7 +421,16 @@ func (t memoryTool) Invoke(ctx context.Context, input json.RawMessage) (agent.Re
 		if limit <= 0 {
 			limit = 5
 		}
-		hits, err := t.mgr.RecallScoped(corr, in.Query, limit, strings.TrimSpace(in.Scope))
+		// The run's per-agent scope (M786) is the DEFAULT visibility: a named
+		// agent recalls its own private notes + shared memory without naming
+		// itself. An explicit scope param wins (e.g. peeking at a teammate's
+		// scope is still expressible — records stay readable, never hidden
+		// behind identity).
+		scope := strings.TrimSpace(in.Scope)
+		if scope == "" {
+			scope = ScopeFrom(ctx)
+		}
+		hits, err := t.mgr.RecallScoped(corr, in.Query, limit, scope)
 		if err != nil {
 			return agent.Result{Output: "recall failed: " + err.Error(), IsError: true}, nil
 		}

--- a/kernel/memory/scope_ctx_test.go
+++ b/kernel/memory/scope_ctx_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestTool_RecallDefaultsToCtxScope: a run carrying a per-agent scope (M786)
+// recalls that scope's private notes + shared memory without naming itself;
+// an explicit scope param still wins; an unscoped ctx sees shared only.
+func TestTool_RecallDefaultsToCtxScope(t *testing.T) {
+	m, _ := newTestManager(t)
+	if _, _, err := m.Remember("", RememberSpec{Subject: "target", Content: "shared-fact"}); err != nil {
+		t.Fatalf("remember shared: %v", err)
+	}
+	if _, _, err := m.Remember("", RememberSpec{
+		Subject: "target notes", Content: "researcher-private-fact",
+		Tags: map[string]string{"scope": "researcher"},
+	}); err != nil {
+		t.Fatalf("remember private: %v", err)
+	}
+	if _, _, err := m.Remember("", RememberSpec{
+		Subject: "target notes", Content: "ops-private-fact",
+		Tags: map[string]string{"scope": "ops"},
+	}); err != nil {
+		t.Fatalf("remember ops: %v", err)
+	}
+	tool := m.Tool()
+
+	recall := func(ctx context.Context, input string) string {
+		t.Helper()
+		res, err := tool.Invoke(ctx, json.RawMessage(input))
+		if err != nil {
+			t.Fatalf("invoke: %v", err)
+		}
+		return res.Output
+	}
+
+	// ctx scope = researcher → shared + researcher, never ops.
+	out := recall(WithScope(context.Background(), "researcher"),
+		`{"action":"recall","query":"target"}`)
+	if !strings.Contains(out, "shared-fact") || !strings.Contains(out, "researcher-private-fact") {
+		t.Errorf("scoped ctx recall missing shared/private: %q", out)
+	}
+	if strings.Contains(out, "ops-private-fact") {
+		t.Errorf("scoped ctx recall leaked another scope: %q", out)
+	}
+
+	// Explicit param wins over the ctx default.
+	out = recall(WithScope(context.Background(), "researcher"),
+		`{"action":"recall","query":"target","scope":"ops"}`)
+	if !strings.Contains(out, "ops-private-fact") || strings.Contains(out, "researcher-private-fact") {
+		t.Errorf("explicit scope param should win: %q", out)
+	}
+
+	// Unscoped ctx: shared only (the pre-M786 behaviour).
+	out = recall(context.Background(), `{"action":"recall","query":"target"}`)
+	if !strings.Contains(out, "shared-fact") ||
+		strings.Contains(out, "researcher-private-fact") || strings.Contains(out, "ops-private-fact") {
+		t.Errorf("unscoped recall must see shared only: %q", out)
+	}
+}
+
+// TestTool_RememberStaysSharedByDefault: ctx scope changes what an agent READS,
+// not what it writes — a remember without an explicit scope param stays shared
+// ("shared brain, private notes": private writes are opt-in via the param).
+func TestTool_RememberStaysSharedByDefault(t *testing.T) {
+	m, _ := newTestManager(t)
+	tool := m.Tool()
+	ctx := WithScope(context.Background(), "researcher")
+	if _, err := tool.Invoke(ctx, json.RawMessage(
+		`{"action":"remember","subject":"finding","content":"useful-for-everyone"}`)); err != nil {
+		t.Fatalf("remember: %v", err)
+	}
+	// Visible to an UNscoped recall → it was written shared.
+	res, err := tool.Invoke(context.Background(), json.RawMessage(`{"action":"recall","query":"finding"}`))
+	if err != nil {
+		t.Fatalf("recall: %v", err)
+	}
+	if !strings.Contains(res.Output, "useful-for-everyone") {
+		t.Errorf("agent write under a scoped ctx should stay shared: %q", res.Output)
+	}
+}

--- a/kernel/runtime/runtime.go
+++ b/kernel/runtime/runtime.go
@@ -1481,7 +1481,10 @@ func (k *Kernel) RunWith(ctx context.Context, corr, intent string) (string, erro
 		if topK <= 0 {
 			topK = 5
 		}
-		if hits, err := k.memory.Recall(corr, intent, topK); err == nil && len(hits) > 0 {
+		// Scoped to the run's agent identity (M786): a named agent's private
+		// notes surface in its injected context; an unscoped run sees shared
+		// memory only (RecallScoped with "" ≡ the previous Recall behaviour).
+		if hits, err := k.memory.RecallScoped(corr, intent, topK, memory.ScopeFrom(runCtx)); err == nil && len(hits) > 0 {
 			system = injectMemory(system, hits)
 		}
 	}

--- a/kernel/runtime/subagent.go
+++ b/kernel/runtime/subagent.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/agezt/agezt/kernel/agent"
 	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/memory"
 	"github.com/agezt/agezt/kernel/roster"
 )
 
@@ -272,6 +273,15 @@ func (k *Kernel) runSubAgent(ctx context.Context, task, model, taskType, agentRe
 	// Carry the tree root to every descendant so the M629 total cap is attributed
 	// to the whole tree, not re-seeded at each level.
 	childCtx = context.WithValue(childCtx, ctxKeyRoot, rootCorr)
+	// A named agent's memory follows it (M786): the child's memory-tool recalls
+	// default to the profile's scope (its private notes + shared memory).
+	if prof != nil {
+		scope := strings.TrimSpace(prof.MemoryScope)
+		if scope == "" {
+			scope = prof.Slug
+		}
+		childCtx = memory.WithScope(childCtx, scope)
+	}
 
 	// A named agent's soul REPLACES the daemon persona layer (it IS this
 	// sub-agent's identity); the sub-agent preamble always stays on top.

--- a/kernel/runtime/subagent_roster_test.go
+++ b/kernel/runtime/subagent_roster_test.go
@@ -11,8 +11,11 @@ import (
 
 	"github.com/agezt/agezt/kernel/agent"
 	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/memory"
 	"github.com/agezt/agezt/kernel/roster"
+	"github.com/agezt/agezt/kernel/runtime"
 	"github.com/agezt/agezt/plugins/providers/mock"
+	"github.com/agezt/agezt/plugins/tools/shell"
 )
 
 // TestDelegate_AsNamedAgent: delegate(agent="researcher") runs the sub-agent AS
@@ -82,6 +85,59 @@ func TestDelegate_AsNamedAgent(t *testing.T) {
 	}
 	if pl.Agent != "researcher" || pl.Model != "agent-model" {
 		t.Errorf("spawn payload agent=%q model=%q, want researcher/agent-model", pl.Agent, pl.Model)
+	}
+}
+
+// TestDelegate_AgentMemoryScopeFollowsChild: the sub-agent's memory-tool
+// recalls default to the profile's scope (M786) — its private notes surface
+// without the child naming itself.
+func TestDelegate_AgentMemoryScopeFollowsChild(t *testing.T) {
+	prov := mock.New(
+		mock.ToolUse("c1", "delegate", map[string]any{"task": "check notes", "agent": "researcher"}),
+		mock.ToolUse("c2", "memory", map[string]any{"action": "recall", "query": "target"}), // child turn 1
+		mock.FinalText("child done"), // child turn 2
+		mock.FinalText("lead done"),  // lead final
+	)
+	k, err := runtime.Open(runtime.Config{
+		BaseDir:          t.TempDir(),
+		Provider:         prov,
+		Tools:            map[string]agent.Tool{"shell": shell.New()},
+		SubAgentTool:     true,
+		SubAgentMaxDepth: 1,
+		MemoryTool:       true,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { k.Close() })
+
+	if _, _, err := k.Memory().Remember("", memory.RememberSpec{
+		Subject: "target notes", Content: "researcher-private-fact",
+		Tags: map[string]string{"scope": "researcher"},
+	}); err != nil {
+		t.Fatalf("remember: %v", err)
+	}
+	if _, err := k.AddProfile(roster.Profile{Slug: "researcher"}); err != nil {
+		t.Fatalf("AddProfile: %v", err)
+	}
+
+	col := &collector{}
+	col.watch(k)
+	if _, _, err := k.Run(context.Background(), "lead task"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	// The child's memory recall surfaced the scope-private note.
+	found := false
+	for _, e := range col.ofKind(event.KindToolResult) {
+		if strings.Contains(string(e.Payload), "researcher-private-fact") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("child's memory recall did not surface the agent's private note")
 	}
 }
 


### PR DESCRIPTION
## What

Running as a roster agent (M783) now wires the profile's **memory scope** (default: its slug) into the whole run:

- **Context injection** recalls the agent's private notes alongside shared memory; a plain run still sees shared only — nothing leaks.
- **Memory tool recalls default to the agent's scope** — "researcher" surfaces its own notes without naming itself; the explicit `scope` param always wins, both directions.
- **Sub-agents inherit it**: `delegate(agent="researcher")` gives the child the profile's scope.
- **Writes stay shared by default** — M652's philosophy (*shared brain, private notes*): an agent's learnings benefit the fleet unless it explicitly scopes a note.

Plumbed as a ctx value in `kernel/memory` (`WithScope`/`ScopeFrom`), applied at `handleRun` and the delegate spawn.

## Validation

- **4 new tests, every layer**: memory-tool matrix (ctx-default / explicit-wins / unscoped-shared-only), writes-stay-shared under a scoped ctx, delegated child's recall surfacing the profile-private note on a real kernel, and **end-to-end over the control plane** — asserted on the actual provider requests: agent run's injected context contained the shared fact AND the private note; the plain run got shared only.
- Full suite green, vet + staticcheck clean, linux cross-build OK, go.mod unchanged, no frontend change. Isolated-daemon smoke (scoped + plain runs): clean, 0 panics.
- CI org-billing still blocked — local battery, arc-authority merge (PRs #136+ pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)