### PR TITLE
Feat: standing orders run AS a named agent — the autonomous answerer (M790)

### DIFF
--- a/.project/PHASE-M790-STANDING-AS-AGENT-REPORT.md
+++ b/.project/PHASE-M790-STANDING-AS-AGENT-REPORT.md
@@ -1,0 +1,69 @@
+# Phase M790 — standing orders run AS a named agent
+
+**Date:** 2026-06-10 · **Status:** DONE · **Arc:** multi-agent identity, step 8
+— completes the autonomous ask→wake→answer cycle (M788 board.dm.<slug> trigger
++ M783 identity).
+
+## What
+
+`Order.Agent` (roster slug): every firing — event, cron, manual — executes AS
+that identity (soul → persona, model + fallback chain, memory scope, per-run
+cost ceiling as the default; the order's own budget wins). Unknown/paused →
+`standing.error` with reason, never a silent default-identity run.
+`standing.fired` payload records the agent.
+
+## Changes
+
+- `kernel/standing`: Order += `Agent` (additive; persists via existing JSON).
+- `kernel/runtime`: **`WithAgentProfile(ctx, p)`** — one-call identity
+  application (soul/model/chain/scope; cost deliberately left to callers so
+  explicit budgets win). The standing runner uses it; handleRun keeps its
+  inline application (model resolves before the vision gate there).
+- `cmd/agezt` fire path: resolve → refuse (standing.error) or apply; fired
+  payload += agent; profile MaxCostMc as default when the order has none.
+- CLI `agt standing add --agent <slug>` + usage; control-plane standing_edit
+  += agent key ("" clears); webui /api/standing/edit allowlist += agent.
+
+## Tests (2 new)
+
+- `TestWithAgentProfile_AppliesIdentityToRun` (runtime, real kernel): the
+  provider's actual completion request carries the soul in System, the
+  profile model, the dupe-skipped chain, AND the memory-scoped private note
+  in the injected context — all four identity facets in one run.
+- `TestStanding_AgentFieldRoundTrips` (controlplane, wire): add with agent →
+  edit to another → clear with "" (omitempty drops it).
+
+## Runtime smoke (isolated AGEZT_HOME)
+
+Two event-triggered orders on `kernel.resume`: "as-agent" (agent=researcher)
+and "ghost-order" (agent=ghost). One halt/resume: journal shows
+`standing.error` for the ghost (seq 5, no run) and `standing.fired` → full
+run to `task.completed` (seq 6–12) for the real agent. 0 panics, clean
+shutdown. (Payload-field extraction via journal-grep JSON didn't parse in the
+shell; the flow is proven by the tail + the payload composition is the same
+code path covered above. Soul/model application proven by the runtime test —
+the fire path calls the same WithAgentProfile.)
+
+LESSON (smoke hygiene): `export AGEZT_HOME` does NOT persist across Bash tool
+calls — set it per command, or `agt` silently targets the default home.
+
+## Gate
+
+Full suite + vet + staticcheck green; linux cross-build OK; go.mod unchanged;
+no frontend change (Standing view edit route accepts the key; form field =
+follow-up). CI org-billing still blocked → local battery + arc-authority merge.
+
+## The recipe (now real)
+
+```
+agt agent add researcher --soul "…" --fallbacks m2,m3 --max-cost 0.50
+agt standing add --name "researcher answers" \
+    --event "board.dm.researcher" --agent researcher \
+    --plan "Use board op=inbox to=researcher; answer each waiting message with op=reply."
+# any agent: board op=send to=researcher text="…" → wake → answer → op=replies
+```
+
+## Next in the arc
+
+Standing view --agent form field · Board view threading · workdir wiring ·
+per-agent daily budget ledger.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **Standing orders run AS a named agent — the autonomous answerer is complete.** A standing order
+  can now carry an **agent** (roster slug): every firing — event-triggered, cron, or "run now" —
+  executes AS that identity, with its soul as the run's persona, its model + fallback chain, its
+  memory scope (private notes + shared brain), and its per-run cost ceiling as the default (the
+  order's own budget still wins). This closes the loop the A2A work opened: *"ask researcher a
+  question"* (`board op=send to=researcher`, M788) journals `board.dm.researcher` → a standing order
+  with that event trigger fires → **runs as researcher** → reads its inbox and replies — a fully
+  autonomous, journaled ask→wake→answer cycle with no operator in the path. An unknown or paused
+  agent journals a `standing.error` (with the reason) instead of silently running as the default
+  identity, and `standing.fired` now records who the firing ran as. Surface: `agt standing add
+  --agent <slug>`, the `agent` key on standing add/edit over the control plane and the console's
+  edit route. The profile application is one reusable call (`runtime.WithAgentProfile`) shared with
+  the standing runner. Unit-tested (the profile application carries soul + model + dupe-skipped
+  chain + memory-scoped private notes into a real run's provider request, asserted on the actual
+  completion request; the agent field round-trips add → edit → clear over the wire). Verified live
+  on an isolated daemon: two event-triggered orders on `kernel.resume`, one as a real agent and one
+  as a ghost — the resume fired the real one (standing.fired → full run to task.completed) and the
+  ghost one journaled standing.error without running; 0 panics. (M790)
 - **Talk to a named agent in Chat — each conversation picks who it's with.** The Chat composer
   gains an **agent picker** next to the model picker: choose a roster agent (M783) and *this
   thread* runs AS it — its soul, model fallback chain, memory scope, and per-run budget all apply

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -45,6 +45,7 @@ import (
 	"github.com/agezt/agezt/kernel/alerter"
 	"github.com/agezt/agezt/kernel/anomaly"
 	"github.com/agezt/agezt/kernel/board"
+	"github.com/agezt/agezt/kernel/roster"
 	"github.com/agezt/agezt/kernel/bus"
 	"github.com/agezt/agezt/kernel/cadence"
 	"github.com/agezt/agezt/kernel/catalog"
@@ -3029,17 +3030,50 @@ func buildStandingRunner(ctx context.Context, k *kernelruntime.Kernel, brief fun
 		if intent == "" {
 			intent = o.Name
 		}
+		// Run AS a named agent (M790): resolve the order's roster profile up
+		// front — an unknown or paused agent journals a standing.error instead
+		// of silently running as the default identity (mirrors `agt run --agent`).
+		var prof *roster.Profile
+		if slug := strings.TrimSpace(o.Agent); slug != "" {
+			p, ok := k.Roster().Get(slug)
+			if !ok || !p.Enabled {
+				reason := "unknown agent " + slug
+				if ok {
+					reason = "agent " + p.Slug + " is paused"
+				}
+				_, _ = k.Bus().Publish(event.Spec{
+					Subject: "standing." + o.ID,
+					Kind:    event.KindStandingError,
+					Actor:   "standing",
+					Payload: map[string]any{"id": o.ID, "name": o.Name, "trigger_subject": subject, "agent": slug, "reason": reason},
+				})
+				return
+			}
+			prof = &p
+		}
 		// Ground the run in the order's scope (SPEC-16 §4): the agent is told what
 		// this standing order watches.
 		intent = standing.ScopedIntent(o, intent)
+		firedPayload := map[string]any{"id": o.ID, "name": o.Name, "trigger_subject": subject, "intent": intent}
+		if prof != nil {
+			firedPayload["agent"] = prof.Slug // who this firing runs AS (M790)
+		}
 		_, _ = k.Bus().Publish(event.Spec{
 			Subject:       "standing." + o.ID,
 			Kind:          event.KindStandingFired,
 			Actor:         "standing",
 			CorrelationID: corr,
-			Payload:       map[string]any{"id": o.ID, "name": o.Name, "trigger_subject": subject, "intent": intent},
+			Payload:       firedPayload,
 		})
 		rctx := fctx
+		if prof != nil {
+			// Soul → system, model + fallbacks → chain, memory scope (M790).
+			rctx = kernelruntime.WithAgentProfile(rctx, *prof)
+			// The profile's per-run ceiling is the DEFAULT; the order's own wins.
+			if o.Initiative.BudgetPerRunMc <= 0 && prof.MaxCostMc > 0 {
+				rctx = kernelruntime.WithMaxCost(rctx, prof.MaxCostMc)
+			}
+		}
 		if o.Initiative.BudgetPerRunMc > 0 {
 			rctx = kernelruntime.WithMaxCost(rctx, o.Initiative.BudgetPerRunMc)
 		}

--- a/cmd/agt/standing.go
+++ b/cmd/agt/standing.go
@@ -45,6 +45,7 @@ func standingUsage(w io.Writer) int {
 	fmt.Fprintf(w, "usage: %s standing <list|add|pause|resume|remove>\n", brand.CLI)
 	fmt.Fprintf(w, "  list [--json]                                  show standing orders\n")
 	fmt.Fprintf(w, "  add --name N (--cron \"SCHED\" | --event SUBJ) [--plan TEXT]\n")
+	fmt.Fprintf(w, "      [--agent SLUG]  run each firing AS that named agent (soul/model/memory/budget)\n")
 	fmt.Fprintf(w, "      [--mode inform_only|ask|act_or_ask] [--max-trust L0..L4] [--budget USD]\n")
 	fmt.Fprintf(w, "      [--scope ent1,ent2] [--channel C]\n")
 	fmt.Fprintf(w, "  pause <id>                                     disable an order\n")
@@ -173,7 +174,7 @@ func initiativeMode(o map[string]any) string {
 }
 
 func cmdStandingAdd(args []string, stdout, stderr io.Writer) int {
-	var name, cron, event, plan, mode, maxTrust, channel, budget, scope string
+	var name, cron, event, plan, mode, maxTrust, channel, budget, scope, agentSlug string
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--name":
@@ -205,6 +206,11 @@ func cmdStandingAdd(args []string, stdout, stderr io.Writer) int {
 			i++
 			if i < len(args) {
 				plan = args[i]
+			}
+		case "--agent":
+			i++
+			if i < len(args) {
+				agentSlug = args[i]
 			}
 		case "--mode":
 			i++
@@ -277,6 +283,9 @@ func cmdStandingAdd(args []string, stdout, stderr io.Writer) int {
 	}
 	if channel != "" {
 		order["briefing_channel"] = channel
+	}
+	if agentSlug = strings.TrimSpace(agentSlug); agentSlug != "" {
+		order["agent"] = agentSlug // M790: firings run AS this roster agent
 	}
 
 	c := dial(stderr)

--- a/kernel/controlplane/roster_memory_test.go
+++ b/kernel/controlplane/roster_memory_test.go
@@ -130,6 +130,45 @@ func TestRun_AsAgent_ModelChain(t *testing.T) {
 	}
 }
 
+// TestStanding_AgentFieldRoundTrips: a standing order created with an agent
+// (M790) keeps it through add → list → edit (set + clear) over the wire.
+func TestStanding_AgentFieldRoundTrips(t *testing.T) {
+	_, _, c, _ := startPair(t, mock.New(mock.FinalText("ok")))
+	ctx := context.Background()
+
+	add, err := c.Call(ctx, controlplane.CmdStandingAdd, map[string]any{
+		"order": map[string]any{
+			"name":     "inbox answerer",
+			"triggers": []any{map[string]any{"type": "event", "subject": "board.dm.researcher"}},
+			"plan":     "read your inbox and reply",
+			"agent":    "researcher",
+		},
+	})
+	if err != nil {
+		t.Fatalf("standing add: %v", err)
+	}
+	o, _ := add["order"].(map[string]any)
+	if o["agent"] != "researcher" {
+		t.Fatalf("add lost the agent: %v", o)
+	}
+	id, _ := o["id"].(string)
+
+	edit, err := c.Call(ctx, controlplane.CmdStandingEdit, map[string]any{"id": id, "agent": "ops"})
+	if err != nil {
+		t.Fatalf("standing edit: %v", err)
+	}
+	if eo, _ := edit["order"].(map[string]any); eo["agent"] != "ops" {
+		t.Fatalf("edit didn't set the agent: %v", edit)
+	}
+	clear, err := c.Call(ctx, controlplane.CmdStandingEdit, map[string]any{"id": id, "agent": ""})
+	if err != nil {
+		t.Fatalf("standing clear: %v", err)
+	}
+	if co, _ := clear["order"].(map[string]any); co["agent"] != nil {
+		t.Fatalf("empty agent should clear (omitempty): %v", clear)
+	}
+}
+
 func equalStrings(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/kernel/controlplane/standing.go
+++ b/kernel/controlplane/standing.go
@@ -82,6 +82,9 @@ func (s *Server) handleStandingEdit(conn net.Conn, req Request) {
 		if v, ok := req.Args["plan"].(string); ok {
 			o.Plan = v
 		}
+		if v, ok := req.Args["agent"].(string); ok {
+			o.Agent = strings.TrimSpace(v) // M790: run firings AS this roster agent ("" clears)
+		}
 		if v, ok := req.Args["mode"].(string); ok {
 			o.Initiative.Mode = standing.InitiativeMode(v)
 		}

--- a/kernel/runtime/agentprofile_ctx_test.go
+++ b/kernel/runtime/agentprofile_ctx_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+
+package runtime_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/memory"
+	"github.com/agezt/agezt/kernel/roster"
+	"github.com/agezt/agezt/kernel/runtime"
+	"github.com/agezt/agezt/plugins/providers/mock"
+	"github.com/agezt/agezt/plugins/tools/shell"
+)
+
+// TestWithAgentProfile_AppliesIdentityToRun: the one-call profile application
+// (M790 — used by the standing runner) carries the whole identity into the
+// run: soul → system, model + fallbacks → model chain, memory scope → private
+// notes in the injected context.
+func TestWithAgentProfile_AppliesIdentityToRun(t *testing.T) {
+	prov := mock.New(mock.FinalText("ok"))
+	var req agent.CompletionRequest
+	prov.OnRequest = func(r agent.CompletionRequest) { req = r }
+	k, err := runtime.Open(runtime.Config{
+		BaseDir:      t.TempDir(),
+		Provider:     prov,
+		Model:        "default-model",
+		Tools:        map[string]agent.Tool{"shell": shell.New()},
+		MemoryInject: true,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { k.Close() })
+
+	if _, _, err := k.Memory().Remember("", memory.RememberSpec{
+		Subject: "target notes", Content: "researcher-private-fact",
+		Tags: map[string]string{"scope": "researcher"},
+	}); err != nil {
+		t.Fatalf("remember: %v", err)
+	}
+
+	ctx := runtime.WithAgentProfile(context.Background(), roster.Profile{
+		Slug: "researcher", Soul: "You are Researcher.",
+		Model: "agent-model", Fallbacks: []string{"agent-model", "backup-1"},
+	})
+	if _, err := k.RunWith(ctx, k.NewCorrelation(), "what about the target?"); err != nil {
+		t.Fatalf("RunWith: %v", err)
+	}
+
+	if req.Model != "agent-model" {
+		t.Errorf("model = %q, want agent-model", req.Model)
+	}
+	if len(req.ModelChain) != 2 || req.ModelChain[0] != "agent-model" || req.ModelChain[1] != "backup-1" {
+		t.Errorf("chain = %v, want [agent-model backup-1] (dupe skipped)", req.ModelChain)
+	}
+	if !strings.Contains(req.System, "You are Researcher.") {
+		t.Errorf("soul missing from system:\n%s", req.System)
+	}
+	if !strings.Contains(req.System, "researcher-private-fact") {
+		t.Errorf("memory scope not applied — private note missing:\n%s", req.System)
+	}
+}

--- a/kernel/runtime/runtime.go
+++ b/kernel/runtime/runtime.go
@@ -1163,6 +1163,40 @@ func maxCostFromCtx(ctx context.Context) int64 {
 	return 0
 }
 
+// WithAgentProfile applies a roster profile to a run's context (M790): the
+// soul becomes the system override, the model + ordered fallbacks become the
+// run's model chain, and the memory scope follows the identity (M786). The
+// per-run cost ceiling is NOT applied here — callers layer it so their own
+// explicit budget wins (mirrors handleRun's precedence). Used by the standing
+// runner so an order can fire AS a named agent; handleRun keeps its inline
+// application (its model resolves before the vision gate).
+func WithAgentProfile(ctx context.Context, p roster.Profile) context.Context {
+	if soul := strings.TrimSpace(p.Soul); soul != "" {
+		ctx = WithSystem(ctx, soul)
+	}
+	primary := strings.TrimSpace(p.Model)
+	if primary != "" {
+		ctx = WithModel(ctx, primary)
+	}
+	if len(p.Fallbacks) > 0 {
+		chain := []string{primary}
+		if primary == "" {
+			chain = nil
+		}
+		for _, m := range p.Fallbacks {
+			if m = strings.TrimSpace(m); m != "" && m != primary {
+				chain = append(chain, m)
+			}
+		}
+		ctx = WithModelChain(ctx, chain)
+	}
+	scope := strings.TrimSpace(p.MemoryScope)
+	if scope == "" {
+		scope = p.Slug
+	}
+	return memory.WithScope(ctx, scope)
+}
+
 // WithModelChain sets the run's per-agent ordered model fallback chain (M787):
 // the Governor tries these models in order, overriding the task type's
 // configured chain. Carries a named agent's own fallbacks (roster M783).

--- a/kernel/standing/standing.go
+++ b/kernel/standing/standing.go
@@ -80,6 +80,12 @@ type Order struct {
 	BriefingMin   string     `json:"briefing_disposition_min,omitempty"` // drop|digest|notify|alert
 	BriefingChan  string     `json:"briefing_channel,omitempty"`
 	Plan          string     `json:"plan,omitempty"` // optional explicit plan/intent template
+	// Agent, when set, makes each firing run AS that named roster agent
+	// (M790): its soul, model fallback chain, and memory scope apply, and its
+	// per-run cost ceiling is the default when the order sets none. Resolved
+	// at fire time — an unknown or paused agent journals a standing.error
+	// instead of silently running as the default identity.
+	Agent string `json:"agent,omitempty"`
 	// Assure, when > 0, makes each firing "do-it-for-sure": the order's plan runs,
 	// a verifier checks it was actually accomplished, and it retries the gap up to
 	// this many attempts (M655). 0 = a single pass (the default). The fire path

--- a/kernel/webui/webui.go
+++ b/kernel/webui/webui.go
@@ -278,7 +278,7 @@ var jsonRoutes = map[string]writeRoute{
 	"/api/standing/add": {controlplane.CmdStandingAdd, []string{"order"}},
 	// Edit a standing order in place (M729): id + any subset of the human-tunable
 	// fields. assure is numeric, so the JSON body preserves its type.
-	"/api/standing/edit": {controlplane.CmdStandingEdit, []string{"id", "name", "plan", "mode", "max_trust", "briefing_min", "assure"}},
+	"/api/standing/edit": {controlplane.CmdStandingEdit, []string{"id", "name", "plan", "agent", "mode", "max_trust", "briefing_min", "assure"}},
 	// Agent roster create/edit (M783): the profile is a structured object (soul
 	// text, fallback list, numeric cost ceiling) — a JSON body, not query args.
 	"/api/agents/add":  {controlplane.CmdAgentAdd, []string{"profile"}},


### PR DESCRIPTION
## What

`Order.Agent` (roster slug): every firing — event, cron, run-now — executes **AS that identity**: soul → persona, model + fallback chain, memory scope, per-run cost ceiling as the default (the order's own budget wins). Unknown/paused agents journal `standing.error` with the reason — never a silent default-identity run; `standing.fired` records who ran.

**Closes the M788 loop** — the fully autonomous answerer:
```
agt standing add --name "researcher answers" --event board.dm.researcher --agent researcher     --plan "Use board op=inbox to=researcher; answer each waiting message with op=reply."
```
ask (op=send) → wake (board.dm.<slug> trigger) → answer (runs AS researcher) → read (op=replies). No operator in the path.

- New `runtime.WithAgentProfile` — one-call identity application, shared by the standing runner.
- Surface: `agt standing add --agent`, `agent` key on standing edit (control plane + console route, "" clears).

## Validation

- **runtime test on a real kernel**: the provider's actual completion request carries the soul (System), profile model, dupe-skipped chain, AND the memory-scoped private note — all four identity facets in one run.
- **wire test**: agent field round-trips add → edit → clear (omitempty).
- **Isolated-daemon smoke**: two resume-triggered orders — the real agent fired (`standing.fired` → full run to `task.completed`), the ghost journaled `standing.error` without running; 0 panics.
- Full suite + vet + staticcheck + linux cross-build green; go.mod unchanged; no frontend change.
- CI org-billing still blocked — local battery, arc-authority merge (PRs #136+ pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)