### PR TITLE
Feat: governed MCP self-install — runtime attach (M796)

### DIFF
--- a/.project/PHASE-M796-MCP-SELF-INSTALL-REPORT.md
+++ b/.project/PHASE-M796-MCP-SELF-INSTALL-REPORT.md
@@ -1,0 +1,86 @@
+# Phase M796 — governed MCP self-install (runtime attach)
+
+**Date:** 2026-06-10 · **Status:** DONE · **Frontier:** gap-analysis #3
+(governed self-install — "ajanlar MCP server bile kurup ekleyip kullanabilir").
+
+## What
+
+`kernel/mcp`: a durable registry of MCP servers + a minimal kernel-native
+MCP client (stdio: initialize → notifications/initialized → tools/list →
+tools/call; line-delimited JSON-RPC, 16 MiB frame cap, handshake/call
+timeouts, stray-notification skipping). An agent (`mcp` tool) or operator
+(`agt mcp` / control plane / webui API) can REGISTER a server and ATTACH it
+while the daemon runs — no restart, no separate bridge binary, no env-var
+surgery. From the next run on, the server's discovered tools are offered to
+every run and delegate child as `mcp_<server>_<tool>` through the SAME
+dynamic merge seam forged script tools ride (merge before the WithTools
+filter). Detach is the kill switch; enabled servers auto-attach at daemon
+boot (per-server failures reported, never fatal); Close detaches all.
+
+## Governance
+
+- **Edict:** new `mcp.install` capability (LevelAsk — attaching spawns an
+  arbitrary process, approve every one) gates the `mcp` tool's
+  add/attach/detach/remove ops (op=list → introspect axis); new `mcp.call`
+  (LevelAskFirst) gates every bridged `mcp_*` call via the toolmap prefix
+  rule. A garbled `mcp` op lands on the gated install axis.
+- **Scrubbed child env:** the spawned server gets PATH/OS vars/per-user dirs
+  only — never AGEZT_* or secret-shaped variables (mirrors the code-exec
+  scrub; unit-tested).
+- **Journal:** `mcp.added/updated/attached/detached/removed` under subject
+  `mcp.<name>`, attach payload carries the discovered tool names.
+- Server names are `[a-z][a-z0-9]{0,15}` — NO underscore/dash, so the
+  toolmap can parse the server out of `mcp_<server>_<tool>` unambiguously;
+  bridged tool names are sanitized to the provider alphabet and capped at 64.
+
+## Design notes
+
+- Kernel spawns the child directly (kernel/plugin precedent) — warden is
+  run-to-completion, MCP needs a long-lived dialog.
+- `Config.MCPDialer` is the test seam (fake Conn injection); `mcp.Conn` is
+  an interface; the pipe-based core (`newClientConn`) is tested without any
+  process.
+- Registration ≠ attach: add persists config, attach spawns. `Enabled`
+  means auto-attach at boot.
+
+## Tests (16 new across 5 packages)
+
+- kernel/mcp client: full dialogue over in-memory pipes incl. notification
+  skipping + server-error surfacing; lost-connection mid-call; env scrub;
+  **live python subprocess e2e** (Dial → handshake → discovery → call
+  "hello ersin" → close; skips without python).
+- kernel/mcp store: CRUD, persistence, validation table (underscore/dash
+  names rejected — toolmap parse invariant).
+- runtime: attach → run OFFERS `mcp_fake_greet` and the call FORWARDS raw
+  args / returns server text (wire-level, mock provider); detach kill
+  switch + double-attach refusal; remove detaches first; boot auto-attach;
+  WithTools allowlist gates bridged tools both ways; hostile tool names
+  sanitized + length-capped.
+- edict toolmap: `mcp_*` → mcp.call; mcp tool op routing (list →
+  introspect; garbled → install).
+- mcptool: self-install loop add→attach→list(live)→detach→remove; error
+  paths; unbound.
+- controlplane: wire round-trip add → attach (names returned, list shows
+  live) → disable auto-attach → detach (conn closed) → remove → ghost refs.
+
+## Smoke (isolated AGEZT_HOME, real daemon, real python MCP server)
+
+`agt mcp add fake --cmd python --arg server.py` → `agt mcp attach fake` →
+**real spawn + handshake**: "attached fake — 2 tool(s): mcp_fake_greet,
+mcp_fake_weather" → list shows ATTACHED (2 tools) → detach → **daemon
+restart**: banner "mcp servers : 1 attached of 1 registered" (boot
+auto-attach proven). Journal: mcp.added → mcp.attached → mcp.detached →
+halt → mcp.attached. Graceful shutdown, smoke dir removed.
+
+## Gate
+
+Full `GOMAXPROCS=3 go test -p 2 ./...` green; vet + staticcheck clean;
+linux cross-build OK; frontend untouched (webui API routes added for the
+M797 console view; dist unchanged); go.mod unchanged; no new env vars.
+CI org-billing still blocked → local battery + arc-authority merge.
+
+## Next
+
+M797: MCP console view (register/attach/detach from the web UI). Then
+gap #5 vector memory, #6 brain distiller. Future polish: per-server Edict
+capabilities (`mcp.<name>`), per-server env (vault-backed), SSE transport.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **Governed self-install: agents can attach MCP servers at runtime.** The new `mcp` tool (and
+  `agt mcp` for operators) registers a Model Context Protocol server — any stdio MCP server, e.g.
+  `npx -y @modelcontextprotocol/server-everything` — and **attaches it while the daemon runs**: the
+  kernel's own minimal MCP client spawns it, handshakes, discovers its tools, and from the next run
+  on every agent (and delegate sub-agent) can call them as `mcp_<server>_<tool>`. No restart, no
+  separate bridge binary, no env-var surgery. Governance is the point: registering/attaching is
+  gated by the new `mcp.install` Edict capability (**Ask on every call** by default — an attach
+  spawns an arbitrary external process), every bridged call exercises the new `mcp.call` capability
+  (ask-first), the spawned server gets a **scrubbed environment** (PATH and friends — never
+  `AGEZT_*` or secret-shaped variables), frames are size-capped, and every lifecycle transition is
+  journaled (`mcp.added/attached/detached/removed`) so `agt why` explains how a server's tools
+  became callable. **Detach is the instant kill switch**; enabled servers auto-attach at daemon
+  boot (per-server failures reported, never fatal). A per-run tool allowlist gates bridged tools
+  exactly like built-ins. Surface: `agt mcp add/attach/detach/enable/disable/remove/list`,
+  control-plane `mcp_*` commands, webui API routes (console view to follow). 16 new tests across
+  five packages — including a **live python MCP subprocess** end-to-end — plus an isolated-daemon
+  smoke: register + attach a real python server via the CLI (2 tools discovered), detach, restart
+  the daemon and watch it auto-attach, with the full journal trail verified. (M796)
 - **Tool Forge console view.** The script-tool forge (M794) gets its operator surface in the web
   UI — a *Tool Forge* view under Agents: draft a script in the browser (language, description, the
   code editor states the `stdin.txt` contract inline, optional input schema), **run a sandbox test

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -97,6 +97,7 @@ import (
 	hatool "github.com/agezt/agezt/plugins/tools/homeassistant"
 	httptool "github.com/agezt/agezt/plugins/tools/http"
 	"github.com/agezt/agezt/plugins/tools/introspecttool"
+	"github.com/agezt/agezt/plugins/tools/mcptool"
 	"github.com/agezt/agezt/plugins/tools/notify"
 	"github.com/agezt/agezt/plugins/tools/peer"
 	"github.com/agezt/agezt/plugins/tools/runstool"
@@ -349,6 +350,12 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// to the live kernel after it opens.
 	forgeToolInst := forgetool.New()
 	tools["tool_forge"] = forgeToolInst
+
+	// MCP self-install tool (`mcp`, M796): the agent extends its own toolbox —
+	// registering and ATTACHING MCP servers at runtime (Edict mcp.install, Ask
+	// by default). Registered now, Bound to the live kernel after it opens.
+	mcpToolInst := mcptool.New()
+	tools["mcp"] = mcpToolInst
 
 	// OnReload is invoked by the control plane's `provider_reload`
 	// command (and `agt provider reload`). It re-reads the vault,
@@ -1249,6 +1256,20 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// Going live still takes an operator promote (`agt toolforge promote`).
 	forgeToolInst.Bind(k)
 	fmt.Fprintf(stdout, "  tool_forge tool  : enabled (the agent can build its own tools; operator promotes)\n")
+
+	// Bind the MCP self-install tool (M796) and auto-attach every ENABLED
+	// registered server. Per-server failures are reported, never fatal — one
+	// broken server must not take the daemon down.
+	mcpToolInst.Bind(k)
+	if registered := k.MCPStore().Count(); registered > 0 {
+		attached, failures := k.AttachEnabledMCPServers(ctx)
+		fmt.Fprintf(stdout, "  mcp servers      : %d attached of %d registered\n", len(attached), registered)
+		for name, aerr := range failures {
+			fmt.Fprintf(stdout, "    %s: attach failed: %v\n", name, aerr)
+		}
+	} else {
+		fmt.Fprintf(stdout, "  mcp self-install : enabled (the agent can attach MCP servers at runtime; Edict mcp.install gates it)\n")
+	}
 
 	// Scheduled intents (autonomy) — fire operator-configured intents on a timer
 	// through the governed loop. Runs on the daemon ctx (halt/shutdown stop it).

--- a/cmd/agt/main.go
+++ b/cmd/agt/main.go
@@ -138,6 +138,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 		return cmdAgent(args[1:], stdout, stderr)
 	case "toolforge":
 		return cmdToolforge(args[1:], stdout, stderr)
+	case "mcp":
+		return cmdMCP(args[1:], stdout, stderr)
 	case "reflect":
 		return cmdReflect(args[1:], stdout, stderr)
 	case "inbox":

--- a/cmd/agt/mcp.go
+++ b/cmd/agt/mcp.go
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/agezt/agezt/internal/brand"
+	"github.com/agezt/agezt/kernel/controlplane"
+)
+
+// cmdMCP dispatches `agt mcp <subcommand>` — the operator surface of MCP
+// self-install (M796): register an MCP server, attach it at runtime (its
+// tools become callable as mcp_<name>_<tool> without a restart), detach
+// (kill switch), enable/disable auto-attach at daemon start, remove. Every
+// mutation is journaled (mcp.*).
+func cmdMCP(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		return mcpUsage(stderr)
+	}
+	switch args[0] {
+	case "list":
+		return cmdMCPList(args[1:], stdout, stderr)
+	case "add", "register":
+		return cmdMCPAdd(args[1:], stdout, stderr)
+	case "attach":
+		return cmdMCPRefAction(args[1:], stdout, stderr, "attach")
+	case "detach":
+		return cmdMCPRefAction(args[1:], stdout, stderr, "detach")
+	case "enable":
+		return cmdMCPSetEnabled(args[1:], stdout, stderr, true)
+	case "disable":
+		return cmdMCPSetEnabled(args[1:], stdout, stderr, false)
+	case "remove", "rm":
+		return cmdMCPRefAction(args[1:], stdout, stderr, "remove")
+	case "-h", "--help", "help":
+		return mcpUsage(stdout)
+	default:
+		fmt.Fprintf(stderr, "%s mcp: unknown subcommand %q\n", brand.CLI, args[0])
+		return mcpUsage(stderr)
+	}
+}
+
+func mcpUsage(w io.Writer) int {
+	fmt.Fprintf(w, "usage: %s mcp <list|add|attach|detach|enable|disable|remove>\n", brand.CLI)
+	fmt.Fprintf(w, "  list [--json]                              registrations + live attachment status\n")
+	fmt.Fprintf(w, "  add <name> --cmd EXE [--arg A ...] [--desc TEXT]\n")
+	fmt.Fprintf(w, "      register a stdio MCP server, e.g. %s mcp add everything --cmd npx --arg -y --arg @modelcontextprotocol/server-everything\n", brand.CLI)
+	fmt.Fprintf(w, "  attach <name|id>                           spawn + handshake NOW; its tools become callable as mcp_<name>_<tool>\n")
+	fmt.Fprintf(w, "  detach <name|id>                           stop it (kill switch); its tools vanish from the next run\n")
+	fmt.Fprintf(w, "  enable|disable <name|id>                   auto-attach at daemon start on/off\n")
+	fmt.Fprintf(w, "  remove <name|id>                           delete the registration (detaches first)\n")
+	return 0
+}
+
+func cmdMCPList(args []string, stdout, stderr io.Writer) int {
+	asJSON := false
+	for _, a := range args {
+		if a == "--json" {
+			asJSON = true
+		}
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := c.Call(ctx, controlplane.CmdMCPList, nil)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s mcp list: %v\n", brand.CLI, err)
+		return 1
+	}
+	if asJSON {
+		return encodeJSON(stdout, res)
+	}
+	servers, _ := res["servers"].([]any)
+	if len(servers) == 0 {
+		fmt.Fprintf(stdout, "no mcp servers yet — register one with `%s mcp add <name> --cmd npx --arg -y --arg <package>`\n", brand.CLI)
+		return 0
+	}
+	for _, raw := range servers {
+		srv, _ := raw.(map[string]any)
+		if srv == nil {
+			continue
+		}
+		state := "registered"
+		if att, _ := srv["attached"].(bool); att {
+			n, _ := srv["tool_count"].(float64)
+			state = fmt.Sprintf("ATTACHED (%d tools)", int(n))
+		}
+		auto := ""
+		if en, _ := srv["enabled"].(bool); en {
+			auto = " auto-attach"
+		}
+		argv := str(srv["command"])
+		if list, _ := srv["args"].([]any); len(list) > 0 {
+			parts := make([]string, 0, len(list))
+			for _, a := range list {
+				parts = append(parts, str(a))
+			}
+			argv += " " + strings.Join(parts, " ")
+		}
+		fmt.Fprintf(stdout, "%-16s %-20s%s  %s\n", str(srv["name"]), state, auto, argv)
+	}
+	fmt.Fprintf(stdout, "%v server(s), %v attached\n", res["count"], res["attached_count"])
+	return 0
+}
+
+func cmdMCPAdd(args []string, stdout, stderr io.Writer) int {
+	name, command, desc := "", "", ""
+	var srvArgs []string
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		need := func() bool {
+			if i+1 >= len(args) {
+				fmt.Fprintf(stderr, "%s mcp add: %s needs a value\n", brand.CLI, a)
+				return false
+			}
+			return true
+		}
+		switch a {
+		case "--cmd", "--command":
+			if !need() {
+				return 2
+			}
+			i++
+			command = args[i]
+		case "--arg":
+			if !need() {
+				return 2
+			}
+			i++
+			srvArgs = append(srvArgs, args[i])
+		case "--desc", "--description":
+			if !need() {
+				return 2
+			}
+			i++
+			desc = args[i]
+		default:
+			if !strings.HasPrefix(a, "--") && name == "" {
+				name = a
+			}
+		}
+	}
+	if name == "" || command == "" {
+		fmt.Fprintf(stderr, "usage: %s mcp add <name> --cmd EXE [--arg A ...] [--desc TEXT]\n", brand.CLI)
+		return 2
+	}
+	server := map[string]any{"name": name, "command": command, "description": desc}
+	if len(srvArgs) > 0 {
+		list := make([]any, len(srvArgs))
+		for i, a := range srvArgs {
+			list[i] = a
+		}
+		server["args"] = list
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := c.Call(ctx, controlplane.CmdMCPAdd, map[string]any{"server": server}); err != nil {
+		fmt.Fprintf(stderr, "%s mcp add: %v\n", brand.CLI, err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "registered %s — attach it now with `%s mcp attach %s` (auto-attaches on daemon start)\n", name, brand.CLI, name)
+	return 0
+}
+
+// cmdMCPRefAction handles the three single-ref subcommands: attach (long
+// timeout — npx may download the server on first run), detach, remove.
+func cmdMCPRefAction(args []string, stdout, stderr io.Writer, action string) int {
+	if len(args) != 1 {
+		fmt.Fprintf(stderr, "usage: %s mcp %s <name|id>\n", brand.CLI, action)
+		return 2
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	timeout := 5 * time.Second
+	cmd := controlplane.CmdMCPDetach
+	switch action {
+	case "attach":
+		cmd, timeout = controlplane.CmdMCPAttach, 2*time.Minute
+	case "remove":
+		cmd = controlplane.CmdMCPRemove
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	res, err := c.Call(ctx, cmd, map[string]any{"ref": args[0]})
+	if err != nil {
+		fmt.Fprintf(stderr, "%s mcp %s: %v\n", brand.CLI, action, err)
+		return 1
+	}
+	switch action {
+	case "attach":
+		tools, _ := res["tools"].([]any)
+		fmt.Fprintf(stdout, "attached %s — %d tool(s) now callable:\n", args[0], len(tools))
+		for _, t := range tools {
+			fmt.Fprintf(stdout, "  %s\n", str(t))
+		}
+	case "detach":
+		fmt.Fprintf(stdout, "detached %s — its tools are gone from the next run\n", args[0])
+	case "remove":
+		if ok, _ := res["removed"].(bool); !ok {
+			fmt.Fprintf(stderr, "%s mcp remove: unknown server %q\n", brand.CLI, args[0])
+			return 1
+		}
+		fmt.Fprintf(stdout, "removed %s\n", args[0])
+	}
+	return 0
+}
+
+func cmdMCPSetEnabled(args []string, stdout, stderr io.Writer, enabled bool) int {
+	verb := "enable"
+	if !enabled {
+		verb = "disable"
+	}
+	if len(args) != 1 {
+		fmt.Fprintf(stderr, "usage: %s mcp %s <name|id>\n", brand.CLI, verb)
+		return 2
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := c.Call(ctx, controlplane.CmdMCPSetEnabled, map[string]any{"ref": args[0], "enabled": enabled}); err != nil {
+		fmt.Fprintf(stderr, "%s mcp %s: %v\n", brand.CLI, verb, err)
+		return 1
+	}
+	state := "will auto-attach on daemon start"
+	if !enabled {
+		state = "will NOT auto-attach on daemon start"
+	}
+	fmt.Fprintf(stdout, "%s %s\n", args[0], state)
+	return 0
+}

--- a/kernel/controlplane/mcp.go
+++ b/kernel/controlplane/mcp.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: MIT
+
+package controlplane
+
+// MCP self-install handlers (M796) — the management path behind `agt mcp`
+// and the console. Lifecycle changes go through the kernel so every
+// add/attach/detach/enable/remove is journaled (mcp.*) and auditable via
+// `agt why`. Servers are addressed by ref = id OR name everywhere.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"strings"
+
+	"github.com/agezt/agezt/kernel/mcp"
+)
+
+// mcpServerView is the stable wire shape for one registration, joined with
+// its live attachment status.
+func (s *Server) mcpServerView(srv mcp.Server) map[string]any {
+	b, _ := json.Marshal(srv)
+	var m map[string]any
+	_ = json.Unmarshal(b, &m)
+	attached := s.k.MCPAttached()
+	if n, live := attached[srv.Name]; live {
+		m["attached"] = true
+		m["tool_count"] = n
+	} else {
+		m["attached"] = false
+	}
+	return m
+}
+
+func (s *Server) handleMCPList(conn net.Conn, req Request) {
+	servers := s.k.MCPStore().List()
+	attached := s.k.MCPAttached()
+	out := make([]any, 0, len(servers))
+	for _, srv := range servers {
+		out = append(out, s.mcpServerView(srv))
+	}
+	s.writeResp(conn, Response{
+		ID:     req.ID,
+		Type:   RespResult,
+		Result: map[string]any{"servers": out, "count": len(out), "attached_count": len(attached)},
+	})
+}
+
+func (s *Server) handleMCPAdd(conn net.Conn, req Request) {
+	raw, ok := req.Args["server"]
+	if !ok {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.server required"})
+		return
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.server: " + err.Error()})
+		return
+	}
+	var srv mcp.Server
+	if err := json.Unmarshal(b, &srv); err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.server: " + err.Error()})
+		return
+	}
+	saved, err := s.k.AddMCPServer("", srv)
+	if err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
+		return
+	}
+	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{"server": s.mcpServerView(saved)}})
+}
+
+func (s *Server) handleMCPAttach(conn net.Conn, req Request) {
+	ref, _ := req.Args["ref"].(string)
+	if strings.TrimSpace(ref) == "" {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.ref required"})
+		return
+	}
+	srv, tools, err := s.k.AttachMCPServer(context.Background(), "", ref)
+	if err != nil {
+		if errors.Is(err, mcp.ErrNotFound) {
+			s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "unknown mcp server: " + ref})
+			return
+		}
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
+		return
+	}
+	s.writeResp(conn, Response{
+		ID:     req.ID,
+		Type:   RespResult,
+		Result: map[string]any{"server": s.mcpServerView(srv), "tools": tools},
+	})
+}
+
+func (s *Server) handleMCPDetach(conn net.Conn, req Request) {
+	ref, _ := req.Args["ref"].(string)
+	if strings.TrimSpace(ref) == "" {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.ref required"})
+		return
+	}
+	if err := s.k.DetachMCPServer("", ref); err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
+		return
+	}
+	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{"detached": true}})
+}
+
+func (s *Server) handleMCPSetEnabled(conn net.Conn, req Request) {
+	ref, _ := req.Args["ref"].(string)
+	if strings.TrimSpace(ref) == "" {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.ref required"})
+		return
+	}
+	enabled := false
+	switch v := req.Args["enabled"].(type) {
+	case bool:
+		enabled = v
+	case string:
+		enabled = strings.EqualFold(v, "true") || v == "1"
+	}
+	srv, err := s.k.SetMCPServerEnabled("", ref, enabled)
+	if err != nil {
+		if errors.Is(err, mcp.ErrNotFound) {
+			s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "unknown mcp server: " + ref})
+			return
+		}
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
+		return
+	}
+	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{"server": s.mcpServerView(srv)}})
+}
+
+func (s *Server) handleMCPRemove(conn net.Conn, req Request) {
+	ref, _ := req.Args["ref"].(string)
+	if strings.TrimSpace(ref) == "" {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.ref required"})
+		return
+	}
+	ok, err := s.k.RemoveMCPServer("", ref)
+	if err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
+		return
+	}
+	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{"removed": ok}})
+}

--- a/kernel/controlplane/mcp_test.go
+++ b/kernel/controlplane/mcp_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+
+package controlplane_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/agezt/agezt/kernel/controlplane"
+	"github.com/agezt/agezt/kernel/mcp"
+	"github.com/agezt/agezt/kernel/runtime"
+	"github.com/agezt/agezt/plugins/providers/mock"
+)
+
+// wireMCPConn is a canned attachment for the wire round-trip.
+type wireMCPConn struct{ closed bool }
+
+func (c *wireMCPConn) Tools() []mcp.ToolDef {
+	return []mcp.ToolDef{{Name: "greet", Description: "greets"}}
+}
+func (c *wireMCPConn) Call(context.Context, string, json.RawMessage) (string, bool, error) {
+	return "hello", false, nil
+}
+func (c *wireMCPConn) Close() error { c.closed = true; return nil }
+
+// TestMCP_WireRoundTrip drives the full operator pipeline over the wire:
+// add → attach (discovered tool names returned, list shows live status) →
+// disable auto-attach → detach → remove. Exactly what `agt mcp` and the
+// console speak.
+func TestMCP_WireRoundTrip(t *testing.T) {
+	conn := &wireMCPConn{}
+	_, _, c, _ := startPairWithConfig(t, runtime.Config{
+		Provider: mock.New(mock.FinalText("unused")),
+		MCPDialer: func(context.Context, string, []string) (mcp.Conn, error) {
+			return conn, nil
+		},
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Add.
+	res, err := c.Call(ctx, controlplane.CmdMCPAdd, map[string]any{
+		"server": map[string]any{"name": "fake", "command": "python", "args": []any{"server.py"}},
+	})
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	srv, _ := res["server"].(map[string]any)
+	if srv["attached"] != false || srv["enabled"] != true {
+		t.Fatalf("added = %v", srv)
+	}
+
+	// Attach → tool names come back, list shows it live.
+	res, err = c.Call(ctx, controlplane.CmdMCPAttach, map[string]any{"ref": "fake"})
+	if err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	tools, _ := res["tools"].([]any)
+	if len(tools) != 1 || tools[0] != "mcp_fake_greet" {
+		t.Fatalf("attach tools = %v", tools)
+	}
+	res, err = c.Call(ctx, controlplane.CmdMCPList, nil)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if ac, _ := res["attached_count"].(float64); ac != 1 {
+		t.Fatalf("attached_count = %v", res["attached_count"])
+	}
+
+	// Disable auto-attach (registration survives, attachment untouched).
+	res, err = c.Call(ctx, controlplane.CmdMCPSetEnabled, map[string]any{"ref": "fake", "enabled": false})
+	if err != nil {
+		t.Fatalf("set_enabled: %v", err)
+	}
+	srv, _ = res["server"].(map[string]any)
+	if srv["enabled"] != false || srv["attached"] != true {
+		t.Fatalf("disabled = %v", srv)
+	}
+
+	// Detach (kill switch).
+	if _, err = c.Call(ctx, controlplane.CmdMCPDetach, map[string]any{"ref": "fake"}); err != nil {
+		t.Fatalf("detach: %v", err)
+	}
+	if !conn.closed {
+		t.Fatal("detach did not close the connection")
+	}
+
+	// Remove.
+	res, err = c.Call(ctx, controlplane.CmdMCPRemove, map[string]any{"ref": "fake"})
+	if err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if removed, _ := res["removed"].(bool); !removed {
+		t.Fatal("remove reported false")
+	}
+
+	// Ghost refs are honest errors.
+	if _, err := c.Call(ctx, controlplane.CmdMCPAttach, map[string]any{"ref": "ghost"}); err == nil {
+		t.Fatal("ghost attach accepted")
+	}
+}

--- a/kernel/controlplane/protocol.go
+++ b/kernel/controlplane/protocol.go
@@ -891,6 +891,19 @@ const (
 	CmdToolforgeQuarantine = "toolforge_quarantine"
 	CmdToolforgeRemove     = "toolforge_remove"
 
+	// MCP self-install (M796) — runtime-attached MCP servers behind
+	// `agt mcp`. Add: args.server (object {name,command,args,description}).
+	// Attach/Detach/Remove: args.ref (name or id). SetEnabled:
+	// args{ref,enabled} (auto-attach at daemon start). List: no args —
+	// returns registrations joined with live attachment status.
+	// Every mutation is journaled (mcp.*).
+	CmdMCPList       = "mcp_list"
+	CmdMCPAdd        = "mcp_add"
+	CmdMCPAttach     = "mcp_attach"
+	CmdMCPDetach     = "mcp_detach"
+	CmdMCPSetEnabled = "mcp_set_enabled"
+	CmdMCPRemove     = "mcp_remove"
+
 	// Sandbox projects (M686) — read-only inspection of what agents BUILT with the
 	// code_exec tool under <baseDir>/sandbox/projects. List: no args, returns each
 	// persistent project with its files (name, bytes, modified). File: args{project,

--- a/kernel/controlplane/server.go
+++ b/kernel/controlplane/server.go
@@ -710,6 +710,18 @@ func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
 		s.handleToolforgeQuarantine(conn, req)
 	case CmdToolforgeRemove:
 		s.handleToolforgeRemove(conn, req)
+	case CmdMCPList:
+		s.handleMCPList(conn, req)
+	case CmdMCPAdd:
+		s.handleMCPAdd(conn, req)
+	case CmdMCPAttach:
+		s.handleMCPAttach(conn, req)
+	case CmdMCPDetach:
+		s.handleMCPDetach(conn, req)
+	case CmdMCPSetEnabled:
+		s.handleMCPSetEnabled(conn, req)
+	case CmdMCPRemove:
+		s.handleMCPRemove(conn, req)
 	case CmdSandboxList:
 		s.handleSandboxList(conn, req)
 	case CmdSandboxFile:

--- a/kernel/edict/edict.go
+++ b/kernel/edict/edict.go
@@ -152,6 +152,20 @@ const (
 	// op=test EXECUTES the draft in the sandbox and maps to CapCodeExec.
 	CapToolForge Capability = "tool.forge"
 
+	// CapMCPInstall gates the SELF-INSTALL ops of the `mcp` tool (M796): the
+	// agent registering, ATTACHING (spawning an arbitrary external process),
+	// detaching, or removing an MCP server at runtime. The strongest
+	// self-extension grant in the system — an attached server's tools are
+	// whatever IT advertises — so Ask on every call by default. The child
+	// gets a scrubbed env (no AGEZT_*/secrets) and every transition is
+	// journaled (mcp.*); detach is the instant kill switch.
+	CapMCPInstall Capability = "mcp.install"
+	// CapMCP gates every CALL of a bridged mcp_<server>_<tool> tool: code
+	// the daemon didn't ship, talking to a process the operator (or an
+	// approved agent) attached. Ask-first by default — vet the first use
+	// per session, then flow.
+	CapMCP Capability = "mcp.call"
+
 	// CapConfigRead / CapConfigWrite gate the `config` tool (M696): the agent
 	// reading vs mutating Config Center settings. Reads (schema/get) are low-risk
 	// and Allow by default. Writes (set/register/unregister) are Ask by default —
@@ -588,6 +602,8 @@ func DefaultLevels() map[Capability]TrustLevel {
 		CapIntrospect:  LevelAllow,    // local read of the daemon's own live state; no mutation, no network — low risk
 		CapCodeExec:    LevelAllow,    // write+run code; sandboxed (scrubbed env, confined dir, capped) and journaled — owner's choice for full autonomy
 		CapToolForge:   LevelAskFirst, // self-modification: the agent authoring its own script tools (going live still needs an operator promote)
+		CapMCPInstall:  LevelAsk,      // self-install: registering/attaching an MCP server spawns an arbitrary process — approve every one
+		CapMCP:         LevelAskFirst, // calling a bridged MCP tool: external, unvetted surface — vet first use per session
 		CapConfigRead:  LevelAllow,    // read Config Center schema/values; no mutation, secrets presence-only
 		CapConfigWrite: LevelAskFirst, // mutate settings / register schema; can reach built-in security fields — confirm first
 	}
@@ -629,7 +645,7 @@ func AllCapabilities() []Capability {
 		CapACPAgent, CapRemoteRun, CapNotify,
 		CapHomeAssistantRead, CapHomeAssistantCall,
 		CapBrowserRead, CapMemory, CapWorld, CapWebSearch, CapSchedule, CapRunsRead, CapStanding, CapBoard, CapSkill,
-		CapIntrospect, CapCodeExec, CapToolForge, CapConfigRead, CapConfigWrite,
+		CapIntrospect, CapCodeExec, CapToolForge, CapMCPInstall, CapMCP, CapConfigRead, CapConfigWrite,
 	}
 	slices.Sort(caps)
 	return caps

--- a/kernel/edict/toolmap.go
+++ b/kernel/edict/toolmap.go
@@ -25,6 +25,11 @@ func CapabilityForToolCall(toolName string, input json.RawMessage) Capability {
 	if strings.HasPrefix(toolName, "forge_") {
 		return CapCodeExec
 	}
+	// Runtime-attached MCP servers (M796): every bridged mcp_<server>_<tool>
+	// call is external code the daemon didn't ship → the mcp.call capability.
+	if strings.HasPrefix(toolName, "mcp_") {
+		return CapMCP
+	}
 	switch toolName {
 	case "shell":
 		return CapShell
@@ -69,6 +74,20 @@ func CapabilityForToolCall(toolName string, input json.RawMessage) Capability {
 			return CapCodeExec
 		}
 		return CapToolForge
+	case "mcp":
+		var p struct {
+			Op string `json:"op"`
+		}
+		_ = json.Unmarshal(input, &p)
+		if strings.EqualFold(strings.TrimSpace(p.Op), "list") {
+			// Listing registrations + live attachments reads the daemon's own
+			// state — the introspection axis, not an install.
+			return CapIntrospect
+		}
+		// add/attach/detach/remove (and anything unrecognised) is the
+		// self-install axis — the high-risk default, so a garbled call lands
+		// on the gated capability rather than silently flowing.
+		return CapMCPInstall
 	case "introspect":
 		return CapIntrospect
 	case "code_exec":

--- a/kernel/edict/toolmap_test.go
+++ b/kernel/edict/toolmap_test.go
@@ -42,6 +42,16 @@ func TestCapabilityForToolCall(t *testing.T) {
 		{"tool_forge", `{"op":"list"}`, CapToolForge},
 		{"tool_forge", `{"op":"  TEST  ","ref":"x"}`, CapCodeExec},
 		{"tool_forge", `{}`, CapToolForge},
+		// MCP self-install (M796): every bridged mcp_<server>_<tool> call is
+		// external code → mcp.call; the mcp tool's install ops are gated,
+		// list reads the daemon's own state.
+		{"mcp_fake_greet", `{"name":"x"}`, CapMCP},
+		{"mcp_everything_read-file", `{}`, CapMCP},
+		{"mcp", `{"op":"add","name":"x"}`, CapMCPInstall},
+		{"mcp", `{"op":"attach","ref":"x"}`, CapMCPInstall},
+		{"mcp", `{"op":"remove","ref":"x"}`, CapMCPInstall},
+		{"mcp", `{"op":"list"}`, CapIntrospect},
+		{"mcp", `{}`, CapMCPInstall}, // garbled call lands on the gated axis
 	}
 	for _, c := range cases {
 		got := CapabilityForToolCall(c.tool, json.RawMessage(c.input))

--- a/kernel/event/kinds.go
+++ b/kernel/event/kinds.go
@@ -288,6 +288,16 @@ const (
 	KindScriptToolPromoted    Kind = "scripttool.promoted"
 	KindScriptToolQuarantined Kind = "scripttool.quarantined"
 	KindScriptToolRemoved     Kind = "scripttool.removed"
+
+	// MCP self-install (M796) — runtime-attached Model Context Protocol
+	// servers. Registering/attaching is the governed self-install path
+	// (`mcp.install` Edict capability); every lifecycle transition is
+	// journaled so `agt why` explains how a server's tools became callable.
+	KindMCPAdded    Kind = "mcp.added"
+	KindMCPUpdated  Kind = "mcp.updated" // enabled/disabled (auto-attach flag)
+	KindMCPAttached Kind = "mcp.attached"
+	KindMCPDetached Kind = "mcp.detached"
+	KindMCPRemoved  Kind = "mcp.removed"
 )
 
 // IsKnown reports whether k is one of the kinds defined in this file. Useful
@@ -402,4 +412,9 @@ var knownKinds = map[Kind]struct{}{
 	KindScriptToolPromoted:        {},
 	KindScriptToolQuarantined:     {},
 	KindScriptToolRemoved:         {},
+	KindMCPAdded:                  {},
+	KindMCPUpdated:                {},
+	KindMCPAttached:               {},
+	KindMCPDetached:               {},
+	KindMCPRemoved:                {},
 }

--- a/kernel/mcp/client.go
+++ b/kernel/mcp/client.go
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: MIT
+
+package mcp
+
+// A minimal MCP (Model Context Protocol) client over stdio: spawn the server
+// process, JSON-RPC `initialize` + `notifications/initialized`, discover its
+// tools (`tools/list`), forward calls (`tools/call`). Line-delimited JSON-RPC
+// frames, size-capped; calls are serialized (one outstanding request), with
+// stray notifications and unrelated ids skipped. Deliberately small — the
+// 90% of MCP that turns a server into callable tools; resources/prompts/SSE
+// can layer on later.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	// maxFrameBytes caps one JSON-RPC line from the server (matches the
+	// external bridge's M185 bound) so a hostile server can't OOM the daemon.
+	maxFrameBytes = 16 << 20
+	// handshakeTimeout bounds initialize + tools/list at attach time.
+	handshakeTimeout = 15 * time.Second
+	// callTimeout bounds one forwarded tools/call when the run's own context
+	// carries no earlier deadline.
+	callTimeout = 90 * time.Second
+
+	protocolVersion = "2024-11-05"
+	clientName      = "agezt"
+)
+
+// ToolDef is one tool an attached server advertises.
+type ToolDef struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	InputSchema json.RawMessage `json:"inputSchema,omitempty"`
+}
+
+// Conn is a live attachment to one MCP server. Implemented by the stdio
+// client here; an interface so the runtime (and tests) never depend on a
+// real child process.
+type Conn interface {
+	// Tools returns the tool list discovered at attach time.
+	Tools() []ToolDef
+	// Call forwards one tools/call and returns the flattened text content
+	// plus the server's own isError verdict.
+	Call(ctx context.Context, tool string, args json.RawMessage) (string, bool, error)
+	// Close detaches: asks the child to exit, then kills it. Idempotent.
+	Close() error
+}
+
+// Dialer spawns + handshakes one server. The runtime takes it as a seam so
+// tests can attach fakes; Dial is the production implementation.
+type Dialer func(ctx context.Context, command string, args []string) (Conn, error)
+
+// jsonrpc wire shapes (only what this client speaks).
+type rpcRequest struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      *int64 `json:"id,omitempty"` // nil = notification
+	Method  string `json:"method"`
+	Params  any    `json:"params,omitempty"`
+}
+
+type rpcResponse struct {
+	ID     *int64          `json:"id"`
+	Result json.RawMessage `json:"result"`
+	Error  *struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// clientConn is the production Conn: one child process, one reader goroutine
+// feeding frames into a channel, calls serialized under mu.
+type clientConn struct {
+	stdin  io.WriteCloser
+	frames chan []byte
+	dead   chan struct{} // closed by the reader on EOF/overflow
+	stop   func()        // kills the child (idempotent via closeOnce)
+
+	mu     sync.Mutex // serializes calls — one outstanding request id
+	nextID atomic.Int64
+
+	tools     []ToolDef
+	closeOnce sync.Once
+}
+
+// Dial spawns command args... and completes the MCP handshake + tool
+// discovery. The child gets a SCRUBBED environment — PATH and friends, never
+// AGEZT_* or secret-shaped variables — so a registered server can't read the
+// daemon's keys out of its env.
+func Dial(ctx context.Context, command string, args []string) (Conn, error) {
+	cmd := exec.Command(command, args...)
+	cmd.Env = scrubbedEnv()
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("mcp: stdin: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("mcp: stdout: %w", err)
+	}
+	cmd.Stderr = io.Discard // server logs are its own business; protocol rides stdout
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("mcp: start %s: %w", command, err)
+	}
+	c := newClientConn(stdin, stdout, func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait() // reap; ignore exit status — we killed it
+	})
+	hctx, cancel := context.WithTimeout(ctx, handshakeTimeout)
+	defer cancel()
+	if err := c.handshake(hctx); err != nil {
+		_ = c.Close()
+		return nil, err
+	}
+	return c, nil
+}
+
+// newClientConn wires a conn over arbitrary pipes — the testable core.
+func newClientConn(stdin io.WriteCloser, stdout io.Reader, stop func()) *clientConn {
+	c := &clientConn{
+		stdin:  stdin,
+		frames: make(chan []byte, 16),
+		dead:   make(chan struct{}),
+		stop:   stop,
+	}
+	go c.readLoop(stdout)
+	return c
+}
+
+// readLoop pushes each stdout line into frames until EOF or an oversized
+// frame, then signals death.
+func (c *clientConn) readLoop(r io.Reader) {
+	defer close(c.dead)
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 64*1024), maxFrameBytes)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		b := make([]byte, len(line))
+		copy(b, line)
+		select {
+		case c.frames <- b:
+		case <-time.After(5 * time.Second):
+			return // consumer gone — stop reading rather than block forever
+		}
+	}
+	// EOF, an oversized frame, or a read error all end the loop the same way:
+	// the deferred close(dead) tells callers the connection is gone. The
+	// specific scanner error adds nothing actionable here.
+	_ = sc.Err()
+}
+
+// handshake: initialize → initialized notification → tools/list.
+func (c *clientConn) handshake(ctx context.Context) error {
+	var initRes json.RawMessage
+	err := c.roundTrip(ctx, "initialize", map[string]any{
+		"protocolVersion": protocolVersion,
+		"capabilities":    map[string]any{},
+		"clientInfo":      map[string]any{"name": clientName, "version": "1"},
+	}, &initRes)
+	if err != nil {
+		return fmt.Errorf("mcp: initialize: %w", err)
+	}
+	if err := c.send(rpcRequest{JSONRPC: "2.0", Method: "notifications/initialized"}); err != nil {
+		return fmt.Errorf("mcp: initialized notification: %w", err)
+	}
+	var listRes struct {
+		Tools []ToolDef `json:"tools"`
+	}
+	if err := c.roundTrip(ctx, "tools/list", map[string]any{}, &listRes); err != nil {
+		return fmt.Errorf("mcp: tools/list: %w", err)
+	}
+	c.tools = listRes.Tools
+	return nil
+}
+
+// Tools implements Conn.
+func (c *clientConn) Tools() []ToolDef {
+	out := make([]ToolDef, len(c.tools))
+	copy(out, c.tools)
+	return out
+}
+
+// Call implements Conn: one tools/call, content flattened to text.
+func (c *clientConn) Call(ctx context.Context, tool string, args json.RawMessage) (string, bool, error) {
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, callTimeout)
+		defer cancel()
+	}
+	if len(args) == 0 {
+		args = json.RawMessage(`{}`) // MCP requires an arguments object
+	}
+	var res struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+		IsError bool `json:"isError"`
+	}
+	err := c.roundTrip(ctx, "tools/call", map[string]any{"name": tool, "arguments": json.RawMessage(args)}, &res)
+	if err != nil {
+		return "", false, err
+	}
+	var parts []string
+	for _, blk := range res.Content {
+		if blk.Text != "" {
+			parts = append(parts, blk.Text)
+		}
+	}
+	return strings.Join(parts, "\n"), res.IsError, nil
+}
+
+// Close implements Conn.
+func (c *clientConn) Close() error {
+	c.closeOnce.Do(func() {
+		_ = c.stdin.Close() // polite: EOF lets a well-behaved server exit
+		select {
+		case <-c.dead:
+		case <-time.After(2 * time.Second):
+		}
+		if c.stop != nil {
+			c.stop()
+		}
+	})
+	return nil
+}
+
+// roundTrip sends one request and waits for ITS response, skipping
+// notifications and unrelated ids. Calls are serialized, so at most one id
+// is ever outstanding.
+func (c *clientConn) roundTrip(ctx context.Context, method string, params any, out any) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	id := c.nextID.Add(1)
+	if err := c.send(rpcRequest{JSONRPC: "2.0", ID: &id, Method: method, Params: params}); err != nil {
+		return err
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-c.dead:
+			return errors.New("mcp: server connection lost")
+		case frame := <-c.frames:
+			var resp rpcResponse
+			if err := json.Unmarshal(frame, &resp); err != nil || resp.ID == nil || *resp.ID != id {
+				continue // notification / unrelated id / junk — skip
+			}
+			if resp.Error != nil {
+				return fmt.Errorf("mcp: %s: server error %d: %s", method, resp.Error.Code, resp.Error.Message)
+			}
+			if out != nil {
+				if err := json.Unmarshal(resp.Result, out); err != nil {
+					return fmt.Errorf("mcp: %s: parse result: %w", method, err)
+				}
+			}
+			return nil
+		}
+	}
+}
+
+func (c *clientConn) send(req rpcRequest) error {
+	b, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+	_, err = c.stdin.Write(append(b, '\n'))
+	return err
+}
+
+// scrubbedEnv builds the child environment: harmless OS variables only
+// (PATH, Windows system vars, per-user dirs npm-style launchers need,
+// locale) — never AGEZT_* or secret-shaped variables. Mirrors the code-exec
+// sandbox's scrub; this is the load-bearing safety property of attach.
+func scrubbedEnv() []string {
+	allow := map[string]bool{
+		"PATH": true, "PATHEXT": true, "COMSPEC": true,
+		"SYSTEMROOT": true, "SYSTEMDRIVE": true, "WINDIR": true,
+		"NUMBER_OF_PROCESSORS": true, "PROCESSOR_ARCHITECTURE": true,
+		"LANG": true, "HOME": true, "USERPROFILE": true,
+		"APPDATA": true, "LOCALAPPDATA": true, "PROGRAMDATA": true,
+		"TEMP": true, "TMP": true, "TMPDIR": true,
+		"PROGRAMFILES": true, "PROGRAMFILES(X86)": true, "PROGRAMW6432": true,
+	}
+	var out []string
+	for _, kv := range os.Environ() {
+		name, _, ok := strings.Cut(kv, "=")
+		if !ok {
+			continue
+		}
+		up := strings.ToUpper(name)
+		if isSecretName(up) {
+			continue
+		}
+		if allow[up] || strings.HasPrefix(up, "LC_") {
+			out = append(out, kv)
+		}
+	}
+	return out
+}
+
+// isSecretName mirrors the code-exec sandbox's rule: anything secret-shaped
+// — and the whole AGEZT_* namespace — never reaches a spawned server.
+func isSecretName(up string) bool {
+	for _, frag := range []string{"KEY", "TOKEN", "SECRET", "PASSWORD", "PASSWD", "CRED", "AWS_", "AGEZT_"} {
+		if strings.Contains(up, frag) {
+			return true
+		}
+	}
+	return false
+}

--- a/kernel/mcp/client_test.go
+++ b/kernel/mcp/client_test.go
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: MIT
+
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeServer speaks just enough MCP over a pipe pair to drive the client:
+// initialize → tools/list (one "echo" tool) → tools/call echoes arguments.
+// It also emits a stray notification before every response, proving the
+// client skips frames that aren't its answer.
+func fakeServer(t *testing.T, r io.Reader, w io.Writer) {
+	t.Helper()
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 64*1024), maxFrameBytes)
+	send := func(v any) {
+		b, _ := json.Marshal(v)
+		_, _ = w.Write(append(b, '\n'))
+	}
+	defer func() { _ = sc.Err() }() // EOF ends the fake server; nothing actionable
+	for sc.Scan() {
+		var req struct {
+			ID     *int64          `json:"id"`
+			Method string          `json:"method"`
+			Params json.RawMessage `json:"params"`
+		}
+		if err := json.Unmarshal(sc.Bytes(), &req); err != nil || req.ID == nil {
+			continue // notification (e.g. notifications/initialized) — no reply
+		}
+		send(map[string]any{"jsonrpc": "2.0", "method": "notifications/message", "params": map[string]any{"level": "info"}})
+		switch req.Method {
+		case "initialize":
+			send(map[string]any{"jsonrpc": "2.0", "id": req.ID, "result": map[string]any{
+				"protocolVersion": protocolVersion, "capabilities": map[string]any{}, "serverInfo": map[string]any{"name": "fake"},
+			}})
+		case "tools/list":
+			send(map[string]any{"jsonrpc": "2.0", "id": req.ID, "result": map[string]any{
+				"tools": []map[string]any{{
+					"name": "echo", "description": "echoes text",
+					"inputSchema": map[string]any{"type": "object"},
+				}},
+			}})
+		case "tools/call":
+			var p struct {
+				Name      string          `json:"name"`
+				Arguments json.RawMessage `json:"arguments"`
+			}
+			_ = json.Unmarshal(req.Params, &p)
+			if p.Name == "boom" {
+				send(map[string]any{"jsonrpc": "2.0", "id": req.ID, "error": map[string]any{"code": -1, "message": "kaput"}})
+				continue
+			}
+			send(map[string]any{"jsonrpc": "2.0", "id": req.ID, "result": map[string]any{
+				"content": []map[string]any{{"type": "text", "text": "echo: " + string(p.Arguments)}},
+				"isError": false,
+			}})
+		default:
+			send(map[string]any{"jsonrpc": "2.0", "id": req.ID, "error": map[string]any{"code": -32601, "message": "no such method"}})
+		}
+	}
+}
+
+func pipeConn(t *testing.T) Conn {
+	t.Helper()
+	clientOut, serverIn := io.Pipe() // client writes → server reads
+	serverOut, clientIn := io.Pipe() // server writes → client reads
+	go func() {
+		fakeServer(t, clientOut, clientIn)
+		_ = clientIn.Close() // EOF on our stdin → hang up our stdout, like a real child exiting
+	}()
+	c := newClientConn(serverIn, serverOut, func() { _ = clientIn.Close() })
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := c.handshake(ctx); err != nil {
+		t.Fatalf("handshake: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+	return c
+}
+
+// TestHandshakeAndCall_SkipsNotifications: the full client dialogue over
+// in-memory pipes — initialize, tool discovery, a call whose answer arrives
+// AFTER an unrelated notification, and a server-side error.
+func TestHandshakeAndCall_SkipsNotifications(t *testing.T) {
+	c := pipeConn(t)
+	tools := c.Tools()
+	if len(tools) != 1 || tools[0].Name != "echo" {
+		t.Fatalf("tools = %+v, want [echo]", tools)
+	}
+	out, isErr, err := c.Call(context.Background(), "echo", json.RawMessage(`{"text":"merhaba"}`))
+	if err != nil || isErr {
+		t.Fatalf("Call: %v / isErr=%v", err, isErr)
+	}
+	if !strings.Contains(out, `"merhaba"`) {
+		t.Fatalf("arguments did not round-trip: %q", out)
+	}
+	if _, _, err := c.Call(context.Background(), "boom", nil); err == nil {
+		t.Fatal("server error not surfaced")
+	}
+}
+
+// TestCall_ConnectionLost: when the server side dies mid-call, the client
+// reports a lost connection instead of hanging.
+func TestCall_ConnectionLost(t *testing.T) {
+	clientOut, serverIn := io.Pipe()
+	serverOut, clientIn := io.Pipe()
+	c := newClientConn(serverIn, serverOut, nil)
+	t.Cleanup(func() { _ = c.Close() })
+	go func() {
+		// Swallow the request, then hang up without answering.
+		buf := make([]byte, 4096)
+		_, _ = clientOut.Read(buf)
+		_ = clientIn.Close()
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := c.roundTrip(ctx, "tools/list", map[string]any{}, nil); err == nil {
+		t.Fatal("lost connection not reported")
+	}
+}
+
+// TestScrubbedEnv: the load-bearing safety property — secrets and the whole
+// AGEZT_* namespace never reach a spawned server; PATH does.
+func TestScrubbedEnv(t *testing.T) {
+	t.Setenv("AGEZT_SECRET_PROBE", "leakme")
+	t.Setenv("MY_API_KEY", "leakme")
+	t.Setenv("PATH", os.Getenv("PATH")) // ensure present
+	for _, kv := range scrubbedEnv() {
+		up := strings.ToUpper(kv)
+		if strings.HasPrefix(up, "AGEZT_") || strings.HasPrefix(up, "MY_API_KEY") {
+			t.Fatalf("secret leaked into child env: %s", kv)
+		}
+	}
+	joined := strings.Join(scrubbedEnv(), "\n")
+	if !strings.Contains(strings.ToUpper(joined), "PATH=") {
+		t.Fatal("PATH missing from child env")
+	}
+}
+
+// pythonPath finds a Python interpreter for the live subprocess test.
+func pythonPath() string {
+	for _, name := range []string{"python", "python3"} {
+		if p, err := exec.LookPath(name); err == nil {
+			return p
+		}
+	}
+	return ""
+}
+
+// fakeServerPy is a complete stdio MCP server in ~25 lines of Python — the
+// live-subprocess counterpart of fakeServer, also used by the smoke.
+const fakeServerPy = `import sys, json
+def send(o):
+    sys.stdout.write(json.dumps(o) + "\n"); sys.stdout.flush()
+for line in sys.stdin:
+    line = line.strip()
+    if not line: continue
+    m = json.loads(line)
+    mid, meth = m.get("id"), m.get("method")
+    if mid is None: continue
+    if meth == "initialize":
+        send({"jsonrpc":"2.0","id":mid,"result":{"protocolVersion":"2024-11-05","capabilities":{},"serverInfo":{"name":"fake","version":"1"}}})
+    elif meth == "tools/list":
+        send({"jsonrpc":"2.0","id":mid,"result":{"tools":[{"name":"greet","description":"greets a name","inputSchema":{"type":"object","properties":{"name":{"type":"string"}}}}]}})
+    elif meth == "tools/call":
+        args = m["params"].get("arguments") or {}
+        send({"jsonrpc":"2.0","id":mid,"result":{"content":[{"type":"text","text":"hello " + str(args.get("name","?"))}],"isError":False}})
+    else:
+        send({"jsonrpc":"2.0","id":mid,"error":{"code":-32601,"message":"nope"}})
+`
+
+// TestDial_LivePythonServer drives the REAL path — spawn, handshake, tool
+// discovery, a call, close — against a python child process. Skipped when no
+// Python is installed.
+func TestDial_LivePythonServer(t *testing.T) {
+	py := pythonPath()
+	if py == "" {
+		t.Skip("python not installed")
+	}
+	script := filepath.Join(t.TempDir(), "server.py")
+	if err := os.WriteFile(script, []byte(fakeServerPy), 0o600); err != nil {
+		t.Fatalf("write server: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	conn, err := Dial(ctx, py, []string{script})
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer conn.Close()
+
+	tools := conn.Tools()
+	if len(tools) != 1 || tools[0].Name != "greet" {
+		t.Fatalf("tools = %+v", tools)
+	}
+	out, isErr, err := conn.Call(ctx, "greet", json.RawMessage(`{"name":"ersin"}`))
+	if err != nil || isErr || out != "hello ersin" {
+		t.Fatalf("Call = %q / %v / %v", out, isErr, err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}

--- a/kernel/mcp/store.go
+++ b/kernel/mcp/store.go
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: MIT
+
+// Package mcp is governed runtime self-install for MCP servers (M796): a
+// durable registry of Model Context Protocol servers plus a minimal MCP
+// client, so an agent (or operator) can ADD a server and ATTACH it while the
+// daemon runs — no restart, no separate bridge binary, no env-var surgery.
+// An attached server's tools are offered to every run as mcp_<server>_<tool>
+// through the same dynamic per-run merge seam forged script tools use.
+//
+// Governance is the point: registering/attaching is gated by the
+// `mcp.install` Edict capability (Ask by default — attaching spawns an
+// arbitrary process), every forwarded call exercises `mcp.call`, the child
+// gets a SCRUBBED environment (no AGEZT_* / secret-shaped vars), frames are
+// size-capped, and every lifecycle transition is journaled (mcp.*) so
+// `agt why` can explain how a server came to be attached. Detach is the
+// instant kill switch.
+//
+// Storage mirrors kernel/roster: a single JSON file rewritten atomically.
+package mcp
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/agezt/agezt/kernel/ulid"
+)
+
+// ErrNotFound is returned for an unknown server id/name.
+var ErrNotFound = errors.New("mcp: server not found")
+
+// Server is one registered MCP server: a stdio command the daemon can spawn
+// and speak MCP to. Name is the immutable handle and the tool-name prefix
+// segment (mcp_<name>_<tool>) — no underscores, so the Edict toolmap can
+// parse the server back out of a tool name unambiguously.
+type Server struct {
+	ID string `json:"id"`
+	// Name is the server's immutable handle: lowercase letters/digits only
+	// (it becomes a tool-name segment, parsed by prefix).
+	Name string `json:"name"`
+	// Command + Args spawn the server process (stdio transport), e.g.
+	// "npx" ["-y","@modelcontextprotocol/server-everything"].
+	Command string   `json:"command"`
+	Args    []string `json:"args,omitempty"`
+	// Enabled means "attach automatically when the daemon starts". A live
+	// attach/detach is a runtime operation independent of this flag.
+	Enabled     bool   `json:"enabled"`
+	Description string `json:"description,omitempty"`
+	CreatedMS   int64  `json:"created_ms"`
+	UpdatedMS   int64  `json:"updated_ms"`
+}
+
+// nameRe: lowercase letter first, then letters/digits. Deliberately NO
+// underscore/dash — the name is parsed out of mcp_<name>_<tool> by the
+// Edict toolmap, so it must never contain the separator.
+var nameRe = regexp.MustCompile(`^[a-z][a-z0-9]{0,15}$`)
+
+const maxArgs = 32
+
+// Validate checks a server's user-supplied fields.
+func Validate(s Server) error {
+	if !nameRe.MatchString(s.Name) {
+		return fmt.Errorf("mcp: name must match %s (it becomes the mcp_<name>_* tool prefix)", nameRe)
+	}
+	if strings.TrimSpace(s.Command) == "" {
+		return errors.New("mcp: command is required")
+	}
+	if len(s.Args) > maxArgs {
+		return fmt.Errorf("mcp: at most %d args", maxArgs)
+	}
+	for _, a := range s.Args {
+		if strings.TrimSpace(a) == "" {
+			return errors.New("mcp: empty arg")
+		}
+	}
+	return nil
+}
+
+// Store is the persistent MCP-server registry, a single JSON file rewritten
+// atomically on change. Safe for concurrent use. Mirrors kernel/roster.Store.
+type Store struct {
+	path    string
+	mu      sync.Mutex
+	now     func() time.Time
+	servers []*Server
+}
+
+// OpenStore opens (or creates) the registry under dir.
+func OpenStore(dir string) (*Store, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("mcp: mkdir %s: %w", dir, err)
+	}
+	s := &Store{path: filepath.Join(dir, "servers.json"), now: time.Now}
+	b, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return s, nil
+		}
+		return nil, fmt.Errorf("mcp: read %s: %w", s.path, err)
+	}
+	if len(b) > 0 {
+		if err := json.Unmarshal(b, &s.servers); err != nil {
+			return nil, fmt.Errorf("mcp: parse %s: %w", s.path, err)
+		}
+	}
+	return s, nil
+}
+
+// Add validates and persists a new server (enabled by default — it will
+// auto-attach on the next daemon start; a LIVE attach is a separate, gated
+// operation). Caller-supplied ID/timestamps are ignored.
+func (s *Store) Add(srv Server) (Server, error) {
+	srv.Name = strings.TrimSpace(srv.Name)
+	srv.Command = strings.TrimSpace(srv.Command)
+	if err := Validate(srv); err != nil {
+		return Server{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, ex := range s.servers {
+		if ex.Name == srv.Name {
+			return Server{}, fmt.Errorf("mcp: name %q already exists", srv.Name)
+		}
+	}
+	now := s.now().UnixMilli()
+	srv.ID = ulid.New()
+	srv.Enabled = true
+	srv.CreatedMS = now
+	srv.UpdatedMS = now
+	cp := srv
+	s.servers = append(s.servers, &cp)
+	if err := s.save(); err != nil {
+		s.servers = s.servers[:len(s.servers)-1]
+		return Server{}, err
+	}
+	return cp, nil
+}
+
+// SetEnabled flips auto-attach-at-start for a server by id or name.
+func (s *Store) SetEnabled(ref string, enabled bool) (Server, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	srv := s.find(ref)
+	if srv == nil {
+		return Server{}, ErrNotFound
+	}
+	prevEnabled, prevUpdated := srv.Enabled, srv.UpdatedMS
+	srv.Enabled = enabled
+	srv.UpdatedMS = s.now().UnixMilli()
+	if err := s.save(); err != nil {
+		srv.Enabled, srv.UpdatedMS = prevEnabled, prevUpdated
+		return Server{}, err
+	}
+	return *srv, nil
+}
+
+// Remove deletes a server by id or name. Returns whether it existed.
+func (s *Store) Remove(ref string) (Server, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, srv := range s.servers {
+		if srv.ID == ref || srv.Name == ref {
+			removed := s.servers
+			gone := *srv
+			s.servers = append(append([]*Server{}, s.servers[:i]...), s.servers[i+1:]...)
+			if err := s.save(); err != nil {
+				s.servers = removed
+				return Server{}, false, err
+			}
+			return gone, true, nil
+		}
+	}
+	return Server{}, false, nil
+}
+
+// Get returns one server by id or name.
+func (s *Store) Get(ref string) (Server, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if srv := s.find(ref); srv != nil {
+		return *srv, true
+	}
+	return Server{}, false
+}
+
+// find returns the live pointer for an id or name. Caller holds s.mu.
+func (s *Store) find(ref string) *Server {
+	for _, srv := range s.servers {
+		if srv.ID == ref || srv.Name == ref {
+			return srv
+		}
+	}
+	return nil
+}
+
+// List returns all servers, sorted by creation time then id.
+func (s *Store) List() []Server {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]Server, 0, len(s.servers))
+	for _, srv := range s.servers {
+		out = append(out, *srv)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].CreatedMS != out[j].CreatedMS {
+			return out[i].CreatedMS < out[j].CreatedMS
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out
+}
+
+// Count returns the number of registered servers.
+func (s *Store) Count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.servers)
+}
+
+func (s *Store) save() error {
+	b, err := json.MarshalIndent(s.servers, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, s.path)
+}

--- a/kernel/mcp/store_test.go
+++ b/kernel/mcp/store_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+
+package mcp
+
+import (
+	"testing"
+	"time"
+)
+
+func openTestStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := OpenStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	tick := int64(0)
+	s.now = func() time.Time {
+		tick++
+		return time.UnixMilli(1_700_000_000_000 + tick)
+	}
+	return s
+}
+
+func TestStore_AddGetRemove(t *testing.T) {
+	s := openTestStore(t)
+	srv, err := s.Add(Server{Name: "everything", Command: "npx", Args: []string{"-y", "@modelcontextprotocol/server-everything"}})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if !srv.Enabled || srv.ID == "" {
+		t.Fatalf("new server = %+v, want enabled with id", srv)
+	}
+	if _, err := s.Add(Server{Name: "everything", Command: "x"}); err == nil {
+		t.Fatal("duplicate name accepted")
+	}
+	if got, found := s.Get("everything"); !found || got.ID != srv.ID {
+		t.Fatalf("Get by name = %+v/%v", got, found)
+	}
+	if _, err := s.SetEnabled(srv.ID, false); err != nil {
+		t.Fatalf("SetEnabled: %v", err)
+	}
+	if got, _ := s.Get(srv.ID); got.Enabled {
+		t.Fatal("disable did not stick")
+	}
+	gone, ok, err := s.Remove("everything")
+	if err != nil || !ok || gone.ID != srv.ID {
+		t.Fatalf("Remove = %+v/%v/%v", gone, ok, err)
+	}
+	if s.Count() != 0 {
+		t.Fatalf("Count = %d", s.Count())
+	}
+}
+
+func TestStore_Persistence(t *testing.T) {
+	dir := t.TempDir()
+	s, err := OpenStore(dir)
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	if _, err := s.Add(Server{Name: "fake", Command: "python", Args: []string{"server.py"}}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	re, err := OpenStore(dir)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	got, found := re.Get("fake")
+	if !found || got.Command != "python" || len(got.Args) != 1 {
+		t.Fatalf("reloaded = %+v/%v", got, found)
+	}
+}
+
+func TestValidateServer(t *testing.T) {
+	ok := Server{Name: "fake9", Command: "python"}
+	if err := Validate(ok); err != nil {
+		t.Fatalf("valid server rejected: %v", err)
+	}
+	cases := []struct {
+		label  string
+		mutate func(*Server)
+	}{
+		// The name becomes the mcp_<name>_* prefix segment — underscores and
+		// dashes would make the Edict toolmap's parse ambiguous.
+		{"underscore in name", func(s *Server) { s.Name = "my_server" }},
+		{"dash in name", func(s *Server) { s.Name = "my-server" }},
+		{"uppercase name", func(s *Server) { s.Name = "Fake" }},
+		{"leading digit", func(s *Server) { s.Name = "9fake" }},
+		{"empty command", func(s *Server) { s.Command = "  " }},
+		{"empty arg", func(s *Server) { s.Args = []string{"x", " "} }},
+	}
+	for _, tc := range cases {
+		s := ok
+		tc.mutate(&s)
+		if err := Validate(s); err == nil {
+			t.Errorf("%s: accepted", tc.label)
+		}
+	}
+}

--- a/kernel/runtime/mcptool.go
+++ b/kernel/runtime/mcptool.go
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: MIT
+
+package runtime
+
+// MCP self-install integration (M796): the kernel-side lifecycle of runtime-
+// attached Model Context Protocol servers. The mcp store holds the registry;
+// this file journals every transition (mcp.*), owns the LIVE attachments
+// (server name → mcp.Conn), and merges each attachment's tools into every
+// run's tool map as mcp_<server>_<tool> — the same dynamic seam forged
+// script tools ride. Detach is the kill switch; Close detaches everything.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/mcp"
+)
+
+// MCPStore returns the durable MCP-server registry (M796). Always non-nil
+// after Open.
+func (k *Kernel) MCPStore() *mcp.Store { return k.mcpStore }
+
+// AddMCPServer validates and persists a new MCP server registration,
+// journaling mcp.added. Registration alone spawns nothing — attach does.
+func (k *Kernel) AddMCPServer(corr string, srv mcp.Server) (mcp.Server, error) {
+	saved, err := k.mcpStore.Add(srv)
+	if err != nil {
+		return mcp.Server{}, err
+	}
+	_, _ = k.bus.Publish(event.Spec{
+		Subject: "mcp." + saved.Name, Kind: event.KindMCPAdded, Actor: "mcp",
+		CorrelationID: corr,
+		Payload:       map[string]any{"id": saved.ID, "name": saved.Name, "command": saved.Command, "args": saved.Args},
+	})
+	return saved, nil
+}
+
+// SetMCPServerEnabled flips a server's auto-attach-at-start flag, journaling
+// mcp.updated. It does not touch a live attachment.
+func (k *Kernel) SetMCPServerEnabled(corr, ref string, enabled bool) (mcp.Server, error) {
+	srv, err := k.mcpStore.SetEnabled(ref, enabled)
+	if err != nil {
+		return mcp.Server{}, err
+	}
+	_, _ = k.bus.Publish(event.Spec{
+		Subject: "mcp." + srv.Name, Kind: event.KindMCPUpdated, Actor: "mcp",
+		CorrelationID: corr,
+		Payload:       map[string]any{"id": srv.ID, "name": srv.Name, "enabled": enabled},
+	})
+	return srv, nil
+}
+
+// AttachMCPServer spawns a registered server, completes the MCP handshake,
+// discovers its tools, and journals mcp.attached with the discovered tool
+// names — from the next run on, every agent is offered them as
+// mcp_<name>_<tool>. Attaching an already-attached server is an error
+// (detach first).
+func (k *Kernel) AttachMCPServer(ctx context.Context, corr, ref string) (mcp.Server, []string, error) {
+	srv, found := k.mcpStore.Get(ref)
+	if !found {
+		return mcp.Server{}, nil, mcp.ErrNotFound
+	}
+	k.mu.Lock()
+	if _, live := k.mcpConns[srv.Name]; live {
+		k.mu.Unlock()
+		return mcp.Server{}, nil, fmt.Errorf("runtime: mcp server %s is already attached", srv.Name)
+	}
+	k.mu.Unlock()
+
+	dial := k.cfg.MCPDialer
+	if dial == nil {
+		dial = mcp.Dial
+	}
+	conn, err := dial(ctx, srv.Command, srv.Args)
+	if err != nil {
+		return mcp.Server{}, nil, err
+	}
+
+	k.mu.Lock()
+	if _, live := k.mcpConns[srv.Name]; live { // raced a concurrent attach
+		k.mu.Unlock()
+		_ = conn.Close()
+		return mcp.Server{}, nil, fmt.Errorf("runtime: mcp server %s is already attached", srv.Name)
+	}
+	k.mcpConns[srv.Name] = conn
+	k.mu.Unlock()
+
+	names := make([]string, 0, len(conn.Tools()))
+	for _, t := range conn.Tools() {
+		names = append(names, mcpToolName(srv.Name, t.Name))
+	}
+	_, _ = k.bus.Publish(event.Spec{
+		Subject: "mcp." + srv.Name, Kind: event.KindMCPAttached, Actor: "mcp",
+		CorrelationID: corr,
+		Payload:       map[string]any{"id": srv.ID, "name": srv.Name, "tools": names},
+	})
+	return srv, names, nil
+}
+
+// DetachMCPServer closes a live attachment — the kill switch: its tools
+// vanish from the next run on. Journals mcp.detached.
+func (k *Kernel) DetachMCPServer(corr, ref string) error {
+	// Resolve a registry ref (id or name) to the live-connection key, but
+	// also accept the bare name of a connection whose registry row is gone.
+	name := ref
+	if srv, found := k.mcpStore.Get(ref); found {
+		name = srv.Name
+	}
+	k.mu.Lock()
+	conn, live := k.mcpConns[name]
+	delete(k.mcpConns, name)
+	k.mu.Unlock()
+	if !live {
+		return fmt.Errorf("runtime: mcp server %s is not attached", name)
+	}
+	_ = conn.Close()
+	_, _ = k.bus.Publish(event.Spec{
+		Subject: "mcp." + name, Kind: event.KindMCPDetached, Actor: "mcp",
+		CorrelationID: corr,
+		Payload:       map[string]any{"name": name},
+	})
+	return nil
+}
+
+// RemoveMCPServer deletes a registration (detaching it first when live),
+// journaling mcp.removed. Returns whether it existed.
+func (k *Kernel) RemoveMCPServer(corr, ref string) (bool, error) {
+	if srv, found := k.mcpStore.Get(ref); found {
+		k.mu.Lock()
+		_, live := k.mcpConns[srv.Name]
+		k.mu.Unlock()
+		if live {
+			_ = k.DetachMCPServer(corr, srv.Name)
+		}
+	}
+	gone, ok, err := k.mcpStore.Remove(ref)
+	if err != nil {
+		return false, err
+	}
+	if ok {
+		_, _ = k.bus.Publish(event.Spec{
+			Subject: "mcp." + gone.Name, Kind: event.KindMCPRemoved, Actor: "mcp",
+			CorrelationID: corr,
+			Payload:       map[string]any{"id": gone.ID, "name": gone.Name},
+		})
+	}
+	return ok, nil
+}
+
+// AttachEnabledMCPServers attaches every enabled registration — the daemon's
+// boot path. Failures are per-server and reported, never fatal: one broken
+// server must not take the others (or the daemon) down.
+func (k *Kernel) AttachEnabledMCPServers(ctx context.Context) (attached []string, failures map[string]error) {
+	failures = map[string]error{}
+	for _, srv := range k.mcpStore.List() {
+		if !srv.Enabled {
+			continue
+		}
+		if _, _, err := k.AttachMCPServer(ctx, "", srv.Name); err != nil {
+			failures[srv.Name] = err
+			continue
+		}
+		attached = append(attached, srv.Name)
+	}
+	return attached, failures
+}
+
+// MCPAttached returns the names of currently-attached servers (sorted) with
+// their bridged tool counts — the status surface for `agt mcp list` and the
+// console.
+func (k *Kernel) MCPAttached() map[string]int {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	out := make(map[string]int, len(k.mcpConns))
+	for name, conn := range k.mcpConns {
+		out[name] = len(conn.Tools())
+	}
+	return out
+}
+
+// closeMCPConns detaches everything — called from Kernel.Close.
+func (k *Kernel) closeMCPConns() {
+	k.mu.Lock()
+	conns := k.mcpConns
+	k.mcpConns = map[string]mcp.Conn{}
+	k.mu.Unlock()
+	for _, conn := range conns {
+		_ = conn.Close()
+	}
+}
+
+// mcpToolName builds the callable name: the mcp_ prefix routes the Edict
+// toolmap to the mcp.call capability and namespaces bridged tools away from
+// built-ins; the server segment (no underscores, by store validation) keeps
+// the origin parseable. The server's own tool name is sanitized to the
+// provider-safe alphabet and the whole thing capped at 64 chars.
+func mcpToolName(server, tool string) string {
+	var b strings.Builder
+	for _, r := range tool {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	name := "mcp_" + server + "_" + b.String()
+	if len(name) > 64 {
+		name = name[:64]
+	}
+	return name
+}
+
+// mergeMCPTools returns the run's tool map extended with every live
+// attachment's tools. Registered tools win a name collision; the input map
+// comes back untouched when nothing is attached.
+func (k *Kernel) mergeMCPTools(tools map[string]agent.Tool) map[string]agent.Tool {
+	k.mu.Lock()
+	type liveConn struct {
+		name string
+		conn mcp.Conn
+	}
+	live := make([]liveConn, 0, len(k.mcpConns))
+	for name, conn := range k.mcpConns {
+		live = append(live, liveConn{name, conn})
+	}
+	k.mu.Unlock()
+	if len(live) == 0 {
+		return tools
+	}
+	sort.Slice(live, func(i, j int) bool { return live[i].name < live[j].name })
+
+	out := make(map[string]agent.Tool, len(tools)+8)
+	for name, t := range tools {
+		out[name] = t
+	}
+	for _, lc := range live {
+		for _, def := range lc.conn.Tools() {
+			name := mcpToolName(lc.name, def.Name)
+			if _, exists := out[name]; exists {
+				continue
+			}
+			out[name] = bridgedMCPTool{name: name, server: lc.name, def: def, conn: lc.conn}
+		}
+	}
+	return out
+}
+
+// bridgedMCPTool adapts one discovered MCP tool to agent.Tool: the call's
+// raw JSON input forwards as the tools/call arguments; the server's text
+// content (and its own isError verdict) come back as the result.
+type bridgedMCPTool struct {
+	name   string
+	server string
+	def    mcp.ToolDef
+	conn   mcp.Conn
+}
+
+func (t bridgedMCPTool) Definition() agent.ToolDef {
+	schema := t.def.InputSchema
+	if len(schema) == 0 {
+		schema = json.RawMessage(`{"type":"object"}`)
+	}
+	desc := strings.TrimSpace(t.def.Description)
+	if desc == "" {
+		desc = t.def.Name
+	}
+	return agent.ToolDef{
+		Name:        t.name,
+		Description: desc + " (via the attached MCP server \"" + t.server + "\")",
+		InputSchema: schema,
+	}
+}
+
+func (t bridgedMCPTool) Invoke(ctx context.Context, raw json.RawMessage) (agent.Result, error) {
+	text, isErr, err := t.conn.Call(ctx, t.def.Name, raw)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return agent.Result{}, err // the run was cancelled, not the tool failing
+		}
+		return agent.Result{Output: t.name + ": " + err.Error(), IsError: true}, nil
+	}
+	if text == "" {
+		text = "(no output)"
+	}
+	return agent.Result{Output: text, IsError: isErr}, nil
+}

--- a/kernel/runtime/mcptool_test.go
+++ b/kernel/runtime/mcptool_test.go
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: MIT
+
+package runtime_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/mcp"
+	"github.com/agezt/agezt/kernel/runtime"
+	"github.com/agezt/agezt/plugins/providers/mock"
+)
+
+// fakeMCPConn is a canned MCP attachment: fixed tools, recorded calls.
+type fakeMCPConn struct {
+	tools    []mcp.ToolDef
+	lastTool string
+	lastArgs string
+	out      string
+	isErr    bool
+	closed   bool
+}
+
+func (c *fakeMCPConn) Tools() []mcp.ToolDef { return c.tools }
+func (c *fakeMCPConn) Call(_ context.Context, tool string, args json.RawMessage) (string, bool, error) {
+	c.lastTool, c.lastArgs = tool, string(args)
+	return c.out, c.isErr, nil
+}
+func (c *fakeMCPConn) Close() error { c.closed = true; return nil }
+
+func openMCPKernel(t *testing.T, prov agent.Provider, conn *fakeMCPConn) (*runtime.Kernel, *int) {
+	t.Helper()
+	dials := 0
+	k, err := runtime.Open(runtime.Config{
+		BaseDir:  t.TempDir(),
+		Provider: prov,
+		MCPDialer: func(_ context.Context, command string, args []string) (mcp.Conn, error) {
+			dials++
+			return conn, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { k.Close() })
+	return k, &dials
+}
+
+// TestAttach_OffersAndForwardsBridgedTool is the M796 e2e: register + attach
+// a server (fake dialer), and a run is offered mcp_<server>_<tool>; the
+// model's call forwards to the connection with the raw arguments, and the
+// server's text comes back.
+func TestAttach_OffersAndForwardsBridgedTool(t *testing.T) {
+	prov := mock.New(
+		mock.ToolUse("c1", "mcp_fake_greet", map[string]any{"name": "ersin"}),
+		mock.FinalText("done"),
+	)
+	var first agent.CompletionRequest
+	seen := false
+	prov.OnRequest = func(r agent.CompletionRequest) {
+		if !seen {
+			first, seen = r, true
+		}
+	}
+	conn := &fakeMCPConn{
+		tools: []mcp.ToolDef{{Name: "greet", Description: "greets a name"}},
+		out:   "hello ersin",
+	}
+	k, dials := openMCPKernel(t, prov, conn)
+
+	if _, err := k.AddMCPServer("", mcp.Server{Name: "fake", Command: "python", Args: []string{"server.py"}}); err != nil {
+		t.Fatalf("AddMCPServer: %v", err)
+	}
+	srv, names, err := k.AttachMCPServer(context.Background(), "", "fake")
+	if err != nil || srv.Name != "fake" {
+		t.Fatalf("Attach: %v / %+v", err, srv)
+	}
+	if len(names) != 1 || names[0] != "mcp_fake_greet" {
+		t.Fatalf("discovered names = %v", names)
+	}
+	if *dials != 1 {
+		t.Fatalf("dials = %d", *dials)
+	}
+
+	if _, err := k.RunWith(context.Background(), k.NewCorrelation(), "greet ersin"); err != nil {
+		t.Fatalf("RunWith: %v", err)
+	}
+	var offered bool
+	for _, d := range first.Tools {
+		if d.Name == "mcp_fake_greet" {
+			offered = true
+			if !strings.Contains(d.Description, "fake") {
+				t.Errorf("description lost server origin: %q", d.Description)
+			}
+		}
+	}
+	if !offered {
+		t.Fatalf("bridged tool not offered; tools = %v", toolNames(first.Tools))
+	}
+	if conn.lastTool != "greet" || !strings.Contains(conn.lastArgs, `"ersin"`) {
+		t.Fatalf("call did not forward: %q %q", conn.lastTool, conn.lastArgs)
+	}
+}
+
+// TestDetach_KillSwitch: after detach the connection is closed and the tools
+// vanish from the next run; double-attach is refused while live.
+func TestDetach_KillSwitch(t *testing.T) {
+	prov := mock.New(mock.FinalText("ok"))
+	var req agent.CompletionRequest
+	prov.OnRequest = func(r agent.CompletionRequest) { req = r }
+	conn := &fakeMCPConn{tools: []mcp.ToolDef{{Name: "greet"}}}
+	k, _ := openMCPKernel(t, prov, conn)
+
+	if _, err := k.AddMCPServer("", mcp.Server{Name: "fake", Command: "python"}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if _, _, err := k.AttachMCPServer(context.Background(), "", "fake"); err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	if _, _, err := k.AttachMCPServer(context.Background(), "", "fake"); err == nil {
+		t.Fatal("double attach accepted")
+	}
+	if err := k.DetachMCPServer("", "fake"); err != nil {
+		t.Fatalf("Detach: %v", err)
+	}
+	if !conn.closed {
+		t.Fatal("detach did not close the connection")
+	}
+	if err := k.DetachMCPServer("", "fake"); err == nil {
+		t.Fatal("detaching a non-attached server accepted")
+	}
+	if _, err := k.RunWith(context.Background(), k.NewCorrelation(), "hi"); err != nil {
+		t.Fatalf("RunWith: %v", err)
+	}
+	if contains(toolNames(req.Tools), "mcp_fake_greet") {
+		t.Fatal("detached server's tool still offered")
+	}
+}
+
+// TestRemove_DetachesFirst and AttachEnabled boot path.
+func TestRemoveAndAttachEnabled(t *testing.T) {
+	prov := mock.New(mock.FinalText("ok"))
+	conn := &fakeMCPConn{tools: []mcp.ToolDef{{Name: "greet"}}}
+	k, dials := openMCPKernel(t, prov, conn)
+
+	if _, err := k.AddMCPServer("", mcp.Server{Name: "fake", Command: "python"}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	// Boot path: enabled servers attach; disabled ones don't.
+	attached, failures := k.AttachEnabledMCPServers(context.Background())
+	if len(attached) != 1 || len(failures) != 0 || *dials != 1 {
+		t.Fatalf("AttachEnabled = %v / %v / dials=%d", attached, failures, *dials)
+	}
+	if n := k.MCPAttached()["fake"]; n != 1 {
+		t.Fatalf("MCPAttached = %v", k.MCPAttached())
+	}
+
+	// Remove detaches first, then deletes the registration.
+	ok, err := k.RemoveMCPServer("", "fake")
+	if err != nil || !ok {
+		t.Fatalf("Remove = %v/%v", ok, err)
+	}
+	if !conn.closed {
+		t.Fatal("remove did not detach/close first")
+	}
+	if k.MCPStore().Count() != 0 || len(k.MCPAttached()) != 0 {
+		t.Fatal("registration or attachment survived remove")
+	}
+}
+
+// TestAllowlistGatesBridgedTools: WithTools applies to MCP tools exactly like
+// registered ones (merge before filter).
+func TestAllowlistGatesBridgedTools(t *testing.T) {
+	prov := mock.New(mock.FinalText("ok"), mock.FinalText("ok"))
+	var req agent.CompletionRequest
+	prov.OnRequest = func(r agent.CompletionRequest) { req = r }
+	conn := &fakeMCPConn{tools: []mcp.ToolDef{{Name: "greet"}}}
+	k, _ := openMCPKernel(t, prov, conn)
+	if _, err := k.AddMCPServer("", mcp.Server{Name: "fake", Command: "python"}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if _, _, err := k.AttachMCPServer(context.Background(), "", "fake"); err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+
+	ctx := runtime.WithTools(context.Background(), []string{"memory"})
+	if _, err := k.RunWith(ctx, k.NewCorrelation(), "restricted"); err != nil {
+		t.Fatalf("RunWith: %v", err)
+	}
+	if contains(toolNames(req.Tools), "mcp_fake_greet") {
+		t.Fatal("allowlist did not gate the bridged tool")
+	}
+	ctx = runtime.WithTools(context.Background(), []string{"mcp_fake_greet"})
+	if _, err := k.RunWith(ctx, k.NewCorrelation(), "allowed"); err != nil {
+		t.Fatalf("RunWith: %v", err)
+	}
+	if !contains(toolNames(req.Tools), "mcp_fake_greet") {
+		t.Fatal("allowlisted bridged tool missing")
+	}
+}
+
+// TestBridgedToolNameSanitized: a server tool with hostile characters becomes
+// a provider-safe, length-capped name.
+func TestBridgedToolNameSanitized(t *testing.T) {
+	prov := mock.New(mock.FinalText("ok"))
+	var req agent.CompletionRequest
+	prov.OnRequest = func(r agent.CompletionRequest) { req = r }
+	long := strings.Repeat("x", 80)
+	conn := &fakeMCPConn{tools: []mcp.ToolDef{{Name: "weird/tool name!" + long}}}
+	k, _ := openMCPKernel(t, prov, conn)
+	if _, err := k.AddMCPServer("", mcp.Server{Name: "fake", Command: "python"}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if _, names, err := k.AttachMCPServer(context.Background(), "", "fake"); err != nil || len(names) != 1 {
+		t.Fatalf("Attach: %v / %v", err, names)
+	}
+	if _, err := k.RunWith(context.Background(), k.NewCorrelation(), "hi"); err != nil {
+		t.Fatalf("RunWith: %v", err)
+	}
+	var got string
+	for _, d := range req.Tools {
+		if strings.HasPrefix(d.Name, "mcp_fake_") {
+			got = d.Name
+		}
+	}
+	if got == "" {
+		t.Fatalf("sanitized tool missing; tools = %v", toolNames(req.Tools))
+	}
+	if len(got) > 64 || strings.ContainsAny(got, "/ !") {
+		t.Fatalf("name not provider-safe: %q (len %d)", got, len(got))
+	}
+}

--- a/kernel/runtime/runtime.go
+++ b/kernel/runtime/runtime.go
@@ -33,6 +33,7 @@ import (
 	"github.com/agezt/agezt/kernel/event"
 	"github.com/agezt/agezt/kernel/governor"
 	"github.com/agezt/agezt/kernel/journal"
+	"github.com/agezt/agezt/kernel/mcp"
 	"github.com/agezt/agezt/kernel/memory"
 	"github.com/agezt/agezt/kernel/reflect"
 	"github.com/agezt/agezt/kernel/roster"
@@ -96,6 +97,10 @@ type Config struct {
 	// The daemon wires the code_exec tool here — same warden isolation,
 	// scrubbed env, and `code.exec` Edict gate as direct code execution.
 	ScriptRunner toolforge.Runner
+
+	// MCPDialer spawns + handshakes one MCP server on attach (M796). Nil
+	// means the production stdio dialer (mcp.Dial); tests inject fakes.
+	MCPDialer mcp.Dialer
 
 	// Model is the default model name passed to the provider.
 	Model string
@@ -339,6 +344,7 @@ type Kernel struct {
 	standing  *standing.Store
 	roster    *roster.Store
 	toolForge *toolforge.Store
+	mcpStore  *mcp.Store
 	artifacts *artifact.Store
 	reflect   *reflect.Engine
 	schedules *cadence.Store        // persistent scheduled-intents store (autonomy)
@@ -354,6 +360,9 @@ type Kernel struct {
 	fanout map[string]int                // spawning correlation_id → sub-agents spawned (M46 fan-out bound)
 	tree   map[string]int                // root correlation_id → total sub-agents in the tree (M629 total bound)
 	steers map[string]*runControl        // correlation_id → live-steering control surface (M608)
+	// mcpConns are the LIVE MCP attachments (M796): server name → connection.
+	// Merged into every run's tool map (mergeMCPTools); detach removes.
+	mcpConns map[string]mcp.Conn
 
 	startTime time.Time // wall-clock at Open() — powers `agt status` uptime
 }
@@ -478,6 +487,16 @@ func Open(cfg Config) (*Kernel, error) {
 		return nil, fmt.Errorf("runtime: toolforge: %w", err)
 	}
 
+	mcpstore, err := mcp.OpenStore(filepath.Join(cfg.BaseDir, "mcp"))
+	if err != nil {
+		j.Close()
+		st.Close()
+		mstore.Close()
+		wstore.Close()
+		skstore.Close()
+		return nil, fmt.Errorf("runtime: mcp: %w", err)
+	}
+
 	// Reflection holds no store of its own — it folds the journal and tunes
 	// the world graph, then journals its report (SPEC-05 §6). Default decay
 	// knobs; the daemon may override via the optional periodic trigger.
@@ -539,6 +558,8 @@ func Open(cfg Config) (*Kernel, error) {
 		standing:     ststore,
 		roster:       rstore,
 		toolForge:    tfstore,
+		mcpStore:     mcpstore,
+		mcpConns:     make(map[string]mcp.Conn),
 		artifacts:    artStore,
 		reflect:      reflectEng,
 		schedules:    schedStore,
@@ -559,7 +580,8 @@ func Open(cfg Config) (*Kernel, error) {
 // Close stops the bus, then closes state and the journal. Pending runs
 // are cancelled via Halt before close.
 func (k *Kernel) Close() error {
-	k.Halt() // cancel any in-flight runs first
+	k.Halt()          // cancel any in-flight runs first
+	k.closeMCPConns() // detach every live MCP server (kills the children)
 	k.bus.Close()
 	// Close every store even if an earlier one errors — the previous short-circuit
 	// returned on the first error and leaked the remaining handles, notably the
@@ -1636,9 +1658,10 @@ func (k *Kernel) RunWith(ctx context.Context, corr, intent string) (string, erro
 
 	// Per-run tool restriction (WithTools): an allowlist (possibly empty = no
 	// tools) scopes what this run may call, without changing the kernel's tool
-	// set. Forged script tools (M794) are merged BEFORE the filter so a
-	// restricted run only sees the forge_<name> tools its allowlist grants.
-	runTools := k.mergeScriptTools(k.tools)
+	// set. Forged script tools (M794) and live MCP attachments (M796) are
+	// merged BEFORE the filter so a restricted run only sees the dynamic
+	// tools its allowlist grants.
+	runTools := k.mergeMCPTools(k.mergeScriptTools(k.tools))
 	if allow, ok := toolsFromCtx(runCtx); ok {
 		runTools = filterTools(runTools, allow)
 	}

--- a/kernel/runtime/subagent.go
+++ b/kernel/runtime/subagent.go
@@ -319,7 +319,7 @@ func (k *Kernel) runSubAgent(ctx context.Context, task, model, taskType, agentRe
 
 	answer, err := agent.Run(childCtx, agent.LoopConfig{
 		Provider:             k.cfg.Provider,
-		Tools:                k.mergeScriptTools(k.tools), // forged script tools reach sub-agents too (M794)
+		Tools:                k.mergeMCPTools(k.mergeScriptTools(k.tools)), // forged + MCP tools reach sub-agents too (M794/M796)
 		Bus:                  k.bus,
 		Model:                subModel,
 		TaskType:             taskType,   // M705: route the sub-agent (chain supplies fallbacks)

--- a/kernel/webui/webui.go
+++ b/kernel/webui/webui.go
@@ -112,6 +112,7 @@ var apiRoutes = map[string]string{
 	"/api/standing":      controlplane.CmdStandingList,
 	"/api/agents":        controlplane.CmdAgentList,
 	"/api/toolforge":     controlplane.CmdToolforgeList,
+	"/api/mcp":           controlplane.CmdMCPList,
 	"/api/inbox":         controlplane.CmdInbox,
 	"/api/board":         controlplane.CmdBoardRead,
 	"/api/autonomy":      controlplane.CmdAutonomyFeed,
@@ -249,7 +250,14 @@ var writeRoutes = map[string]writeRoute{
 	"/api/toolforge/promote":    {controlplane.CmdToolforgePromote, []string{"ref"}},
 	"/api/toolforge/quarantine": {controlplane.CmdToolforgeQuarantine, []string{"ref", "reason"}},
 	"/api/toolforge/remove":     {controlplane.CmdToolforgeRemove, []string{"ref"}},
-	"/api/reflect/run":          {controlplane.CmdReflectRun, nil},
+	// MCP self-install lifecycle (M796): attach spawns the registered server
+	// NOW (its tools go live for the next run); detach is the kill switch;
+	// enable flips auto-attach at daemon start. ref = name or id.
+	"/api/mcp/attach":  {controlplane.CmdMCPAttach, []string{"ref"}},
+	"/api/mcp/detach":  {controlplane.CmdMCPDetach, []string{"ref"}},
+	"/api/mcp/enable":  {controlplane.CmdMCPSetEnabled, []string{"ref", "enabled"}},
+	"/api/mcp/remove":  {controlplane.CmdMCPRemove, []string{"ref"}},
+	"/api/reflect/run": {controlplane.CmdReflectRun, nil},
 	// Provider keyring switch/remove (M700): activate or remove a key, reloading
 	// the provider in place. (Add is a jsonRoute — the value is a secret body.)
 	"/api/provider/keys/activate": {controlplane.CmdProviderKeyActivate, []string{"env", "label"}},
@@ -298,6 +306,9 @@ var jsonRoutes = map[string]writeRoute{
 	// (code body, schema text) — a JSON body, not query args.
 	"/api/toolforge/draft": {controlplane.CmdToolforgeDraft, []string{"tool"}},
 	"/api/toolforge/edit":  {controlplane.CmdToolforgeEdit, []string{"ref", "tool"}},
+	// Register an MCP server (M796): the server is a structured object
+	// (command + args list) — a JSON body, not query args.
+	"/api/mcp/add": {controlplane.CmdMCPAdd, []string{"server"}},
 	// Create a schedule (M715): intent + a timing mode. Numeric timing args (e.g.
 	// interval_sec, at_minutes, once_at_unix) ride the JSON body so they keep their
 	// types — a query arg would stringify them.

--- a/kernel/webui/webui_test.go
+++ b/kernel/webui/webui_test.go
@@ -554,7 +554,7 @@ func TestAPIReadOnly(t *testing.T) {
 	// never issues anything outside the known read set.
 	readOnly := map[string]bool{
 		"status": true, "config": true, "runs_list": true, "runs_stats": true, "budget": true, "cache_stats": true, "provider_stats": true, "tool_stats": true, "edict_stats": true, "schedule_list": true, "memory_list": true, "world_list": true,
-		"skill_list": true, "standing_list": true, "agent_list": true, "toolforge_list": true, "inbox": true, "reflect_show": true, "approvals": true,
+		"skill_list": true, "standing_list": true, "agent_list": true, "toolforge_list": true, "mcp_list": true, "inbox": true, "reflect_show": true, "approvals": true,
 		"plan_stats": true, "edict_show": true, "tool_list": true, "board_read": true, "autonomy_feed": true,
 		"catalog_list": true, "sandbox_list": true,
 		"config_schema": true, "config_values": true, "routing_get": true, "persona_get": true, "prompts_get": true,

--- a/plugins/tools/mcptool/tool.go
+++ b/plugins/tools/mcptool/tool.go
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: MIT
+
+// Package mcptool is the in-process `mcp` tool (M796): governed self-install.
+// The agent extends its OWN reach at runtime — register an MCP server
+// (op=add), ATTACH it (op=attach: the daemon spawns the process, handshakes,
+// and from the next run on its tools are callable as mcp_<server>_<tool>),
+// detach it (the kill switch), list, or remove. Install ops are gated by the
+// `mcp.install` Edict capability (Ask by default — attaching runs an
+// arbitrary external process); every bridged call later exercises
+// `mcp.call`. The child gets a scrubbed environment and every lifecycle
+// transition is journaled (mcp.*).
+package mcptool
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/mcp"
+)
+
+// Kernel is the slice of the runtime kernel this tool drives — satisfied by
+// *runtime.Kernel and easy to fake in tests.
+type Kernel interface {
+	AddMCPServer(corr string, srv mcp.Server) (mcp.Server, error)
+	AttachMCPServer(ctx context.Context, corr, ref string) (mcp.Server, []string, error)
+	DetachMCPServer(corr, ref string) error
+	RemoveMCPServer(corr, ref string) (bool, error)
+	MCPStore() *mcp.Store
+	MCPAttached() map[string]int
+}
+
+// Tool implements agent.Tool. Construct with New, then Bind the live kernel.
+type Tool struct {
+	mu sync.RWMutex
+	k  Kernel
+}
+
+// New returns an unbound Tool — Invoke reports the surface unavailable until
+// Bind is called.
+func New() *Tool { return &Tool{} }
+
+// Bind wires the live kernel. Called once after the kernel opens.
+func (t *Tool) Bind(k Kernel) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.k = k
+}
+
+func (t *Tool) current() Kernel {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.k
+}
+
+// Definition implements agent.Tool.
+func (t *Tool) Definition() agent.ToolDef {
+	return agent.ToolDef{
+		Name: "mcp",
+		Description: "Extend your own toolbox by installing MCP (Model Context Protocol) servers at runtime. " +
+			"op=add registers a server (a stdio command, e.g. command \"npx\" args [\"-y\",\"@modelcontextprotocol/server-everything\"]); " +
+			"op=attach spawns it and discovers its tools — from your NEXT run they are callable as mcp_<name>_<tool>; " +
+			"op=detach stops it (its tools vanish); op=list shows registrations and what is live; op=remove deletes a registration. " +
+			"Use this when a task needs a capability an existing MCP server provides. " +
+			"Installs are operator-governed (approval) and journaled.",
+		InputSchema: json.RawMessage(`{
+  "type": "object",
+  "required": ["op"],
+  "properties": {
+    "op":          {"type":"string", "enum":["add","attach","detach","list","remove"]},
+    "name":        {"type":"string", "description":"For op=add: the server's handle (lowercase letters/digits, e.g. \"everything\"); its tools appear as mcp_<name>_<tool>."},
+    "command":     {"type":"string", "description":"For op=add: the executable to spawn (stdio MCP server), e.g. \"npx\"."},
+    "args":        {"type":"array", "items":{"type":"string"}, "description":"For op=add: the command's arguments, e.g. [\"-y\",\"@modelcontextprotocol/server-everything\"]."},
+    "description": {"type":"string", "description":"For op=add (optional): what this server provides."},
+    "ref":         {"type":"string", "description":"For op=attach/detach/remove: the server's name or id."}
+  }
+}`),
+	}
+}
+
+type input struct {
+	Op          string   `json:"op"`
+	Name        string   `json:"name"`
+	Command     string   `json:"command"`
+	Args        []string `json:"args"`
+	Description string   `json:"description"`
+	Ref         string   `json:"ref"`
+}
+
+// Invoke implements agent.Tool.
+func (t *Tool) Invoke(ctx context.Context, raw json.RawMessage) (agent.Result, error) {
+	var in input
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return agent.Result{}, fmt.Errorf("mcp: parse input: %w", err)
+	}
+	k := t.current()
+	if k == nil {
+		return errResult("mcp self-install is not available on this daemon"), nil
+	}
+	corr := agent.CorrelationFromContext(ctx)
+
+	switch in.Op {
+	case "add":
+		srv, err := k.AddMCPServer(corr, mcp.Server{
+			Name:        in.Name,
+			Command:     in.Command,
+			Args:        in.Args,
+			Description: in.Description,
+		})
+		if err != nil {
+			return errResult(err.Error()), nil
+		}
+		return okJSON(map[string]any{
+			"name": srv.Name, "command": srv.Command, "args": srv.Args,
+			"message": "registered — attach it (op=attach) to make its tools callable",
+		}), nil
+
+	case "attach":
+		if strings.TrimSpace(in.Ref) == "" {
+			return errResult(`op=attach needs a "ref" (the server's name or id)`), nil
+		}
+		srv, tools, err := k.AttachMCPServer(ctx, corr, in.Ref)
+		if err != nil {
+			return errResult(err.Error()), nil
+		}
+		return okJSON(map[string]any{
+			"name": srv.Name, "tools": tools,
+			"message": fmt.Sprintf("attached — %d tool(s) callable from your next run", len(tools)),
+		}), nil
+
+	case "detach":
+		if strings.TrimSpace(in.Ref) == "" {
+			return errResult(`op=detach needs a "ref" (the server's name or id)`), nil
+		}
+		if err := k.DetachMCPServer(corr, in.Ref); err != nil {
+			return errResult(err.Error()), nil
+		}
+		return okJSON(map[string]any{"message": "detached — its tools are no longer offered"}), nil
+
+	case "list":
+		attached := k.MCPAttached()
+		servers := k.MCPStore().List()
+		views := make([]map[string]any, 0, len(servers))
+		for _, srv := range servers {
+			v := map[string]any{
+				"name": srv.Name, "command": srv.Command, "args": srv.Args,
+				"auto_attach": srv.Enabled, "attached": false,
+			}
+			if n, live := attached[srv.Name]; live {
+				v["attached"] = true
+				v["tool_count"] = n
+			}
+			if srv.Description != "" {
+				v["description"] = srv.Description
+			}
+			views = append(views, v)
+		}
+		// A live connection whose registry row was removed still matters.
+		for name, n := range attached {
+			if _, found := k.MCPStore().Get(name); !found {
+				views = append(views, map[string]any{"name": name, "attached": true, "tool_count": n, "unregistered": true})
+			}
+		}
+		sort.Slice(views, func(i, j int) bool {
+			return views[i]["name"].(string) < views[j]["name"].(string)
+		})
+		return okJSON(map[string]any{"count": len(views), "servers": views}), nil
+
+	case "remove":
+		if strings.TrimSpace(in.Ref) == "" {
+			return errResult(`op=remove needs a "ref" (the server's name or id)`), nil
+		}
+		ok, err := k.RemoveMCPServer(corr, in.Ref)
+		if err != nil {
+			return errResult(err.Error()), nil
+		}
+		if !ok {
+			return errResult("no mcp server " + in.Ref), nil
+		}
+		return okJSON(map[string]any{"message": "removed (detached first if it was live)"}), nil
+
+	case "":
+		return errResult("op required (add|attach|detach|list|remove)"), nil
+	default:
+		return errResult("unknown op " + in.Op + " (add|attach|detach|list|remove)"), nil
+	}
+}
+
+func okJSON(v any) agent.Result {
+	enc, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return errResult("marshal: " + err.Error())
+	}
+	return agent.Result{Output: string(enc)}
+}
+
+func errResult(msg string) agent.Result {
+	return agent.Result{Output: "mcp: " + msg, IsError: true}
+}

--- a/plugins/tools/mcptool/tool_test.go
+++ b/plugins/tools/mcptool/tool_test.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MIT
+
+package mcptool
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/agezt/agezt/kernel/mcp"
+)
+
+// fakeKernel backs the tool with a real registry store and a canned
+// attachment table — the kernel's journaling/spawning is covered by runtime
+// tests.
+type fakeKernel struct {
+	store    *mcp.Store
+	attached map[string]int
+}
+
+func (f *fakeKernel) AddMCPServer(_ string, srv mcp.Server) (mcp.Server, error) {
+	return f.store.Add(srv)
+}
+
+func (f *fakeKernel) AttachMCPServer(_ context.Context, _, ref string) (mcp.Server, []string, error) {
+	srv, found := f.store.Get(ref)
+	if !found {
+		return mcp.Server{}, nil, mcp.ErrNotFound
+	}
+	f.attached[srv.Name] = 2
+	return srv, []string{"mcp_" + srv.Name + "_greet", "mcp_" + srv.Name + "_read"}, nil
+}
+
+func (f *fakeKernel) DetachMCPServer(_, ref string) error {
+	delete(f.attached, ref)
+	return nil
+}
+
+func (f *fakeKernel) RemoveMCPServer(_, ref string) (bool, error) {
+	_, ok, err := f.store.Remove(ref)
+	return ok, err
+}
+
+func (f *fakeKernel) MCPStore() *mcp.Store        { return f.store }
+func (f *fakeKernel) MCPAttached() map[string]int { return f.attached }
+
+func newBound(t *testing.T) (*Tool, *fakeKernel) {
+	t.Helper()
+	store, err := mcp.OpenStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	fk := &fakeKernel{store: store, attached: map[string]int{}}
+	tool := New()
+	tool.Bind(fk)
+	return tool, fk
+}
+
+func invoke(t *testing.T, tool *Tool, in map[string]any) (string, bool) {
+	t.Helper()
+	raw, _ := json.Marshal(in)
+	res, err := tool.Invoke(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("Invoke(%v): %v", in, err)
+	}
+	return res.Output, res.IsError
+}
+
+// TestSelfInstallLoop: the agent's whole surface — add → attach (tool names
+// come back) → list shows live status → detach → remove.
+func TestSelfInstallLoop(t *testing.T) {
+	tool, fk := newBound(t)
+
+	out, isErr := invoke(t, tool, map[string]any{
+		"op": "add", "name": "fake", "command": "python", "args": []string{"server.py"},
+	})
+	if isErr || !strings.Contains(out, "registered") {
+		t.Fatalf("add: err=%v out=%s", isErr, out)
+	}
+
+	out, isErr = invoke(t, tool, map[string]any{"op": "attach", "ref": "fake"})
+	if isErr || !strings.Contains(out, "mcp_fake_greet") {
+		t.Fatalf("attach: err=%v out=%s", isErr, out)
+	}
+
+	out, _ = invoke(t, tool, map[string]any{"op": "list"})
+	if !strings.Contains(out, `"attached": true`) || !strings.Contains(out, `"tool_count": 2`) {
+		t.Fatalf("list: %s", out)
+	}
+
+	out, isErr = invoke(t, tool, map[string]any{"op": "detach", "ref": "fake"})
+	if isErr || !strings.Contains(out, "detached") {
+		t.Fatalf("detach: err=%v out=%s", isErr, out)
+	}
+	if len(fk.attached) != 0 {
+		t.Fatal("detach did not clear the attachment")
+	}
+
+	out, isErr = invoke(t, tool, map[string]any{"op": "remove", "ref": "fake"})
+	if isErr || !strings.Contains(out, "removed") {
+		t.Fatalf("remove: err=%v out=%s", isErr, out)
+	}
+	if fk.store.Count() != 0 {
+		t.Fatal("remove did not delete the registration")
+	}
+}
+
+func TestErrors(t *testing.T) {
+	tool, _ := newBound(t)
+	if out, isErr := invoke(t, tool, map[string]any{"op": "attach", "ref": "ghost"}); !isErr || !strings.Contains(out, "not found") {
+		t.Fatalf("ghost attach: err=%v out=%s", isErr, out)
+	}
+	if out, isErr := invoke(t, tool, map[string]any{"op": "add", "name": "Bad-Name", "command": "x"}); !isErr {
+		t.Fatalf("bad name accepted: %s", out)
+	}
+	if out, isErr := invoke(t, New(), map[string]any{"op": "list"}); !isErr || !strings.Contains(out, "not available") {
+		t.Fatalf("unbound: err=%v out=%s", isErr, out)
+	}
+}


### PR DESCRIPTION
## What

**Gap-analysis frontier #3: governed self-install.** Agents (and operators) can now attach MCP servers **while the daemon runs** — no restart, no separate bridge binary, no env-var surgery:

```
mcp op=add (register)  →  mcp op=attach (Edict-gated spawn + handshake + discovery)
                                 ↓
        every run + delegate child offered mcp_<server>_<tool>
                                 ↓
        mcp op=detach = instant kill switch · enabled servers auto-attach at boot
```

## Governance (the point)

- **`mcp.install` (new, LevelAsk)** — attaching spawns an arbitrary external process; approve every one. Gates the `mcp` tool's add/attach/detach/remove (op=list → introspect axis; garbled ops land on the gated axis).
- **`mcp.call` (new, LevelAskFirst)** — every bridged `mcp_*` call is code the daemon didn't ship (toolmap prefix rule).
- **Scrubbed child env** — PATH/OS vars/per-user dirs only; never `AGEZT_*` or secret-shaped variables (unit-tested).
- **Journaled lifecycle** — `mcp.added/updated/attached/detached/removed` under `mcp.<name>`; attach payload carries discovered tool names.
- Server names `[a-z][a-z0-9]*` (no underscore/dash) so `mcp_<server>_<tool>` parses losslessly; bridged names sanitized to the provider alphabet + 64-capped; 16 MiB frame cap; handshake/call timeouts.
- Per-run **WithTools allowlist gates bridged tools** exactly like built-ins (merge before filter).

## Design

- `kernel/mcp`: roster-pattern registry + minimal kernel-native stdio MCP client (initialize → initialized → tools/list → tools/call). Single static binary preserved; kernel spawns the child directly (kernel/plugin precedent — warden is run-to-completion, MCP needs a long-lived dialog).
- `Config.MCPDialer` is the test seam; `mcp.Conn` is an interface; the pipe-based client core tests without any process.
- Surfaces: `mcp` agent tool, `agt mcp add/attach/detach/enable/disable/remove/list`, controlplane `mcp_*`, webui routes (GET /api/mcp + attach/detach/enable/remove writeRoutes + add jsonRoute). Console view → M797.

## Tests — 16 new across 5 packages

Client dialogue over in-memory pipes (notification skipping, server errors, lost connection) · **live python MCP subprocess e2e** (Dial → discovery → "hello ersin" → close) · env scrub · store CRUD/validation (underscore names rejected — parse invariant) · runtime wire-level: attach → run OFFERS + FORWARDS, detach kill switch, double-attach refusal, remove-detaches-first, boot auto-attach, allowlist both ways, hostile-name sanitization · edict routing · mcptool loop · controlplane round-trip.

## Smoke (isolated AGEZT_HOME, real daemon, real python MCP server)

`agt mcp add fake --cmd python --arg server.py` → `attach` → **real spawn+handshake: 2 tools discovered (mcp_fake_greet, mcp_fake_weather)** → list ATTACHED → detach → **daemon restart: banner "mcp servers : 1 attached of 1 registered"** (boot auto-attach proven) → journal trail added→attached→detached→halt→attached.

## Local battery (CI org billing still blocked)

Full `GOMAXPROCS=3 go test -p 2 ./...` ✅ · vet ✅ · staticcheck ✅ · linux cross-build ✅ · staged gofmt sweep ✅ (caught 4 files pre-commit) · go.mod unchanged (1 dep) · no new env vars · frontend untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)