### PR TITLE
Feat: script-tool forge — agent code becomes a callable tool (M794)

### DIFF
--- a/.project/PHASE-M794-SCRIPT-TOOL-FORGE-REPORT.md
+++ b/.project/PHASE-M794-SCRIPT-TOOL-FORGE-REPORT.md
@@ -1,0 +1,93 @@
+# Phase M794 — script-tool forge: agent code becomes a callable tool
+
+**Date:** 2026-06-10 · **Status:** DONE · **Frontier:** gap-analysis #4
+(code→tool promotion — the close of the write→use→improve cycle).
+
+## What
+
+`kernel/toolforge`: a durable, journaled registry of **script tools** —
+named scripts (Python/Node/Deno) that, once **tested and promoted**, are
+offered to every run (and every sub-agent) as real callable tools named
+`forge_<name>`, executed through the existing code_exec sandbox.
+
+The governed pipeline: **draft → test → (operator) promote → live**, with
+quarantine as the kill switch. The core invariant is *only tested code is
+ever live*: `Promote` refuses (`ErrUntested`) until a sandbox test of the
+CURRENT code passed, and any code/language edit demotes the tool back to
+draft with its test record cleared.
+
+## Design
+
+- **Store** (`scripttools.json`, roster pattern): atomic rewrite, mutex,
+  rollback-on-save-fail, ULID ids, unique immutable names
+  (`^[a-z][a-z0-9_]{0,39}$`), validation (desc required ≤2KiB, code ≤128KiB,
+  optional JSON-object input schema ≤16KiB). Statuses draft/active/quarantined.
+- **Execution** rides code_exec untouched: `codeexec.Tool.RunScript(ctx,
+  lang, code, inputJSON)` (new export) marshals a normal code_exec input —
+  the call's raw JSON input becomes `stdin` (surfaced to the script as
+  `./stdin.txt`), stdout+stderr come back, ephemeral dir, scrubbed env,
+  warden limits. The kernel sees only the `toolforge.Runner` interface
+  (`Config.ScriptRunner`); cmd/agezt wires the code_exec tool in — the
+  kernel still never imports plugins.
+- **Offering seam**: `k.mergeScriptTools(k.tools)` in RunWith — merged
+  BEFORE the WithTools filter (a restricted run can't smuggle forged tools
+  back) and BEFORE injectEnvironment (the model's tool preamble sees them).
+  Same merge on the delegate child path. No-active-scripts path is
+  allocation-free.
+- **Edict**: every `forge_*` call maps to `code.exec` (it IS sandboxed code
+  execution — promotion changes who can be called, never what the sandbox
+  allows). New `tool.forge` capability (AskFirst, like `skill`) gates the
+  authoring ops of the `tool_forge` agent tool; `op=test` maps to
+  `code.exec` because it runs code.
+- **Agent surface** (`tool_forge`, plugins/tools/forgetool): draft / update /
+  test / list / show. Promotion is deliberately NOT a tool op — an agent can
+  author and test, only the operator promotes (controlplane + CLI + webui).
+- **Operator surface**: `agt toolforge list|show|draft|edit|test|promote|
+  quarantine|remove` (code via `--file`); controlplane `toolforge_*` cmds;
+  webui routes (GET /api/toolforge; POST test/promote/quarantine/remove as
+  writeRoutes, draft/edit as jsonRoutes). Console view → next milestone.
+- **Journal**: `scripttool.created/updated/tested/promoted/quarantined/
+  removed` under subject `toolforge.<name>` — `agt why` explains how a tool
+  came to be, who tested it, when it went live, when it was pulled.
+
+## Tests (17 new across 6 packages)
+
+- toolforge store: full lifecycle (draft never offered → promote refused
+  untested → test → promote → quarantine → re-promote), code-edit demotes +
+  clears test record, identity/lifecycle fields protected from mutators,
+  validation table, name uniqueness, persistence round-trip, remove.
+- runtime e2e (mock provider + stub runner): promoted tool OFFERED to the
+  model and EXECUTED (runner receives stored lang/code + the call's raw
+  JSON); draft/quarantined never offered; WithTools allowlist gates forged
+  tools both ways; failed test recorded + promote refused.
+- edict toolmap: `forge_*` → code.exec; tool_forge op routing (test →
+  code.exec, rest → tool.forge).
+- forgetool: authoring loop (draft/test/list/show/update-demotes), failing
+  test reports FAILED + sandbox output, promote-is-not-a-tool-op, unbound.
+- controlplane wire round-trip: the full operator pipeline incl. list
+  doesn't leak code bodies, show does carry them, failed test keeps the gate
+  shut.
+- codeexec live (skips without Python): RunScript stdin.txt contract, exit
+  code → isError, unavailable language honesty.
+
+## Smoke (isolated AGEZT_HOME, real daemon, real Python)
+
+draft weather.py → premature promote REFUSED ("no passing test") → `agt
+toolforge test weather --input '{"city":"izmir"}'` ran in the real sandbox
+and printed `weather for izmir: sunny, 28C` → promote → list shows ACTIVE →
+`forge_weather` → quarantine → re-promote (test record survived) → code edit
+demoted to draft/untested. Journal: created/tested/promoted/quarantined/
+promoted/updated, all subject `toolforge.weather`. Daemon banner shows the
+new tool line. Graceful shutdown; smoke dir removed.
+
+## Gate
+
+Full `GOMAXPROCS=3 go test -p 2 ./...` green; vet + staticcheck clean;
+linux cross-build OK; 457 vitest green (frontend untouched, dist unchanged);
+go.mod unchanged; no new env vars (configEnvVars untouched).
+CI org-billing still blocked → local battery + arc-authority merge.
+
+## Next
+
+M795: Forge console view (list/draft/test/promote from the web UI). Then
+gap #3 governed self-install, #5 vector memory, #6 brain distiller.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **The agent can now build its own tools — the script-tool forge.** Code an agent (or operator)
+  writes can be promoted into a **durable, callable tool**: draft a named script (Python/Node/Deno)
+  with the new `tool_forge` tool, **test it in the code_exec sandbox** (the call's JSON input
+  arrives as `./stdin.txt`, stdout becomes the tool result), and once a test of the current code
+  passes, the **operator promotes it** (`agt toolforge promote`) — from then on every run and every
+  delegate sub-agent is offered it as a real `forge_<name>` tool. This closes the
+  write→use→improve cycle: code worth keeping becomes a tool instead of being rewritten every run.
+  Governance is the point — *only tested code is ever live*: promotion is refused until a sandbox
+  test of the current code passed, **any code edit demotes the tool back to draft** with its test
+  record cleared, quarantine is the instant kill switch, and promotion is deliberately not an agent
+  op. Every transition is journaled (`scripttool.created/tested/promoted/quarantined/…`) so
+  `agt why` explains how a tool came to be. Execution rides the same warden-isolated,
+  secret-scrubbed sandbox as `code_exec` and every `forge_*` call exercises the same `code.exec`
+  Edict capability; authoring is gated by the new `tool.forge` capability (ask-first, like
+  `skill`). A per-run tool allowlist gates forged tools exactly like registered ones. Surface:
+  `agt toolforge list/show/draft/edit/test/promote/quarantine/remove` (code via `--file`),
+  control-plane `toolforge_*` commands, webui API routes (console view to follow). 17 new tests
+  across the store/runtime/edict/tool/control-plane/codeexec layers, plus an isolated-daemon smoke
+  in which a real Python script was drafted, refused promotion untested, tested live in the
+  sandbox, promoted, quarantined, and demoted by a code edit — all journaled. (M794)
 - **Each named agent gets a daily allowance — the identity budget ledger.** A roster profile gains
   **max cost per day** (`--max-daily`, the Config-style USD field on the Roster view): the Governor
   now keeps a **per-agent daily ledger** — every completion an identity makes, whether from

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -93,6 +93,7 @@ import (
 	"github.com/agezt/agezt/plugins/tools/coding"
 	configtool "github.com/agezt/agezt/plugins/tools/config"
 	filetool "github.com/agezt/agezt/plugins/tools/file"
+	"github.com/agezt/agezt/plugins/tools/forgetool"
 	hatool "github.com/agezt/agezt/plugins/tools/homeassistant"
 	httptool "github.com/agezt/agezt/plugins/tools/http"
 	"github.com/agezt/agezt/plugins/tools/introspecttool"
@@ -342,6 +343,13 @@ func runDaemon(stdout, stderr io.Writer) int {
 	introspectToolInst := introspecttool.New()
 	tools["introspect"] = introspectToolInst
 
+	// Tool-forge tool (`tool_forge`, M794): the agent builds its OWN tools —
+	// drafts a script, tests it in the code_exec sandbox, and once the operator
+	// promotes it every run can call it as forge_<name>. Registered now, Bound
+	// to the live kernel after it opens.
+	forgeToolInst := forgetool.New()
+	tools["tool_forge"] = forgeToolInst
+
 	// OnReload is invoked by the control plane's `provider_reload`
 	// command (and `agt provider reload`). It re-reads the vault,
 	// re-runs primary-provider selection against the freshly-reloaded
@@ -505,6 +513,12 @@ func runDaemon(stdout, stderr io.Writer) int {
 		SubAgentMaxFanout:          subAgentFanout,
 		SubAgentMaxSpendMicrocents: subAgentSpendCap,
 		SubAgentMaxTotal:           subAgentTotal,
+	}
+	// Script-tool forge runner (M794): forged tools execute through the same
+	// code_exec sandbox (warden isolation, scrubbed env). Only wired when the
+	// sandbox is available — without it the forge reports itself unavailable.
+	if ce, ok := tools["code_exec"].(*codeexec.Tool); ok {
+		cfg.ScriptRunner = ce
 	}
 	// Per-run wall-clock timeout (M31): AGEZT_RUN_TIMEOUT=<duration> caps how
 	// long a single run may take inside a live session. Off by default (only
@@ -1229,6 +1243,12 @@ func runDaemon(stdout, stderr io.Writer) int {
 		ce.Bind(k.Bus())
 		fmt.Fprintf(stdout, "  code_exec tool   : enabled (the agent can write & run code: %s)\n", strings.Join(ce.Languages(), ", "))
 	}
+
+	// Bind the tool-forge tool to the live kernel (M794), so the agent can draft
+	// and test its own script tools through the journaled scripttool.* lifecycle.
+	// Going live still takes an operator promote (`agt toolforge promote`).
+	forgeToolInst.Bind(k)
+	fmt.Fprintf(stdout, "  tool_forge tool  : enabled (the agent can build its own tools; operator promotes)\n")
 
 	// Scheduled intents (autonomy) — fire operator-configured intents on a timer
 	// through the governed loop. Runs on the daemon ctx (halt/shutdown stop it).

--- a/cmd/agt/main.go
+++ b/cmd/agt/main.go
@@ -136,6 +136,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 		return cmdStanding(args[1:], stdout, stderr)
 	case "agent":
 		return cmdAgent(args[1:], stdout, stderr)
+	case "toolforge":
+		return cmdToolforge(args[1:], stdout, stderr)
 	case "reflect":
 		return cmdReflect(args[1:], stdout, stderr)
 	case "inbox":

--- a/cmd/agt/toolforge.go
+++ b/cmd/agt/toolforge.go
@@ -1,0 +1,428 @@
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/agezt/agezt/internal/brand"
+	"github.com/agezt/agezt/kernel/controlplane"
+)
+
+// cmdToolforge dispatches `agt toolforge <subcommand>` — the operator surface
+// of the script-tool forge (M794): agent-authored (or operator-authored)
+// scripts tested in the code_exec sandbox and promoted into callable
+// forge_<name> tools. Promotion lives HERE, not in the agent's tool, so a
+// human signs off before code goes live. Every mutation is journaled
+// (scripttool.*).
+func cmdToolforge(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		return toolforgeUsage(stderr)
+	}
+	switch args[0] {
+	case "list":
+		return cmdToolforgeList(args[1:], stdout, stderr)
+	case "show":
+		return cmdToolforgeShow(args[1:], stdout, stderr)
+	case "draft", "add", "create":
+		return cmdToolforgeDraft(args[1:], stdout, stderr)
+	case "edit", "set":
+		return cmdToolforgeEdit(args[1:], stdout, stderr)
+	case "test":
+		return cmdToolforgeTest(args[1:], stdout, stderr)
+	case "promote":
+		return cmdToolforgePromote(args[1:], stdout, stderr)
+	case "quarantine":
+		return cmdToolforgeQuarantine(args[1:], stdout, stderr)
+	case "remove", "rm":
+		return cmdToolforgeRemove(args[1:], stdout, stderr)
+	case "-h", "--help", "help":
+		return toolforgeUsage(stdout)
+	default:
+		fmt.Fprintf(stderr, "%s toolforge: unknown subcommand %q\n", brand.CLI, args[0])
+		return toolforgeUsage(stderr)
+	}
+}
+
+func toolforgeUsage(w io.Writer) int {
+	fmt.Fprintf(w, "usage: %s toolforge <list|show|draft|edit|test|promote|quarantine|remove>\n", brand.CLI)
+	fmt.Fprintf(w, "  list [--json]                                   show all script tools\n")
+	fmt.Fprintf(w, "  show <name|id> [--json]                         one tool's full record (incl. code)\n")
+	fmt.Fprintf(w, "  draft <name> --lang L --desc TEXT (--file PATH | --code SRC) [--schema-file PATH]\n")
+	fmt.Fprintf(w, "  edit <name|id> [--desc TEXT] [--lang L] [--file PATH | --code SRC] [--schema-file PATH]\n")
+	fmt.Fprintf(w, "       (a code change demotes the tool to draft and clears its test record)\n")
+	fmt.Fprintf(w, "  test <name|id> [--input JSON]                   run the code once in the sandbox; promotion requires a pass\n")
+	fmt.Fprintf(w, "  promote <name|id>                               make a TESTED tool live (callable as forge_<name>)\n")
+	fmt.Fprintf(w, "  quarantine <name|id> [--reason TEXT]            pull a live tool from production (kill switch)\n")
+	fmt.Fprintf(w, "  remove <name|id>                                delete a tool\n")
+	fmt.Fprintf(w, "script contract: the call's JSON input is in ./stdin.txt; print the result to stdout; exit non-zero on failure\n")
+	return 0
+}
+
+func cmdToolforgeList(args []string, stdout, stderr io.Writer) int {
+	asJSON := false
+	for _, a := range args {
+		if a == "--json" {
+			asJSON = true
+		}
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := c.Call(ctx, controlplane.CmdToolforgeList, nil)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s toolforge list: %v\n", brand.CLI, err)
+		return 1
+	}
+	if asJSON {
+		return encodeJSON(stdout, res)
+	}
+	tools, _ := res["tools"].([]any)
+	if len(tools) == 0 {
+		fmt.Fprintf(stdout, "no script tools yet — draft one with `%s toolforge draft <name> --lang python --desc \"...\" --file tool.py`\n", brand.CLI)
+		return 0
+	}
+	for _, raw := range tools {
+		st, _ := raw.(map[string]any)
+		if st == nil {
+			continue
+		}
+		status, _ := st["status"].(string)
+		tested := "untested"
+		if ok, _ := st["tested_ok"].(bool); ok {
+			tested = "tested"
+		}
+		fmt.Fprintf(stdout, "%-24s %-12s %-8s lang=%s", str(st["name"]), strings.ToUpper(status), tested, str(st["language"]))
+		if ca := str(st["callable_as"]); ca != "" {
+			fmt.Fprintf(stdout, " → %s", ca)
+		}
+		fmt.Fprintln(stdout)
+	}
+	fmt.Fprintf(stdout, "%v tool(s), %v live\n", res["count"], res["active_count"])
+	return 0
+}
+
+func cmdToolforgeShow(args []string, stdout, stderr io.Writer) int {
+	asJSON := false
+	ref := ""
+	for _, a := range args {
+		if a == "--json" {
+			asJSON = true
+		} else if !strings.HasPrefix(a, "--") && ref == "" {
+			ref = a
+		}
+	}
+	if ref == "" {
+		fmt.Fprintf(stderr, "usage: %s toolforge show <name|id> [--json]\n", brand.CLI)
+		return 2
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := c.Call(ctx, controlplane.CmdToolforgeShow, map[string]any{"ref": ref})
+	if err != nil {
+		fmt.Fprintf(stderr, "%s toolforge show: %v\n", brand.CLI, err)
+		return 1
+	}
+	st, _ := res["tool"].(map[string]any)
+	if st == nil {
+		fmt.Fprintf(stderr, "%s toolforge show: unknown tool %q\n", brand.CLI, ref)
+		return 1
+	}
+	if asJSON {
+		return encodeJSON(stdout, st)
+	}
+	fmt.Fprintf(stdout, "name:        %s\n", str(st["name"]))
+	fmt.Fprintf(stdout, "id:          %s\n", str(st["id"]))
+	fmt.Fprintf(stdout, "status:      %s\n", str(st["status"]))
+	fmt.Fprintf(stdout, "language:    %s\n", str(st["language"]))
+	tested := "no"
+	if ok, _ := st["tested_ok"].(bool); ok {
+		tested = "yes"
+	}
+	fmt.Fprintf(stdout, "tested:      %s\n", tested)
+	if ca := str(st["callable_as"]); ca != "" {
+		fmt.Fprintf(stdout, "callable as: %s\n", ca)
+	}
+	if v := str(st["description"]); v != "" {
+		fmt.Fprintf(stdout, "description: %s\n", v)
+	}
+	if v := str(st["input_schema"]); v != "" {
+		fmt.Fprintf(stdout, "schema:      %s\n", v)
+	}
+	if v := str(st["code"]); v != "" {
+		fmt.Fprintf(stdout, "code:\n  %s\n", strings.ReplaceAll(v, "\n", "\n  "))
+	}
+	return 0
+}
+
+// toolforgeFlags parses the shared draft/edit flag set. Code can ride from a
+// file (--file, the natural authoring path) or inline (--code).
+type toolforgeFlags struct {
+	desc, lang, code, schema string
+	set                      map[string]bool
+}
+
+func parseToolforgeFlags(args []string, stderr io.Writer, cmd string) (toolforgeFlags, []string, bool) {
+	f := toolforgeFlags{set: map[string]bool{}}
+	var rest []string
+	need := func(i int, flag string) bool {
+		if i+1 >= len(args) {
+			fmt.Fprintf(stderr, "%s toolforge %s: %s needs a value\n", brand.CLI, cmd, flag)
+			return false
+		}
+		return true
+	}
+	readFile := func(path, what string) (string, bool) {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			fmt.Fprintf(stderr, "%s toolforge %s: read %s: %v\n", brand.CLI, cmd, what, err)
+			return "", false
+		}
+		return string(b), true
+	}
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch a {
+		case "--desc", "--description":
+			if !need(i, a) {
+				return f, nil, false
+			}
+			i++
+			f.desc, f.set["desc"] = args[i], true
+		case "--lang", "--language":
+			if !need(i, a) {
+				return f, nil, false
+			}
+			i++
+			f.lang, f.set["lang"] = args[i], true
+		case "--code":
+			if !need(i, a) {
+				return f, nil, false
+			}
+			i++
+			f.code, f.set["code"] = args[i], true
+		case "--file":
+			if !need(i, a) {
+				return f, nil, false
+			}
+			i++
+			src, ok := readFile(args[i], "--file")
+			if !ok {
+				return f, nil, false
+			}
+			f.code, f.set["code"] = src, true
+		case "--schema-file":
+			if !need(i, a) {
+				return f, nil, false
+			}
+			i++
+			sch, ok := readFile(args[i], "--schema-file")
+			if !ok {
+				return f, nil, false
+			}
+			f.schema, f.set["schema"] = sch, true
+		default:
+			rest = append(rest, a)
+		}
+	}
+	return f, rest, true
+}
+
+func cmdToolforgeDraft(args []string, stdout, stderr io.Writer) int {
+	f, rest, ok := parseToolforgeFlags(args, stderr, "draft")
+	if !ok {
+		return 2
+	}
+	if len(rest) != 1 || !f.set["code"] {
+		fmt.Fprintf(stderr, "usage: %s toolforge draft <name> --lang L --desc TEXT (--file PATH | --code SRC) [--schema-file PATH]\n", brand.CLI)
+		return 2
+	}
+	tool := map[string]any{
+		"name": rest[0], "description": f.desc, "language": f.lang,
+		"code": f.code, "input_schema": f.schema,
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := c.Call(ctx, controlplane.CmdToolforgeDraft, map[string]any{"tool": tool})
+	if err != nil {
+		fmt.Fprintf(stderr, "%s toolforge draft: %v\n", brand.CLI, err)
+		return 1
+	}
+	st, _ := res["tool"].(map[string]any)
+	fmt.Fprintf(stdout, "drafted %s (%s) — test it with `%s toolforge test %s`, then promote\n",
+		str(st["name"]), str(st["language"]), brand.CLI, str(st["name"]))
+	return 0
+}
+
+func cmdToolforgeEdit(args []string, stdout, stderr io.Writer) int {
+	f, rest, ok := parseToolforgeFlags(args, stderr, "edit")
+	if !ok {
+		return 2
+	}
+	if len(rest) != 1 || len(f.set) == 0 {
+		fmt.Fprintf(stderr, "usage: %s toolforge edit <name|id> [--desc TEXT] [--lang L] [--file PATH | --code SRC] [--schema-file PATH]\n", brand.CLI)
+		return 2
+	}
+	tool := map[string]any{
+		"description": f.desc, "language": f.lang, "code": f.code, "input_schema": f.schema,
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := c.Call(ctx, controlplane.CmdToolforgeEdit, map[string]any{"ref": rest[0], "tool": tool})
+	if err != nil {
+		fmt.Fprintf(stderr, "%s toolforge edit: %v\n", brand.CLI, err)
+		return 1
+	}
+	st, _ := res["tool"].(map[string]any)
+	note := ""
+	if ok, _ := st["tested_ok"].(bool); !ok {
+		note = " (draft again — re-test before promoting)"
+	}
+	fmt.Fprintf(stdout, "updated %s%s\n", str(st["name"]), note)
+	return 0
+}
+
+func cmdToolforgeTest(args []string, stdout, stderr io.Writer) int {
+	ref, input := "", ""
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--input":
+			if i+1 >= len(args) {
+				fmt.Fprintf(stderr, "%s toolforge test: --input needs a value\n", brand.CLI)
+				return 2
+			}
+			i++
+			input = args[i]
+		default:
+			if !strings.HasPrefix(args[i], "--") && ref == "" {
+				ref = args[i]
+			}
+		}
+	}
+	if ref == "" {
+		fmt.Fprintf(stderr, "usage: %s toolforge test <name|id> [--input JSON]\n", brand.CLI)
+		return 2
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	// A sandbox run can legitimately take minutes (pip installs, network) —
+	// give it the sandbox's own ceiling rather than the 5s management budget.
+	ctx, cancel := context.WithTimeout(context.Background(), 11*time.Minute)
+	defer cancel()
+	res, err := c.Call(ctx, controlplane.CmdToolforgeTest, map[string]any{"ref": ref, "input": input})
+	if err != nil {
+		fmt.Fprintf(stderr, "%s toolforge test: %v\n", brand.CLI, err)
+		return 1
+	}
+	out, _ := res["output"].(string)
+	if passed, _ := res["ok"].(bool); passed {
+		fmt.Fprintf(stdout, "PASS — promote with `%s toolforge promote %s`\n%s\n", brand.CLI, ref, out)
+		return 0
+	}
+	fmt.Fprintf(stdout, "FAIL — fix the code and re-test\n%s\n", out)
+	return 1
+}
+
+func cmdToolforgePromote(args []string, stdout, stderr io.Writer) int {
+	if len(args) != 1 {
+		fmt.Fprintf(stderr, "usage: %s toolforge promote <name|id>\n", brand.CLI)
+		return 2
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := c.Call(ctx, controlplane.CmdToolforgePromote, map[string]any{"ref": args[0]})
+	if err != nil {
+		fmt.Fprintf(stderr, "%s toolforge promote: %v\n", brand.CLI, err)
+		return 1
+	}
+	st, _ := res["tool"].(map[string]any)
+	fmt.Fprintf(stdout, "promoted %s — live for every run as %s\n", str(st["name"]), str(st["callable_as"]))
+	return 0
+}
+
+func cmdToolforgeQuarantine(args []string, stdout, stderr io.Writer) int {
+	ref, reason := "", ""
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--reason":
+			if i+1 >= len(args) {
+				fmt.Fprintf(stderr, "%s toolforge quarantine: --reason needs a value\n", brand.CLI)
+				return 2
+			}
+			i++
+			reason = args[i]
+		default:
+			if !strings.HasPrefix(args[i], "--") && ref == "" {
+				ref = args[i]
+			}
+		}
+	}
+	if ref == "" {
+		fmt.Fprintf(stderr, "usage: %s toolforge quarantine <name|id> [--reason TEXT]\n", brand.CLI)
+		return 2
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := c.Call(ctx, controlplane.CmdToolforgeQuarantine, map[string]any{"ref": ref, "reason": reason})
+	if err != nil {
+		fmt.Fprintf(stderr, "%s toolforge quarantine: %v\n", brand.CLI, err)
+		return 1
+	}
+	st, _ := res["tool"].(map[string]any)
+	fmt.Fprintf(stdout, "quarantined %s — no longer offered to runs\n", str(st["name"]))
+	return 0
+}
+
+func cmdToolforgeRemove(args []string, stdout, stderr io.Writer) int {
+	if len(args) != 1 {
+		fmt.Fprintf(stderr, "usage: %s toolforge remove <name|id>\n", brand.CLI)
+		return 2
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := c.Call(ctx, controlplane.CmdToolforgeRemove, map[string]any{"ref": args[0]})
+	if err != nil {
+		fmt.Fprintf(stderr, "%s toolforge remove: %v\n", brand.CLI, err)
+		return 1
+	}
+	if ok, _ := res["removed"].(bool); !ok {
+		fmt.Fprintf(stderr, "%s toolforge remove: unknown tool %q\n", brand.CLI, args[0])
+		return 1
+	}
+	fmt.Fprintf(stdout, "removed %s\n", args[0])
+	return 0
+}

--- a/kernel/controlplane/protocol.go
+++ b/kernel/controlplane/protocol.go
@@ -876,6 +876,21 @@ const (
 	CmdAgentSetEnabled = "agent_set_enabled"
 	CmdAgentRemove     = "agent_remove"
 
+	// Script-tool forge (M794) — agent-authored code promoted into callable
+	// forge_<name> tools, behind `agt toolforge`. Draft: args.tool (object).
+	// Edit: args{ref, tool}. Test: args{ref, input?} (runs the code in the
+	// sandbox and records the verdict; promotion requires a pass). Promote /
+	// Quarantine(+reason?) / Remove / Show: args.ref. List: no args.
+	// ref = id OR name. Every mutation is journaled (scripttool.*).
+	CmdToolforgeList       = "toolforge_list"
+	CmdToolforgeShow       = "toolforge_show"
+	CmdToolforgeDraft      = "toolforge_draft"
+	CmdToolforgeEdit       = "toolforge_edit"
+	CmdToolforgeTest       = "toolforge_test"
+	CmdToolforgePromote    = "toolforge_promote"
+	CmdToolforgeQuarantine = "toolforge_quarantine"
+	CmdToolforgeRemove     = "toolforge_remove"
+
 	// Sandbox projects (M686) — read-only inspection of what agents BUILT with the
 	// code_exec tool under <baseDir>/sandbox/projects. List: no args, returns each
 	// persistent project with its files (name, bytes, modified). File: args{project,

--- a/kernel/controlplane/server.go
+++ b/kernel/controlplane/server.go
@@ -694,6 +694,22 @@ func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
 		s.handleAgentSetEnabled(conn, req)
 	case CmdAgentRemove:
 		s.handleAgentRemove(conn, req)
+	case CmdToolforgeList:
+		s.handleToolforgeList(conn, req)
+	case CmdToolforgeShow:
+		s.handleToolforgeShow(conn, req)
+	case CmdToolforgeDraft:
+		s.handleToolforgeDraft(conn, req)
+	case CmdToolforgeEdit:
+		s.handleToolforgeEdit(conn, req)
+	case CmdToolforgeTest:
+		s.handleToolforgeTest(conn, req)
+	case CmdToolforgePromote:
+		s.handleToolforgePromote(conn, req)
+	case CmdToolforgeQuarantine:
+		s.handleToolforgeQuarantine(conn, req)
+	case CmdToolforgeRemove:
+		s.handleToolforgeRemove(conn, req)
 	case CmdSandboxList:
 		s.handleSandboxList(conn, req)
 	case CmdSandboxFile:

--- a/kernel/controlplane/toolforge.go
+++ b/kernel/controlplane/toolforge.go
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: MIT
+
+package controlplane
+
+// Script-tool forge handlers (M794) — the management path behind
+// `agt toolforge` and the console. Lifecycle changes go through the kernel
+// so every draft/edit/test/promote/quarantine/remove is journaled
+// (scripttool.*) and auditable via `agt why`. Tools are addressed by
+// ref = id OR name everywhere. Promotion lives HERE — an operator surface,
+// not a tool op — so an agent can author and test but never self-promote.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"strings"
+
+	"github.com/agezt/agezt/kernel/toolforge"
+)
+
+// scriptToolView is the stable wire shape for one script tool. The code body
+// rides along only when full is set (list stays light; show carries it).
+func scriptToolView(st toolforge.ScriptTool, full bool) map[string]any {
+	b, _ := json.Marshal(st)
+	var m map[string]any
+	_ = json.Unmarshal(b, &m)
+	if !full {
+		delete(m, "code")
+	}
+	if st.Status == toolforge.StatusActive {
+		m["callable_as"] = "forge_" + st.Name
+	}
+	return m
+}
+
+func (s *Server) handleToolforgeList(conn net.Conn, req Request) {
+	tools := s.k.ToolForge().List()
+	out := make([]any, 0, len(tools))
+	active := 0
+	for _, st := range tools {
+		out = append(out, scriptToolView(st, false))
+		if st.Status == toolforge.StatusActive {
+			active++
+		}
+	}
+	s.writeResp(conn, Response{
+		ID:     req.ID,
+		Type:   RespResult,
+		Result: map[string]any{"tools": out, "count": len(out), "active_count": active},
+	})
+}
+
+func (s *Server) handleToolforgeShow(conn net.Conn, req Request) {
+	ref, _ := req.Args["ref"].(string)
+	if strings.TrimSpace(ref) == "" {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.ref required"})
+		return
+	}
+	st, found := s.k.ToolForge().Get(strings.TrimSpace(ref))
+	if !found {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "unknown script tool: " + ref})
+		return
+	}
+	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{"tool": scriptToolView(st, true)}})
+}
+
+func (s *Server) handleToolforgeDraft(conn net.Conn, req Request) {
+	raw, ok := req.Args["tool"]
+	if !ok {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.tool required"})
+		return
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.tool: " + err.Error()})
+		return
+	}
+	var st toolforge.ScriptTool
+	if err := json.Unmarshal(b, &st); err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.tool: " + err.Error()})
+		return
+	}
+	saved, err := s.k.DraftScriptTool("", st)
+	if err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
+		return
+	}
+	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{"tool": scriptToolView(saved, false)}})
+}
+
+// handleToolforgeEdit applies args.tool's MUTABLE fields to the tool named by
+// args.ref: non-empty description/language/input_schema and code replace the
+// stored values (identity/lifecycle fields are protected by the store, and a
+// code/language change demotes the tool to draft with its test record
+// cleared).
+func (s *Server) handleToolforgeEdit(conn net.Conn, req Request) {
+	ref, _ := req.Args["ref"].(string)
+	if strings.TrimSpace(ref) == "" {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.ref required"})
+		return
+	}
+	raw, ok := req.Args["tool"]
+	if !ok {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.tool required"})
+		return
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.tool: " + err.Error()})
+		return
+	}
+	var in toolforge.ScriptTool
+	if err := json.Unmarshal(b, &in); err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.tool: " + err.Error()})
+		return
+	}
+	st, found, err := s.k.UpdateScriptTool("", ref, func(dst *toolforge.ScriptTool) {
+		if strings.TrimSpace(in.Description) != "" {
+			dst.Description = in.Description
+		}
+		if strings.TrimSpace(in.Language) != "" {
+			dst.Language = in.Language
+		}
+		if in.Code != "" {
+			dst.Code = in.Code
+		}
+		if strings.TrimSpace(in.InputSchema) != "" {
+			dst.InputSchema = in.InputSchema
+		}
+	})
+	if err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
+		return
+	}
+	if !found {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "unknown script tool: " + ref})
+		return
+	}
+	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{"tool": scriptToolView(st, false)}})
+}
+
+func (s *Server) handleToolforgeTest(conn net.Conn, req Request) {
+	ref, _ := req.Args["ref"].(string)
+	if strings.TrimSpace(ref) == "" {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.ref required"})
+		return
+	}
+	sample, _ := req.Args["input"].(string)
+	st, out, err := s.k.TestScriptTool(context.Background(), "", ref, sample)
+	if err != nil {
+		if errors.Is(err, toolforge.ErrNotFound) {
+			s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "unknown script tool: " + ref})
+			return
+		}
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
+		return
+	}
+	s.writeResp(conn, Response{
+		ID:     req.ID,
+		Type:   RespResult,
+		Result: map[string]any{"tool": scriptToolView(st, false), "ok": st.TestedOK, "output": out},
+	})
+}
+
+func (s *Server) handleToolforgePromote(conn net.Conn, req Request) {
+	ref, _ := req.Args["ref"].(string)
+	if strings.TrimSpace(ref) == "" {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.ref required"})
+		return
+	}
+	st, err := s.k.PromoteScriptTool("", ref)
+	if err != nil {
+		if errors.Is(err, toolforge.ErrNotFound) {
+			s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "unknown script tool: " + ref})
+			return
+		}
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
+		return
+	}
+	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{"tool": scriptToolView(st, false)}})
+}
+
+func (s *Server) handleToolforgeQuarantine(conn net.Conn, req Request) {
+	ref, _ := req.Args["ref"].(string)
+	if strings.TrimSpace(ref) == "" {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.ref required"})
+		return
+	}
+	reason, _ := req.Args["reason"].(string)
+	st, err := s.k.QuarantineScriptTool("", ref, reason)
+	if err != nil {
+		if errors.Is(err, toolforge.ErrNotFound) {
+			s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "unknown script tool: " + ref})
+			return
+		}
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
+		return
+	}
+	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{"tool": scriptToolView(st, false)}})
+}
+
+func (s *Server) handleToolforgeRemove(conn net.Conn, req Request) {
+	ref, _ := req.Args["ref"].(string)
+	if strings.TrimSpace(ref) == "" {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.ref required"})
+		return
+	}
+	ok, err := s.k.RemoveScriptTool("", ref)
+	if err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
+		return
+	}
+	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{"removed": ok}})
+}

--- a/kernel/controlplane/toolforge_test.go
+++ b/kernel/controlplane/toolforge_test.go
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MIT
+
+package controlplane_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agezt/agezt/kernel/controlplane"
+	"github.com/agezt/agezt/kernel/runtime"
+	"github.com/agezt/agezt/plugins/providers/mock"
+)
+
+// wireRunner fakes the code-exec sandbox behind the control plane: pass/fail
+// is scripted per test.
+type wireRunner struct {
+	out   string
+	isErr bool
+}
+
+func (r *wireRunner) RunScript(_ context.Context, _, _, _ string) (string, bool, error) {
+	return r.out, r.isErr, nil
+}
+
+// TestToolforge_WireRoundTrip drives the full operator pipeline over the
+// wire: draft → promote refused (untested) → test (pass) → promote → list
+// shows it live → quarantine → edit code (demote) → remove. This is exactly
+// what `agt toolforge` and the console speak.
+func TestToolforge_WireRoundTrip(t *testing.T) {
+	runner := &wireRunner{out: "echo-ok"}
+	_, _, c, _ := startPairWithConfig(t, runtime.Config{
+		Provider:     mock.New(mock.FinalText("unused")),
+		ScriptRunner: runner,
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Draft.
+	res, err := c.Call(ctx, controlplane.CmdToolforgeDraft, map[string]any{
+		"tool": map[string]any{
+			"name": "echo", "description": "echoes input", "language": "python",
+			"code": "print(open('stdin.txt').read())",
+		},
+	})
+	if err != nil {
+		t.Fatalf("draft: %v", err)
+	}
+	tool, _ := res["tool"].(map[string]any)
+	if tool["status"] != "draft" {
+		t.Fatalf("draft status = %v", tool["status"])
+	}
+
+	// Promote before any test → refused (the forge's core invariant).
+	if _, err := c.Call(ctx, controlplane.CmdToolforgePromote, map[string]any{"ref": "echo"}); err == nil ||
+		!strings.Contains(err.Error(), "test") {
+		t.Fatalf("untested promote: got %v, want a test-first refusal", err)
+	}
+
+	// Test (sandbox pass) → recorded.
+	res, err = c.Call(ctx, controlplane.CmdToolforgeTest, map[string]any{"ref": "echo", "input": `{"x":1}`})
+	if err != nil {
+		t.Fatalf("test: %v", err)
+	}
+	if ok, _ := res["ok"].(bool); !ok || res["output"] != "echo-ok" {
+		t.Fatalf("test verdict = %v / %v", res["ok"], res["output"])
+	}
+
+	// Promote → ACTIVE, callable as forge_echo.
+	res, err = c.Call(ctx, controlplane.CmdToolforgePromote, map[string]any{"ref": "echo"})
+	if err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+	tool, _ = res["tool"].(map[string]any)
+	if tool["status"] != "active" || tool["callable_as"] != "forge_echo" {
+		t.Fatalf("promoted = %v", tool)
+	}
+
+	// List counts it as live; the code body stays out of the list view.
+	res, err = c.Call(ctx, controlplane.CmdToolforgeList, nil)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if ac, _ := res["active_count"].(float64); ac != 1 {
+		t.Fatalf("active_count = %v", res["active_count"])
+	}
+	tools, _ := res["tools"].([]any)
+	if first, _ := tools[0].(map[string]any); first["code"] != nil {
+		t.Fatal("list leaked the code body")
+	}
+
+	// Show carries the full record.
+	res, err = c.Call(ctx, controlplane.CmdToolforgeShow, map[string]any{"ref": "echo"})
+	if err != nil {
+		t.Fatalf("show: %v", err)
+	}
+	tool, _ = res["tool"].(map[string]any)
+	if code, _ := tool["code"].(string); !strings.Contains(code, "stdin.txt") {
+		t.Fatalf("show missing code: %v", tool)
+	}
+
+	// Quarantine (kill switch).
+	res, err = c.Call(ctx, controlplane.CmdToolforgeQuarantine, map[string]any{"ref": "echo", "reason": "smoke"})
+	if err != nil {
+		t.Fatalf("quarantine: %v", err)
+	}
+	tool, _ = res["tool"].(map[string]any)
+	if tool["status"] != "quarantined" {
+		t.Fatalf("quarantined = %v", tool["status"])
+	}
+
+	// Edit the code → demoted to draft, test record cleared.
+	res, err = c.Call(ctx, controlplane.CmdToolforgeEdit, map[string]any{
+		"ref": "echo", "tool": map[string]any{"code": "print('v2')"},
+	})
+	if err != nil {
+		t.Fatalf("edit: %v", err)
+	}
+	tool, _ = res["tool"].(map[string]any)
+	if tool["status"] != "draft" || tool["tested_ok"] != false {
+		t.Fatalf("code edit = %v/%v, want draft/untested", tool["status"], tool["tested_ok"])
+	}
+
+	// Remove.
+	res, err = c.Call(ctx, controlplane.CmdToolforgeRemove, map[string]any{"ref": "echo"})
+	if err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if removed, _ := res["removed"].(bool); !removed {
+		t.Fatal("remove reported false")
+	}
+}
+
+// TestToolforge_FailedTestKeepsGateShut: a failing sandbox run is recorded
+// honestly over the wire and promotion stays refused.
+func TestToolforge_FailedTestKeepsGateShut(t *testing.T) {
+	runner := &wireRunner{out: "Traceback ...", isErr: true}
+	_, _, c, _ := startPairWithConfig(t, runtime.Config{
+		Provider:     mock.New(mock.FinalText("unused")),
+		ScriptRunner: runner,
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if _, err := c.Call(ctx, controlplane.CmdToolforgeDraft, map[string]any{
+		"tool": map[string]any{"name": "broken", "description": "d", "language": "python", "code": "boom("},
+	}); err != nil {
+		t.Fatalf("draft: %v", err)
+	}
+	res, err := c.Call(ctx, controlplane.CmdToolforgeTest, map[string]any{"ref": "broken"})
+	if err != nil {
+		t.Fatalf("test: %v", err)
+	}
+	if ok, _ := res["ok"].(bool); ok {
+		t.Fatal("failing run reported ok")
+	}
+	if _, err := c.Call(ctx, controlplane.CmdToolforgePromote, map[string]any{"ref": "broken"}); err == nil {
+		t.Fatal("promote accepted after a failed test")
+	}
+}

--- a/kernel/edict/edict.go
+++ b/kernel/edict/edict.go
@@ -143,6 +143,15 @@ const (
 	// who want confirmation set it to ask/deny in the policy center.
 	CapCodeExec Capability = "code.exec"
 
+	// CapToolForge gates the AUTHORING ops of the `tool_forge` tool (M794):
+	// the agent drafting, editing, listing, and inspecting its own script
+	// tools. Like CapSkill, a genuine self-modification grant — but a draft
+	// is never live (promotion is operator-driven through the control plane,
+	// not a tool op), every transition is journaled (scripttool.*), and
+	// quarantine is an instant kill switch — so ask-first by default.
+	// op=test EXECUTES the draft in the sandbox and maps to CapCodeExec.
+	CapToolForge Capability = "tool.forge"
+
 	// CapConfigRead / CapConfigWrite gate the `config` tool (M696): the agent
 	// reading vs mutating Config Center settings. Reads (schema/get) are low-risk
 	// and Allow by default. Writes (set/register/unregister) are Ask by default —
@@ -578,6 +587,7 @@ func DefaultLevels() map[Capability]TrustLevel {
 		CapSkill:       LevelAskFirst, // self-modification: the agent authoring/promoting its own skills
 		CapIntrospect:  LevelAllow,    // local read of the daemon's own live state; no mutation, no network — low risk
 		CapCodeExec:    LevelAllow,    // write+run code; sandboxed (scrubbed env, confined dir, capped) and journaled — owner's choice for full autonomy
+		CapToolForge:   LevelAskFirst, // self-modification: the agent authoring its own script tools (going live still needs an operator promote)
 		CapConfigRead:  LevelAllow,    // read Config Center schema/values; no mutation, secrets presence-only
 		CapConfigWrite: LevelAskFirst, // mutate settings / register schema; can reach built-in security fields — confirm first
 	}
@@ -619,7 +629,7 @@ func AllCapabilities() []Capability {
 		CapACPAgent, CapRemoteRun, CapNotify,
 		CapHomeAssistantRead, CapHomeAssistantCall,
 		CapBrowserRead, CapMemory, CapWorld, CapWebSearch, CapSchedule, CapRunsRead, CapStanding, CapBoard, CapSkill,
-		CapIntrospect, CapCodeExec, CapConfigRead, CapConfigWrite,
+		CapIntrospect, CapCodeExec, CapToolForge, CapConfigRead, CapConfigWrite,
 	}
 	slices.Sort(caps)
 	return caps

--- a/kernel/edict/toolmap.go
+++ b/kernel/edict/toolmap.go
@@ -18,6 +18,13 @@ import (
 // Kept in this package (not the runtime) so the mapping lives next to
 // the Capability constants and can grow as new tools land.
 func CapabilityForToolCall(toolName string, input json.RawMessage) Capability {
+	// Forged script tools (M794): every promoted script is offered as
+	// forge_<name> and EXECUTES code in the code-exec sandbox, so each call
+	// exercises exactly the code.exec capability — promotion changes who can
+	// be called, never what the sandbox allows.
+	if strings.HasPrefix(toolName, "forge_") {
+		return CapCodeExec
+	}
 	switch toolName {
 	case "shell":
 		return CapShell
@@ -51,6 +58,17 @@ func CapabilityForToolCall(toolName string, input json.RawMessage) Capability {
 		return CapBoard
 	case "skill":
 		return CapSkill
+	case "tool_forge":
+		var p struct {
+			Op string `json:"op"`
+		}
+		_ = json.Unmarshal(input, &p)
+		if strings.EqualFold(strings.TrimSpace(p.Op), "test") {
+			// op=test RUNS the draft's code in the sandbox — that's a real
+			// code execution, so it exercises code.exec, not just authoring.
+			return CapCodeExec
+		}
+		return CapToolForge
 	case "introspect":
 		return CapIntrospect
 	case "code_exec":

--- a/kernel/edict/toolmap_test.go
+++ b/kernel/edict/toolmap_test.go
@@ -33,6 +33,15 @@ func TestCapabilityForToolCall(t *testing.T) {
 		{"homeassistant", `{"operation":"  CALL_SERVICE  "}`, CapHomeAssistantCall},
 		{"homeassistant", `{}`, CapHomeAssistantRead}, // unparsed/absent op → read (low-risk default)
 		{"unknown-tool", `{}`, Capability("unknown-tool")},
+		// Script-tool forge (M794): every forged forge_<name> call IS a
+		// sandboxed code execution; tool_forge authoring is its own grant,
+		// except op=test, which runs code.
+		{"forge_fetch_weather", `{"city":"izmir"}`, CapCodeExec},
+		{"forge_x", `{}`, CapCodeExec},
+		{"tool_forge", `{"op":"draft","name":"x"}`, CapToolForge},
+		{"tool_forge", `{"op":"list"}`, CapToolForge},
+		{"tool_forge", `{"op":"  TEST  ","ref":"x"}`, CapCodeExec},
+		{"tool_forge", `{}`, CapToolForge},
 	}
 	for _, c := range cases {
 		got := CapabilityForToolCall(c.tool, json.RawMessage(c.input))

--- a/kernel/event/kinds.go
+++ b/kernel/event/kinds.go
@@ -277,6 +277,17 @@ const (
 	// the run timeline show what code ran and how it ended. The warden additionally
 	// emits its own warden.exec for the underlying process.
 	KindCodeExecuted Kind = "code.executed"
+
+	// Script-tool forge (M794) — agent-authored code promoted into durable,
+	// callable tools (forge_<name>), executed through the code-exec sandbox.
+	// Lifecycle is journaled so `agt why` can explain how a tool came to be,
+	// who tested it, and when it went live (or was pulled).
+	KindScriptToolCreated     Kind = "scripttool.created"
+	KindScriptToolUpdated     Kind = "scripttool.updated" // edit (code changes demote to draft)
+	KindScriptToolTested      Kind = "scripttool.tested"  // a sandbox test of the current code (ok true/false)
+	KindScriptToolPromoted    Kind = "scripttool.promoted"
+	KindScriptToolQuarantined Kind = "scripttool.quarantined"
+	KindScriptToolRemoved     Kind = "scripttool.removed"
 )
 
 // IsKnown reports whether k is one of the kinds defined in this file. Useful
@@ -385,4 +396,10 @@ var knownKinds = map[Kind]struct{}{
 	KindAssureVerdict:             {},
 	KindBoardPosted:               {},
 	KindCodeExecuted:              {},
+	KindScriptToolCreated:         {},
+	KindScriptToolUpdated:         {},
+	KindScriptToolTested:          {},
+	KindScriptToolPromoted:        {},
+	KindScriptToolQuarantined:     {},
+	KindScriptToolRemoved:         {},
 }

--- a/kernel/runtime/runtime.go
+++ b/kernel/runtime/runtime.go
@@ -41,6 +41,7 @@ import (
 	"github.com/agezt/agezt/kernel/standing"
 	"github.com/agezt/agezt/kernel/state"
 	"github.com/agezt/agezt/kernel/tenantctx"
+	"github.com/agezt/agezt/kernel/toolforge"
 	"github.com/agezt/agezt/kernel/ulid"
 	"github.com/agezt/agezt/kernel/warden"
 	"github.com/agezt/agezt/kernel/worldmodel"
@@ -87,6 +88,14 @@ type Config struct {
 
 	// Tools are the in-process tools advertised to the model.
 	Tools map[string]agent.Tool
+
+	// ScriptRunner executes forged script tools (M794) in the code-exec
+	// sandbox. When set, every run is additionally offered the toolforge
+	// store's ACTIVE scripts as callable `forge_<name>` tools; nil disables
+	// the offering (drafting/testing then reports the forge unavailable).
+	// The daemon wires the code_exec tool here — same warden isolation,
+	// scrubbed env, and `code.exec` Edict gate as direct code execution.
+	ScriptRunner toolforge.Runner
 
 	// Model is the default model name passed to the provider.
 	Model string
@@ -329,6 +338,7 @@ type Kernel struct {
 	skillDir  *skill.FileStore
 	standing  *standing.Store
 	roster    *roster.Store
+	toolForge *toolforge.Store
 	artifacts *artifact.Store
 	reflect   *reflect.Engine
 	schedules *cadence.Store        // persistent scheduled-intents store (autonomy)
@@ -458,6 +468,16 @@ func Open(cfg Config) (*Kernel, error) {
 		return nil, fmt.Errorf("runtime: roster: %w", err)
 	}
 
+	tfstore, err := toolforge.Open(filepath.Join(cfg.BaseDir, "toolforge"))
+	if err != nil {
+		j.Close()
+		st.Close()
+		mstore.Close()
+		wstore.Close()
+		skstore.Close()
+		return nil, fmt.Errorf("runtime: toolforge: %w", err)
+	}
+
 	// Reflection holds no store of its own — it folds the journal and tunes
 	// the world graph, then journals its report (SPEC-05 §6). Default decay
 	// knobs; the daemon may override via the optional periodic trigger.
@@ -518,6 +538,7 @@ func Open(cfg Config) (*Kernel, error) {
 		skillDir:     skstore,
 		standing:     ststore,
 		roster:       rstore,
+		toolForge:    tfstore,
 		artifacts:    artStore,
 		reflect:      reflectEng,
 		schedules:    schedStore,
@@ -1614,10 +1635,12 @@ func (k *Kernel) RunWith(ctx context.Context, corr, intent string) (string, erro
 	}
 
 	// Per-run tool restriction (WithTools): an allowlist (possibly empty = no
-	// tools) scopes what this run may call, without changing the kernel's tool set.
-	runTools := k.tools
+	// tools) scopes what this run may call, without changing the kernel's tool
+	// set. Forged script tools (M794) are merged BEFORE the filter so a
+	// restricted run only sees the forge_<name> tools its allowlist grants.
+	runTools := k.mergeScriptTools(k.tools)
 	if allow, ok := toolsFromCtx(runCtx); ok {
-		runTools = filterTools(k.tools, allow)
+		runTools = filterTools(runTools, allow)
 	}
 
 	// Host-environment preamble (M609): prepend OS/arch, the shell the shell tool

--- a/kernel/runtime/scripttool.go
+++ b/kernel/runtime/scripttool.go
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: MIT
+
+package runtime
+
+// Script-tool forge integration (M794): the kernel-side lifecycle of
+// agent-authored scripts becoming callable tools. The toolforge store holds
+// the records; this file journals every transition (scripttool.*), runs
+// sandbox tests through cfg.ScriptRunner, and merges the ACTIVE scripts into
+// each run's tool map as `forge_<name>` tools. Execution rides the same
+// code-exec sandbox (warden isolation, scrubbed env) and the same `code.exec`
+// Edict capability as direct code execution — promotion changes WHO can be
+// called, never what the sandbox allows.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/toolforge"
+)
+
+// ToolForge returns the durable script-tool store (M794). Always non-nil
+// after Open.
+func (k *Kernel) ToolForge() *toolforge.Store { return k.toolForge }
+
+// DraftScriptTool validates and persists a new DRAFT script tool, journaling
+// scripttool.created so the tool's birth is auditable.
+func (k *Kernel) DraftScriptTool(corr string, st toolforge.ScriptTool) (toolforge.ScriptTool, error) {
+	saved, err := k.toolForge.Add(st)
+	if err != nil {
+		return toolforge.ScriptTool{}, err
+	}
+	_, _ = k.bus.Publish(event.Spec{
+		Subject: "toolforge." + saved.Name, Kind: event.KindScriptToolCreated, Actor: "toolforge",
+		CorrelationID: corr,
+		Payload:       map[string]any{"id": saved.ID, "name": saved.Name, "language": saved.Language, "code_bytes": len(saved.Code)},
+	})
+	return saved, nil
+}
+
+// UpdateScriptTool edits a script tool's mutable fields via mutate,
+// journaling scripttool.updated. The store demotes the tool to draft and
+// clears its test record when the code/language changed — the payload says
+// so, so `agt why` can explain why a live tool went dark. Returns false +
+// nil error for an unknown ref (standing pattern).
+func (k *Kernel) UpdateScriptTool(corr, ref string, mutate func(*toolforge.ScriptTool)) (toolforge.ScriptTool, bool, error) {
+	st, err := k.toolForge.Update(ref, mutate)
+	if errors.Is(err, toolforge.ErrNotFound) {
+		return toolforge.ScriptTool{}, false, nil
+	}
+	if err != nil {
+		return toolforge.ScriptTool{}, false, err
+	}
+	_, _ = k.bus.Publish(event.Spec{
+		Subject: "toolforge." + st.Name, Kind: event.KindScriptToolUpdated, Actor: "toolforge",
+		CorrelationID: corr,
+		Payload:       map[string]any{"id": st.ID, "name": st.Name, "status": string(st.Status), "tested_ok": st.TestedOK},
+	})
+	return st, true, nil
+}
+
+// TestScriptTool runs a script tool's CURRENT code once in the code-exec
+// sandbox with input as the call payload (surfaced to the script as
+// ./stdin.txt), records the verdict on the tool (Promote requires a pass),
+// and journals scripttool.tested. The sandbox output comes back verbatim so
+// the author can iterate.
+func (k *Kernel) TestScriptTool(ctx context.Context, corr, ref, input string) (toolforge.ScriptTool, string, error) {
+	if k.cfg.ScriptRunner == nil {
+		return toolforge.ScriptTool{}, "", errors.New("runtime: script tools are not available on this daemon (no sandbox runner)")
+	}
+	st, found := k.toolForge.Get(ref)
+	if !found {
+		return toolforge.ScriptTool{}, "", toolforge.ErrNotFound
+	}
+	if strings.TrimSpace(input) == "" {
+		input = "{}"
+	}
+	out, isErr, err := k.cfg.ScriptRunner.RunScript(ctx, st.Language, st.Code, input)
+	if err != nil {
+		return toolforge.ScriptTool{}, "", err
+	}
+	ok := !isErr
+	rec, rerr := k.toolForge.RecordTest(st.ID, ok)
+	if rerr != nil {
+		return toolforge.ScriptTool{}, "", rerr
+	}
+	_, _ = k.bus.Publish(event.Spec{
+		Subject: "toolforge." + st.Name, Kind: event.KindScriptToolTested, Actor: "toolforge",
+		CorrelationID: corr,
+		Payload:       map[string]any{"id": st.ID, "name": st.Name, "ok": ok, "output_bytes": len(out)},
+	})
+	return rec, out, nil
+}
+
+// PromoteScriptTool moves a tested draft/quarantined tool to ACTIVE — from
+// the next run on, every agent is offered it as forge_<name>. Journals
+// scripttool.promoted.
+func (k *Kernel) PromoteScriptTool(corr, ref string) (toolforge.ScriptTool, error) {
+	st, err := k.toolForge.Promote(ref)
+	if err != nil {
+		return toolforge.ScriptTool{}, err
+	}
+	_, _ = k.bus.Publish(event.Spec{
+		Subject: "toolforge." + st.Name, Kind: event.KindScriptToolPromoted, Actor: "toolforge",
+		CorrelationID: corr,
+		Payload:       map[string]any{"id": st.ID, "name": st.Name, "language": st.Language},
+	})
+	return st, nil
+}
+
+// QuarantineScriptTool pulls an active tool from production — the kill
+// switch. Journals scripttool.quarantined with the operator's reason.
+func (k *Kernel) QuarantineScriptTool(corr, ref, reason string) (toolforge.ScriptTool, error) {
+	st, err := k.toolForge.Quarantine(ref)
+	if err != nil {
+		return toolforge.ScriptTool{}, err
+	}
+	payload := map[string]any{"id": st.ID, "name": st.Name}
+	if reason = strings.TrimSpace(reason); reason != "" {
+		payload["reason"] = reason
+	}
+	_, _ = k.bus.Publish(event.Spec{
+		Subject: "toolforge." + st.Name, Kind: event.KindScriptToolQuarantined, Actor: "toolforge",
+		CorrelationID: corr,
+		Payload:       payload,
+	})
+	return st, nil
+}
+
+// RemoveScriptTool deletes a script tool, journaling scripttool.removed when
+// it existed. Returns whether it existed.
+func (k *Kernel) RemoveScriptTool(corr, ref string) (bool, error) {
+	gone, ok, err := k.toolForge.Remove(ref)
+	if err != nil {
+		return false, err
+	}
+	if ok {
+		_, _ = k.bus.Publish(event.Spec{
+			Subject: "toolforge." + gone.Name, Kind: event.KindScriptToolRemoved, Actor: "toolforge",
+			CorrelationID: corr,
+			Payload:       map[string]any{"id": gone.ID, "name": gone.Name},
+		})
+	}
+	return ok, nil
+}
+
+// mergeScriptTools returns the run's tool map extended with the forge's
+// ACTIVE scripts as callable forge_<name> tools. Registered tools always win
+// a name collision (the forge_ prefix makes one effectively impossible, but
+// a script must never shadow a real tool). Returns the input map untouched
+// when there is nothing to offer, so the common no-scripts path stays
+// allocation-free.
+func (k *Kernel) mergeScriptTools(tools map[string]agent.Tool) map[string]agent.Tool {
+	if k.toolForge == nil || k.cfg.ScriptRunner == nil {
+		return tools
+	}
+	active := k.toolForge.Active()
+	if len(active) == 0 {
+		return tools
+	}
+	out := make(map[string]agent.Tool, len(tools)+len(active))
+	for name, t := range tools {
+		out[name] = t
+	}
+	for _, st := range active {
+		name := forgedToolName(st.Name)
+		if _, exists := out[name]; exists {
+			continue
+		}
+		out[name] = forgedTool{st: st, runner: k.cfg.ScriptRunner}
+	}
+	return out
+}
+
+// forgedToolName is the callable name of a promoted script: the prefix both
+// namespaces scripts away from built-in tools and lets the Edict toolmap
+// route every forged call to the `code.exec` capability.
+func forgedToolName(name string) string { return "forge_" + name }
+
+// defaultForgedSchema is offered when the author supplied no input schema:
+// a permissive object — the whole call input reaches the script as JSON.
+const defaultForgedSchema = `{
+  "type": "object",
+  "properties": {
+    "input": {"type": "string", "description": "Free-form input for the script."}
+  }
+}`
+
+// forgedTool adapts one ACTIVE script-tool record to agent.Tool: the call's
+// raw JSON input rides into the sandbox (the script reads it from
+// ./stdin.txt) and combined stdout+stderr comes back as the result.
+type forgedTool struct {
+	st     toolforge.ScriptTool
+	runner toolforge.Runner
+}
+
+func (t forgedTool) Definition() agent.ToolDef {
+	schema := strings.TrimSpace(t.st.InputSchema)
+	if schema == "" {
+		schema = defaultForgedSchema
+	}
+	desc := strings.TrimSpace(t.st.Description) +
+		" (Forged script tool: a vetted " + t.st.Language +
+		" script run in the sandbox; this call's JSON input is available to it as ./stdin.txt.)"
+	return agent.ToolDef{
+		Name:        forgedToolName(t.st.Name),
+		Description: desc,
+		InputSchema: json.RawMessage(schema),
+	}
+}
+
+func (t forgedTool) Invoke(ctx context.Context, raw json.RawMessage) (agent.Result, error) {
+	in := string(raw)
+	if strings.TrimSpace(in) == "" {
+		in = "{}"
+	}
+	out, isErr, err := t.runner.RunScript(ctx, t.st.Language, t.st.Code, in)
+	if err != nil {
+		return agent.Result{Output: forgedToolName(t.st.Name) + ": " + err.Error(), IsError: true}, nil
+	}
+	return agent.Result{Output: out, IsError: isErr}, nil
+}

--- a/kernel/runtime/scripttool_test.go
+++ b/kernel/runtime/scripttool_test.go
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: MIT
+
+package runtime_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/runtime"
+	"github.com/agezt/agezt/kernel/toolforge"
+	"github.com/agezt/agezt/plugins/providers/mock"
+)
+
+// stubRunner fakes the code-exec sandbox: it records what was asked and
+// returns a canned output.
+type stubRunner struct {
+	lang, code, input string
+	calls             int
+	out               string
+	isErr             bool
+}
+
+func (r *stubRunner) RunScript(_ context.Context, language, code, inputJSON string) (string, bool, error) {
+	r.calls++
+	r.lang, r.code, r.input = language, code, inputJSON
+	return r.out, r.isErr, nil
+}
+
+func openForgeKernel(t *testing.T, prov agent.Provider, runner toolforge.Runner) *runtime.Kernel {
+	t.Helper()
+	k, err := runtime.Open(runtime.Config{
+		BaseDir:      t.TempDir(),
+		Provider:     prov,
+		ScriptRunner: runner,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { k.Close() })
+	return k
+}
+
+// promoteEcho drafts + test-passes + promotes one script tool named "echo".
+func promoteEcho(t *testing.T, k *runtime.Kernel, runner *stubRunner) toolforge.ScriptTool {
+	t.Helper()
+	st, err := k.DraftScriptTool("", toolforge.ScriptTool{
+		Name:        "echo",
+		Description: "echoes its input back",
+		Language:    "python",
+		Code:        "print(open('stdin.txt').read())",
+	})
+	if err != nil {
+		t.Fatalf("DraftScriptTool: %v", err)
+	}
+	runner.out, runner.isErr = "test-ok", false
+	rec, out, err := k.TestScriptTool(context.Background(), "", st.ID, `{"sample":1}`)
+	if err != nil || !rec.TestedOK || out != "test-ok" {
+		t.Fatalf("TestScriptTool = %v/%v/%q", rec.TestedOK, err, out)
+	}
+	if runner.input != `{"sample":1}` {
+		t.Fatalf("test input = %q, want the sample payload", runner.input)
+	}
+	if _, err := k.PromoteScriptTool("", st.ID); err != nil {
+		t.Fatalf("PromoteScriptTool: %v", err)
+	}
+	return st
+}
+
+// TestRunWith_OffersAndExecutesForgedTool is the arc's e2e: a drafted, tested,
+// PROMOTED script is offered to the model as forge_echo, the model calls it,
+// the sandbox runner receives the script + the call's raw JSON input, and its
+// stdout flows back into the loop.
+func TestRunWith_OffersAndExecutesForgedTool(t *testing.T) {
+	prov := mock.New(
+		mock.ToolUse("c1", "forge_echo", map[string]any{"text": "merhaba"}),
+		mock.FinalText("done"),
+	)
+	var first agent.CompletionRequest
+	seen := false
+	prov.OnRequest = func(r agent.CompletionRequest) {
+		if !seen {
+			first, seen = r, true
+		}
+	}
+	runner := &stubRunner{}
+	k := openForgeKernel(t, prov, runner)
+	promoteEcho(t, k, runner)
+
+	runner.out, runner.isErr = "echoed: merhaba", false
+	calls := runner.calls
+	if _, err := k.RunWith(context.Background(), k.NewCorrelation(), "echo something"); err != nil {
+		t.Fatalf("RunWith: %v", err)
+	}
+
+	// The model was OFFERED the forged tool, with the forge description note.
+	var def *agent.ToolDef
+	for i := range first.Tools {
+		if first.Tools[i].Name == "forge_echo" {
+			def = &first.Tools[i]
+		}
+	}
+	if def == nil {
+		t.Fatalf("forge_echo not offered; tools = %v", toolNames(first.Tools))
+	}
+	if !strings.Contains(def.Description, "echoes its input back") {
+		t.Errorf("description lost: %q", def.Description)
+	}
+
+	// The runner executed the stored script with the call's raw input.
+	if runner.calls != calls+1 {
+		t.Fatalf("runner calls = %d, want one run-call", runner.calls-calls)
+	}
+	if runner.lang != "python" || !strings.Contains(runner.code, "stdin.txt") {
+		t.Errorf("runner got %q/%q, want the stored script", runner.lang, runner.code)
+	}
+	if !strings.Contains(runner.input, `"merhaba"`) {
+		t.Errorf("call input did not reach the script: %q", runner.input)
+	}
+}
+
+// TestRunWith_DraftAndQuarantineNeverOffered: only ACTIVE tools reach the
+// model — a draft (even tested) and a quarantined tool stay invisible.
+func TestRunWith_DraftAndQuarantineNeverOffered(t *testing.T) {
+	prov := mock.New(mock.FinalText("ok"), mock.FinalText("ok"))
+	var req agent.CompletionRequest
+	prov.OnRequest = func(r agent.CompletionRequest) { req = r }
+	runner := &stubRunner{}
+	k := openForgeKernel(t, prov, runner)
+
+	st, err := k.DraftScriptTool("", toolforge.ScriptTool{
+		Name: "echo", Description: "d", Language: "python", Code: "print(1)",
+	})
+	if err != nil {
+		t.Fatalf("DraftScriptTool: %v", err)
+	}
+	if _, err := k.RunWith(context.Background(), k.NewCorrelation(), "hi"); err != nil {
+		t.Fatalf("RunWith(draft): %v", err)
+	}
+	if names := toolNames(req.Tools); contains(names, "forge_echo") {
+		t.Fatalf("a DRAFT was offered: %v", names)
+	}
+
+	runner.out = "ok"
+	if _, _, err := k.TestScriptTool(context.Background(), "", st.ID, ""); err != nil {
+		t.Fatalf("TestScriptTool: %v", err)
+	}
+	if _, err := k.PromoteScriptTool("", st.ID); err != nil {
+		t.Fatalf("Promote: %v", err)
+	}
+	if _, err := k.QuarantineScriptTool("", st.ID, "smoke"); err != nil {
+		t.Fatalf("Quarantine: %v", err)
+	}
+	if _, err := k.RunWith(context.Background(), k.NewCorrelation(), "hi again"); err != nil {
+		t.Fatalf("RunWith(quarantined): %v", err)
+	}
+	if names := toolNames(req.Tools); contains(names, "forge_echo") {
+		t.Fatalf("a QUARANTINED tool was offered: %v", names)
+	}
+}
+
+// TestRunWith_ToolAllowlistGatesForgedTools: a per-run tool restriction
+// (WithTools) applies to forged tools exactly like registered ones — merge
+// happens before the filter, so a restricted run can't smuggle them back.
+func TestRunWith_ToolAllowlistGatesForgedTools(t *testing.T) {
+	prov := mock.New(mock.FinalText("ok"), mock.FinalText("ok"))
+	var req agent.CompletionRequest
+	prov.OnRequest = func(r agent.CompletionRequest) { req = r }
+	runner := &stubRunner{}
+	k := openForgeKernel(t, prov, runner)
+	promoteEcho(t, k, runner)
+
+	ctx := runtime.WithTools(context.Background(), []string{"memory"}) // not forge_echo
+	if _, err := k.RunWith(ctx, k.NewCorrelation(), "restricted"); err != nil {
+		t.Fatalf("RunWith: %v", err)
+	}
+	if names := toolNames(req.Tools); contains(names, "forge_echo") {
+		t.Fatalf("allowlist did not gate the forged tool: %v", names)
+	}
+
+	ctx = runtime.WithTools(context.Background(), []string{"forge_echo"})
+	if _, err := k.RunWith(ctx, k.NewCorrelation(), "allowed"); err != nil {
+		t.Fatalf("RunWith: %v", err)
+	}
+	if names := toolNames(req.Tools); !contains(names, "forge_echo") {
+		t.Fatalf("allowlisted forged tool missing: %v", names)
+	}
+}
+
+// TestTestScriptTool_FailureRecordedAndPromoteRefused: a failing sandbox test
+// is recorded honestly and keeps the promotion gate shut.
+func TestTestScriptTool_FailureRecordedAndPromoteRefused(t *testing.T) {
+	prov := mock.New(mock.FinalText("ok"))
+	runner := &stubRunner{out: "Traceback ...", isErr: true}
+	k := openForgeKernel(t, prov, runner)
+
+	st, err := k.DraftScriptTool("", toolforge.ScriptTool{
+		Name: "broken", Description: "d", Language: "python", Code: "boom(",
+	})
+	if err != nil {
+		t.Fatalf("DraftScriptTool: %v", err)
+	}
+	rec, out, err := k.TestScriptTool(context.Background(), "", st.Name, "")
+	if err != nil {
+		t.Fatalf("TestScriptTool: %v", err)
+	}
+	if rec.TestedOK || !strings.Contains(out, "Traceback") {
+		t.Fatalf("failure not recorded: ok=%v out=%q", rec.TestedOK, out)
+	}
+	if _, err := k.PromoteScriptTool("", st.ID); err == nil {
+		t.Fatal("promote accepted after a FAILED test")
+	}
+}
+
+func toolNames(defs []agent.ToolDef) []string {
+	out := make([]string, 0, len(defs))
+	for _, d := range defs {
+		out = append(out, d.Name)
+	}
+	return out
+}
+
+func contains(names []string, want string) bool {
+	for _, n := range names {
+		if n == want {
+			return true
+		}
+	}
+	return false
+}

--- a/kernel/runtime/subagent.go
+++ b/kernel/runtime/subagent.go
@@ -319,7 +319,7 @@ func (k *Kernel) runSubAgent(ctx context.Context, task, model, taskType, agentRe
 
 	answer, err := agent.Run(childCtx, agent.LoopConfig{
 		Provider:             k.cfg.Provider,
-		Tools:                k.tools,
+		Tools:                k.mergeScriptTools(k.tools), // forged script tools reach sub-agents too (M794)
 		Bus:                  k.bus,
 		Model:                subModel,
 		TaskType:             taskType,   // M705: route the sub-agent (chain supplies fallbacks)

--- a/kernel/toolforge/toolforge.go
+++ b/kernel/toolforge/toolforge.go
@@ -1,0 +1,386 @@
+// SPDX-License-Identifier: MIT
+
+// Package toolforge is the script-tool forge (M794): agent-authored code
+// promoted into durable, callable tools — the close of the write→use→improve
+// cycle. An agent (or operator) DRAFTS a named script, TESTS it in the
+// code-exec sandbox, and once a test of the current code has passed the
+// OPERATOR promotes it; from then on every run is offered the script as a
+// real tool named `forge_<name>`, executed through the same warden-isolated,
+// secret-scrubbed sandbox as `code_exec` and gated by the same `code.exec`
+// Edict capability. Quarantine is the instant kill switch, and ANY edit to
+// the code demotes the tool back to draft with its test record cleared —
+// only tested code is ever live.
+//
+// Storage mirrors kernel/roster: a single JSON file rewritten atomically on
+// change, safe for concurrent use; every lifecycle mutation is journaled by
+// the kernel (scripttool.*) so `agt why` can explain how a tool came to be.
+package toolforge
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/agezt/agezt/kernel/ulid"
+)
+
+// ErrNotFound is returned for an unknown script-tool id/name.
+var ErrNotFound = errors.New("toolforge: script tool not found")
+
+// ErrUntested is returned by Promote when the CURRENT code has no passing
+// test on record — the forge's core invariant: only tested code goes live.
+var ErrUntested = errors.New("toolforge: the current code has no passing test — run a test first")
+
+// Status is a script tool's lifecycle state.
+type Status string
+
+const (
+	// StatusDraft: authored but not live — never offered to runs.
+	StatusDraft Status = "draft"
+	// StatusActive: promoted — offered to every run as forge_<name>.
+	StatusActive Status = "active"
+	// StatusQuarantined: pulled from production (kill switch); re-promotable.
+	StatusQuarantined Status = "quarantined"
+)
+
+// ScriptTool is one named, durable script the agent can call as a tool.
+type ScriptTool struct {
+	ID string `json:"id"`
+	// Name is the tool's immutable handle; runs see it as `forge_<name>`.
+	Name string `json:"name"`
+	// Description is what the MODEL reads to decide when to call it.
+	Description string `json:"description"`
+	// Language is the sandbox runtime id ("python", "node", "deno").
+	// Availability is judged at test/run time by the sandbox itself.
+	Language string `json:"language"`
+	// Code is the script body. Contract: the invoking call's JSON input is
+	// written to ./stdin.txt in the work dir; stdout becomes the tool result.
+	Code string `json:"code"`
+	// InputSchema is an optional JSON-Schema object describing the call
+	// input; empty means a permissive default schema.
+	InputSchema string `json:"input_schema,omitempty"`
+
+	Status Status `json:"status"`
+	// TestedOK records whether the CURRENT code has a passing sandbox test;
+	// cleared by any code/language edit. Promote requires it.
+	TestedOK bool  `json:"tested_ok"`
+	TestedMS int64 `json:"tested_ms,omitempty"`
+
+	CreatedMS int64 `json:"created_ms"`
+	UpdatedMS int64 `json:"updated_ms"`
+}
+
+// Runner executes a script in the code-exec sandbox: the call's raw JSON
+// input rides in as inputJSON (surfaced to the script as ./stdin.txt) and
+// combined stdout+stderr comes back. isError mirrors the sandbox's own
+// verdict (non-zero exit, timeout, unavailable language...). Implemented by
+// the code_exec tool; the daemon is the single wiring point.
+type Runner interface {
+	RunScript(ctx context.Context, language, code, inputJSON string) (output string, isError bool, err error)
+}
+
+// nameRe: a tool-name token — lowercase start, then letters/digits/underscore.
+// `forge_` + 40 chars stays well inside provider tool-name limits.
+var nameRe = regexp.MustCompile(`^[a-z][a-z0-9_]{0,39}$`)
+
+var langRe = regexp.MustCompile(`^[a-z][a-z0-9]{0,15}$`)
+
+const (
+	maxCodeBytes   = 128 * 1024 // a tool, not a codebase
+	maxDescBytes   = 2 * 1024
+	maxSchemaBytes = 16 * 1024
+)
+
+// Validate checks a script tool's user-supplied fields (identity/lifecycle
+// fields are kernel-assigned and not judged here).
+func Validate(st ScriptTool) error {
+	if !nameRe.MatchString(st.Name) {
+		return fmt.Errorf("toolforge: name must match %s", nameRe)
+	}
+	if strings.TrimSpace(st.Description) == "" {
+		return errors.New("toolforge: description is required (the model reads it to decide when to call the tool)")
+	}
+	if len(st.Description) > maxDescBytes {
+		return fmt.Errorf("toolforge: description exceeds %d bytes", maxDescBytes)
+	}
+	if !langRe.MatchString(st.Language) {
+		return errors.New("toolforge: language is required (a sandbox runtime id, e.g. python/node/deno)")
+	}
+	if strings.TrimSpace(st.Code) == "" {
+		return errors.New("toolforge: code is required")
+	}
+	if len(st.Code) > maxCodeBytes {
+		return fmt.Errorf("toolforge: code exceeds %d bytes", maxCodeBytes)
+	}
+	if s := strings.TrimSpace(st.InputSchema); s != "" {
+		if len(s) > maxSchemaBytes {
+			return fmt.Errorf("toolforge: input_schema exceeds %d bytes", maxSchemaBytes)
+		}
+		var obj map[string]any
+		if err := json.Unmarshal([]byte(s), &obj); err != nil {
+			return fmt.Errorf("toolforge: input_schema must be a JSON object: %w", err)
+		}
+	}
+	return nil
+}
+
+// Store is the persistent script-tool registry, a single JSON file rewritten
+// atomically on change. Safe for concurrent use. Mirrors kernel/roster.Store.
+type Store struct {
+	path  string
+	mu    sync.Mutex
+	now   func() time.Time
+	tools []*ScriptTool
+}
+
+// Open opens (or creates) the script-tool store under dir.
+func Open(dir string) (*Store, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("toolforge: mkdir %s: %w", dir, err)
+	}
+	s := &Store{path: filepath.Join(dir, "scripttools.json"), now: time.Now}
+	b, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return s, nil
+		}
+		return nil, fmt.Errorf("toolforge: read %s: %w", s.path, err)
+	}
+	if len(b) > 0 {
+		if err := json.Unmarshal(b, &s.tools); err != nil {
+			return nil, fmt.Errorf("toolforge: parse %s: %w", s.path, err)
+		}
+	}
+	return s, nil
+}
+
+// Add validates and persists a new DRAFT script tool, assigning an id +
+// timestamps. Caller-supplied ID/Status/Tested*/timestamps are ignored
+// (kernel-assigned). The name must be unique across the forge.
+func (s *Store) Add(st ScriptTool) (ScriptTool, error) {
+	st.Name = strings.TrimSpace(st.Name)
+	st.Language = strings.TrimSpace(st.Language)
+	if err := Validate(st); err != nil {
+		return ScriptTool{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, ex := range s.tools {
+		if ex.Name == st.Name {
+			return ScriptTool{}, fmt.Errorf("toolforge: name %q already exists", st.Name)
+		}
+	}
+	now := s.now().UnixMilli()
+	st.ID = ulid.New()
+	st.Status = StatusDraft
+	st.TestedOK = false
+	st.TestedMS = 0
+	st.CreatedMS = now
+	st.UpdatedMS = now
+	cp := st
+	s.tools = append(s.tools, &cp)
+	if err := s.save(); err != nil {
+		s.tools = s.tools[:len(s.tools)-1]
+		return ScriptTool{}, err
+	}
+	return cp, nil
+}
+
+// Update applies edits to a script tool's mutable fields via mutate,
+// re-validates, and persists. Identity and lifecycle fields — ID, Name,
+// CreatedMS, Status, TestedOK/TestedMS — are preserved regardless of what
+// mutate does, EXCEPT that changing Code or Language demotes the tool to
+// draft and clears its test record: only tested code is ever live. Rolled
+// back in memory on validation/save failure.
+func (s *Store) Update(ref string, mutate func(*ScriptTool)) (ScriptTool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	st := s.find(ref)
+	if st == nil {
+		return ScriptTool{}, ErrNotFound
+	}
+	snapshot := *st
+	mutate(st)
+	// Protect identity + lifecycle fields from the mutator: the name is the
+	// tool's ADDRESS, and status/test records move only through their own
+	// governed transitions.
+	st.ID, st.Name, st.CreatedMS = snapshot.ID, snapshot.Name, snapshot.CreatedMS
+	st.Status, st.TestedOK, st.TestedMS = snapshot.Status, snapshot.TestedOK, snapshot.TestedMS
+	st.Language = strings.TrimSpace(st.Language)
+	if st.Code != snapshot.Code || st.Language != snapshot.Language {
+		st.Status = StatusDraft
+		st.TestedOK = false
+		st.TestedMS = 0
+	}
+	st.UpdatedMS = s.now().UnixMilli()
+	if err := Validate(*st); err != nil {
+		*st = snapshot
+		return ScriptTool{}, err
+	}
+	if err := s.save(); err != nil {
+		*st = snapshot
+		return ScriptTool{}, err
+	}
+	return *st, nil
+}
+
+// RecordTest stamps the outcome of a sandbox test of the CURRENT code.
+func (s *Store) RecordTest(ref string, ok bool) (ScriptTool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	st := s.find(ref)
+	if st == nil {
+		return ScriptTool{}, ErrNotFound
+	}
+	prevOK, prevMS := st.TestedOK, st.TestedMS
+	st.TestedOK = ok
+	st.TestedMS = s.now().UnixMilli()
+	if err := s.save(); err != nil {
+		st.TestedOK, st.TestedMS = prevOK, prevMS
+		return ScriptTool{}, err
+	}
+	return *st, nil
+}
+
+// Promote moves a draft or quarantined tool to ACTIVE — from then on every
+// run is offered it as forge_<name>. Refused with ErrUntested unless the
+// current code has a passing test on record.
+func (s *Store) Promote(ref string) (ScriptTool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	st := s.find(ref)
+	if st == nil {
+		return ScriptTool{}, ErrNotFound
+	}
+	if st.Status == StatusActive {
+		return ScriptTool{}, fmt.Errorf("toolforge: %s is already active", st.Name)
+	}
+	if !st.TestedOK {
+		return ScriptTool{}, ErrUntested
+	}
+	prevStatus, prevUpdated := st.Status, st.UpdatedMS
+	st.Status = StatusActive
+	st.UpdatedMS = s.now().UnixMilli()
+	if err := s.save(); err != nil {
+		st.Status, st.UpdatedMS = prevStatus, prevUpdated
+		return ScriptTool{}, err
+	}
+	return *st, nil
+}
+
+// Quarantine pulls an ACTIVE tool from production — the kill switch. The
+// test record survives, so an un-edited tool can be re-promoted directly.
+func (s *Store) Quarantine(ref string) (ScriptTool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	st := s.find(ref)
+	if st == nil {
+		return ScriptTool{}, ErrNotFound
+	}
+	if st.Status != StatusActive {
+		return ScriptTool{}, fmt.Errorf("toolforge: %s is %s, not active", st.Name, st.Status)
+	}
+	prevStatus, prevUpdated := st.Status, st.UpdatedMS
+	st.Status = StatusQuarantined
+	st.UpdatedMS = s.now().UnixMilli()
+	if err := s.save(); err != nil {
+		st.Status, st.UpdatedMS = prevStatus, prevUpdated
+		return ScriptTool{}, err
+	}
+	return *st, nil
+}
+
+// Remove deletes a script tool by id or name. Returns whether it existed.
+func (s *Store) Remove(ref string) (ScriptTool, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, st := range s.tools {
+		if st.ID == ref || st.Name == ref {
+			removed := s.tools
+			gone := *st
+			s.tools = append(append([]*ScriptTool{}, s.tools[:i]...), s.tools[i+1:]...)
+			if err := s.save(); err != nil {
+				s.tools = removed // restore: disk write failed, keep the tool
+				return ScriptTool{}, false, err
+			}
+			return gone, true, nil
+		}
+	}
+	return ScriptTool{}, false, nil
+}
+
+// Get returns one script tool by id or name.
+func (s *Store) Get(ref string) (ScriptTool, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if st := s.find(ref); st != nil {
+		return *st, true
+	}
+	return ScriptTool{}, false
+}
+
+// find returns the live pointer for an id or name. Caller holds s.mu.
+func (s *Store) find(ref string) *ScriptTool {
+	for _, st := range s.tools {
+		if st.ID == ref || st.Name == ref {
+			return st
+		}
+	}
+	return nil
+}
+
+// List returns all script tools, sorted by creation time then id.
+func (s *Store) List() []ScriptTool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]ScriptTool, 0, len(s.tools))
+	for _, st := range s.tools {
+		out = append(out, *st)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].CreatedMS != out[j].CreatedMS {
+			return out[i].CreatedMS < out[j].CreatedMS
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out
+}
+
+// Active returns only the tools currently offered to runs, sorted like List.
+func (s *Store) Active() []ScriptTool {
+	all := s.List()
+	out := all[:0]
+	for _, st := range all {
+		if st.Status == StatusActive {
+			out = append(out, st)
+		}
+	}
+	return out
+}
+
+// Count returns the number of script tools.
+func (s *Store) Count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.tools)
+}
+
+func (s *Store) save() error {
+	b, err := json.MarshalIndent(s.tools, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, s.path)
+}

--- a/kernel/toolforge/toolforge_test.go
+++ b/kernel/toolforge/toolforge_test.go
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: MIT
+
+package toolforge
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func openStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	// Deterministic, strictly-increasing clock: same-millisecond Adds would
+	// otherwise flip List's creation-time sort onto the ID tiebreaker.
+	tick := int64(0)
+	s.now = func() time.Time {
+		tick++
+		return time.UnixMilli(1_700_000_000_000 + tick)
+	}
+	return s
+}
+
+func draft(t *testing.T, s *Store, name string) ScriptTool {
+	t.Helper()
+	st, err := s.Add(ScriptTool{
+		Name:        name,
+		Description: "echoes its input",
+		Language:    "python",
+		Code:        "print(open('stdin.txt').read())",
+	})
+	if err != nil {
+		t.Fatalf("Add(%s): %v", name, err)
+	}
+	return st
+}
+
+// TestLifecycle_TestedCodeGoesLive walks the governed pipeline end to end:
+// draft (never offered) → promote refused while untested → passing test →
+// promote → active (offered) → quarantine (pulled) → re-promote without a
+// re-test (the code didn't change).
+func TestLifecycle_TestedCodeGoesLive(t *testing.T) {
+	s := openStore(t)
+	st := draft(t, s, "echo")
+	if st.Status != StatusDraft || st.TestedOK {
+		t.Fatalf("new draft = %s/%v, want draft/untested", st.Status, st.TestedOK)
+	}
+	if len(s.Active()) != 0 {
+		t.Fatal("a draft must never be offered")
+	}
+
+	if _, err := s.Promote(st.ID); !errors.Is(err, ErrUntested) {
+		t.Fatalf("promote untested: got %v, want ErrUntested", err)
+	}
+
+	if _, err := s.RecordTest(st.ID, true); err != nil {
+		t.Fatalf("RecordTest: %v", err)
+	}
+	got, err := s.Promote(st.ID)
+	if err != nil {
+		t.Fatalf("Promote: %v", err)
+	}
+	if got.Status != StatusActive {
+		t.Fatalf("status = %s, want active", got.Status)
+	}
+	if act := s.Active(); len(act) != 1 || act[0].Name != "echo" {
+		t.Fatalf("Active = %v, want [echo]", act)
+	}
+
+	if _, err := s.Quarantine(st.ID); err != nil {
+		t.Fatalf("Quarantine: %v", err)
+	}
+	if len(s.Active()) != 0 {
+		t.Fatal("a quarantined tool must not be offered")
+	}
+	// Un-edited code keeps its passing test → direct re-promote works.
+	if got, err = s.Promote(st.Name); err != nil || got.Status != StatusActive {
+		t.Fatalf("re-promote = %s/%v, want active/nil", got.Status, err)
+	}
+}
+
+// TestUpdate_CodeChangeDemotes: editing the code of an ACTIVE tool pulls it
+// back to draft and clears the test record — only tested code is ever live.
+// Editing only the description demotes nothing.
+func TestUpdate_CodeChangeDemotes(t *testing.T) {
+	s := openStore(t)
+	st := draft(t, s, "echo")
+	if _, err := s.RecordTest(st.ID, true); err != nil {
+		t.Fatalf("RecordTest: %v", err)
+	}
+	if _, err := s.Promote(st.ID); err != nil {
+		t.Fatalf("Promote: %v", err)
+	}
+
+	// A docs-only edit keeps the tool live and tested.
+	got, err := s.Update(st.ID, func(dst *ScriptTool) { dst.Description = "better words" })
+	if err != nil {
+		t.Fatalf("Update(desc): %v", err)
+	}
+	if got.Status != StatusActive || !got.TestedOK {
+		t.Fatalf("desc edit demoted: %s/%v", got.Status, got.TestedOK)
+	}
+
+	// A code edit demotes + clears the test record.
+	got, err = s.Update(st.ID, func(dst *ScriptTool) { dst.Code = "print('v2')" })
+	if err != nil {
+		t.Fatalf("Update(code): %v", err)
+	}
+	if got.Status != StatusDraft || got.TestedOK || got.TestedMS != 0 {
+		t.Fatalf("code edit = %s/%v/%d, want draft/untested/0", got.Status, got.TestedOK, got.TestedMS)
+	}
+	if len(s.Active()) != 0 {
+		t.Fatal("edited tool still offered")
+	}
+	if _, err := s.Promote(st.ID); !errors.Is(err, ErrUntested) {
+		t.Fatalf("promote after edit: got %v, want ErrUntested", err)
+	}
+}
+
+// TestUpdate_ProtectsIdentity: a hostile mutator cannot rename a tool,
+// resurrect it, or forge a test record.
+func TestUpdate_ProtectsIdentity(t *testing.T) {
+	s := openStore(t)
+	st := draft(t, s, "echo")
+	got, err := s.Update(st.ID, func(dst *ScriptTool) {
+		dst.ID = "evil"
+		dst.Name = "other"
+		dst.Status = StatusActive
+		dst.TestedOK = true
+		dst.CreatedMS = 1
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if got.ID != st.ID || got.Name != "echo" || got.Status != StatusDraft || got.TestedOK || got.CreatedMS != st.CreatedMS {
+		t.Fatalf("identity/lifecycle not protected: %+v", got)
+	}
+}
+
+func TestValidate(t *testing.T) {
+	base := ScriptTool{Name: "ok_tool", Description: "d", Language: "python", Code: "print(1)"}
+	if err := Validate(base); err != nil {
+		t.Fatalf("valid tool rejected: %v", err)
+	}
+	cases := []struct {
+		label  string
+		mutate func(*ScriptTool)
+	}{
+		{"bad name (dash)", func(st *ScriptTool) { st.Name = "bad-name" }},
+		{"bad name (upper)", func(st *ScriptTool) { st.Name = "Bad" }},
+		{"bad name (leading digit)", func(st *ScriptTool) { st.Name = "1tool" }},
+		{"empty description", func(st *ScriptTool) { st.Description = "  " }},
+		{"empty language", func(st *ScriptTool) { st.Language = "" }},
+		{"empty code", func(st *ScriptTool) { st.Code = " " }},
+		{"oversized code", func(st *ScriptTool) { st.Code = strings.Repeat("x", maxCodeBytes+1) }},
+		{"schema not an object", func(st *ScriptTool) { st.InputSchema = `["nope"]` }},
+		{"schema not JSON", func(st *ScriptTool) { st.InputSchema = `{nope` }},
+	}
+	for _, tc := range cases {
+		st := base
+		tc.mutate(&st)
+		if err := Validate(st); err == nil {
+			t.Errorf("%s: accepted", tc.label)
+		}
+	}
+}
+
+func TestAdd_NameUnique(t *testing.T) {
+	s := openStore(t)
+	draft(t, s, "echo")
+	if _, err := s.Add(ScriptTool{Name: "echo", Description: "d", Language: "node", Code: "x"}); err == nil {
+		t.Fatal("duplicate name accepted")
+	}
+}
+
+func TestQuarantine_OnlyActive(t *testing.T) {
+	s := openStore(t)
+	st := draft(t, s, "echo")
+	if _, err := s.Quarantine(st.ID); err == nil {
+		t.Fatal("quarantining a draft accepted (drafts are not live)")
+	}
+}
+
+// TestPersistence_RoundTrip: records survive a reopen, addressed by id or name.
+func TestPersistence_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	st, err := s.Add(ScriptTool{Name: "echo", Description: "d", Language: "python", Code: "print(1)", InputSchema: `{"type":"object"}`})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if _, err := s.RecordTest("echo", true); err != nil { // by name
+		t.Fatalf("RecordTest: %v", err)
+	}
+
+	re, err := Open(dir)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	got, found := re.Get(st.ID)
+	if !found || !got.TestedOK || got.InputSchema != `{"type":"object"}` {
+		t.Fatalf("reloaded = %+v / %v", got, found)
+	}
+	if _, found := re.Get("echo"); !found {
+		t.Fatal("lookup by name failed after reopen")
+	}
+	if filepath.Base(re.path) != "scripttools.json" {
+		t.Fatalf("unexpected store file %s", re.path)
+	}
+}
+
+func TestRemove(t *testing.T) {
+	s := openStore(t)
+	st := draft(t, s, "echo")
+	gone, ok, err := s.Remove(st.Name)
+	if err != nil || !ok || gone.ID != st.ID {
+		t.Fatalf("Remove = %+v/%v/%v", gone, ok, err)
+	}
+	if _, ok, _ := s.Remove(st.Name); ok {
+		t.Fatal("second remove reported existing")
+	}
+	if s.Count() != 0 {
+		t.Fatalf("Count = %d, want 0", s.Count())
+	}
+}

--- a/kernel/webui/webui.go
+++ b/kernel/webui/webui.go
@@ -111,6 +111,7 @@ var apiRoutes = map[string]string{
 	"/api/skills":        controlplane.CmdSkillList,
 	"/api/standing":      controlplane.CmdStandingList,
 	"/api/agents":        controlplane.CmdAgentList,
+	"/api/toolforge":     controlplane.CmdToolforgeList,
 	"/api/inbox":         controlplane.CmdInbox,
 	"/api/board":         controlplane.CmdBoardRead,
 	"/api/autonomy":      controlplane.CmdAutonomyFeed,
@@ -160,7 +161,7 @@ var readArgsRoutes = map[string]writeRoute{
 	// Resolved HITL approval history (M773): a timeline of past approval requests
 	// joined with their granted/denied/timeout outcome. Read-only.
 	"/api/approvals_log": {controlplane.CmdApprovalsLog, []string{"limit", "denied"}},
-	"/api/plan_history": {controlplane.CmdPlanHistory, []string{"limit", "status"}},
+	"/api/plan_history":  {controlplane.CmdPlanHistory, []string{"limit", "status"}},
 	// Provider keyring list (M700): labels + active + last-4 for one env var.
 	// Read-only — values never leave the daemon.
 	"/api/provider/keys": {controlplane.CmdProviderKeyList, []string{"env"}},
@@ -184,8 +185,8 @@ var readArgsRoutes = map[string]writeRoute{
 // its inverse (resume), and HITL approval resolution (decide). Each is
 // POST-only (see writeProxy).
 var writeRoutes = map[string]writeRoute{
-	"/api/halt":             {controlplane.CmdHalt, []string{"reason"}},
-	"/api/resume":           {controlplane.CmdResume, []string{"reason"}},
+	"/api/halt":   {controlplane.CmdHalt, []string{"reason"}},
+	"/api/resume": {controlplane.CmdResume, []string{"reason"}},
 	// Pulse pause/resume (M743): the proactive-heartbeat master switch. No args.
 	"/api/pulse/pause":  {controlplane.CmdPulsePause, nil},
 	"/api/pulse/resume": {controlplane.CmdPulseResume, nil},
@@ -209,7 +210,7 @@ var writeRoutes = map[string]writeRoute{
 	// without a daemon restart. No args.
 	"/api/provider/reload": {controlplane.CmdProviderReload, nil},
 	// Send an outbound message via a configured channel (M747): channel + to + text.
-	"/api/send": {controlplane.CmdSend, []string{"channel", "to", "text"}},
+	"/api/send":             {controlplane.CmdSend, []string{"channel", "to", "text"}},
 	"/api/cancel_run":       {controlplane.CmdCancelRun, []string{"correlation"}},
 	"/api/budget_set":       {controlplane.CmdBudgetSet, []string{"ceiling_mc"}},
 	"/api/run/pause":        {controlplane.CmdRunPause, []string{"correlation"}},
@@ -238,7 +239,14 @@ var writeRoutes = map[string]writeRoute{
 	// Agent roster lifecycle (M783): pause/resume/remove a named agent (ref = id or slug).
 	"/api/agents/enable": {controlplane.CmdAgentSetEnabled, []string{"ref", "enabled"}},
 	"/api/agents/remove": {controlplane.CmdAgentRemove, []string{"ref"}},
-	"/api/reflect/run":      {controlplane.CmdReflectRun, nil},
+	// Script-tool forge lifecycle (M794): test runs the code in the sandbox and
+	// records the verdict; promote/quarantine move a TESTED tool in/out of
+	// production; remove deletes it. ref = id or name.
+	"/api/toolforge/test":       {controlplane.CmdToolforgeTest, []string{"ref", "input"}},
+	"/api/toolforge/promote":    {controlplane.CmdToolforgePromote, []string{"ref"}},
+	"/api/toolforge/quarantine": {controlplane.CmdToolforgeQuarantine, []string{"ref", "reason"}},
+	"/api/toolforge/remove":     {controlplane.CmdToolforgeRemove, []string{"ref"}},
+	"/api/reflect/run":          {controlplane.CmdReflectRun, nil},
 	// Provider keyring switch/remove (M700): activate or remove a key, reloading
 	// the provider in place. (Add is a jsonRoute — the value is a secret body.)
 	"/api/provider/keys/activate": {controlplane.CmdProviderKeyActivate, []string{"env", "label"}},
@@ -283,6 +291,10 @@ var jsonRoutes = map[string]writeRoute{
 	// text, fallback list, numeric cost ceiling) — a JSON body, not query args.
 	"/api/agents/add":  {controlplane.CmdAgentAdd, []string{"profile"}},
 	"/api/agents/edit": {controlplane.CmdAgentEdit, []string{"ref", "profile"}},
+	// Script-tool forge draft/edit (M794): the tool is a structured object
+	// (code body, schema text) — a JSON body, not query args.
+	"/api/toolforge/draft": {controlplane.CmdToolforgeDraft, []string{"tool"}},
+	"/api/toolforge/edit":  {controlplane.CmdToolforgeEdit, []string{"ref", "tool"}},
 	// Create a schedule (M715): intent + a timing mode. Numeric timing args (e.g.
 	// interval_sec, at_minutes, once_at_unix) ride the JSON body so they keep their
 	// types — a query arg would stringify them.

--- a/kernel/webui/webui_test.go
+++ b/kernel/webui/webui_test.go
@@ -554,7 +554,7 @@ func TestAPIReadOnly(t *testing.T) {
 	// never issues anything outside the known read set.
 	readOnly := map[string]bool{
 		"status": true, "config": true, "runs_list": true, "runs_stats": true, "budget": true, "cache_stats": true, "provider_stats": true, "tool_stats": true, "edict_stats": true, "schedule_list": true, "memory_list": true, "world_list": true,
-		"skill_list": true, "standing_list": true, "agent_list": true, "inbox": true, "reflect_show": true, "approvals": true,
+		"skill_list": true, "standing_list": true, "agent_list": true, "toolforge_list": true, "inbox": true, "reflect_show": true, "approvals": true,
 		"plan_stats": true, "edict_show": true, "tool_list": true, "board_read": true, "autonomy_feed": true,
 		"catalog_list": true, "sandbox_list": true,
 		"config_schema": true, "config_values": true, "routing_get": true, "persona_get": true, "prompts_get": true,

--- a/plugins/tools/codeexec/codeexec.go
+++ b/plugins/tools/codeexec/codeexec.go
@@ -294,6 +294,25 @@ func (t *Tool) Invoke(ctx context.Context, raw json.RawMessage) (agent.Result, e
 	return render(lang, projectSlug, dir, ephemeral, timeout, res), nil
 }
 
+// RunScript executes a stored script once in the sandbox: an ephemeral work
+// dir, the daemon's scrubbed env, and inputJSON surfaced to the script as
+// ./stdin.txt. It is the execution backend of the script-tool forge (M794) —
+// structurally satisfying the kernel's toolforge.Runner contract without the
+// kernel importing this plugin. isError mirrors the tool's own verdict
+// (unavailable language, non-zero exit, timeout), so a failed forged call
+// reads exactly like a failed code_exec call.
+func (t *Tool) RunScript(ctx context.Context, language, code, inputJSON string) (string, bool, error) {
+	raw, err := json.Marshal(input{Language: language, Code: code, Stdin: inputJSON})
+	if err != nil {
+		return "", false, fmt.Errorf("code_exec: marshal script input: %w", err)
+	}
+	res, err := t.Invoke(ctx, raw)
+	if err != nil {
+		return "", false, err
+	}
+	return res.Output, res.IsError, nil
+}
+
 // workDir resolves where this run executes. With no project name it returns a
 // fresh ephemeral temp dir (caller removes it). With a project name it returns
 // a stable per-project dir that persists across calls.

--- a/plugins/tools/codeexec/runscript_test.go
+++ b/plugins/tools/codeexec/runscript_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+
+package codeexec
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestRunScript_LiveStdinContract proves the script-tool forge's execution
+// contract (M794) against a real interpreter: the call's JSON input lands in
+// ./stdin.txt, stdout comes back, and a non-zero exit reads as isError —
+// exactly like a direct code_exec call. Skipped when no Python is installed.
+func TestRunScript_LiveStdinContract(t *testing.T) {
+	rt := DetectRuntimes()
+	if _, ok := rt[LangPython]; !ok {
+		t.Skip("python not installed")
+	}
+	tool := New(t.TempDir(), rt)
+
+	out, isErr, err := tool.RunScript(context.Background(), LangPython,
+		`import json; d=json.load(open("stdin.txt")); print("city=" + d["city"])`,
+		`{"city":"izmir"}`)
+	if err != nil {
+		t.Fatalf("RunScript: %v", err)
+	}
+	if isErr {
+		t.Fatalf("unexpected error result:\n%s", out)
+	}
+	if !strings.Contains(out, "city=izmir") {
+		t.Fatalf("input did not reach the script via stdin.txt:\n%s", out)
+	}
+
+	// A failing script (non-zero exit) must read as a tool error, not a Go error.
+	out, isErr, err = tool.RunScript(context.Background(), LangPython,
+		`import sys; print("boom"); sys.exit(3)`, "{}")
+	if err != nil {
+		t.Fatalf("RunScript(fail): %v", err)
+	}
+	if !isErr || !strings.Contains(out, "exit code 3") {
+		t.Fatalf("failure verdict wrong: isErr=%v out:\n%s", isErr, out)
+	}
+
+	// An unavailable language is an honest tool error too.
+	out, isErr, err = tool.RunScript(context.Background(), "cobol", "x", "{}")
+	if err != nil || !isErr || !strings.Contains(out, "not available") {
+		t.Fatalf("unknown language: err=%v isErr=%v out=%s", err, isErr, out)
+	}
+}

--- a/plugins/tools/forgetool/tool.go
+++ b/plugins/tools/forgetool/tool.go
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: MIT
+
+// Package forgetool is the in-process `tool_forge` tool (M794): the agent
+// builds its OWN tools. It drafts a named script (Python/Node/Deno), tests
+// it in the code-exec sandbox, and iterates; once a test of the current code
+// passes, the OPERATOR promotes it (`agt toolforge promote` / the console)
+// and from then on every run can call it as a real `forge_<name>` tool.
+// Authoring is gated by the `tool.forge` Edict capability; op=test executes
+// code and is gated by `code.exec`. Every transition is journaled
+// (scripttool.*) and quarantine is the operator's instant kill switch.
+package forgetool
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/toolforge"
+)
+
+// Kernel is the slice of the runtime kernel this tool drives — satisfied by
+// *runtime.Kernel and easy to fake in tests.
+type Kernel interface {
+	DraftScriptTool(corr string, st toolforge.ScriptTool) (toolforge.ScriptTool, error)
+	UpdateScriptTool(corr, ref string, mutate func(*toolforge.ScriptTool)) (toolforge.ScriptTool, bool, error)
+	TestScriptTool(ctx context.Context, corr, ref, input string) (toolforge.ScriptTool, string, error)
+	ToolForge() *toolforge.Store
+}
+
+// Tool implements agent.Tool. Construct with New, then Bind the live kernel
+// once it opens (the daemon is the single wiring point).
+type Tool struct {
+	mu sync.RWMutex
+	k  Kernel
+}
+
+// New returns an unbound Tool — Invoke reports the forge unavailable until
+// Bind is called.
+func New() *Tool { return &Tool{} }
+
+// Bind wires the live kernel. Called once after the kernel opens.
+func (t *Tool) Bind(k Kernel) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.k = k
+}
+
+func (t *Tool) current() Kernel {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.k
+}
+
+// Definition implements agent.Tool.
+func (t *Tool) Definition() agent.ToolDef {
+	return agent.ToolDef{
+		Name: "tool_forge",
+		Description: "Build your own durable tools out of code. " +
+			"op=draft saves a named script (python/node/deno) as a DRAFT tool; " +
+			"op=test runs the draft once in the sandbox with a sample JSON input (your script reads it from ./stdin.txt and must print its result to stdout); " +
+			"op=update edits a draft (changing the code clears its test record and demotes an active tool back to draft); " +
+			"op=list and op=show inspect your tools. " +
+			"A draft only goes LIVE when the operator promotes it — after a passing test — and is then callable by every agent as forge_<name>. " +
+			"Use this when you've written code worth keeping: turn it into a tool instead of rewriting it every run.",
+		InputSchema: json.RawMessage(`{
+  "type": "object",
+  "required": ["op"],
+  "properties": {
+    "op":           {"type":"string", "enum":["draft","update","test","list","show"]},
+    "name":         {"type":"string", "description":"For op=draft: the tool's handle (lowercase letters/digits/underscore, e.g. \"fetch_weather\"); callable as forge_<name> once promoted."},
+    "description":  {"type":"string", "description":"For op=draft/update: what the tool does and when to call it — the model-facing description."},
+    "language":     {"type":"string", "description":"For op=draft/update: the sandbox runtime, e.g. \"python\", \"node\", or \"deno\"."},
+    "code":         {"type":"string", "description":"For op=draft/update: the script. Contract: the call's JSON input is in ./stdin.txt; print the result to stdout; exit non-zero on failure."},
+    "input_schema": {"type":"string", "description":"For op=draft/update (optional): a JSON-Schema object (as a string) describing the tool's input."},
+    "ref":          {"type":"string", "description":"For op=update/test/show: the tool's id or name."},
+    "input":        {"type":"string", "description":"For op=test (optional): a sample JSON input for the run (default {})."}
+  }
+}`),
+	}
+}
+
+type input struct {
+	Op          string `json:"op"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Language    string `json:"language"`
+	Code        string `json:"code"`
+	InputSchema string `json:"input_schema"`
+	Ref         string `json:"ref"`
+	Input       string `json:"input"`
+}
+
+// Invoke implements agent.Tool.
+func (t *Tool) Invoke(ctx context.Context, raw json.RawMessage) (agent.Result, error) {
+	var in input
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return agent.Result{}, fmt.Errorf("tool_forge: parse input: %w", err)
+	}
+	k := t.current()
+	if k == nil {
+		return errResult("the tool forge is not available on this daemon"), nil
+	}
+	corr := agent.CorrelationFromContext(ctx)
+
+	switch in.Op {
+	case "draft":
+		st, err := k.DraftScriptTool(corr, toolforge.ScriptTool{
+			Name:        in.Name,
+			Description: in.Description,
+			Language:    in.Language,
+			Code:        in.Code,
+			InputSchema: in.InputSchema,
+		})
+		if err != nil {
+			return errResult(err.Error()), nil
+		}
+		v := view(st)
+		v["message"] = "drafted — test it (op=test), then ask the operator to promote it"
+		return okJSON(v), nil
+
+	case "update":
+		if strings.TrimSpace(in.Ref) == "" {
+			return errResult(`op=update needs a "ref" (the tool's id or name)`), nil
+		}
+		st, found, err := k.UpdateScriptTool(corr, in.Ref, func(dst *toolforge.ScriptTool) {
+			if strings.TrimSpace(in.Description) != "" {
+				dst.Description = in.Description
+			}
+			if strings.TrimSpace(in.Language) != "" {
+				dst.Language = in.Language
+			}
+			if in.Code != "" {
+				dst.Code = in.Code
+			}
+			if strings.TrimSpace(in.InputSchema) != "" {
+				dst.InputSchema = in.InputSchema
+			}
+		})
+		if err != nil {
+			return errResult(err.Error()), nil
+		}
+		if !found {
+			return errResult("no script tool " + in.Ref), nil
+		}
+		v := view(st)
+		msg := "updated"
+		if !st.TestedOK {
+			msg = "updated — the code changed, so it's a draft again; re-test before asking for promotion"
+		}
+		v["message"] = msg
+		return okJSON(v), nil
+
+	case "test":
+		if strings.TrimSpace(in.Ref) == "" {
+			return errResult(`op=test needs a "ref" (the tool's id or name)`), nil
+		}
+		st, out, err := k.TestScriptTool(ctx, corr, in.Ref, in.Input)
+		if err != nil {
+			return errResult(err.Error()), nil
+		}
+		verdict := "PASSED — ask the operator to promote it (agt toolforge promote " + st.Name + ")"
+		if !st.TestedOK {
+			verdict = "FAILED — fix the code (op=update) and test again"
+		}
+		return agent.Result{Output: "test " + verdict + "\n\n" + out, IsError: !st.TestedOK}, nil
+
+	case "list":
+		all := k.ToolForge().List()
+		views := make([]map[string]any, 0, len(all))
+		for _, st := range all {
+			views = append(views, view(st))
+		}
+		return okJSON(map[string]any{"count": len(views), "tools": views}), nil
+
+	case "show":
+		if strings.TrimSpace(in.Ref) == "" {
+			return errResult(`op=show needs a "ref" (the tool's id or name)`), nil
+		}
+		st, found := k.ToolForge().Get(strings.TrimSpace(in.Ref))
+		if !found {
+			return errResult("no script tool " + in.Ref), nil
+		}
+		v := view(st)
+		v["code"] = st.Code
+		if st.InputSchema != "" {
+			v["input_schema"] = st.InputSchema
+		}
+		return okJSON(v), nil
+
+	case "":
+		return errResult("op required (draft|update|test|list|show)"), nil
+	default:
+		return errResult("unknown op " + in.Op + " (draft|update|test|list|show)"), nil
+	}
+}
+
+func view(st toolforge.ScriptTool) map[string]any {
+	v := map[string]any{
+		"id":        st.ID,
+		"name":      st.Name,
+		"language":  st.Language,
+		"status":    string(st.Status),
+		"tested_ok": st.TestedOK,
+	}
+	if st.Description != "" {
+		v["description"] = st.Description
+	}
+	if st.Status == toolforge.StatusActive {
+		v["callable_as"] = "forge_" + st.Name
+	}
+	return v
+}
+
+func okJSON(v any) agent.Result {
+	enc, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return errResult("marshal: " + err.Error())
+	}
+	return agent.Result{Output: string(enc)}
+}
+
+func errResult(msg string) agent.Result {
+	return agent.Result{Output: "tool_forge: " + msg, IsError: true}
+}

--- a/plugins/tools/forgetool/tool_test.go
+++ b/plugins/tools/forgetool/tool_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: MIT
+
+package forgetool
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/agezt/agezt/kernel/toolforge"
+)
+
+// fakeKernel drives the tool against a real toolforge.Store with a canned
+// sandbox verdict — the kernel's journaling is covered by runtime tests.
+type fakeKernel struct {
+	store   *toolforge.Store
+	testOut string
+	testOK  bool
+}
+
+func (f *fakeKernel) DraftScriptTool(_ string, st toolforge.ScriptTool) (toolforge.ScriptTool, error) {
+	return f.store.Add(st)
+}
+
+func (f *fakeKernel) UpdateScriptTool(_, ref string, mutate func(*toolforge.ScriptTool)) (toolforge.ScriptTool, bool, error) {
+	st, err := f.store.Update(ref, mutate)
+	if errors.Is(err, toolforge.ErrNotFound) {
+		return toolforge.ScriptTool{}, false, nil
+	}
+	if err != nil {
+		return toolforge.ScriptTool{}, false, err
+	}
+	return st, true, nil
+}
+
+func (f *fakeKernel) TestScriptTool(_ context.Context, _, ref, _ string) (toolforge.ScriptTool, string, error) {
+	st, err := f.store.RecordTest(ref, f.testOK)
+	return st, f.testOut, err
+}
+
+func (f *fakeKernel) ToolForge() *toolforge.Store { return f.store }
+
+func newBound(t *testing.T) (*Tool, *fakeKernel) {
+	t.Helper()
+	store, err := toolforge.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("toolforge.Open: %v", err)
+	}
+	fk := &fakeKernel{store: store, testOut: "ok", testOK: true}
+	tool := New()
+	tool.Bind(fk)
+	return tool, fk
+}
+
+func invoke(t *testing.T, tool *Tool, in map[string]any) (string, bool) {
+	t.Helper()
+	raw, _ := json.Marshal(in)
+	res, err := tool.Invoke(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("Invoke(%v): %v", in, err)
+	}
+	return res.Output, res.IsError
+}
+
+// TestAuthoringLoop walks the agent's whole surface: draft → test (pass) →
+// list/show → update code (demote warning) → and confirms promotion is NOT a
+// tool op (the operator owns it).
+func TestAuthoringLoop(t *testing.T) {
+	tool, fk := newBound(t)
+
+	out, isErr := invoke(t, tool, map[string]any{
+		"op": "draft", "name": "echo", "description": "echoes input",
+		"language": "python", "code": "print(open('stdin.txt').read())",
+	})
+	if isErr || !strings.Contains(out, "drafted") {
+		t.Fatalf("draft: err=%v out=%s", isErr, out)
+	}
+
+	out, isErr = invoke(t, tool, map[string]any{"op": "test", "ref": "echo", "input": `{"x":1}`})
+	if isErr || !strings.Contains(out, "PASSED") {
+		t.Fatalf("test: err=%v out=%s", isErr, out)
+	}
+
+	out, _ = invoke(t, tool, map[string]any{"op": "list"})
+	if !strings.Contains(out, `"echo"`) || !strings.Contains(out, `"draft"`) {
+		t.Fatalf("list: %s", out)
+	}
+	out, _ = invoke(t, tool, map[string]any{"op": "show", "ref": "echo"})
+	if !strings.Contains(out, "stdin.txt") {
+		t.Fatalf("show missing code: %s", out)
+	}
+
+	out, isErr = invoke(t, tool, map[string]any{"op": "update", "ref": "echo", "code": "print('v2')"})
+	if isErr || !strings.Contains(out, "re-test") {
+		t.Fatalf("update should warn about the demotion: err=%v out=%s", isErr, out)
+	}
+	if st, _ := fk.store.Get("echo"); st.TestedOK || st.Status != toolforge.StatusDraft {
+		t.Fatalf("code update did not demote: %+v", st)
+	}
+
+	// Promotion is the operator's move, not an agent op.
+	out, isErr = invoke(t, tool, map[string]any{"op": "promote", "ref": "echo"})
+	if !isErr || !strings.Contains(out, "unknown op") {
+		t.Fatalf("promote must not be a tool op: err=%v out=%s", isErr, out)
+	}
+}
+
+// TestFailingTestReportsFAILED: the verdict and the sandbox output both reach
+// the agent so it can iterate.
+func TestFailingTestReportsFAILED(t *testing.T) {
+	tool, fk := newBound(t)
+	invoke(t, tool, map[string]any{
+		"op": "draft", "name": "broken", "description": "d", "language": "python", "code": "boom(",
+	})
+	fk.testOK, fk.testOut = false, "SyntaxError: unexpected EOF"
+	out, isErr := invoke(t, tool, map[string]any{"op": "test", "ref": "broken"})
+	if !isErr || !strings.Contains(out, "FAILED") || !strings.Contains(out, "SyntaxError") {
+		t.Fatalf("failing test misreported: err=%v out=%s", isErr, out)
+	}
+}
+
+// TestUnbound: before Bind, every op reports the forge unavailable.
+func TestUnbound(t *testing.T) {
+	out, isErr := invoke(t, New(), map[string]any{"op": "list"})
+	if !isErr || !strings.Contains(out, "not available") {
+		t.Fatalf("unbound: err=%v out=%s", isErr, out)
+	}
+}


### PR DESCRIPTION
## What

**Gap-analysis frontier #4: code→tool promotion** — the close of the write→use→improve cycle. Agent-authored code can now become a **durable, callable tool** through a governed pipeline:

```
tool_forge op=draft  →  op=test (real sandbox run)  →  agt toolforge promote (OPERATOR)
                                                          ↓
                              every run + delegate child offered forge_<name>
```

## Governance (the point)

- **Only tested code is ever live**: `Promote` refuses (`ErrUntested`) until a sandbox test of the CURRENT code passed; **any code edit demotes to draft** and clears the test record.
- **Promotion is not an agent op** — `tool_forge` can draft/update/test/list/show; going live takes `agt toolforge promote` / controlplane / webui.
- **Quarantine** = instant kill switch; an un-edited tool re-promotes directly (test record survives).
- **Edict**: every `forge_*` call maps to `code.exec` (it IS sandboxed code execution); new `tool.forge` cap (AskFirst, like `skill`) gates authoring; `op=test` maps to `code.exec`.
- Per-run **WithTools allowlist gates forged tools** exactly like registered ones (merge before filter).
- Every transition journaled: `scripttool.created/updated/tested/promoted/quarantined/removed`.

## Design

- `kernel/toolforge`: roster-pattern atomic store (`scripttools.json`), validation, lifecycle invariants.
- Execution rides **code_exec untouched**: new `RunScript` export marshals a normal code_exec input — call's raw JSON → `stdin.txt`, stdout → tool result, ephemeral dir, scrubbed env, warden limits. Kernel sees only the `toolforge.Runner` interface (**kernel still never imports plugins**).
- Offering seam: `mergeScriptTools` in RunWith (before WithTools filter + env preamble) and on the delegate child path.
- Surfaces: `agt toolforge list|show|draft|edit|test|promote|quarantine|remove` (code via `--file`), `toolforge_*` controlplane cmds, webui routes (GET /api/toolforge + draft/edit jsonRoutes + test/promote/quarantine/remove writeRoutes). Console view → M795.

## Tests — 17 new across 6 packages

store lifecycle/demote/protection/validation/persistence · runtime e2e (offered + executed via stub runner; draft/quarantined invisible; allowlist both ways; failed test keeps gate shut) · edict toolmap routing · forgetool authoring loop · controlplane wire round-trip (list never leaks code bodies) · codeexec live stdin.txt contract (real python).

## Smoke (isolated AGEZT_HOME, real daemon, real python)

draft → premature promote **REFUSED** → `toolforge test --input '{"city":"izmir"}'` → real sandbox printed `weather for izmir: sunny, 28C` → promote → ACTIVE as `forge_weather` → quarantine → re-promote → code edit demoted. Journal trail: created/tested/promoted/quarantined/promoted/updated.

## Local battery (CI org billing still blocked)

Full `GOMAXPROCS=3 go test -p 2 ./...` ✅ · vet ✅ · staticcheck ✅ · linux cross-build ✅ · 457 vitest ✅ (frontend untouched, dist unchanged) · staged-blob gofmt sweep ✅ (caught + fixed 2 files pre-commit) · go.mod unchanged · no new env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)