### PR TITLE
Feat: agents ask each other questions — addressed board messages with replies (M788)

### DIFF
--- a/.project/PHASE-M788-A2A-ASK-REPLY-REPORT.md
+++ b/.project/PHASE-M788-A2A-ASK-REPLY-REPORT.md
@@ -1,0 +1,46 @@
+# Phase M788 — A2A ask/reply: addressed agent-to-agent messages
+
+**Date:** 2026-06-10 · **Status:** DONE · **Arc:** multi-agent identity, step 6
+(gap #2 of the vision gap analysis — direct agent-to-agent messaging).
+
+## What
+
+The shared board (M647) grows an addressed layer: send (to=slug, returns id) ·
+inbox (unanswered-first; all=true includes answered) · reply (id → linked,
+addressed back to the asker) · replies (the asker reads answers). Addressed
+messages journal `board.posted` under **`board.dm.<recipient>`**, so a standing
+order with that event trigger wakes exactly the agent being asked (M656 wake +
+M783 identity = ask → wake → answer → read).
+
+## Changes
+
+- `kernel/board`: Message += ID/To/ReplyTo (additive, old board.json loads);
+  `Send` (id-assigning generalisation; Post now wraps it) + `Get`/`Inbox`
+  (case-insensitive, unanswered filter)/`Replies` (conversation order).
+- `plugins/tools/boardtool`: ops send/inbox/reply/replies; `PostNotifier`
+  re-signed to carry the full Message (breaking change, both callers in-PR);
+  msgView += id/to/reply_to; description teaches the ask/reply flow + the
+  board.dm.<slug> wake trigger.
+- `cmd/agezt`: notifier publishes `board.dm.<recipient>` for addressed
+  messages, payload += id/to/reply_to.
+
+## Tests (4 new/extended)
+
+- kernel/board: round-trip + persistence (ids, case-insensitive inbox,
+  broadcast never in inboxes, reply clears unanswered, includeAnswered,
+  Replies linkage, reopen).
+- boardtool: `TestAskReplyRoundTrip` (send→inbox→reply→inbox-clears→replies,
+  addressed back to asker, send AND reply notify); bad-input table (no
+  to/text/id, ghost-id reply); notifier re-sign covered by updated
+  `TestPost_NotifiesWithCorrelation`; read/inbox/replies never notify.
+
+## Gate
+
+Full suite `-p 2 ./...` green; vet + staticcheck clean; linux cross-build OK;
+go.mod unchanged; no frontend change (Board view renders new fields via the
+same JSON). CI org-billing still blocked → local battery + arc-authority merge.
+
+## Next in the arc
+
+Chat: converse AS a named agent · workdir wiring · per-agent daily budget
+ledger · Board view: render to/reply_to threading.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **Agents can now ask each other questions — addressed messages with replies.** The shared board
+  (M647) grows a direct agent-to-agent layer: `board op=send to=researcher` addresses a message to a
+  named agent and returns its **message id**; `op=inbox to=researcher` shows what's **waiting** for
+  an agent (answered messages drop out; `all=true` shows history); `op=reply id=…` answers a message
+  — linked back and addressed to the asker — and `op=replies id=…` is where the asker reads the
+  answer. The wake-up half is event-driven and composes with what already exists: an addressed
+  message journals `board.posted` under **`board.dm.<recipient>`** (instead of `board.<topic>`), so
+  a standing order with that event trigger wakes exactly the agent being asked — which, running as
+  its roster identity (M783), reads its inbox and replies. Ask → wake → answer → read, fully
+  journaled, every message with an id, recipient, and reply linkage, persistent across restarts.
+  Plain topic posts (M647) are untouched and never appear in inboxes. Store-level round-trip tested
+  (ids, case-insensitive inbox, unanswered filtering, reply linkage, reopen persistence); the tool's
+  full ask/reply flow tested op-by-op (send→inbox→reply→inbox-clears→replies, addressed
+  notifications for send AND reply, bad-input table); the daemon's notifier carries the new
+  addressed fields and recipient-keyed subject. (M788)
 - **A named agent's own model fallback chain.** The roster profile's ordered **fallbacks** (stored
   since M783) are now live routing: a run AS a named agent — and every sub-agent spawned via
   `delegate(agent="…")` — carries `[primary, fallbacks…]` as its **per-request model chain**, and

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -44,6 +44,7 @@ import (
 	"github.com/agezt/agezt/kernel/agent"
 	"github.com/agezt/agezt/kernel/alerter"
 	"github.com/agezt/agezt/kernel/anomaly"
+	"github.com/agezt/agezt/kernel/board"
 	"github.com/agezt/agezt/kernel/bus"
 	"github.com/agezt/agezt/kernel/cadence"
 	"github.com/agezt/agezt/kernel/catalog"
@@ -1176,14 +1177,29 @@ func runDaemon(stdout, stderr io.Writer) int {
 	} else {
 		// Journal each post as a board.posted event under subject "board.<topic>"
 		// (M656), so a standing order can trigger on a topic and one agent's post
-		// wakes another. The posting run's correlation ties the event into `agt why`.
-		boardToolInst.OnPost(func(topic, from, text, corr string) {
-			payload := map[string]any{"topic": topic, "chars": len(text)}
-			if from != "" {
-				payload["from"] = from
+		// wakes another. An ADDRESSED message (M788) publishes under
+		// "board.dm.<recipient>" instead, so a standing order can wake exactly
+		// the agent being asked. The posting run's correlation ties into `agt why`.
+		boardToolInst.OnPost(func(m board.Message, corr string) {
+			subject := "board." + boardSubjectSlug(m.Topic)
+			if m.To != "" {
+				subject = "board.dm." + boardSubjectSlug(m.To)
+			}
+			payload := map[string]any{"topic": m.Topic, "chars": len(m.Text)}
+			if m.ID != "" {
+				payload["id"] = m.ID
+			}
+			if m.From != "" {
+				payload["from"] = m.From
+			}
+			if m.To != "" {
+				payload["to"] = m.To
+			}
+			if m.ReplyTo != "" {
+				payload["reply_to"] = m.ReplyTo
 			}
 			_, _ = k.Bus().Publish(event.Spec{
-				Subject:       "board." + boardSubjectSlug(topic),
+				Subject:       subject,
 				Kind:          event.KindBoardPosted,
 				Actor:         "board",
 				CorrelationID: corr,

--- a/kernel/board/a2a_test.go
+++ b/kernel/board/a2a_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+
+package board
+
+import "testing"
+
+// TestSendInboxReplies_RoundTripAndPersistence: addressed messages get ids,
+// land in the recipient's inbox (unanswered first), replies link back and
+// clear the inbox, and everything survives a reopen.
+func TestSendInboxReplies_RoundTripAndPersistence(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	q, err := s.Send(Message{Topic: "dm", From: "planner", To: "researcher", Text: "deploy target?"}, 1000)
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if q.ID == "" {
+		t.Fatal("Send assigned no id")
+	}
+	if _, err := s.Send(Message{Topic: "dm", From: "x", To: "Researcher", Text: "second"}, 1001); err != nil {
+		t.Fatalf("Send 2: %v", err)
+	}
+
+	// Inbox: case-insensitive recipient match, newest first, both waiting.
+	in := s.Inbox("RESEARCHER", 0, false)
+	if len(in) != 2 || in[0].Text != "second" || in[1].ID != q.ID {
+		t.Fatalf("inbox wrong: %+v", in)
+	}
+	// Plain topic posts never appear in an inbox.
+	if _, err := s.Post("dm", "y", "broadcast", 1002); err != nil {
+		t.Fatalf("Post: %v", err)
+	}
+	if got := len(s.Inbox("researcher", 0, false)); got != 2 {
+		t.Fatalf("broadcast leaked into inbox: %d", got)
+	}
+
+	// Reply links back, clears the unanswered inbox, shows under Replies.
+	r, err := s.Send(Message{Topic: "dm", From: "researcher", To: "planner", ReplyTo: q.ID, Text: "prod-eu"}, 1003)
+	if err != nil {
+		t.Fatalf("reply Send: %v", err)
+	}
+	if got := s.Inbox("researcher", 0, false); len(got) != 1 || got[0].Text != "second" {
+		t.Fatalf("answered message should leave the inbox: %+v", got)
+	}
+	if got := s.Inbox("researcher", 0, true); len(got) != 2 {
+		t.Fatalf("includeAnswered should show both: %+v", got)
+	}
+	reps := s.Replies(q.ID, 0)
+	if len(reps) != 1 || reps[0].ID != r.ID || reps[0].To != "planner" {
+		t.Fatalf("replies wrong: %+v", reps)
+	}
+	if _, ok := s.Get(q.ID); !ok {
+		t.Fatal("Get lost the message")
+	}
+
+	// Reopen: ids/addressing/links survive.
+	s2, err := Open(dir)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	if reps := s2.Replies(q.ID, 0); len(reps) != 1 || reps[0].Text != "prod-eu" {
+		t.Fatalf("replies lost on reopen: %+v", reps)
+	}
+}

--- a/kernel/board/board.go
+++ b/kernel/board/board.go
@@ -25,18 +25,26 @@ import (
 	"sort"
 	"strings"
 	"sync"
+
+	"github.com/agezt/agezt/kernel/ulid"
 )
 
 // MaxMessages bounds the on-disk board so it can't grow without limit; the
 // oldest are dropped first.
 const MaxMessages = 1000
 
-// Message is one board post.
+// Message is one board post. Addressed messaging (M788): To names the
+// recipient agent (a roster slug or any agreed name) for direct agent-to-agent
+// messages; ReplyTo links an answer back to the message it answers; ID makes
+// both possible. Plain topic posts (M647) simply leave them empty.
 type Message struct {
-	Topic string `json:"topic"`
-	From  string `json:"from,omitempty"`
-	Text  string `json:"text"`
-	TSMS  int64  `json:"ts_ms"`
+	ID      string `json:"id,omitempty"`
+	Topic   string `json:"topic"`
+	From    string `json:"from,omitempty"`
+	To      string `json:"to,omitempty"`
+	ReplyTo string `json:"reply_to,omitempty"`
+	Text    string `json:"text"`
+	TSMS    int64  `json:"ts_ms"`
 }
 
 // Store is the persistent, concurrency-safe message board. Many agents (and
@@ -62,9 +70,21 @@ func Open(dir string) (*Store, error) {
 	return s, nil
 }
 
-// Post appends a message and persists, dropping the oldest past MaxMessages.
+// Post appends a topic message and persists. Kept as the M647 surface; it is
+// Send with no recipient.
 func (s *Store) Post(topic, from, text string, nowMS int64) (Message, error) {
-	m := Message{Topic: strings.TrimSpace(topic), From: strings.TrimSpace(from), Text: text, TSMS: nowMS}
+	return s.Send(Message{Topic: topic, From: from, Text: text}, nowMS)
+}
+
+// Send appends a message — addressed (To set) or plain — assigning its ID and
+// timestamp, and persists, dropping the oldest past MaxMessages (M788).
+func (s *Store) Send(m Message, nowMS int64) (Message, error) {
+	m.ID = ulid.New()
+	m.Topic = strings.TrimSpace(m.Topic)
+	m.From = strings.TrimSpace(m.From)
+	m.To = strings.TrimSpace(m.To)
+	m.ReplyTo = strings.TrimSpace(m.ReplyTo)
+	m.TSMS = nowMS
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.msgs = append(s.msgs, m)
@@ -72,6 +92,68 @@ func (s *Store) Post(topic, from, text string, nowMS int64) (Message, error) {
 		s.msgs = s.msgs[len(s.msgs)-MaxMessages:]
 	}
 	return m, s.save()
+}
+
+// Get returns one message by id.
+func (s *Store) Get(id string) (Message, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, m := range s.msgs {
+		if m.ID == id {
+			return m, true
+		}
+	}
+	return Message{}, false
+}
+
+// Inbox returns up to limit messages ADDRESSED to `to` (case-insensitive),
+// newest first. With includeAnswered=false (the usual call), messages that
+// already have a reply on the board are dropped — "what's waiting for me".
+func (s *Store) Inbox(to string, limit int, includeAnswered bool) []Message {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	to = strings.ToLower(strings.TrimSpace(to))
+	answered := map[string]bool{}
+	if !includeAnswered {
+		for _, m := range s.msgs {
+			if m.ReplyTo != "" {
+				answered[m.ReplyTo] = true
+			}
+		}
+	}
+	out := make([]Message, 0, 8)
+	for _, m := range s.msgs {
+		if m.To == "" || strings.ToLower(m.To) != to {
+			continue
+		}
+		if !includeAnswered && answered[m.ID] {
+			continue
+		}
+		out = append(out, m)
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].TSMS > out[j].TSMS })
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+// Replies returns up to limit replies to the message id, OLDEST first
+// (conversation order) — what the asker reads back.
+func (s *Store) Replies(id string, limit int) []Message {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]Message, 0, 4)
+	for _, m := range s.msgs {
+		if m.ReplyTo == id {
+			out = append(out, m)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].TSMS < out[j].TSMS })
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out
 }
 
 // Read returns up to limit messages, newest first, optionally filtered to a

--- a/plugins/tools/boardtool/board.go
+++ b/plugins/tools/boardtool/board.go
@@ -29,16 +29,21 @@ const (
 // can inject a fake without a real on-disk store.
 type boardStore interface {
 	Post(topic, from, text string, nowMS int64) (board.Message, error)
+	Send(m board.Message, nowMS int64) (board.Message, error)
 	Read(topic string, limit int) []board.Message
+	Inbox(to string, limit int, includeAnswered bool) []board.Message
+	Replies(id string, limit int) []board.Message
+	Get(id string) (board.Message, bool)
 	Topics() map[string]int
 }
 
-// PostNotifier is called after a successful post so the host can journal a
-// board.posted event (M656) — the primitive that lets one agent's post wake
-// another agent (a standing order triggered on "board.<topic>"). Kept as a plain
-// closure so this plugin stays free of the kernel bus/event packages and is
-// trivially testable. corr is the posting run's correlation id (may be empty).
-type PostNotifier func(topic, from, text, corr string)
+// PostNotifier is called after a successful post/send so the host can journal a
+// board.posted event (M656/M788) — the primitive that lets one agent's message
+// wake another (a standing order triggered on "board.<topic>", or on
+// "board.dm.<slug>" for an addressed message). Kept as a plain closure so this
+// plugin stays free of the kernel bus/event packages and is trivially testable.
+// corr is the posting run's correlation id (may be empty).
+type PostNotifier func(m board.Message, corr string)
 
 // Tool implements agent.Tool. Created unbound via New(); Bind opens the store.
 type Tool struct {

--- a/plugins/tools/boardtool/board_test.go
+++ b/plugins/tools/boardtool/board_test.go
@@ -16,12 +16,63 @@ import (
 // asserted without touching disk (the store itself is tested in kernel/board).
 type fakeStore struct {
 	msgs []board.Message
+	seq  int
 }
 
 func (f *fakeStore) Post(topic, from, text string, nowMS int64) (board.Message, error) {
-	m := board.Message{Topic: topic, From: from, Text: text, TSMS: nowMS}
+	return f.Send(board.Message{Topic: topic, From: from, Text: text}, nowMS)
+}
+
+func (f *fakeStore) Send(m board.Message, nowMS int64) (board.Message, error) {
+	f.seq++
+	m.ID = "msg-" + string(rune('0'+f.seq))
+	m.TSMS = nowMS
 	f.msgs = append(f.msgs, m)
 	return m, nil
+}
+
+func (f *fakeStore) Get(id string) (board.Message, bool) {
+	for _, m := range f.msgs {
+		if m.ID == id {
+			return m, true
+		}
+	}
+	return board.Message{}, false
+}
+
+func (f *fakeStore) Inbox(to string, limit int, includeAnswered bool) []board.Message {
+	answered := map[string]bool{}
+	if !includeAnswered {
+		for _, m := range f.msgs {
+			if m.ReplyTo != "" {
+				answered[m.ReplyTo] = true
+			}
+		}
+	}
+	out := make([]board.Message, 0, len(f.msgs))
+	for _, m := range f.msgs {
+		if m.To == to && !answered[m.ID] {
+			out = append(out, m)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].TSMS > out[j].TSMS })
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+func (f *fakeStore) Replies(id string, limit int) []board.Message {
+	out := make([]board.Message, 0, 4)
+	for _, m := range f.msgs {
+		if m.ReplyTo == id {
+			out = append(out, m)
+		}
+	}
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out
 }
 
 func (f *fakeStore) Read(topic string, limit int) []board.Message {
@@ -152,30 +203,110 @@ func TestBadInputs(t *testing.T) {
 
 func TestPost_NotifiesWithCorrelation(t *testing.T) {
 	tool := newTool(t)
-	var got struct{ topic, from, text, corr string }
+	var got board.Message
+	var gotCorr string
 	calls := 0
-	tool.OnPost(func(topic, from, text, corr string) {
+	tool.OnPost(func(m board.Message, corr string) {
 		calls++
-		got.topic, got.from, got.text, got.corr = topic, from, text, corr
+		got, gotCorr = m, corr
 	})
 	ctx := agent.WithCorrelation(context.Background(), "run-42")
 	raw, _ := json.Marshal(map[string]any{"op": "post", "topic": "handoff", "from": "ci", "text": "build green"})
 	if _, err := tool.Invoke(ctx, raw); err != nil {
 		t.Fatalf("Invoke: %v", err)
 	}
-	if calls != 1 || got.topic != "handoff" || got.from != "ci" || got.text != "build green" || got.corr != "run-42" {
-		t.Errorf("notifier got %+v (calls=%d), want handoff/ci/build green/run-42", got, calls)
+	if calls != 1 || got.Topic != "handoff" || got.From != "ci" || got.Text != "build green" || gotCorr != "run-42" {
+		t.Errorf("notifier got %+v corr=%q (calls=%d), want handoff/ci/build green/run-42", got, gotCorr, calls)
 	}
 }
 
 func TestRead_DoesNotNotify(t *testing.T) {
 	tool := newTool(t)
 	calls := 0
-	tool.OnPost(func(_, _, _, _ string) { calls++ })
+	tool.OnPost(func(board.Message, string) { calls++ })
 	invoke(t, tool, map[string]any{"op": "read"})
 	invoke(t, tool, map[string]any{"op": "topics"})
+	invoke(t, tool, map[string]any{"op": "inbox", "to": "x"})
+	invoke(t, tool, map[string]any{"op": "replies", "id": "msg-1"})
 	if calls != 0 {
-		t.Errorf("only posts should notify, got %d", calls)
+		t.Errorf("only post/send/reply should notify, got %d", calls)
+	}
+}
+
+// TestAskReplyRoundTrip drives the whole A2A flow (M788) through the tool:
+// planner sends researcher a question → researcher's inbox shows it waiting →
+// researcher replies → the reply leaves the inbox and shows up under
+// op=replies for the original id, addressed back to the asker.
+func TestAskReplyRoundTrip(t *testing.T) {
+	tool := newTool(t)
+	var notified []board.Message
+	tool.OnPost(func(m board.Message, _ string) { notified = append(notified, m) })
+
+	sent, isErr := invoke(t, tool, map[string]any{
+		"op": "send", "to": "researcher", "from": "planner", "text": "what is the deploy target?"})
+	if isErr {
+		t.Fatalf("send errored: %v", sent)
+	}
+	id := sent["sent"].(map[string]any)["id"].(string)
+	if id == "" {
+		t.Fatal("send returned no message id")
+	}
+
+	inbox, _ := invoke(t, tool, map[string]any{"op": "inbox", "to": "researcher"})
+	if inbox["count"].(float64) != 1 {
+		t.Fatalf("inbox count = %v, want 1", inbox["count"])
+	}
+	waiting := inbox["waiting"].([]any)[0].(map[string]any)
+	if waiting["from"] != "planner" || waiting["id"] != id {
+		t.Fatalf("inbox message wrong: %+v", waiting)
+	}
+
+	if _, isErr := invoke(t, tool, map[string]any{
+		"op": "reply", "id": id, "from": "researcher", "text": "prod-eu"}); isErr {
+		t.Fatal("reply errored")
+	}
+
+	// Answered → leaves the unanswered inbox; visible with all=true.
+	inbox2, _ := invoke(t, tool, map[string]any{"op": "inbox", "to": "researcher"})
+	if inbox2["count"].(float64) != 0 {
+		t.Errorf("answered message still waiting: %v", inbox2)
+	}
+	inboxAll, _ := invoke(t, tool, map[string]any{"op": "inbox", "to": "researcher", "all": true})
+	if inboxAll["count"].(float64) != 1 {
+		t.Errorf("all=true should include the answered message: %v", inboxAll)
+	}
+
+	// The asker reads the answer.
+	replies, _ := invoke(t, tool, map[string]any{"op": "replies", "id": id})
+	if replies["count"].(float64) != 1 {
+		t.Fatalf("replies count = %v, want 1", replies["count"])
+	}
+	r := replies["replies"].([]any)[0].(map[string]any)
+	if r["text"] != "prod-eu" || r["to"] != "planner" || r["reply_to"] != id {
+		t.Errorf("reply wrong: %+v", r)
+	}
+
+	// Both the send and the reply notified (addressed messages journal too).
+	if len(notified) != 2 || notified[0].To != "researcher" || notified[1].To != "planner" {
+		t.Errorf("notifications wrong: %+v", notified)
+	}
+}
+
+// TestSendReplyBadInputs: missing to/text/id and replying to a ghost id are
+// clear tool errors.
+func TestSendReplyBadInputs(t *testing.T) {
+	tool := newTool(t)
+	for _, c := range []map[string]any{
+		{"op": "send", "text": "no recipient"},
+		{"op": "send", "to": "x"}, // no text
+		{"op": "inbox"},           // whose inbox?
+		{"op": "reply", "text": "no id"},
+		{"op": "reply", "id": "ghost", "text": "orphan"},
+		{"op": "replies"},
+	} {
+		if _, isErr := invoke(t, tool, c); !isErr {
+			t.Errorf("expected error for %v", c)
+		}
 	}
 }
 

--- a/plugins/tools/boardtool/tool.go
+++ b/plugins/tools/boardtool/tool.go
@@ -19,17 +19,23 @@ func (t *Tool) Definition() agent.ToolDef {
 		Name: "board",
 		Description: "A shared message board every agent on this daemon can use to coordinate: " +
 			"op=post leaves a message on a topic; op=read returns recent messages (optionally for " +
-			"one topic); op=topics lists the active topics. Use it to talk to other agents, hand off " +
-			"findings, or leave a note for your next cycle. The board is shared and persistent.",
+			"one topic); op=topics lists the active topics. Direct agent-to-agent messaging: " +
+			"op=send addresses a message to a named agent (to = its agent slug; returns the message id) " +
+			"— it journals board.dm.<slug>, so a standing order can wake that agent; op=inbox lists what " +
+			"is waiting for an agent (unanswered first); op=reply answers a message by id; op=replies " +
+			"reads the answers to a message you sent. The board is shared and persistent.",
 		InputSchema: json.RawMessage(`{
   "type": "object",
   "required": ["op"],
   "properties": {
-    "op":    {"type":"string", "enum":["post","read","topics"]},
-    "topic": {"type":"string", "description":"The topic to post under, or to filter reads by (a short label)."},
-    "text":  {"type":"string", "description":"For op=post: the message body."},
-    "from":  {"type":"string", "description":"For op=post (optional): who is posting (e.g. a role like \"researcher\")."},
-    "limit": {"type":"integer", "description":"For op=read: max messages (default 20, max 100)."}
+    "op":    {"type":"string", "enum":["post","read","topics","send","inbox","reply","replies"]},
+    "topic": {"type":"string", "description":"The topic to post under, or to filter reads by (a short label). For op=send: optional, defaults to \"dm\"."},
+    "text":  {"type":"string", "description":"For op=post/send/reply: the message body."},
+    "from":  {"type":"string", "description":"Who is posting/sending/replying — use YOUR agent slug so replies can find you."},
+    "to":    {"type":"string", "description":"For op=send: the recipient agent's slug. For op=inbox: whose inbox to read (your slug)."},
+    "id":    {"type":"string", "description":"For op=reply: the message id being answered. For op=replies: the message id whose answers to read."},
+    "all":   {"type":"boolean", "description":"For op=inbox: include already-answered messages too (default false = only what's waiting)."},
+    "limit": {"type":"integer", "description":"For op=read/inbox/replies: max messages (default 20, max 100)."}
   }
 }`),
 	}
@@ -40,7 +46,21 @@ type input struct {
 	Topic string `json:"topic"`
 	Text  string `json:"text"`
 	From  string `json:"from"`
+	To    string `json:"to"`
+	ID    string `json:"id"`
+	All   bool   `json:"all"`
 	Limit int    `json:"limit"`
+}
+
+// clampLimit applies the shared read-limit bounds.
+func clampLimit(n int) int {
+	if n <= 0 {
+		return DefaultReadLimit
+	}
+	if n > MaxReadLimit {
+		return MaxReadLimit
+	}
+	return n
 }
 
 // Invoke implements agent.Tool.
@@ -69,19 +89,79 @@ func (t *Tool) Invoke(ctx context.Context, raw json.RawMessage) (agent.Result, e
 		// Journal the post so standing orders can react to it (M656). corr ties
 		// the board.posted event to the run that posted (CorrelationFromContext).
 		if notify != nil {
-			notify(m.Topic, m.From, m.Text, agent.CorrelationFromContext(ctx))
+			notify(m, agent.CorrelationFromContext(ctx))
 		}
 		return okJSON(map[string]any{"posted": msgView(m)}), nil
 
+	case "send":
+		if strings.TrimSpace(in.To) == "" {
+			return errResult(`op=send needs "to" (the recipient agent's slug)`), nil
+		}
+		if strings.TrimSpace(in.Text) == "" {
+			return errResult(`op=send needs "text"`), nil
+		}
+		topic := strings.TrimSpace(in.Topic)
+		if topic == "" {
+			topic = "dm"
+		}
+		m, err := st.Send(board.Message{Topic: topic, From: in.From, To: in.To, Text: in.Text}, nowFn())
+		if err != nil {
+			return errResult(err.Error()), nil
+		}
+		if notify != nil {
+			notify(m, agent.CorrelationFromContext(ctx))
+		}
+		return okJSON(map[string]any{"sent": msgView(m),
+			"hint": "the recipient answers with op=reply id=" + m.ID + "; check op=replies id=" + m.ID}), nil
+
+	case "inbox":
+		if strings.TrimSpace(in.To) == "" {
+			return errResult(`op=inbox needs "to" (whose inbox — your agent slug)`), nil
+		}
+		msgs := st.Inbox(in.To, clampLimit(in.Limit), in.All)
+		views := make([]map[string]any, 0, len(msgs))
+		for _, m := range msgs {
+			views = append(views, msgView(m))
+		}
+		return okJSON(map[string]any{"to": in.To, "count": len(views), "waiting": views}), nil
+
+	case "reply":
+		if strings.TrimSpace(in.ID) == "" {
+			return errResult(`op=reply needs "id" (the message being answered)`), nil
+		}
+		if strings.TrimSpace(in.Text) == "" {
+			return errResult(`op=reply needs "text"`), nil
+		}
+		orig, ok := st.Get(strings.TrimSpace(in.ID))
+		if !ok {
+			return errResult("no message with id " + in.ID), nil
+		}
+		// The reply goes back to the asker: addressed to orig.From, same topic,
+		// linked via ReplyTo so op=replies finds it.
+		m, err := st.Send(board.Message{
+			Topic: orig.Topic, From: in.From, To: orig.From, ReplyTo: orig.ID, Text: in.Text,
+		}, nowFn())
+		if err != nil {
+			return errResult(err.Error()), nil
+		}
+		if notify != nil {
+			notify(m, agent.CorrelationFromContext(ctx))
+		}
+		return okJSON(map[string]any{"replied": msgView(m)}), nil
+
+	case "replies":
+		if strings.TrimSpace(in.ID) == "" {
+			return errResult(`op=replies needs "id" (your sent message's id)`), nil
+		}
+		msgs := st.Replies(strings.TrimSpace(in.ID), clampLimit(in.Limit))
+		views := make([]map[string]any, 0, len(msgs))
+		for _, m := range msgs {
+			views = append(views, msgView(m))
+		}
+		return okJSON(map[string]any{"id": in.ID, "count": len(views), "replies": views}), nil
+
 	case "read":
-		limit := in.Limit
-		if limit <= 0 {
-			limit = DefaultReadLimit
-		}
-		if limit > MaxReadLimit {
-			limit = MaxReadLimit
-		}
-		msgs := st.Read(in.Topic, limit)
+		msgs := st.Read(in.Topic, clampLimit(in.Limit))
 		views := make([]map[string]any, 0, len(msgs))
 		for _, m := range msgs {
 			views = append(views, msgView(m))
@@ -96,16 +176,25 @@ func (t *Tool) Invoke(ctx context.Context, raw json.RawMessage) (agent.Result, e
 		return okJSON(map[string]any{"topics": st.Topics()}), nil
 
 	case "":
-		return errResult("op required (post|read|topics)"), nil
+		return errResult("op required (post|read|topics|send|inbox|reply|replies)"), nil
 	default:
-		return errResult("unknown op " + in.Op + " (post|read|topics)"), nil
+		return errResult("unknown op " + in.Op + " (post|read|topics|send|inbox|reply|replies)"), nil
 	}
 }
 
 func msgView(m board.Message) map[string]any {
 	v := map[string]any{"topic": m.Topic, "text": m.Text}
+	if m.ID != "" {
+		v["id"] = m.ID
+	}
 	if m.From != "" {
 		v["from"] = m.From
+	}
+	if m.To != "" {
+		v["to"] = m.To
+	}
+	if m.ReplyTo != "" {
+		v["reply_to"] = m.ReplyTo
 	}
 	if m.TSMS > 0 {
 		v["at"] = time.UnixMilli(m.TSMS).Format(time.RFC3339)


### PR DESCRIPTION
## What

Gap #2 of the vision analysis: **direct agent-to-agent messaging**. The shared board (M647) grows an addressed layer:

- `board op=send to=researcher text=…` → addressed message, returns its **id**
- `op=inbox to=researcher` → what's **waiting** (answered drop out; `all=true` = history)
- `op=reply id=…` → answer, linked + addressed back to the asker
- `op=replies id=…` → the asker reads the answer

**Wake-up composes with what exists**: addressed messages journal `board.posted` under **`board.dm.<recipient>`**, so a standing order with that trigger wakes exactly the agent being asked — which, running as its roster identity (M783), reads its inbox and replies. Ask → wake → answer → read, fully journaled, persistent.

- `kernel/board`: Message += ID/To/ReplyTo (additive — old board.json loads); `Send`/`Get`/`Inbox`/`Replies`.
- `boardtool`: 4 new ops; `PostNotifier` re-signed to carry the full Message (both callers updated in-PR).
- Plain topic posts (M647) untouched and never appear in inboxes.

## Validation

- **Store round-trip + persistence**: ids, case-insensitive inbox, broadcasts never in inboxes, reply clears the unanswered inbox, `includeAnswered`, reply linkage, reopen.
- **Tool flow op-by-op**: send→inbox→reply→inbox-clears→replies (addressed back to the asker), send AND reply notify, read/inbox/replies never notify, bad-input table (missing to/text/id, ghost-id reply).
- Full suite green, vet + staticcheck clean, linux cross-build OK, go.mod unchanged, no frontend change.
- CI org-billing still blocked — local battery, arc-authority merge (PRs #136+ pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)