### PR TITLE
Feat: workflow engine core — typed-node graphs, governed (M798)

### DIFF
--- a/.project/PHASE-M798-WORKFLOW-ENGINE-CORE-REPORT.md
+++ b/.project/PHASE-M798-WORKFLOW-ENGINE-CORE-REPORT.md
@@ -1,0 +1,92 @@
+# Phase M798 — workflow engine core (n8n-style typed-node graphs)
+
+**Date:** 2026-06-10 · **Status:** DONE · **Arc:** workflow engine, step 1
+(owner ask: "n8n'den hallice", React Flow canvas, copilot-designed schemas,
+internal-tool access, cron/event/manual starts).
+
+Arc plan ratified in chat: M798 core engine → M799 triggers (cron/event) →
+M800 node library (http/code/forEach/switch/parallel/merge/approval/
+subworkflow/notify/error branch) → M801 React Flow canvas editor →
+M802 copilot + agent `workflow` tool.
+
+## What
+
+`kernel/workflow`: durable, named graphs of TYPED nodes wired by edges —
+unlike kernel/planner (intent → agent-loop per node), a workflow node is a
+precise deterministic step. M798 node set: **trigger** (manual), **tool**
+(one governed tool call: {tool, args}), **llm** (one completion: {prompt,
+system, model}), **condition** ({left, op, right} → true/false ports),
+**transform** ({template}), **delay** ({seconds ≤600}).
+
+Data flows with **{{path}} templates** (kernel/workflow/template.go):
+{{trigger.payload.city}}, {{node.output}}, deep JSON paths with array
+indexes ({{fetch.output.items.0.title}}). Tool/transform outputs that parse
+as JSON stay STRUCTURED so downstream templates reach into them; unknown
+paths render "" (debuggable, never fatal).
+
+## Engine (kernel/runtime/workflowrun.go)
+
+Token-flow over the validated DAG: trigger fires, each completing node
+fires its outgoing edges (a condition fires exactly one port), a node runs
+once on its first token. Governance is inherited, not reinvented:
+
+- **tool nodes pass k.policyHook** — the SAME Edict gate as agent-loop
+  calls (deny refuses the node; ask blocks on the approval registry), and
+  they see the full dynamic tool map (built-ins + forge_* + mcp_*).
+- **llm nodes ride the Governor** (TaskType "workflow" → routable +
+  metered like any other class).
+- Every run journals workflow.started → workflow.node (ok/error/port) →
+  workflow.completed|failed under subject workflow.<name> — the M801
+  canvas will replay these live.
+- Halted kernel refuses; ctx cancellation honored between/inside nodes;
+  256-step defense cap atop cycle-free validation.
+
+## Validation (the canvas's contract)
+
+Exactly one trigger; unique ids; known types; edges resolve; condition
+edges need port true/false, others default-port only; trigger has no
+incoming edges; acyclic (Kahn); per-type config checks; ≤100 nodes,
+≤300 edges, ≤32KiB config. Store.Save validates BEFORE disk and upserts
+by name wholesale (ID/CreatedMS/Enabled survive an update).
+
+## Surfaces
+
+controlplane workflow_list/show/save/remove/set_enabled/run (run is
+synchronous, 15m bound, returns {executed, outputs, correlation_id});
+`agt workflow list|show|save --file|run --payload|enable|disable|remove`;
+webui routes (GET /api/workflows + /show readArgs; save/run jsonRoutes;
+enable/remove writeRoutes) — API parity ready for the M801 canvas.
+
+## Tests (10 new across 3 packages)
+
+- workflow: Validate accept + 17-case reject table; Interpolate/Lookup
+  table (deep paths, arrays, objects→JSON, misses, dangling braces);
+  store upsert-by-name (identity+enabled survive; invalid never touches
+  disk); persistence round-trip.
+- runtime e2e: linear data flow (payload→tool args→parsed JSON→transform→
+  llm prompt, journal arc started/4×node/completed asserted); condition
+  branching both ways (untaken branch never runs); policy gates tool nodes
+  (default-deny, tool never invoked); tool failure fails the run
+  (downstream never runs).
+- controlplane wire round-trip: save/validate-refusal/list-stays-light/
+  show-full-graph/run-with-payload/disable/remove/ghost refs.
+
+## Smoke (isolated AGEZT_HOME, real daemon)
+
+`agt workflow save --file flow.json` (6 nodes: trigger→transform→condition
+→{delay→win | lose}) → run with score 80: TRUE branch, 1s delay, output
+"KAZANDIN — merhaba ersin, skor: 80" → run with score 20: FALSE branch,
+"bir dahaki sefere…". Both runs listed per-node outputs with correlations.
+
+## Gate
+
+Full `GOMAXPROCS=3 go test -p 2 ./...` green; vet + staticcheck clean;
+linux cross-build OK; frontend untouched (canvas is M801; dist unchanged);
+go.mod unchanged; no new env vars. CI org-billing still blocked → local
+battery + arc-authority merge.
+
+## Next
+
+M799: triggers — the trigger node gains {kind: manual|cron|event} config;
+a workflow trigger runner (cadence + standing-runner patterns) fires
+enabled workflows with the event payload as {{trigger.payload}}.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **Workflow engine (core): durable, typed-node graphs — n8n-style, governed.** New
+  `kernel/workflow` + `agt workflow`: build a named graph of **typed nodes** — `trigger` (manual;
+  cron/event triggers next), `tool` (one governed call to ANY tool, built-in, forged, or
+  MCP-bridged), `llm` (one completion through the Governor), `condition` (true/false branching),
+  `transform`, `delay` — wired by edges and carrying data with **{{path}} templates**
+  (`{{trigger.payload.city}}`, `{{fetch.output.items.0.title}}`; JSON outputs stay structured so
+  downstream nodes reach into them). Unlike `agt plan` (intent → an agent loop per node), a
+  workflow node is a precise, deterministic step — and governance is inherited, not reinvented:
+  **tool nodes pass the exact same Edict policy gate as agent tool calls** (deny refuses the node,
+  ask blocks on the operator), llm nodes are routed/metered by the Governor, and every run journals
+  a `workflow.started → workflow.node… → workflow.completed|failed` arc the console canvas will
+  replay live. Graphs are validated hard before they ever touch disk (exactly one trigger, acyclic,
+  ports legal, per-type configs) and saved by name (`agt workflow save --file graph.json`), run on
+  demand with a payload (`agt workflow run <name> --payload '{...}'` → per-node outputs), and
+  exposed over the control plane + web API for the upcoming React Flow canvas editor (M801) and
+  copilot (M802). 10 new tests incl. a wire-level data-flow e2e and an isolated-daemon smoke whose
+  6-node branching pipeline took the true branch ("KAZANDIN…") at score 80 and the false branch at
+  score 20, per-node outputs and journal arc verified. (M798)
 - **MCP Servers console view.** MCP self-install (M796) gets its operator surface — an *MCP
   Servers* view under Agents: register a stdio server in the browser (the form explains the
   no-underscore name rule and splits args for you), **attach behind a confirm dialog** that says

--- a/cmd/agt/main.go
+++ b/cmd/agt/main.go
@@ -140,6 +140,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 		return cmdToolforge(args[1:], stdout, stderr)
 	case "mcp":
 		return cmdMCP(args[1:], stdout, stderr)
+	case "workflow":
+		return cmdWorkflow(args[1:], stdout, stderr)
 	case "reflect":
 		return cmdReflect(args[1:], stdout, stderr)
 	case "inbox":

--- a/cmd/agt/workflow.go
+++ b/cmd/agt/workflow.go
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/agezt/agezt/internal/brand"
+	"github.com/agezt/agezt/kernel/controlplane"
+)
+
+// cmdWorkflow dispatches `agt workflow <subcommand>` — the operator surface
+// of the workflow engine (M798): durable, named graphs of typed nodes
+// (trigger/tool/llm/condition/transform/delay) saved as JSON, run on demand
+// (cron/event triggers arrive with M799), every run arc journaled
+// (workflow.*). The console canvas edits the same graphs.
+func cmdWorkflow(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		return workflowUsage(stderr)
+	}
+	switch args[0] {
+	case "list":
+		return cmdWorkflowList(args[1:], stdout, stderr)
+	case "show":
+		return cmdWorkflowShow(args[1:], stdout, stderr)
+	case "save", "add", "import":
+		return cmdWorkflowSave(args[1:], stdout, stderr)
+	case "run":
+		return cmdWorkflowRun(args[1:], stdout, stderr)
+	case "enable":
+		return cmdWorkflowSetEnabled(args[1:], stdout, stderr, true)
+	case "disable":
+		return cmdWorkflowSetEnabled(args[1:], stdout, stderr, false)
+	case "remove", "rm":
+		return cmdWorkflowRemove(args[1:], stdout, stderr)
+	case "-h", "--help", "help":
+		return workflowUsage(stdout)
+	default:
+		fmt.Fprintf(stderr, "%s workflow: unknown subcommand %q\n", brand.CLI, args[0])
+		return workflowUsage(stderr)
+	}
+}
+
+func workflowUsage(w io.Writer) int {
+	fmt.Fprintf(w, "usage: %s workflow <list|show|save|run|enable|disable|remove>\n", brand.CLI)
+	fmt.Fprintf(w, "  list [--json]                      all workflows (name, nodes, enabled)\n")
+	fmt.Fprintf(w, "  show <name|id> [--json]            one workflow's full graph\n")
+	fmt.Fprintf(w, "  save --file GRAPH.json             create or update (upsert by name) a workflow\n")
+	fmt.Fprintf(w, "  run <name|id> [--payload JSON]     execute now; payload lands in {{trigger.payload}}\n")
+	fmt.Fprintf(w, "  enable|disable <name|id>           arm/disarm its triggers (M799)\n")
+	fmt.Fprintf(w, "  remove <name|id>                   delete a workflow\n")
+	fmt.Fprintf(w, "node types: trigger, tool {tool,args}, llm {prompt,system,model}, condition {left,op,right},\n")
+	fmt.Fprintf(w, "            transform {template}, delay {seconds} — string fields take {{node_id.output}} templates\n")
+	return 0
+}
+
+func cmdWorkflowList(args []string, stdout, stderr io.Writer) int {
+	asJSON := false
+	for _, a := range args {
+		if a == "--json" {
+			asJSON = true
+		}
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := c.Call(ctx, controlplane.CmdWorkflowList, nil)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s workflow list: %v\n", brand.CLI, err)
+		return 1
+	}
+	if asJSON {
+		return encodeJSON(stdout, res)
+	}
+	items, _ := res["workflows"].([]any)
+	if len(items) == 0 {
+		fmt.Fprintf(stdout, "no workflows yet — save one with `%s workflow save --file graph.json` or build it on the console canvas\n", brand.CLI)
+		return 0
+	}
+	for _, raw := range items {
+		w, _ := raw.(map[string]any)
+		if w == nil {
+			continue
+		}
+		state := "enabled"
+		if en, _ := w["enabled"].(bool); !en {
+			state = "disabled"
+		}
+		nodes, _ := w["node_count"].(float64)
+		fmt.Fprintf(stdout, "%-24s %-9s %d node(s)", str(w["name"]), state, int(nodes))
+		if d := str(w["description"]); d != "" {
+			fmt.Fprintf(stdout, "  %s", d)
+		}
+		fmt.Fprintln(stdout)
+	}
+	fmt.Fprintf(stdout, "%v workflow(s)\n", res["count"])
+	return 0
+}
+
+func cmdWorkflowShow(args []string, stdout, stderr io.Writer) int {
+	asJSON := false
+	ref := ""
+	for _, a := range args {
+		if a == "--json" {
+			asJSON = true
+		} else if !strings.HasPrefix(a, "--") && ref == "" {
+			ref = a
+		}
+	}
+	if ref == "" {
+		fmt.Fprintf(stderr, "usage: %s workflow show <name|id> [--json]\n", brand.CLI)
+		return 2
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := c.Call(ctx, controlplane.CmdWorkflowShow, map[string]any{"ref": ref})
+	if err != nil {
+		fmt.Fprintf(stderr, "%s workflow show: %v\n", brand.CLI, err)
+		return 1
+	}
+	w, _ := res["workflow"].(map[string]any)
+	if w == nil {
+		fmt.Fprintf(stderr, "%s workflow show: unknown workflow %q\n", brand.CLI, ref)
+		return 1
+	}
+	// The graph IS the artifact — print it as JSON either way; --json just
+	// skips the human header.
+	if !asJSON {
+		state := "enabled"
+		if en, _ := w["enabled"].(bool); !en {
+			state = "disabled"
+		}
+		fmt.Fprintf(stdout, "%s (%s) — %v node(s), %v edge(s)\n", str(w["name"]), state, w["node_count"], w["edge_count"])
+	}
+	return encodeJSON(stdout, w)
+}
+
+func cmdWorkflowSave(args []string, stdout, stderr io.Writer) int {
+	file := ""
+	for i := 0; i < len(args); i++ {
+		if args[i] == "--file" {
+			if i+1 >= len(args) {
+				fmt.Fprintf(stderr, "%s workflow save: --file needs a path\n", brand.CLI)
+				return 2
+			}
+			i++
+			file = args[i]
+		}
+	}
+	if file == "" {
+		fmt.Fprintf(stderr, "usage: %s workflow save --file GRAPH.json\n", brand.CLI)
+		return 2
+	}
+	b, err := os.ReadFile(file)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s workflow save: read %s: %v\n", brand.CLI, file, err)
+		return 1
+	}
+	var graph map[string]any
+	if err := json.Unmarshal(b, &graph); err != nil {
+		fmt.Fprintf(stderr, "%s workflow save: %s is not valid JSON: %v\n", brand.CLI, file, err)
+		return 1
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	res, err := c.Call(ctx, controlplane.CmdWorkflowSave, map[string]any{"workflow": graph})
+	if err != nil {
+		fmt.Fprintf(stderr, "%s workflow save: %v\n", brand.CLI, err)
+		return 1
+	}
+	w, _ := res["workflow"].(map[string]any)
+	verb := "updated"
+	if created, _ := res["created"].(bool); created {
+		verb = "created"
+	}
+	fmt.Fprintf(stdout, "%s %s (%v node(s)) — run it with `%s workflow run %s`\n", verb, str(w["name"]), w["node_count"], brand.CLI, str(w["name"]))
+	return 0
+}
+
+func cmdWorkflowRun(args []string, stdout, stderr io.Writer) int {
+	ref, payloadRaw := "", ""
+	asJSON := false
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--payload":
+			if i+1 >= len(args) {
+				fmt.Fprintf(stderr, "%s workflow run: --payload needs a value\n", brand.CLI)
+				return 2
+			}
+			i++
+			payloadRaw = args[i]
+		case "--json":
+			asJSON = true
+		default:
+			if !strings.HasPrefix(args[i], "--") && ref == "" {
+				ref = args[i]
+			}
+		}
+	}
+	if ref == "" {
+		fmt.Fprintf(stderr, "usage: %s workflow run <name|id> [--payload JSON] [--json]\n", brand.CLI)
+		return 2
+	}
+	callArgs := map[string]any{"ref": ref}
+	if payloadRaw != "" {
+		// A JSON payload rides structured; anything else rides as a string.
+		var v any
+		if err := json.Unmarshal([]byte(payloadRaw), &v); err == nil {
+			callArgs["payload"] = v
+		} else {
+			callArgs["payload"] = payloadRaw
+		}
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	// Runs can legitimately take minutes (delay nodes, slow tools, HITL asks).
+	ctx, cancel := context.WithTimeout(context.Background(), 16*time.Minute)
+	defer cancel()
+	res, err := c.Call(ctx, controlplane.CmdWorkflowRun, callArgs)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s workflow run: %v\n", brand.CLI, err)
+		return 1
+	}
+	if asJSON {
+		return encodeJSON(stdout, res)
+	}
+	executed, _ := res["executed"].([]any)
+	fmt.Fprintf(stdout, "completed — %d node(s) executed (correlation %s)\n", len(executed), str(res["correlation_id"]))
+	outputs, _ := res["outputs"].(map[string]any)
+	for _, raw := range executed {
+		id := str(raw)
+		out := outputs[id]
+		rendered := ""
+		switch v := out.(type) {
+		case string:
+			rendered = v
+		case nil:
+			rendered = ""
+		default:
+			b, _ := json.Marshal(v)
+			rendered = string(b)
+		}
+		if len(rendered) > 120 {
+			rendered = rendered[:120] + "…"
+		}
+		fmt.Fprintf(stdout, "  %-20s %s\n", id, rendered)
+	}
+	return 0
+}
+
+func cmdWorkflowSetEnabled(args []string, stdout, stderr io.Writer, enabled bool) int {
+	verb := "enable"
+	if !enabled {
+		verb = "disable"
+	}
+	if len(args) != 1 {
+		fmt.Fprintf(stderr, "usage: %s workflow %s <name|id>\n", brand.CLI, verb)
+		return 2
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := c.Call(ctx, controlplane.CmdWorkflowSetEnabled, map[string]any{"ref": args[0], "enabled": enabled}); err != nil {
+		fmt.Fprintf(stderr, "%s workflow %s: %v\n", brand.CLI, verb, err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "%s %sd\n", args[0], verb)
+	return 0
+}
+
+func cmdWorkflowRemove(args []string, stdout, stderr io.Writer) int {
+	if len(args) != 1 {
+		fmt.Fprintf(stderr, "usage: %s workflow remove <name|id>\n", brand.CLI)
+		return 2
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := c.Call(ctx, controlplane.CmdWorkflowRemove, map[string]any{"ref": args[0]})
+	if err != nil {
+		fmt.Fprintf(stderr, "%s workflow remove: %v\n", brand.CLI, err)
+		return 1
+	}
+	if ok, _ := res["removed"].(bool); !ok {
+		fmt.Fprintf(stderr, "%s workflow remove: unknown workflow %q\n", brand.CLI, args[0])
+		return 1
+	}
+	fmt.Fprintf(stdout, "removed %s\n", args[0])
+	return 0
+}

--- a/kernel/controlplane/protocol.go
+++ b/kernel/controlplane/protocol.go
@@ -904,6 +904,19 @@ const (
 	CmdMCPSetEnabled = "mcp_set_enabled"
 	CmdMCPRemove     = "mcp_remove"
 
+	// Workflow engine (M798) — durable typed-node graphs behind
+	// `agt workflow` and the console canvas. Save: args.workflow (the whole
+	// graph object; upsert by name). Run: args{ref, payload?} — executes
+	// synchronously and returns {outputs, executed}. Show/Remove: args.ref.
+	// SetEnabled: args{ref, enabled} (arms triggers — M799). List: no args.
+	// Every mutation + every run arc is journaled (workflow.*).
+	CmdWorkflowList       = "workflow_list"
+	CmdWorkflowShow       = "workflow_show"
+	CmdWorkflowSave       = "workflow_save"
+	CmdWorkflowRemove     = "workflow_remove"
+	CmdWorkflowSetEnabled = "workflow_set_enabled"
+	CmdWorkflowRun        = "workflow_run"
+
 	// Sandbox projects (M686) — read-only inspection of what agents BUILT with the
 	// code_exec tool under <baseDir>/sandbox/projects. List: no args, returns each
 	// persistent project with its files (name, bytes, modified). File: args{project,

--- a/kernel/controlplane/server.go
+++ b/kernel/controlplane/server.go
@@ -722,6 +722,18 @@ func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
 		s.handleMCPSetEnabled(conn, req)
 	case CmdMCPRemove:
 		s.handleMCPRemove(conn, req)
+	case CmdWorkflowList:
+		s.handleWorkflowList(conn, req)
+	case CmdWorkflowShow:
+		s.handleWorkflowShow(conn, req)
+	case CmdWorkflowSave:
+		s.handleWorkflowSave(conn, req)
+	case CmdWorkflowRemove:
+		s.handleWorkflowRemove(conn, req)
+	case CmdWorkflowSetEnabled:
+		s.handleWorkflowSetEnabled(conn, req)
+	case CmdWorkflowRun:
+		s.handleWorkflowRun(conn, req)
 	case CmdSandboxList:
 		s.handleSandboxList(conn, req)
 	case CmdSandboxFile:

--- a/kernel/controlplane/workflow.go
+++ b/kernel/controlplane/workflow.go
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: MIT
+
+package controlplane
+
+// Workflow engine handlers (M798) — the management + run path behind
+// `agt workflow` and the console canvas. Lifecycle changes go through the
+// kernel so every save/enable/remove and every run arc is journaled
+// (workflow.*). Workflows are addressed by ref = id OR name everywhere.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/agezt/agezt/kernel/workflow"
+)
+
+// workflowRunTimeout bounds one synchronous run over the wire — generous
+// (delay nodes alone may sleep minutes), but never unbounded.
+const workflowRunTimeout = 15 * time.Minute
+
+// workflowView is the stable wire shape. The full graph rides only when
+// full is set (list stays light; show/save carry it for the canvas).
+func workflowView(w workflow.Workflow, full bool) map[string]any {
+	b, _ := json.Marshal(w)
+	var m map[string]any
+	_ = json.Unmarshal(b, &m)
+	m["node_count"] = len(w.Nodes)
+	m["edge_count"] = len(w.Edges)
+	if !full {
+		delete(m, "nodes")
+		delete(m, "edges")
+	}
+	return m
+}
+
+func (s *Server) handleWorkflowList(conn net.Conn, req Request) {
+	items := s.k.Workflows().List()
+	out := make([]any, 0, len(items))
+	enabled := 0
+	for _, w := range items {
+		out = append(out, workflowView(w, false))
+		if w.Enabled {
+			enabled++
+		}
+	}
+	s.writeResp(conn, Response{
+		ID:     req.ID,
+		Type:   RespResult,
+		Result: map[string]any{"workflows": out, "count": len(out), "enabled_count": enabled},
+	})
+}
+
+func (s *Server) handleWorkflowShow(conn net.Conn, req Request) {
+	ref, _ := req.Args["ref"].(string)
+	if strings.TrimSpace(ref) == "" {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.ref required"})
+		return
+	}
+	w, found := s.k.Workflows().Get(strings.TrimSpace(ref))
+	if !found {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "unknown workflow: " + ref})
+		return
+	}
+	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{"workflow": workflowView(w, true)}})
+}
+
+func (s *Server) handleWorkflowSave(conn net.Conn, req Request) {
+	raw, ok := req.Args["workflow"]
+	if !ok {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.workflow required"})
+		return
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.workflow: " + err.Error()})
+		return
+	}
+	var w workflow.Workflow
+	if err := json.Unmarshal(b, &w); err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.workflow: " + err.Error()})
+		return
+	}
+	saved, created, err := s.k.SaveWorkflow("", w)
+	if err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
+		return
+	}
+	s.writeResp(conn, Response{
+		ID:     req.ID,
+		Type:   RespResult,
+		Result: map[string]any{"workflow": workflowView(saved, true), "created": created},
+	})
+}
+
+func (s *Server) handleWorkflowRemove(conn net.Conn, req Request) {
+	ref, _ := req.Args["ref"].(string)
+	if strings.TrimSpace(ref) == "" {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.ref required"})
+		return
+	}
+	ok, err := s.k.RemoveWorkflow("", ref)
+	if err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
+		return
+	}
+	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{"removed": ok}})
+}
+
+func (s *Server) handleWorkflowSetEnabled(conn net.Conn, req Request) {
+	ref, _ := req.Args["ref"].(string)
+	if strings.TrimSpace(ref) == "" {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.ref required"})
+		return
+	}
+	enabled := false
+	switch v := req.Args["enabled"].(type) {
+	case bool:
+		enabled = v
+	case string:
+		enabled = strings.EqualFold(v, "true") || v == "1"
+	}
+	w, err := s.k.SetWorkflowEnabled("", ref, enabled)
+	if err != nil {
+		if errors.Is(err, workflow.ErrNotFound) {
+			s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "unknown workflow: " + ref})
+			return
+		}
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
+		return
+	}
+	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{"workflow": workflowView(w, false)}})
+}
+
+func (s *Server) handleWorkflowRun(conn net.Conn, req Request) {
+	ref, _ := req.Args["ref"].(string)
+	if strings.TrimSpace(ref) == "" {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.ref required"})
+		return
+	}
+	// payload may be any JSON value (object on the canvas, a string from the
+	// CLI's --payload) — passed verbatim into {{trigger.payload}}.
+	payload := req.Args["payload"]
+	corr := s.k.NewCorrelation()
+	ctx, cancel := context.WithTimeout(context.Background(), workflowRunTimeout)
+	defer cancel()
+	res, err := s.k.RunWorkflow(ctx, corr, ref, payload)
+	if err != nil {
+		if errors.Is(err, workflow.ErrNotFound) {
+			s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "unknown workflow: " + ref})
+			return
+		}
+		s.writeResp(conn, Response{
+			ID: req.ID, Type: RespError,
+			Error: err.Error() + " (correlation " + corr + ")",
+		})
+		return
+	}
+	s.writeResp(conn, Response{
+		ID:   req.ID,
+		Type: RespResult,
+		Result: map[string]any{
+			"correlation_id": corr,
+			"executed":       res.Executed,
+			"outputs":        res.Outputs,
+		},
+	})
+}

--- a/kernel/controlplane/workflow_test.go
+++ b/kernel/controlplane/workflow_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: MIT
+
+package controlplane_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/controlplane"
+	"github.com/agezt/agezt/kernel/edict"
+	"github.com/agezt/agezt/kernel/runtime"
+	"github.com/agezt/agezt/plugins/providers/mock"
+)
+
+// wireEchoTool is the tool-node double for the wire round-trip.
+type wireEchoTool struct{ last string }
+
+func (t *wireEchoTool) Definition() agent.ToolDef {
+	return agent.ToolDef{Name: "echo", Description: "echoes", InputSchema: json.RawMessage(`{"type":"object"}`)}
+}
+
+func (t *wireEchoTool) Invoke(_ context.Context, raw json.RawMessage) (agent.Result, error) {
+	t.last = string(raw)
+	return agent.Result{Output: `{"status":"done"}`}, nil
+}
+
+// TestWorkflow_WireRoundTrip drives the full operator pipeline over the
+// wire: save (validated) → list → show (full graph) → run with a payload
+// (templates resolve, outputs come back) → disable → remove. Exactly what
+// `agt workflow` and the console canvas speak.
+func TestWorkflow_WireRoundTrip(t *testing.T) {
+	tool := &wireEchoTool{}
+	k, _, c, _ := startPairWithConfig(t, runtime.Config{
+		Provider: mock.New(mock.FinalText("unused")),
+		Tools:    map[string]agent.Tool{"echo": tool},
+	})
+	k.Edict().SetLevel("echo", edict.LevelAllow)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	graph := map[string]any{
+		"name":        "wire-flow",
+		"description": "round-trip demo",
+		"nodes": []any{
+			map[string]any{"id": "start", "type": "trigger"},
+			map[string]any{"id": "call", "type": "tool",
+				"config": map[string]any{"tool": "echo", "args": map[string]any{"who": "{{trigger.payload.who}}"}}},
+			map[string]any{"id": "shape", "type": "transform",
+				"config": map[string]any{"template": "status={{call.output.status}}"}},
+		},
+		"edges": []any{
+			map[string]any{"from": "start", "to": "call"},
+			map[string]any{"from": "call", "to": "shape"},
+		},
+	}
+
+	// Save (create).
+	res, err := c.Call(ctx, controlplane.CmdWorkflowSave, map[string]any{"workflow": graph})
+	if err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if created, _ := res["created"].(bool); !created {
+		t.Fatalf("created = %v", res["created"])
+	}
+
+	// An invalid graph is refused with the validator's reason.
+	bad := map[string]any{"name": "bad-flow", "nodes": []any{map[string]any{"id": "a", "type": "tool", "config": map[string]any{"tool": "x"}}}}
+	if _, err := c.Call(ctx, controlplane.CmdWorkflowSave, map[string]any{"workflow": bad}); err == nil ||
+		!strings.Contains(err.Error(), "trigger") {
+		t.Fatalf("invalid save: %v", err)
+	}
+
+	// List is light (no nodes); show carries the full graph.
+	res, err = c.Call(ctx, controlplane.CmdWorkflowList, nil)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	items, _ := res["workflows"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("list count = %d", len(items))
+	}
+	if first, _ := items[0].(map[string]any); first["nodes"] != nil {
+		t.Fatal("list leaked the graph body")
+	}
+	res, err = c.Call(ctx, controlplane.CmdWorkflowShow, map[string]any{"ref": "wire-flow"})
+	if err != nil {
+		t.Fatalf("show: %v", err)
+	}
+	wf, _ := res["workflow"].(map[string]any)
+	if nodes, _ := wf["nodes"].([]any); len(nodes) != 3 {
+		t.Fatalf("show graph = %v", wf["nodes"])
+	}
+
+	// Run with a payload: the template reaches the tool; outputs return.
+	res, err = c.Call(ctx, controlplane.CmdWorkflowRun, map[string]any{
+		"ref": "wire-flow", "payload": map[string]any{"who": "ersin"},
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !strings.Contains(tool.last, `"ersin"`) {
+		t.Fatalf("payload did not reach the tool: %q", tool.last)
+	}
+	outputs, _ := res["outputs"].(map[string]any)
+	if outputs["shape"] != "status=done" {
+		t.Fatalf("outputs = %v", outputs)
+	}
+	if executed, _ := res["executed"].([]any); len(executed) != 3 {
+		t.Fatalf("executed = %v", res["executed"])
+	}
+
+	// Disable → remove → ghost refs are honest errors.
+	if _, err := c.Call(ctx, controlplane.CmdWorkflowSetEnabled, map[string]any{"ref": "wire-flow", "enabled": false}); err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+	res, err = c.Call(ctx, controlplane.CmdWorkflowRemove, map[string]any{"ref": "wire-flow"})
+	if err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if removed, _ := res["removed"].(bool); !removed {
+		t.Fatal("remove reported false")
+	}
+	if _, err := c.Call(ctx, controlplane.CmdWorkflowRun, map[string]any{"ref": "wire-flow"}); err == nil {
+		t.Fatal("running a removed workflow accepted")
+	}
+}

--- a/kernel/event/kinds.go
+++ b/kernel/event/kinds.go
@@ -298,6 +298,18 @@ const (
 	KindMCPAttached Kind = "mcp.attached"
 	KindMCPDetached Kind = "mcp.detached"
 	KindMCPRemoved  Kind = "mcp.removed"
+
+	// Workflow engine (M798) — durable typed-node graphs. CRUD plus one
+	// started/node.../completed|failed arc per run, all under subject
+	// "workflow.<name>", so the console canvas can replay a run live and
+	// `agt why` explains what each node did.
+	KindWorkflowSaved     Kind = "workflow.saved"
+	KindWorkflowUpdated   Kind = "workflow.updated" // enabled/disabled
+	KindWorkflowRemoved   Kind = "workflow.removed"
+	KindWorkflowStarted   Kind = "workflow.started"
+	KindWorkflowNode      Kind = "workflow.node" // one node executed (ok/error, fired port)
+	KindWorkflowCompleted Kind = "workflow.completed"
+	KindWorkflowFailed    Kind = "workflow.failed"
 )
 
 // IsKnown reports whether k is one of the kinds defined in this file. Useful
@@ -417,4 +429,11 @@ var knownKinds = map[Kind]struct{}{
 	KindMCPAttached:               {},
 	KindMCPDetached:               {},
 	KindMCPRemoved:                {},
+	KindWorkflowSaved:             {},
+	KindWorkflowUpdated:           {},
+	KindWorkflowRemoved:           {},
+	KindWorkflowStarted:           {},
+	KindWorkflowNode:              {},
+	KindWorkflowCompleted:         {},
+	KindWorkflowFailed:            {},
 }

--- a/kernel/runtime/runtime.go
+++ b/kernel/runtime/runtime.go
@@ -45,6 +45,7 @@ import (
 	"github.com/agezt/agezt/kernel/toolforge"
 	"github.com/agezt/agezt/kernel/ulid"
 	"github.com/agezt/agezt/kernel/warden"
+	"github.com/agezt/agezt/kernel/workflow"
 	"github.com/agezt/agezt/kernel/worldmodel"
 )
 
@@ -345,6 +346,7 @@ type Kernel struct {
 	roster    *roster.Store
 	toolForge *toolforge.Store
 	mcpStore  *mcp.Store
+	workflows *workflow.Store
 	artifacts *artifact.Store
 	reflect   *reflect.Engine
 	schedules *cadence.Store        // persistent scheduled-intents store (autonomy)
@@ -497,6 +499,16 @@ func Open(cfg Config) (*Kernel, error) {
 		return nil, fmt.Errorf("runtime: mcp: %w", err)
 	}
 
+	wfstore, err := workflow.OpenStore(filepath.Join(cfg.BaseDir, "workflows"))
+	if err != nil {
+		j.Close()
+		st.Close()
+		mstore.Close()
+		wstore.Close()
+		skstore.Close()
+		return nil, fmt.Errorf("runtime: workflows: %w", err)
+	}
+
 	// Reflection holds no store of its own — it folds the journal and tunes
 	// the world graph, then journals its report (SPEC-05 §6). Default decay
 	// knobs; the daemon may override via the optional periodic trigger.
@@ -560,6 +572,7 @@ func Open(cfg Config) (*Kernel, error) {
 		toolForge:    tfstore,
 		mcpStore:     mcpstore,
 		mcpConns:     make(map[string]mcp.Conn),
+		workflows:    wfstore,
 		artifacts:    artStore,
 		reflect:      reflectEng,
 		schedules:    schedStore,

--- a/kernel/runtime/workflowrun.go
+++ b/kernel/runtime/workflowrun.go
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: MIT
+
+package runtime
+
+// Workflow engine integration (M798): the kernel-side CRUD + execution of
+// kernel/workflow graphs. Execution is token-flow over the validated DAG:
+// the trigger fires, each completing node fires its outgoing edges (a
+// condition fires exactly one port), and a node runs once on its first
+// incoming token. Tool nodes pass the SAME Edict policy hook as agent-loop
+// tool calls (deny/ask semantics identical), llm nodes ride the Governor
+// (budgets/routing/cost metering), and every step is journaled
+// (workflow.*) so the console canvas can replay a run live.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/workflow"
+)
+
+// Workflows returns the durable workflow store (M798). Always non-nil after
+// Open.
+func (k *Kernel) Workflows() *workflow.Store { return k.workflows }
+
+// SaveWorkflow validates and upserts a workflow (the canvas posts the whole
+// graph), journaling workflow.saved with created/updated.
+func (k *Kernel) SaveWorkflow(corr string, w workflow.Workflow) (workflow.Workflow, bool, error) {
+	saved, created, err := k.workflows.Save(w)
+	if err != nil {
+		return workflow.Workflow{}, false, err
+	}
+	action := "updated"
+	if created {
+		action = "created"
+	}
+	_, _ = k.bus.Publish(event.Spec{
+		Subject: "workflow." + saved.Name, Kind: event.KindWorkflowSaved, Actor: "workflow",
+		CorrelationID: corr,
+		Payload:       map[string]any{"id": saved.ID, "name": saved.Name, "action": action, "nodes": len(saved.Nodes), "edges": len(saved.Edges)},
+	})
+	return saved, created, nil
+}
+
+// SetWorkflowEnabled arms/disarms a workflow's triggers, journaling
+// workflow.updated.
+func (k *Kernel) SetWorkflowEnabled(corr, ref string, enabled bool) (workflow.Workflow, error) {
+	w, err := k.workflows.SetEnabled(ref, enabled)
+	if err != nil {
+		return workflow.Workflow{}, err
+	}
+	_, _ = k.bus.Publish(event.Spec{
+		Subject: "workflow." + w.Name, Kind: event.KindWorkflowUpdated, Actor: "workflow",
+		CorrelationID: corr,
+		Payload:       map[string]any{"id": w.ID, "name": w.Name, "enabled": enabled},
+	})
+	return w, nil
+}
+
+// RemoveWorkflow deletes a workflow, journaling workflow.removed when it
+// existed.
+func (k *Kernel) RemoveWorkflow(corr, ref string) (bool, error) {
+	gone, ok, err := k.workflows.Remove(ref)
+	if err != nil {
+		return false, err
+	}
+	if ok {
+		_, _ = k.bus.Publish(event.Spec{
+			Subject: "workflow." + gone.Name, Kind: event.KindWorkflowRemoved, Actor: "workflow",
+			CorrelationID: corr,
+			Payload:       map[string]any{"id": gone.ID, "name": gone.Name},
+		})
+	}
+	return ok, nil
+}
+
+// workflowStepCap is a defense-in-depth bound on executed steps per run —
+// validation already rejects cycles, so this can only fire on an engine bug.
+const workflowStepCap = 256
+
+// RunWorkflowResult carries one run's outcome: per-node outputs (by node id)
+// and the ordered list of executed node ids.
+type RunWorkflowResult struct {
+	Outputs  map[string]any
+	Executed []string
+}
+
+// RunWorkflow executes one stored workflow under corr. payload becomes
+// {{trigger.payload}}. Halted kernels refuse; the run respects ctx
+// cancellation between and inside nodes. The first failing node fails the
+// run (error branching arrives with M800).
+func (k *Kernel) RunWorkflow(ctx context.Context, corr, ref string, payload any) (RunWorkflowResult, error) {
+	k.mu.Lock()
+	halted := k.halted
+	k.mu.Unlock()
+	if halted {
+		return RunWorkflowResult{}, ErrHalted
+	}
+	w, found := k.workflows.Get(ref)
+	if !found {
+		return RunWorkflowResult{}, workflow.ErrNotFound
+	}
+	if err := workflow.Validate(w); err != nil { // defense: stores can predate rules
+		return RunWorkflowResult{}, err
+	}
+
+	_, _ = k.bus.Publish(event.Spec{
+		Subject: "workflow." + w.Name, Kind: event.KindWorkflowStarted, Actor: "workflow",
+		CorrelationID: corr,
+		Payload:       map[string]any{"id": w.ID, "name": w.Name, "nodes": len(w.Nodes)},
+	})
+
+	res, err := k.runWorkflowGraph(ctx, corr, w, payload)
+	if err != nil {
+		_, _ = k.bus.Publish(event.Spec{
+			Subject: "workflow." + w.Name, Kind: event.KindWorkflowFailed, Actor: "workflow",
+			CorrelationID: corr,
+			Payload:       map[string]any{"id": w.ID, "name": w.Name, "error": err.Error(), "executed": res.Executed},
+		})
+		return res, err
+	}
+	_, _ = k.bus.Publish(event.Spec{
+		Subject: "workflow." + w.Name, Kind: event.KindWorkflowCompleted, Actor: "workflow",
+		CorrelationID: corr,
+		Payload:       map[string]any{"id": w.ID, "name": w.Name, "executed": res.Executed},
+	})
+	return res, nil
+}
+
+func (k *Kernel) runWorkflowGraph(ctx context.Context, corr string, w workflow.Workflow, payload any) (RunWorkflowResult, error) {
+	// Outgoing edges grouped by (from, port).
+	edges := map[string]map[string][]string{}
+	for _, e := range w.Edges {
+		if edges[e.From] == nil {
+			edges[e.From] = map[string][]string{}
+		}
+		edges[e.From][e.Port] = append(edges[e.From][e.Port], e.To)
+	}
+
+	data := map[string]any{"trigger": map[string]any{"payload": payload}}
+	res := RunWorkflowResult{Outputs: map[string]any{}}
+	executed := map[string]bool{}
+
+	queue := []string{w.TriggerNode().ID}
+	steps := 0
+	for len(queue) > 0 {
+		if err := ctx.Err(); err != nil {
+			return res, err
+		}
+		steps++
+		if steps > workflowStepCap {
+			return res, errors.New("workflow: step cap exceeded (engine bug — the graph validated as acyclic)")
+		}
+		id := queue[0]
+		queue = queue[1:]
+		if executed[id] {
+			continue // a node runs once: first token wins
+		}
+		executed[id] = true
+		node := w.NodeByID(id)
+
+		output, port, err := k.execWorkflowNode(ctx, corr, node, data, payload)
+		nodePayload := map[string]any{
+			"workflow": w.Name, "node": id, "type": node.Type, "ok": err == nil,
+		}
+		if node.Label != "" {
+			nodePayload["label"] = node.Label
+		}
+		if port != "" {
+			nodePayload["port"] = port
+		}
+		if err != nil {
+			nodePayload["error"] = err.Error()
+		}
+		_, _ = k.bus.Publish(event.Spec{
+			Subject: "workflow." + w.Name, Kind: event.KindWorkflowNode, Actor: "workflow",
+			CorrelationID: corr,
+			Payload:       nodePayload,
+		})
+		if err != nil {
+			return res, fmt.Errorf("node %s: %w", id, err)
+		}
+
+		data[id] = map[string]any{"output": output}
+		res.Outputs[id] = output
+		res.Executed = append(res.Executed, id)
+		queue = append(queue, edges[id][port]...)
+	}
+	return res, nil
+}
+
+// execWorkflowNode runs one node and returns (output, firedPort, error).
+// Every node except condition fires the default "" port.
+func (k *Kernel) execWorkflowNode(ctx context.Context, corr string, n *workflow.Node, data map[string]any, payload any) (any, string, error) {
+	switch n.Type {
+	case workflow.NodeTrigger:
+		return payload, "", nil
+
+	case workflow.NodeTool:
+		var c workflow.ToolConfig
+		if err := json.Unmarshal(n.Config, &c); err != nil {
+			return nil, "", err
+		}
+		args := strings.TrimSpace(workflow.Interpolate(string(c.Args), data))
+		if args == "" {
+			args = "{}"
+		}
+		// The exact policy gate agent-loop tool calls pass: deny refuses the
+		// node, ask blocks on the operator via the approval registry.
+		verdict := k.policyHook(ctx, agent.ToolCall{ID: "wf-" + n.ID, Name: c.Tool, Input: json.RawMessage(args)})
+		if !verdict.Allow {
+			reason := verdict.Reason
+			if reason == "" {
+				reason = "denied by policy"
+			}
+			return nil, "", fmt.Errorf("tool %s refused: %s", c.Tool, reason)
+		}
+		tools := k.mergeMCPTools(k.mergeScriptTools(k.tools))
+		tool, ok := tools[c.Tool]
+		if !ok {
+			return nil, "", fmt.Errorf("unknown tool %q", c.Tool)
+		}
+		out, err := tool.Invoke(ctx, json.RawMessage(args))
+		if err != nil {
+			return nil, "", err
+		}
+		if out.IsError {
+			return nil, "", fmt.Errorf("tool %s failed: %s", c.Tool, truncateForErr(out.Output))
+		}
+		return parseMaybeJSON(out.Output), "", nil
+
+	case workflow.NodeLLM:
+		var c workflow.LLMConfig
+		if err := json.Unmarshal(n.Config, &c); err != nil {
+			return nil, "", err
+		}
+		model := strings.TrimSpace(c.Model)
+		if model == "" {
+			model = k.cfg.Model
+		}
+		resp, err := k.cfg.Provider.Complete(ctx, agent.CompletionRequest{
+			Model:    model,
+			System:   workflow.Interpolate(c.System, data),
+			TaskType: "workflow", // route + meter workflow completions as their own class
+			Messages: []agent.Message{{Role: agent.RoleUser, Content: workflow.Interpolate(c.Prompt, data)}},
+		})
+		if err != nil {
+			return nil, "", err
+		}
+		return strings.TrimSpace(resp.Message.Content), "", nil
+
+	case workflow.NodeCondition:
+		var c workflow.ConditionConfig
+		if err := json.Unmarshal(n.Config, &c); err != nil {
+			return nil, "", err
+		}
+		left := workflow.Interpolate(c.Left, data)
+		right := workflow.Interpolate(c.Right, data)
+		truth, err := evalCondition(left, c.Op, right)
+		if err != nil {
+			return nil, "", err
+		}
+		port := "false"
+		if truth {
+			port = "true"
+		}
+		return truth, port, nil
+
+	case workflow.NodeTransform:
+		var c workflow.TransformConfig
+		if err := json.Unmarshal(n.Config, &c); err != nil {
+			return nil, "", err
+		}
+		return parseMaybeJSON(workflow.Interpolate(c.Template, data)), "", nil
+
+	case workflow.NodeDelay:
+		var c workflow.DelayConfig
+		if err := json.Unmarshal(n.Config, &c); err != nil {
+			return nil, "", err
+		}
+		select {
+		case <-time.After(time.Duration(c.Seconds * float64(time.Second))):
+			return c.Seconds, "", nil
+		case <-ctx.Done():
+			return nil, "", ctx.Err()
+		}
+
+	default:
+		return nil, "", fmt.Errorf("unknown node type %q", n.Type)
+	}
+}
+
+func evalCondition(left, op, right string) (bool, error) {
+	switch op {
+	case "equals":
+		return left == right, nil
+	case "not_equals":
+		return left != right, nil
+	case "contains":
+		return strings.Contains(left, right), nil
+	case "not_empty":
+		return strings.TrimSpace(left) != "", nil
+	case "empty":
+		return strings.TrimSpace(left) == "", nil
+	case "gt", "lt":
+		l, lerr := strconv.ParseFloat(strings.TrimSpace(left), 64)
+		r, rerr := strconv.ParseFloat(strings.TrimSpace(right), 64)
+		if lerr != nil || rerr != nil {
+			return false, fmt.Errorf("condition %s needs numbers, got %q / %q", op, left, right)
+		}
+		if op == "gt" {
+			return l > r, nil
+		}
+		return l < r, nil
+	default:
+		return false, fmt.Errorf("unknown condition op %q", op)
+	}
+}
+
+// parseMaybeJSON keeps structured outputs structured: a tool/transform whose
+// text parses as JSON becomes the parsed value (so {{node.output.field}}
+// works downstream); anything else stays a string.
+func parseMaybeJSON(s string) any {
+	t := strings.TrimSpace(s)
+	if len(t) > 0 && (t[0] == '{' || t[0] == '[') {
+		var v any
+		if err := json.Unmarshal([]byte(t), &v); err == nil {
+			return v
+		}
+	}
+	return s
+}
+
+func truncateForErr(s string) string {
+	if len(s) > 400 {
+		return s[:400] + "…"
+	}
+	return s
+}

--- a/kernel/runtime/workflowrun_test.go
+++ b/kernel/runtime/workflowrun_test.go
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: MIT
+
+package runtime_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/edict"
+	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/runtime"
+	"github.com/agezt/agezt/kernel/workflow"
+	"github.com/agezt/agezt/plugins/providers/mock"
+)
+
+// echoTool records its input and returns a canned output — the workflow
+// engine's tool-node test double.
+type echoTool struct {
+	mu     sync.Mutex
+	inputs []string
+	out    string
+	isErr  bool
+}
+
+func (t *echoTool) Definition() agent.ToolDef {
+	return agent.ToolDef{Name: "echo", Description: "echoes", InputSchema: json.RawMessage(`{"type":"object"}`)}
+}
+
+func (t *echoTool) Invoke(_ context.Context, raw json.RawMessage) (agent.Result, error) {
+	t.mu.Lock()
+	t.inputs = append(t.inputs, string(raw))
+	t.mu.Unlock()
+	return agent.Result{Output: t.out, IsError: t.isErr}, nil
+}
+
+func openWorkflowKernel(t *testing.T, prov agent.Provider, tool *echoTool) *runtime.Kernel {
+	t.Helper()
+	k, err := runtime.Open(runtime.Config{
+		BaseDir:  t.TempDir(),
+		Provider: prov,
+		Tools:    map[string]agent.Tool{"echo": tool},
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { k.Close() })
+	return k
+}
+
+func saveFlow(t *testing.T, k *runtime.Kernel, w workflow.Workflow) {
+	t.Helper()
+	if _, _, err := k.SaveWorkflow("", w); err != nil {
+		t.Fatalf("SaveWorkflow: %v", err)
+	}
+}
+
+// TestRunWorkflow_LinearDataFlow is the engine e2e: trigger payload flows
+// through templates into a tool node, the tool's JSON output is parsed so a
+// transform can reach INTO it, and an llm node sees the transformed value in
+// its prompt — with the journal carrying the whole started→node…→completed arc.
+func TestRunWorkflow_LinearDataFlow(t *testing.T) {
+	prov := mock.New(mock.FinalText("looks sunny"))
+	var llmReq agent.CompletionRequest
+	prov.OnRequest = func(r agent.CompletionRequest) { llmReq = r }
+	tool := &echoTool{out: `{"temp": 28, "sky": "clear"}`}
+	k := openWorkflowKernel(t, prov, tool)
+	k.Edict().SetLevel("echo", edict.LevelAllow) // the policy-gate test covers the deny path
+
+	saveFlow(t, k, workflow.Workflow{
+		Name: "weather-brief",
+		Nodes: []workflow.Node{
+			{ID: "start", Type: workflow.NodeTrigger},
+			{ID: "fetch", Type: workflow.NodeTool, Config: json.RawMessage(`{"tool":"echo","args":{"city":"{{trigger.payload.city}}"}}`)},
+			{ID: "shape", Type: workflow.NodeTransform, Config: json.RawMessage(`{"template":"temp is {{fetch.output.temp}} and sky {{fetch.output.sky}}"}`)},
+			{ID: "brief", Type: workflow.NodeLLM, Config: json.RawMessage(`{"prompt":"one line: {{shape.output}}","system":"you brief weather"}`)},
+		},
+		Edges: []workflow.Edge{
+			{From: "start", To: "fetch"},
+			{From: "fetch", To: "shape"},
+			{From: "shape", To: "brief"},
+		},
+	})
+
+	// Watch the journal arc.
+	var mu sync.Mutex
+	kinds := []string{}
+	sub, err := k.Bus().Subscribe("workflow.weather-brief", 32)
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer sub.Cancel()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for ev := range sub.C {
+			mu.Lock()
+			kinds = append(kinds, string(ev.Kind))
+			done := ev.Kind == event.KindWorkflowCompleted || ev.Kind == event.KindWorkflowFailed
+			mu.Unlock()
+			if done {
+				return
+			}
+		}
+	}()
+
+	res, err := k.RunWorkflow(context.Background(), k.NewCorrelation(), "weather-brief",
+		map[string]any{"city": "izmir"})
+	if err != nil {
+		t.Fatalf("RunWorkflow: %v", err)
+	}
+	<-done
+
+	if got := strings.Join(res.Executed, ","); got != "start,fetch,shape,brief" {
+		t.Fatalf("executed = %s", got)
+	}
+	// Trigger payload reached the tool through the template.
+	if len(tool.inputs) != 1 || !strings.Contains(tool.inputs[0], `"izmir"`) {
+		t.Fatalf("tool args = %v", tool.inputs)
+	}
+	// The tool's JSON output was parsed and reached the llm via the transform.
+	if !strings.Contains(llmReq.Messages[0].Content, "temp is 28 and sky clear") {
+		t.Fatalf("llm prompt = %q", llmReq.Messages[0].Content)
+	}
+	if llmReq.System != "you brief weather" || llmReq.TaskType != "workflow" {
+		t.Fatalf("llm system/tasktype = %q/%q", llmReq.System, llmReq.TaskType)
+	}
+	if res.Outputs["brief"] != "looks sunny" {
+		t.Fatalf("llm output = %v", res.Outputs["brief"])
+	}
+	mu.Lock()
+	arc := strings.Join(kinds, ",")
+	mu.Unlock()
+	if !strings.HasPrefix(arc, "workflow.started") || !strings.HasSuffix(arc, "workflow.completed") ||
+		strings.Count(arc, "workflow.node") != 4 {
+		t.Fatalf("journal arc = %s", arc)
+	}
+}
+
+// TestRunWorkflow_ConditionBranching: only the matching port's branch runs.
+func TestRunWorkflow_ConditionBranching(t *testing.T) {
+	tool := &echoTool{out: "ran"}
+	k := openWorkflowKernel(t, mock.New(), tool)
+
+	saveFlow(t, k, workflow.Workflow{
+		Name: "branchy",
+		Nodes: []workflow.Node{
+			{ID: "start", Type: workflow.NodeTrigger},
+			{ID: "check", Type: workflow.NodeCondition, Config: json.RawMessage(`{"left":"{{trigger.payload.n}}","op":"gt","right":"10"}`)},
+			{ID: "big", Type: workflow.NodeTransform, Config: json.RawMessage(`{"template":"BIG"}`)},
+			{ID: "small", Type: workflow.NodeTransform, Config: json.RawMessage(`{"template":"SMALL"}`)},
+		},
+		Edges: []workflow.Edge{
+			{From: "start", To: "check"},
+			{From: "check", To: "big", Port: "true"},
+			{From: "check", To: "small", Port: "false"},
+		},
+	})
+
+	res, err := k.RunWorkflow(context.Background(), k.NewCorrelation(), "branchy", map[string]any{"n": 42})
+	if err != nil {
+		t.Fatalf("RunWorkflow: %v", err)
+	}
+	if res.Outputs["big"] != "BIG" {
+		t.Fatalf("true branch did not run: %v", res.Outputs)
+	}
+	if _, ran := res.Outputs["small"]; ran {
+		t.Fatal("false branch ran on a true condition")
+	}
+
+	res, err = k.RunWorkflow(context.Background(), k.NewCorrelation(), "branchy", map[string]any{"n": 3})
+	if err != nil {
+		t.Fatalf("RunWorkflow(small): %v", err)
+	}
+	if res.Outputs["small"] != "SMALL" {
+		t.Fatalf("false branch did not run: %v", res.Outputs)
+	}
+	if _, ran := res.Outputs["big"]; ran {
+		t.Fatal("true branch ran on a false condition")
+	}
+}
+
+// TestRunWorkflow_PolicyGatesToolNodes: a tool whose capability is unknown to
+// the policy engine is default-denied — exactly like an agent-loop call.
+func TestRunWorkflow_PolicyGatesToolNodes(t *testing.T) {
+	tool := &echoTool{out: "never"}
+	k := openWorkflowKernel(t, mock.New(), tool)
+
+	saveFlow(t, k, workflow.Workflow{
+		Name: "gated",
+		Nodes: []workflow.Node{
+			{ID: "start", Type: workflow.NodeTrigger},
+			// "echo" is not a known capability → Capability("echo") → default-deny.
+			{ID: "call", Type: workflow.NodeTool, Config: json.RawMessage(`{"tool":"echo","args":{}}`)},
+		},
+		Edges: []workflow.Edge{{From: "start", To: "call"}},
+	})
+
+	_, err := k.RunWorkflow(context.Background(), k.NewCorrelation(), "gated", nil)
+	if err == nil || !strings.Contains(err.Error(), "refused") {
+		t.Fatalf("policy did not gate the tool node: %v", err)
+	}
+	if len(tool.inputs) != 0 {
+		t.Fatal("denied tool was still invoked")
+	}
+}
+
+// TestRunWorkflow_ToolFailureFailsRun: an IsError tool result fails the run
+// and journals workflow.failed (error branching is M800).
+func TestRunWorkflow_ToolFailureFailsRun(t *testing.T) {
+	tool := &echoTool{out: "boom", isErr: true}
+	k := openWorkflowKernel(t, mock.New(), tool)
+	// Allow the echo capability so we hit the FAILURE path, not the policy.
+	k.Edict().SetLevel("echo", edict.LevelAllow)
+
+	saveFlow(t, k, workflow.Workflow{
+		Name: "failing",
+		Nodes: []workflow.Node{
+			{ID: "start", Type: workflow.NodeTrigger},
+			{ID: "call", Type: workflow.NodeTool, Config: json.RawMessage(`{"tool":"echo","args":{}}`)},
+			{ID: "after", Type: workflow.NodeTransform, Config: json.RawMessage(`{"template":"unreachable"}`)},
+		},
+		Edges: []workflow.Edge{{From: "start", To: "call"}, {From: "call", To: "after"}},
+	})
+
+	res, err := k.RunWorkflow(context.Background(), k.NewCorrelation(), "failing", nil)
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("tool failure not surfaced: %v", err)
+	}
+	if _, ran := res.Outputs["after"]; ran {
+		t.Fatal("downstream node ran after a failure")
+	}
+}

--- a/kernel/webui/webui.go
+++ b/kernel/webui/webui.go
@@ -113,6 +113,7 @@ var apiRoutes = map[string]string{
 	"/api/agents":        controlplane.CmdAgentList,
 	"/api/toolforge":     controlplane.CmdToolforgeList,
 	"/api/mcp":           controlplane.CmdMCPList,
+	"/api/workflows":     controlplane.CmdWorkflowList,
 	"/api/inbox":         controlplane.CmdInbox,
 	"/api/board":         controlplane.CmdBoardRead,
 	"/api/autonomy":      controlplane.CmdAutonomyFeed,
@@ -174,6 +175,9 @@ var readArgsRoutes = map[string]writeRoute{
 	// One script tool's full record incl. the code body (M795) — the list route
 	// deliberately strips code; the Forge view's editor fetches it here. Read-only.
 	"/api/toolforge/show": {controlplane.CmdToolforgeShow, []string{"ref"}},
+	// One workflow's full graph (M798) — the list stays light; the canvas
+	// editor fetches nodes+edges here. Read-only.
+	"/api/workflows/show": {controlplane.CmdWorkflowShow, []string{"ref"}},
 	// Dry-run a policy decision (M753): "if the agent asked to do <capability> with
 	// <input>, would the edict engine allow / ask / deny it, and via which rule?".
 	// Read-only — eng.Decide mutates nothing.
@@ -253,11 +257,15 @@ var writeRoutes = map[string]writeRoute{
 	// MCP self-install lifecycle (M796): attach spawns the registered server
 	// NOW (its tools go live for the next run); detach is the kill switch;
 	// enable flips auto-attach at daemon start. ref = name or id.
-	"/api/mcp/attach":  {controlplane.CmdMCPAttach, []string{"ref"}},
-	"/api/mcp/detach":  {controlplane.CmdMCPDetach, []string{"ref"}},
-	"/api/mcp/enable":  {controlplane.CmdMCPSetEnabled, []string{"ref", "enabled"}},
-	"/api/mcp/remove":  {controlplane.CmdMCPRemove, []string{"ref"}},
-	"/api/reflect/run": {controlplane.CmdReflectRun, nil},
+	"/api/mcp/attach": {controlplane.CmdMCPAttach, []string{"ref"}},
+	"/api/mcp/detach": {controlplane.CmdMCPDetach, []string{"ref"}},
+	"/api/mcp/enable": {controlplane.CmdMCPSetEnabled, []string{"ref", "enabled"}},
+	"/api/mcp/remove": {controlplane.CmdMCPRemove, []string{"ref"}},
+	// Workflow lifecycle (M798): enable arms triggers (M799); remove deletes.
+	// (Save and run carry structured bodies — they are jsonRoutes.)
+	"/api/workflows/enable": {controlplane.CmdWorkflowSetEnabled, []string{"ref", "enabled"}},
+	"/api/workflows/remove": {controlplane.CmdWorkflowRemove, []string{"ref"}},
+	"/api/reflect/run":      {controlplane.CmdReflectRun, nil},
 	// Provider keyring switch/remove (M700): activate or remove a key, reloading
 	// the provider in place. (Add is a jsonRoute — the value is a secret body.)
 	"/api/provider/keys/activate": {controlplane.CmdProviderKeyActivate, []string{"env", "label"}},
@@ -309,6 +317,10 @@ var jsonRoutes = map[string]writeRoute{
 	// Register an MCP server (M796): the server is a structured object
 	// (command + args list) — a JSON body, not query args.
 	"/api/mcp/add": {controlplane.CmdMCPAdd, []string{"server"}},
+	// Workflow save/run (M798): the graph (nodes+edges) and the run payload
+	// are structured objects — JSON bodies, not query args.
+	"/api/workflows/save": {controlplane.CmdWorkflowSave, []string{"workflow"}},
+	"/api/workflows/run":  {controlplane.CmdWorkflowRun, []string{"ref", "payload"}},
 	// Create a schedule (M715): intent + a timing mode. Numeric timing args (e.g.
 	// interval_sec, at_minutes, once_at_unix) ride the JSON body so they keep their
 	// types — a query arg would stringify them.

--- a/kernel/webui/webui_test.go
+++ b/kernel/webui/webui_test.go
@@ -554,7 +554,7 @@ func TestAPIReadOnly(t *testing.T) {
 	// never issues anything outside the known read set.
 	readOnly := map[string]bool{
 		"status": true, "config": true, "runs_list": true, "runs_stats": true, "budget": true, "cache_stats": true, "provider_stats": true, "tool_stats": true, "edict_stats": true, "schedule_list": true, "memory_list": true, "world_list": true,
-		"skill_list": true, "standing_list": true, "agent_list": true, "toolforge_list": true, "mcp_list": true, "inbox": true, "reflect_show": true, "approvals": true,
+		"skill_list": true, "standing_list": true, "agent_list": true, "toolforge_list": true, "mcp_list": true, "workflow_list": true, "inbox": true, "reflect_show": true, "approvals": true,
 		"plan_stats": true, "edict_show": true, "tool_list": true, "board_read": true, "autonomy_feed": true,
 		"catalog_list": true, "sandbox_list": true,
 		"config_schema": true, "config_values": true, "routing_get": true, "persona_get": true, "prompts_get": true,

--- a/kernel/workflow/template.go
+++ b/kernel/workflow/template.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+
+package workflow
+
+// {{path}} template interpolation — how data flows between nodes. A path
+// walks the run context: {{trigger.payload}}, {{<node_id>.output}}, and any
+// deeper JSON the upstream node produced ({{fetch.output.items.0.title}}).
+// Deliberately tiny: dotted lookups only, no expressions, no pipes — a
+// transform node (or, later, a code node) is where real reshaping happens.
+// Unknown paths resolve to "" rather than failing the run: a half-filled
+// template is visible in the output and easy to debug from the journal.
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+)
+
+// Interpolate replaces every {{path}} in s with the value at that path in
+// data. Strings insert verbatim; everything else inserts as compact JSON.
+func Interpolate(s string, data map[string]any) string {
+	var b strings.Builder
+	for {
+		start := strings.Index(s, "{{")
+		if start < 0 {
+			b.WriteString(s)
+			return b.String()
+		}
+		end := strings.Index(s[start:], "}}")
+		if end < 0 {
+			b.WriteString(s)
+			return b.String()
+		}
+		b.WriteString(s[:start])
+		path := strings.TrimSpace(s[start+2 : start+end])
+		b.WriteString(renderValue(Lookup(data, path)))
+		s = s[start+end+2:]
+	}
+}
+
+// Lookup resolves a dotted path against nested maps/slices (JSON shapes).
+// Array steps are decimal indexes. A miss anywhere returns nil.
+func Lookup(data map[string]any, path string) any {
+	if path == "" {
+		return nil
+	}
+	var cur any = data
+	for step := range strings.SplitSeq(path, ".") {
+		switch v := cur.(type) {
+		case map[string]any:
+			next, ok := v[step]
+			if !ok {
+				return nil
+			}
+			cur = next
+		case []any:
+			idx, err := strconv.Atoi(step)
+			if err != nil || idx < 0 || idx >= len(v) {
+				return nil
+			}
+			cur = v[idx]
+		default:
+			return nil
+		}
+	}
+	return cur
+}
+
+func renderValue(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return t
+	default:
+		b, err := json.Marshal(t)
+		if err != nil {
+			return ""
+		}
+		return string(b)
+	}
+}

--- a/kernel/workflow/workflow.go
+++ b/kernel/workflow/workflow.go
@@ -1,0 +1,472 @@
+// SPDX-License-Identifier: MIT
+
+// Package workflow is the n8n-style workflow engine (M798): durable, named
+// graphs of TYPED nodes — trigger, tool, llm, condition, transform, delay —
+// wired by edges and carrying data between nodes with {{path}} templates.
+// Unlike kernel/planner (intent-in, agent-loop-per-node), a workflow node is
+// a precise, deterministic step: THIS tool with THESE args, THIS prompt to
+// THIS model, THIS branch on THIS value. The graph is what you see on the
+// console canvas; the engine (kernel/runtime) executes it under the same
+// governance as everything else — tool nodes pass Edict, llm nodes ride the
+// Governor, every step is journaled (workflow.*).
+//
+// Storage mirrors kernel/standing: one atomic JSON file, journaled CRUD.
+package workflow
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/agezt/agezt/kernel/ulid"
+)
+
+// ErrNotFound is returned for an unknown workflow id/name.
+var ErrNotFound = errors.New("workflow: not found")
+
+// Node types the M798 engine executes. The set grows by arc (http, code,
+// forEach, parallel, approval, subworkflow... — M800).
+const (
+	NodeTrigger   = "trigger"   // the single entry point (manual in M798; cron/event in M799)
+	NodeTool      = "tool"      // one governed tool call: config {tool, args}
+	NodeLLM       = "llm"       // one completion: config {prompt, system?, model?}
+	NodeCondition = "condition" // branch: config {left, op, right} → "true"/"false" ports
+	NodeTransform = "transform" // pure template: config {template} → output
+	NodeDelay     = "delay"     // wait: config {seconds}
+)
+
+// knownTypes gates validation; ordered for error messages.
+var knownTypes = []string{NodeTrigger, NodeTool, NodeLLM, NodeCondition, NodeTransform, NodeDelay}
+
+// Node is one typed step on the canvas.
+type Node struct {
+	ID    string `json:"id"`   // unique within the workflow, [a-z0-9_-]
+	Type  string `json:"type"` // one of the Node* constants
+	Label string `json:"label,omitempty"`
+	// Config is the type-specific payload (see the constants above). Its
+	// string fields may carry {{path}} templates resolved at run time
+	// against upstream outputs: {{trigger.payload}}, {{<node_id>.output}}.
+	Config json.RawMessage `json:"config,omitempty"`
+	// X/Y are canvas coordinates — pure presentation, never semantics.
+	X float64 `json:"x,omitempty"`
+	Y float64 `json:"y,omitempty"`
+}
+
+// Edge wires From's completion to To's execution. Port selects a labelled
+// output: a condition node fires exactly one of "true"/"false"; every other
+// node fires its "" (default) port.
+type Edge struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+	Port string `json:"port,omitempty"`
+}
+
+// Workflow is one durable, named graph.
+type Workflow struct {
+	ID   string `json:"id"`
+	Name string `json:"name"` // unique handle, immutable shape rules like roster slugs
+	// Enabled gates triggers (M799) — a disabled workflow never auto-fires;
+	// a manual run is still allowed (that's how you test a draft).
+	Enabled     bool   `json:"enabled"`
+	Description string `json:"description,omitempty"`
+	Nodes       []Node `json:"nodes"`
+	Edges       []Edge `json:"edges,omitempty"`
+	CreatedMS   int64  `json:"created_ms"`
+	UpdatedMS   int64  `json:"updated_ms"`
+}
+
+var (
+	nameRe = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,63}$`)
+	idRe   = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{0,63}$`)
+)
+
+const (
+	maxNodes        = 100
+	maxEdges        = 300
+	maxConfigBytes  = 32 * 1024
+	maxDelaySeconds = 600
+)
+
+// Validate checks a workflow's shape: name/id rules, exactly one trigger,
+// known node types, edges that resolve, legal ports, per-type config, and an
+// acyclic graph. The engine refuses to run anything Validate rejects.
+func Validate(w Workflow) error {
+	if !nameRe.MatchString(w.Name) {
+		return fmt.Errorf("workflow: name must match %s", nameRe)
+	}
+	if len(w.Nodes) == 0 {
+		return errors.New("workflow: at least one node (the trigger) is required")
+	}
+	if len(w.Nodes) > maxNodes {
+		return fmt.Errorf("workflow: at most %d nodes", maxNodes)
+	}
+	if len(w.Edges) > maxEdges {
+		return fmt.Errorf("workflow: at most %d edges", maxEdges)
+	}
+
+	byID := make(map[string]*Node, len(w.Nodes))
+	triggers := 0
+	for i := range w.Nodes {
+		n := &w.Nodes[i]
+		if !idRe.MatchString(n.ID) {
+			return fmt.Errorf("workflow: node id %q must match %s", n.ID, idRe)
+		}
+		if _, dup := byID[n.ID]; dup {
+			return fmt.Errorf("workflow: duplicate node id %q", n.ID)
+		}
+		byID[n.ID] = n
+		if len(n.Config) > maxConfigBytes {
+			return fmt.Errorf("workflow: node %s config exceeds %d bytes", n.ID, maxConfigBytes)
+		}
+		if err := validateNodeConfig(n); err != nil {
+			return err
+		}
+		if n.Type == NodeTrigger {
+			triggers++
+		}
+	}
+	if triggers != 1 {
+		return fmt.Errorf("workflow: exactly one trigger node required, found %d", triggers)
+	}
+
+	indeg := map[string]int{}
+	adj := map[string][]string{}
+	for _, e := range w.Edges {
+		from, ok := byID[e.From]
+		if !ok {
+			return fmt.Errorf("workflow: edge from unknown node %q", e.From)
+		}
+		if _, ok := byID[e.To]; !ok {
+			return fmt.Errorf("workflow: edge to unknown node %q", e.To)
+		}
+		if e.From == e.To {
+			return fmt.Errorf("workflow: self-edge on %q", e.From)
+		}
+		switch from.Type {
+		case NodeCondition:
+			if e.Port != "true" && e.Port != "false" {
+				return fmt.Errorf("workflow: edge from condition %q needs port \"true\" or \"false\"", e.From)
+			}
+		default:
+			if e.Port != "" {
+				return fmt.Errorf("workflow: edge from %q (%s) must use the default port", e.From, from.Type)
+			}
+		}
+		if from.Type == NodeTrigger && byID[e.To].Type == NodeTrigger {
+			return errors.New("workflow: trigger cannot feed a trigger")
+		}
+		adj[e.From] = append(adj[e.From], e.To)
+		indeg[e.To]++
+	}
+	for _, n := range w.Nodes {
+		if n.Type == NodeTrigger && indeg[n.ID] > 0 {
+			return errors.New("workflow: the trigger cannot have incoming edges")
+		}
+	}
+
+	// Acyclicity (Kahn) over the whole graph.
+	queue := make([]string, 0, len(w.Nodes))
+	deg := make(map[string]int, len(w.Nodes))
+	for id := range byID {
+		deg[id] = indeg[id]
+		if indeg[id] == 0 {
+			queue = append(queue, id)
+		}
+	}
+	seen := 0
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+		seen++
+		for _, next := range adj[id] {
+			deg[next]--
+			if deg[next] == 0 {
+				queue = append(queue, next)
+			}
+		}
+	}
+	if seen != len(w.Nodes) {
+		return errors.New("workflow: the graph has a cycle")
+	}
+	return nil
+}
+
+// Per-type config shapes (also the engine's parse targets).
+type ToolConfig struct {
+	Tool string          `json:"tool"`
+	Args json.RawMessage `json:"args,omitempty"` // templated JSON
+}
+
+type LLMConfig struct {
+	Prompt string `json:"prompt"` // templated
+	System string `json:"system,omitempty"`
+	Model  string `json:"model,omitempty"`
+}
+
+type ConditionConfig struct {
+	Left  string `json:"left"` // templated
+	Op    string `json:"op"`   // equals|not_equals|contains|not_empty|empty|gt|lt
+	Right string `json:"right,omitempty"`
+}
+
+type TransformConfig struct {
+	Template string `json:"template"` // templated → becomes the node's output
+}
+
+type DelayConfig struct {
+	Seconds float64 `json:"seconds"`
+}
+
+var conditionOps = map[string]bool{
+	"equals": true, "not_equals": true, "contains": true,
+	"not_empty": true, "empty": true, "gt": true, "lt": true,
+}
+
+func validateNodeConfig(n *Node) error {
+	switch n.Type {
+	case NodeTrigger:
+		return nil // manual in M798; trigger kinds arrive with M799
+	case NodeTool:
+		var c ToolConfig
+		if err := json.Unmarshal(orEmpty(n.Config), &c); err != nil {
+			return fmt.Errorf("workflow: node %s: tool config: %w", n.ID, err)
+		}
+		if strings.TrimSpace(c.Tool) == "" {
+			return fmt.Errorf("workflow: node %s: tool name is required", n.ID)
+		}
+		return nil
+	case NodeLLM:
+		var c LLMConfig
+		if err := json.Unmarshal(orEmpty(n.Config), &c); err != nil {
+			return fmt.Errorf("workflow: node %s: llm config: %w", n.ID, err)
+		}
+		if strings.TrimSpace(c.Prompt) == "" {
+			return fmt.Errorf("workflow: node %s: llm prompt is required", n.ID)
+		}
+		return nil
+	case NodeCondition:
+		var c ConditionConfig
+		if err := json.Unmarshal(orEmpty(n.Config), &c); err != nil {
+			return fmt.Errorf("workflow: node %s: condition config: %w", n.ID, err)
+		}
+		if !conditionOps[c.Op] {
+			return fmt.Errorf("workflow: node %s: condition op %q (want equals|not_equals|contains|not_empty|empty|gt|lt)", n.ID, c.Op)
+		}
+		return nil
+	case NodeTransform:
+		var c TransformConfig
+		if err := json.Unmarshal(orEmpty(n.Config), &c); err != nil {
+			return fmt.Errorf("workflow: node %s: transform config: %w", n.ID, err)
+		}
+		if c.Template == "" {
+			return fmt.Errorf("workflow: node %s: transform template is required", n.ID)
+		}
+		return nil
+	case NodeDelay:
+		var c DelayConfig
+		if err := json.Unmarshal(orEmpty(n.Config), &c); err != nil {
+			return fmt.Errorf("workflow: node %s: delay config: %w", n.ID, err)
+		}
+		if c.Seconds <= 0 || c.Seconds > maxDelaySeconds {
+			return fmt.Errorf("workflow: node %s: delay seconds must be in (0, %d]", n.ID, maxDelaySeconds)
+		}
+		return nil
+	default:
+		return fmt.Errorf("workflow: node %s: unknown type %q (want %s)", n.ID, n.Type, strings.Join(knownTypes, "|"))
+	}
+}
+
+func orEmpty(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return json.RawMessage(`{}`)
+	}
+	return raw
+}
+
+// TriggerNode returns the workflow's single trigger (Validate guarantees it).
+func (w Workflow) TriggerNode() *Node {
+	for i := range w.Nodes {
+		if w.Nodes[i].Type == NodeTrigger {
+			return &w.Nodes[i]
+		}
+	}
+	return nil
+}
+
+// NodeByID resolves one node.
+func (w Workflow) NodeByID(id string) *Node {
+	for i := range w.Nodes {
+		if w.Nodes[i].ID == id {
+			return &w.Nodes[i]
+		}
+	}
+	return nil
+}
+
+// Store is the persistent workflow registry, a single JSON file rewritten
+// atomically on change. Safe for concurrent use. Mirrors kernel/standing.
+type Store struct {
+	path  string
+	mu    sync.Mutex
+	now   func() time.Time
+	items []*Workflow
+}
+
+// OpenStore opens (or creates) the registry under dir.
+func OpenStore(dir string) (*Store, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("workflow: mkdir %s: %w", dir, err)
+	}
+	s := &Store{path: filepath.Join(dir, "workflows.json"), now: time.Now}
+	b, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return s, nil
+		}
+		return nil, fmt.Errorf("workflow: read %s: %w", s.path, err)
+	}
+	if len(b) > 0 {
+		if err := json.Unmarshal(b, &s.items); err != nil {
+			return nil, fmt.Errorf("workflow: parse %s: %w", s.path, err)
+		}
+	}
+	return s, nil
+}
+
+// Save upserts a workflow by name: a new name is created (id assigned,
+// enabled by default), an existing one is replaced wholesale — the canvas
+// always posts the complete graph. Identity/lifecycle fields (ID, CreatedMS,
+// Enabled) survive an update. Returns the stored value + whether it was
+// created.
+func (s *Store) Save(w Workflow) (Workflow, bool, error) {
+	w.Name = strings.TrimSpace(w.Name)
+	if err := Validate(w); err != nil {
+		return Workflow{}, false, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.now().UnixMilli()
+	for _, ex := range s.items {
+		if ex.Name == w.Name {
+			snapshot := *ex
+			w.ID, w.CreatedMS, w.Enabled = ex.ID, ex.CreatedMS, ex.Enabled
+			w.UpdatedMS = now
+			*ex = w
+			if err := s.save(); err != nil {
+				*ex = snapshot
+				return Workflow{}, false, err
+			}
+			return *ex, false, nil
+		}
+	}
+	w.ID = ulid.New()
+	w.Enabled = true
+	w.CreatedMS = now
+	w.UpdatedMS = now
+	cp := w
+	s.items = append(s.items, &cp)
+	if err := s.save(); err != nil {
+		s.items = s.items[:len(s.items)-1]
+		return Workflow{}, false, err
+	}
+	return cp, true, nil
+}
+
+// SetEnabled flips trigger-arming for a workflow by id or name.
+func (s *Store) SetEnabled(ref string, enabled bool) (Workflow, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	w := s.find(ref)
+	if w == nil {
+		return Workflow{}, ErrNotFound
+	}
+	prevEnabled, prevUpdated := w.Enabled, w.UpdatedMS
+	w.Enabled = enabled
+	w.UpdatedMS = s.now().UnixMilli()
+	if err := s.save(); err != nil {
+		w.Enabled, w.UpdatedMS = prevEnabled, prevUpdated
+		return Workflow{}, err
+	}
+	return *w, nil
+}
+
+// Remove deletes a workflow by id or name. Returns whether it existed.
+func (s *Store) Remove(ref string) (Workflow, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, w := range s.items {
+		if w.ID == ref || w.Name == ref {
+			removed := s.items
+			gone := *w
+			s.items = append(append([]*Workflow{}, s.items[:i]...), s.items[i+1:]...)
+			if err := s.save(); err != nil {
+				s.items = removed
+				return Workflow{}, false, err
+			}
+			return gone, true, nil
+		}
+	}
+	return Workflow{}, false, nil
+}
+
+// Get returns one workflow by id or name.
+func (s *Store) Get(ref string) (Workflow, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if w := s.find(ref); w != nil {
+		return *w, true
+	}
+	return Workflow{}, false
+}
+
+func (s *Store) find(ref string) *Workflow {
+	for _, w := range s.items {
+		if w.ID == ref || w.Name == ref {
+			return w
+		}
+	}
+	return nil
+}
+
+// List returns all workflows, sorted by creation time then id.
+func (s *Store) List() []Workflow {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]Workflow, 0, len(s.items))
+	for _, w := range s.items {
+		out = append(out, *w)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].CreatedMS != out[j].CreatedMS {
+			return out[i].CreatedMS < out[j].CreatedMS
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out
+}
+
+// Count returns the number of stored workflows.
+func (s *Store) Count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.items)
+}
+
+func (s *Store) save() error {
+	b, err := json.MarshalIndent(s.items, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, s.path)
+}

--- a/kernel/workflow/workflow_test.go
+++ b/kernel/workflow/workflow_test.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: MIT
+
+package workflow
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func graph(nodes []Node, edges []Edge) Workflow {
+	return Workflow{Name: "test-flow", Nodes: nodes, Edges: edges}
+}
+
+func trigger() Node { return Node{ID: "start", Type: NodeTrigger} }
+
+func toolNode(id string) Node {
+	return Node{ID: id, Type: NodeTool, Config: json.RawMessage(`{"tool":"shell","args":{"command":"ls"}}`)}
+}
+
+func TestValidate_Accepts(t *testing.T) {
+	w := graph(
+		[]Node{
+			trigger(),
+			toolNode("fetch"),
+			{ID: "check", Type: NodeCondition, Config: json.RawMessage(`{"left":"{{fetch.output}}","op":"not_empty"}`)},
+			{ID: "shape", Type: NodeTransform, Config: json.RawMessage(`{"template":"got: {{fetch.output}}"}`)},
+			{ID: "think", Type: NodeLLM, Config: json.RawMessage(`{"prompt":"summarize {{shape.output}}"}`)},
+			{ID: "wait", Type: NodeDelay, Config: json.RawMessage(`{"seconds":1}`)},
+		},
+		[]Edge{
+			{From: "start", To: "fetch"},
+			{From: "fetch", To: "check"},
+			{From: "check", To: "shape", Port: "true"},
+			{From: "check", To: "wait", Port: "false"},
+			{From: "shape", To: "think"},
+		},
+	)
+	if err := Validate(w); err != nil {
+		t.Fatalf("valid workflow rejected: %v", err)
+	}
+}
+
+func TestValidate_Rejects(t *testing.T) {
+	cases := []struct {
+		label string
+		w     Workflow
+		want  string
+	}{
+		{"bad name", Workflow{Name: "Bad Name", Nodes: []Node{trigger()}}, "name"},
+		{"no nodes", Workflow{Name: "x"}, "at least one"},
+		{"no trigger", graph([]Node{toolNode("a")}, nil), "exactly one trigger"},
+		{"two triggers", graph([]Node{trigger(), {ID: "t2", Type: NodeTrigger}}, nil), "exactly one trigger"},
+		{"dup id", graph([]Node{trigger(), toolNode("a"), toolNode("a")}, nil), "duplicate"},
+		{"bad node id", graph([]Node{trigger(), {ID: "Bad ID", Type: NodeTool, Config: json.RawMessage(`{"tool":"x"}`)}}, nil), "node id"},
+		{"unknown type", graph([]Node{trigger(), {ID: "a", Type: "spaceship"}}, nil), "unknown type"},
+		{"edge to ghost", graph([]Node{trigger()}, []Edge{{From: "start", To: "ghost"}}), "unknown node"},
+		{"self edge", graph([]Node{trigger(), toolNode("a")}, []Edge{{From: "a", To: "a"}}), "self-edge"},
+		{"trigger with incoming", graph([]Node{trigger(), toolNode("a")}, []Edge{{From: "a", To: "start"}}), "incoming"},
+		{"condition without port", graph(
+			[]Node{trigger(), {ID: "c", Type: NodeCondition, Config: json.RawMessage(`{"left":"x","op":"not_empty"}`)}, toolNode("a")},
+			[]Edge{{From: "start", To: "c"}, {From: "c", To: "a"}}), "port"},
+		{"port on plain node", graph([]Node{trigger(), toolNode("a")}, []Edge{{From: "start", To: "a", Port: "true"}}), "default port"},
+		{"cycle", graph(
+			[]Node{trigger(), toolNode("a"), toolNode("b")},
+			[]Edge{{From: "start", To: "a"}, {From: "a", To: "b"}, {From: "b", To: "a"}}), "cycle"},
+		{"tool without name", graph([]Node{trigger(), {ID: "a", Type: NodeTool, Config: json.RawMessage(`{}`)}}, nil), "tool name"},
+		{"llm without prompt", graph([]Node{trigger(), {ID: "a", Type: NodeLLM, Config: json.RawMessage(`{}`)}}, nil), "prompt"},
+		{"condition bad op", graph([]Node{trigger(), {ID: "a", Type: NodeCondition, Config: json.RawMessage(`{"left":"x","op":"vibes"}`)}}, nil), "op"},
+		{"delay out of range", graph([]Node{trigger(), {ID: "a", Type: NodeDelay, Config: json.RawMessage(`{"seconds":99999}`)}}, nil), "seconds"},
+	}
+	for _, tc := range cases {
+		err := Validate(tc.w)
+		if err == nil {
+			t.Errorf("%s: accepted", tc.label)
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.want) {
+			t.Errorf("%s: error %q does not mention %q", tc.label, err, tc.want)
+		}
+	}
+}
+
+func TestInterpolate(t *testing.T) {
+	data := map[string]any{
+		"trigger": map[string]any{"payload": map[string]any{"city": "izmir", "n": float64(3)}},
+		"fetch":   map[string]any{"output": map[string]any{"items": []any{map[string]any{"title": "first"}, "second"}}},
+		"plain":   map[string]any{"output": "hello"},
+	}
+	cases := []struct{ in, want string }{
+		{"city={{trigger.payload.city}}", "city=izmir"},
+		{"n={{trigger.payload.n}}", "n=3"},
+		{"t={{fetch.output.items.0.title}}", "t=first"},
+		{"s={{ fetch.output.items.1 }}", "s=second"},
+		{"whole={{plain.output}}", "whole=hello"},
+		{"obj={{fetch.output}}", `obj={"items":[{"title":"first"},"second"]}`},
+		{"miss=[{{ghost.output}}]", "miss=[]"}, // unknown path → empty, run survives
+		{"no templates here", "no templates here"},
+		{"dangling {{open", "dangling {{open"},
+	}
+	for _, tc := range cases {
+		if got := Interpolate(tc.in, data); got != tc.want {
+			t.Errorf("Interpolate(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestStore_UpsertByName(t *testing.T) {
+	s, err := OpenStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	w := graph([]Node{trigger(), toolNode("a")}, []Edge{{From: "start", To: "a"}})
+	saved, created, err := s.Save(w)
+	if err != nil || !created || saved.ID == "" || !saved.Enabled {
+		t.Fatalf("first save = %+v/%v/%v", saved, created, err)
+	}
+
+	// Disable, then upsert a new graph under the same name: identity +
+	// enabled survive, the graph is replaced wholesale.
+	if _, err := s.SetEnabled(saved.Name, false); err != nil {
+		t.Fatalf("SetEnabled: %v", err)
+	}
+	w2 := w
+	w2.Nodes = []Node{trigger(), toolNode("a"), toolNode("b")}
+	w2.Edges = []Edge{{From: "start", To: "a"}, {From: "a", To: "b"}}
+	updated, created, err := s.Save(w2)
+	if err != nil || created {
+		t.Fatalf("upsert = %v/%v", created, err)
+	}
+	if updated.ID != saved.ID || updated.Enabled || len(updated.Nodes) != 3 {
+		t.Fatalf("upsert lost identity/state: %+v", updated)
+	}
+
+	// Invalid graphs never reach disk.
+	bad := w
+	bad.Nodes = nil
+	if _, _, err := s.Save(bad); err == nil {
+		t.Fatal("invalid save accepted")
+	}
+	if got, _ := s.Get(saved.ID); len(got.Nodes) != 3 {
+		t.Fatalf("failed save mutated the store: %+v", got)
+	}
+}
+
+func TestStore_Persistence(t *testing.T) {
+	dir := t.TempDir()
+	s, _ := OpenStore(dir)
+	if _, _, err := s.Save(graph([]Node{trigger()}, nil)); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	re, err := OpenStore(dir)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	if got, found := re.Get("test-flow"); !found || got.TriggerNode() == nil {
+		t.Fatalf("reload = %+v/%v", got, found)
+	}
+	gone, ok, err := re.Remove("test-flow")
+	if err != nil || !ok || gone.Name != "test-flow" || re.Count() != 0 {
+		t.Fatalf("Remove = %+v/%v/%v count=%d", gone, ok, err, re.Count())
+	}
+}


### PR DESCRIPTION
## What

**Workflow arc, step 1** (owner ask: an n8n-but-better workflow engine — React Flow canvas, copilot-designed schemas, internal-tool access, cron/event/manual starts). This PR ships the **core engine**; the ratified arc continues with M799 triggers → M800 node library → M801 React Flow canvas editor → M802 copilot.

`kernel/workflow`: durable, **named graphs of typed nodes** — `trigger` · `tool` (one governed call to ANY tool: built-in, `forge_*`, `mcp_*`) · `llm` (one Governor-routed completion) · `condition` (true/false ports) · `transform` · `delay` — wired by edges, with data flowing through **`{{path}}` templates** (`{{trigger.payload.city}}`, `{{fetch.output.items.0.title}}`; JSON outputs stay structured downstream; misses render empty, never fatal).

## Governance (inherited, not reinvented)

- **Tool nodes pass the exact same `policyHook` as agent-loop tool calls** — deny refuses the node, ask blocks on the HITL approval registry (unit-proven: a default-denied tool is never invoked).
- **LLM nodes ride the Governor** with `TaskType="workflow"` → routable + budget-metered like any class.
- Every run journals `workflow.started → workflow.node… → workflow.completed|failed` under `workflow.<name>` — the M801 canvas replays these live.
- Hard validation BEFORE disk: exactly one trigger, acyclic (Kahn), legal ports, per-type configs, size caps. Halt/ctx honored; 256-step defense cap.

## Surfaces

`agt workflow list|show|save --file|run --payload|enable|disable|remove` · controlplane `workflow_*` (run sync, 15m bound → `{executed, outputs, correlation_id}`) · webui API routes (list/show/save/run/enable/remove) — canvas-ready.

## Tests — 10 new across 3 packages

Validate 17-case reject table · template table (deep paths/arrays/objects/misses) · store upsert-by-name (identity+enabled survive; invalid never touches disk) · **engine e2e**: payload→tool args→parsed JSON→transform→llm prompt with the journal arc asserted; condition branching both ways; policy-deny; tool-failure stops downstream · controlplane wire round-trip.

## Smoke (isolated AGEZT_HOME, real daemon)

6-node branching pipeline saved + run twice via CLI:
- score 80 → TRUE branch + 1s delay → `KAZANDIN — merhaba ersin, skor: 80`
- score 20 → FALSE branch → `bir dahaki sefere — merhaba ersin, skor: 20`

Per-node outputs + correlations printed; both runs journaled.

## Local battery (CI org billing still blocked)

Full `GOMAXPROCS=3 go test -p 2 ./...` ✅ · vet ✅ · staticcheck ✅ · linux cross-build ✅ · staged gofmt sweep ✅ · go.mod unchanged · no new env vars · frontend untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)