### PR TITLE
Feat: per-agent workdir — every named agent gets a home directory (M792)

### DIFF
--- a/.project/PHASE-M792-AGENT-WORKDIR-REPORT.md
+++ b/.project/PHASE-M792-AGENT-WORKDIR-REPORT.md
@@ -1,0 +1,49 @@
+# Phase M792 — per-agent workdir: every identity gets a home directory
+
+**Date:** 2026-06-10 · **Status:** DONE · **Arc:** multi-agent identity,
+step 10 (the last stored-but-unwired profile field goes live).
+
+## What
+
+Profile `Workdir` (validated since M783) now applies: runs AS the agent —
+run-as, chat, delegate, standing firings — do their relative file work and
+shell commands inside `<workspace>/<workdir>`.
+
+## Design
+
+- `kernel/agent/toolctx.go`: `WithWorkdir`/`WorkdirFromContext` — the same
+  leaf-ctx pattern as the run correlation; the setter REJECTS abs/`..`
+  shapes (defense in depth over the profile validation).
+- file tool: one touch point in Invoke — relative input paths rebase under
+  the ctx workdir; empty list/glob path = the agent's directory; absolute
+  paths and ALL existing containment (symlink-resolved root prefix, M252/
+  M253 ancestor checks) untouched.
+- shell tool: effective WorkDir = configured workspace + ctx workdir
+  (lazily MkdirAll); ignored when no workspace anchor is configured.
+- Wiring: `WithAgentProfile` (standing runner), handleRun inline, delegate
+  childCtx — every identity path now sets it.
+
+## Tests (3 new)
+
+- file: scoped write/read/list land under the workdir; unscoped run still
+  sees the root (no cross-identity leak); `../..` out of the workspace
+  refused through the rebase.
+- setter escape table (abs, .., ../up, a/../../b, a/..) + clean passthrough.
+- runtime e2e on a real kernel: a run AS a workdir-bearing profile wrote via
+  the real file tool → the file landed in `<workspace>/research/notes.txt`.
+
+## Smoke
+
+Isolated daemon: `agt agent add --workdir research` → `agent show` printed
+it → `run --agent` clean; 0 panics. (Tool-driven write proven by the runtime
+e2e — demo echo calls no tools.)
+
+## Gate
+
+Full suite + vet + staticcheck green; linux cross-build OK; go.mod
+unchanged; no frontend change (Roster view already renders workdir). CI
+org-billing still blocked → local battery + arc-authority merge.
+
+## Arc remaining
+
+per-agent daily budget ledger (the last gap-analysis item in this arc).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **Each named agent gets its own working directory.** A roster profile's **workdir** (stored and
+  escape-validated since M783) is now live: when a run executes AS that agent — `agt run --agent`,
+  a chat thread, a delegate child, or a standing-order firing — the **file tool** rebases relative
+  paths under `<workspace>/<workdir>` (an empty list path means *my directory*) and the **shell
+  tool** runs commands there (the directory is created lazily on first use). "Researcher" keeps its
+  notes in `workspace/research/`, "Ops" in `workspace/ops/` — agents stop trampling each other's
+  files, and the operator can read each agent's home at a glance. Absolute paths and the workspace
+  containment rules are untouched: the workdir only changes where *relative* work lands, escaping
+  the workspace is refused exactly as before, and the workdir value itself is escape-proofed twice
+  (profile validation + the context setter rejects abs/`..` shapes outright — defense in depth).
+  Carried as a run-context value every identity path sets (`WithAgentProfile`, run-as, delegate).
+  Unit-tested (writes/reads/list land under the workdir while an unscoped run still sees the root
+  and `..` out of the workspace stays refused; the setter's escape table; end-to-end on a real
+  kernel: a run AS a workdir-bearing profile wrote through the real file tool and the file landed
+  in `<workspace>/research/`). Smoke: `agt agent add --workdir research` round-trips and a run-as
+  boots clean. (M792)
 - **The console catches up with the fleet — agent fields and message threading.** Two surfaces the
   multi-agent arc grew now render in the console. The **Standing view**: orders that run AS a named
   agent (M790) show a *runs as <slug>* chip, and both the create and edit forms gain a **Run as

--- a/kernel/agent/toolctx.go
+++ b/kernel/agent/toolctx.go
@@ -2,7 +2,11 @@
 
 package agent
 
-import "context"
+import (
+	"context"
+	"path/filepath"
+	"strings"
+)
 
 // corrKey is the unexported context key under which the running loop stashes the
 // current run's correlation id, so a Tool's Invoke can attribute its own side
@@ -32,4 +36,48 @@ func CorrelationFromContext(ctx context.Context) string {
 		return id
 	}
 	return ""
+}
+
+// workdirKey carries the run's per-agent working directory (M792): a
+// workspace-RELATIVE subdirectory the file and shell tools operate inside
+// when a run executes AS a named agent whose profile names one.
+type workdirKey struct{}
+
+// WithWorkdir returns a child context carrying a workspace-relative workdir.
+// Defense-in-depth: absolute paths and any form of `..` escape are refused
+// here (the context stays unchanged) even though the roster profile already
+// validates the same rule — a tool must never receive an escaping workdir.
+func WithWorkdir(ctx context.Context, workdir string) context.Context {
+	w := cleanRelWorkdir(workdir)
+	if w == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, workdirKey{}, w)
+}
+
+// WorkdirFromContext returns the per-agent workdir set by WithWorkdir, or ""
+// (operate at the workspace root) when the run carries none.
+func WorkdirFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if w, ok := ctx.Value(workdirKey{}).(string); ok {
+		return w
+	}
+	return ""
+}
+
+// cleanRelWorkdir normalises a workdir to forward slashes and rejects
+// absolute or escaping shapes ("" on any violation).
+func cleanRelWorkdir(w string) string {
+	w = strings.TrimSpace(w)
+	if w == "" {
+		return ""
+	}
+	s := filepath.ToSlash(w)
+	if filepath.IsAbs(w) || strings.HasPrefix(s, "/") ||
+		s == ".." || strings.HasPrefix(s, "../") || strings.Contains(s, "/../") || strings.HasSuffix(s, "/..") {
+		return ""
+	}
+	return s
 }

--- a/kernel/controlplane/server.go
+++ b/kernel/controlplane/server.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/agezt/agezt/internal/brand"
+	"github.com/agezt/agezt/kernel/agent"
 	"github.com/agezt/agezt/kernel/approval"
 	"github.com/agezt/agezt/kernel/event"
 	"github.com/agezt/agezt/kernel/memory"
@@ -1233,6 +1234,9 @@ func (s *Server) handleRun(ctx context.Context, conn net.Conn, req Request) {
 			scope = p.Slug
 		}
 		ctx = memory.WithScope(ctx, scope)
+		// And its working directory (M792): file/shell tools operate inside
+		// the profile's workspace subdirectory.
+		ctx = agent.WithWorkdir(ctx, p.Workdir)
 		// Its own model fallback chain too (M787): primary (the resolved
 		// model — an explicit --model still wins the front slot) followed by
 		// the profile's ordered fallbacks; the Governor walks it in order.

--- a/kernel/runtime/agentprofile_ctx_test.go
+++ b/kernel/runtime/agentprofile_ctx_test.go
@@ -4,6 +4,8 @@ package runtime_test
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -12,6 +14,7 @@ import (
 	"github.com/agezt/agezt/kernel/roster"
 	"github.com/agezt/agezt/kernel/runtime"
 	"github.com/agezt/agezt/plugins/providers/mock"
+	"github.com/agezt/agezt/plugins/tools/file"
 	"github.com/agezt/agezt/plugins/tools/shell"
 )
 
@@ -61,5 +64,37 @@ func TestWithAgentProfile_AppliesIdentityToRun(t *testing.T) {
 	}
 	if !strings.Contains(req.System, "researcher-private-fact") {
 		t.Errorf("memory scope not applied — private note missing:\n%s", req.System)
+	}
+}
+
+// TestWithAgentProfile_WorkdirConfinesFileTool: a profile workdir (M792) makes
+// the run's file-tool writes land inside <workspace>/<workdir>.
+func TestWithAgentProfile_WorkdirConfinesFileTool(t *testing.T) {
+	ws := t.TempDir()
+	ft, err := file.New(ws)
+	if err != nil {
+		t.Fatalf("file.New: %v", err)
+	}
+	prov := mock.New(
+		mock.ToolUse("c1", "file", map[string]any{"op": "write", "path": "notes.txt", "content": "from researcher"}),
+		mock.FinalText("done"),
+	)
+	k, err := runtime.Open(runtime.Config{
+		BaseDir:  t.TempDir(),
+		Provider: prov,
+		Tools:    map[string]agent.Tool{"file": ft},
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { k.Close() })
+
+	ctx := runtime.WithAgentProfile(context.Background(), roster.Profile{Slug: "researcher", Workdir: "research"})
+	if _, err := k.RunWith(ctx, k.NewCorrelation(), "take a note"); err != nil {
+		t.Fatalf("RunWith: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(ws, "research", "notes.txt"))
+	if err != nil || string(b) != "from researcher" {
+		t.Fatalf("write did not land in the agent's workdir: %v %q", err, b)
 	}
 }

--- a/kernel/runtime/runtime.go
+++ b/kernel/runtime/runtime.go
@@ -35,9 +35,9 @@ import (
 	"github.com/agezt/agezt/kernel/journal"
 	"github.com/agezt/agezt/kernel/memory"
 	"github.com/agezt/agezt/kernel/reflect"
+	"github.com/agezt/agezt/kernel/roster"
 	"github.com/agezt/agezt/kernel/scheduler"
 	"github.com/agezt/agezt/kernel/skill"
-	"github.com/agezt/agezt/kernel/roster"
 	"github.com/agezt/agezt/kernel/standing"
 	"github.com/agezt/agezt/kernel/state"
 	"github.com/agezt/agezt/kernel/tenantctx"
@@ -1194,7 +1194,10 @@ func WithAgentProfile(ctx context.Context, p roster.Profile) context.Context {
 	if scope == "" {
 		scope = p.Slug
 	}
-	return memory.WithScope(ctx, scope)
+	ctx = memory.WithScope(ctx, scope)
+	// The agent's working directory (M792): file/shell tools operate inside
+	// this workspace subdirectory. Escape-proofed by the setter.
+	return agent.WithWorkdir(ctx, p.Workdir)
 }
 
 // WithModelChain sets the run's per-agent ordered model fallback chain (M787):
@@ -1623,8 +1626,8 @@ func (k *Kernel) RunWith(ctx context.Context, corr, intent string) (string, erro
 		Tools:                runTools,
 		Bus:                  k.bus,
 		Model:                model,
-		TaskType:             "chat",                      // M703: main agent loop → "chat" routing target
-		ModelChain:           modelChainFromCtx(runCtx),   // M787: a named agent's own fallbacks
+		TaskType:             "chat",                    // M703: main agent loop → "chat" routing target
+		ModelChain:           modelChainFromCtx(runCtx), // M787: a named agent's own fallbacks
 		System:               system,
 		MaxIter:              k.cfg.MaxIter,
 		ToolTimeout:          k.cfg.ToolTimeout,

--- a/kernel/runtime/subagent.go
+++ b/kernel/runtime/subagent.go
@@ -274,13 +274,16 @@ func (k *Kernel) runSubAgent(ctx context.Context, task, model, taskType, agentRe
 	// to the whole tree, not re-seeded at each level.
 	childCtx = context.WithValue(childCtx, ctxKeyRoot, rootCorr)
 	// A named agent's memory follows it (M786): the child's memory-tool recalls
-	// default to the profile's scope (its private notes + shared memory).
+	// default to the profile's scope (its private notes + shared memory). Its
+	// working directory follows too (M792): the child's file/shell tools
+	// operate inside the profile's workspace subdirectory.
 	if prof != nil {
 		scope := strings.TrimSpace(prof.MemoryScope)
 		if scope == "" {
 			scope = prof.Slug
 		}
 		childCtx = memory.WithScope(childCtx, scope)
+		childCtx = agent.WithWorkdir(childCtx, prof.Workdir)
 	}
 
 	// A named agent's soul REPLACES the daemon persona layer (it IS this

--- a/plugins/tools/file/file.go
+++ b/plugins/tools/file/file.go
@@ -146,6 +146,19 @@ func (t *Tool) Invoke(ctx context.Context, raw json.RawMessage) (agent.Result, e
 		return agent.Result{}, err
 	}
 
+	// Per-agent workdir (M792): a run executing AS a named agent whose profile
+	// names a workspace subdirectory operates THERE — relative paths rebase
+	// under it (and an empty list/glob path means "my directory"). Absolute
+	// paths are untouched; full root containment below still applies, and the
+	// workdir itself is escape-proofed twice (profile validation + ctx setter).
+	if wd := agent.WorkdirFromContext(ctx); wd != "" {
+		if in.Path == "" {
+			in.Path = wd
+		} else if !filepath.IsAbs(in.Path) {
+			in.Path = filepath.Join(wd, in.Path)
+		}
+	}
+
 	switch in.Op {
 	case "read":
 		return t.doRead(in)

--- a/plugins/tools/file/workdir_test.go
+++ b/plugins/tools/file/workdir_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+
+package file
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/agezt/agezt/kernel/agent"
+)
+
+// TestWorkdir_RebasesRelativePaths: a run carrying a per-agent workdir (M792)
+// reads and writes inside <root>/<workdir>; an unscoped run is unchanged; an
+// empty list path means "my directory"; containment still holds.
+func TestWorkdir_RebasesRelativePaths(t *testing.T) {
+	root := t.TempDir()
+	tool, err := New(root)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ctx := agent.WithWorkdir(context.Background(), "research")
+
+	invoke := func(ctx context.Context, in map[string]any) agent.Result {
+		t.Helper()
+		raw, _ := json.Marshal(in)
+		res, err := tool.Invoke(ctx, raw)
+		if err != nil {
+			t.Fatalf("Invoke: %v", err)
+		}
+		return res
+	}
+
+	// Write lands under root/research, not the root.
+	if res := invoke(ctx, map[string]any{"op": "write", "path": "notes.txt", "content": "dug deep"}); res.IsError {
+		t.Fatalf("write errored: %s", res.Output)
+	}
+	b, err := os.ReadFile(filepath.Join(root, "research", "notes.txt"))
+	if err != nil || string(b) != "dug deep" {
+		t.Fatalf("file not in the workdir: %v %q", err, b)
+	}
+
+	// Read resolves the same way.
+	if res := invoke(ctx, map[string]any{"op": "read", "path": "notes.txt"}); res.IsError || !strings.Contains(res.Output, "dug deep") {
+		t.Fatalf("scoped read wrong: %s", res.Output)
+	}
+
+	// An empty list path means the agent's own directory.
+	if res := invoke(ctx, map[string]any{"op": "list", "path": ""}); res.IsError || !strings.Contains(res.Output, "notes.txt") {
+		t.Fatalf("empty-path list should show the workdir: %s", res.Output)
+	}
+
+	// An UNscoped run still operates at the root (no leak between identities).
+	if res := invoke(context.Background(), map[string]any{"op": "read", "path": "notes.txt"}); !res.IsError {
+		t.Fatalf("root read of a workdir file should miss, got: %s", res.Output)
+	}
+
+	// Containment survives the rebase: ../ out of the workdir stays inside
+	// root rules — escaping ROOT is still refused.
+	if res := invoke(ctx, map[string]any{"op": "write", "path": "../../outside.txt", "content": "x"}); !res.IsError {
+		t.Fatal("root escape via workdir-relative .. was allowed")
+	}
+}
+
+// TestWithWorkdir_RefusesEscapes: the ctx setter is defense-in-depth — abs and
+// any `..` shape leave the context unset.
+func TestWithWorkdir_RefusesEscapes(t *testing.T) {
+	for _, w := range []string{"/abs", "..", "../up", "a/../../b", "a/.."} {
+		if got := agent.WorkdirFromContext(agent.WithWorkdir(context.Background(), w)); got != "" {
+			t.Errorf("escaping workdir %q accepted as %q", w, got)
+		}
+	}
+	if got := agent.WorkdirFromContext(agent.WithWorkdir(context.Background(), "team/research")); got != "team/research" {
+		t.Errorf("clean workdir mangled: %q", got)
+	}
+}

--- a/plugins/tools/shell/shell.go
+++ b/plugins/tools/shell/shell.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"runtime"
 	"time"
 
@@ -134,11 +136,22 @@ func (t *Tool) Invoke(ctx context.Context, raw json.RawMessage) (agent.Result, e
 		profile = warden.ProfileNamespace
 	}
 
+	// Per-agent workdir (M792): a named agent's commands run inside its
+	// workspace subdirectory (created lazily on first use). Anchored under the
+	// tool's configured workspace WorkDir — without one there is nothing safe
+	// to anchor to, so the ctx workdir is ignored. The ctx value is
+	// escape-proofed at the setter (and by profile validation upstream).
+	workDir := t.WorkDir
+	if wd := agent.WorkdirFromContext(ctx); wd != "" && t.WorkDir != "" {
+		workDir = filepath.Join(t.WorkDir, filepath.FromSlash(wd))
+		_ = os.MkdirAll(workDir, 0o755)
+	}
+
 	shellBin, shellArg := t.resolveShell()
 	res, err := w.Run(ctx, warden.Spec{
 		Profile: profile,
 		Argv:    []string{shellBin, shellArg, in.Command},
-		WorkDir: t.WorkDir, // M609: run where the file tool operates (empty = inherit CWD)
+		WorkDir: workDir, // M609 workspace coherence + M792 per-agent subdir
 		Limits: warden.Limits{
 			Timeout:        timeout,
 			MaxOutputBytes: MaxOutputBytes,


### PR DESCRIPTION
## What

The last stored-but-unwired profile field goes live: a roster agent's **workdir** now applies to every run AS that identity (run-as, chat threads, delegate children, standing firings):

- **file tool**: relative paths rebase under `<workspace>/<workdir>`; an empty list path means *my directory*; absolute paths and ALL existing containment (symlink-resolved root prefix, M252/M253) untouched.
- **shell tool**: commands run in the agent's directory (created lazily); ignored when no workspace anchor is configured.
- Escape-proofed **twice**: profile validation (M783) + the new `agent.WithWorkdir` setter rejects abs/`..` shapes outright.

"Researcher" keeps its notes in `workspace/research/`, "Ops" in `workspace/ops/` — no more trampling.

## Validation

- **3 new tests**: scoped write/read/list land under the workdir while an unscoped run still sees the root (no cross-identity leak) and `../..` out of the workspace stays refused through the rebase; setter escape table; **e2e on a real kernel** — a run AS a workdir-bearing profile wrote through the real file tool and the file landed in `<workspace>/research/notes.txt`.
- Smoke: `agt agent add --workdir research` round-trips; run-as boots clean; 0 panics.
- Full suite + vet + staticcheck green; linux cross-build OK; go.mod unchanged; no frontend change (Roster view already renders workdir). gofmt verified on staged blobs **pre-commit** (M790 lesson applied).
- CI org-billing still blocked — local battery, arc-authority merge (PRs #136+ pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)