### PR TITLE
Feat: workflow node library — 8 new node types + error port (M800)

### DIFF
--- a/.project/PHASE-M800-WORKFLOW-NODE-LIBRARY-REPORT.md
+++ b/.project/PHASE-M800-WORKFLOW-NODE-LIBRARY-REPORT.md
@@ -1,0 +1,69 @@
+# Phase M800 — workflow node library
+
+**Date:** 2026-06-10 · **Status:** DONE · **Arc:** workflow engine, step 3.
+
+## What — 8 new node types + the error port
+
+- **http** {method GET|POST, url, headers?, body?} — rides the REGISTERED
+  http tool: its host allowlist / egress guard and the CapHTTPGet/Post
+  policy mapping apply exactly as for an agent's own call.
+- **code** {language, code, input?} — the M794 sandbox runner; interpolated
+  input lands as ./stdin.txt; gated by the same code.exec policy axis.
+- **map** {items, template} / **filter** {items, left, op, right} —
+  per-item templates with {{item}}, {{item.field}}, {{index}}; items
+  accepts "{{a.output.list}}" or a bare path; 1000-element cap.
+- **switch** {value, cases:[{equals, port}]} — multi-way branch; declared
+  case ports + "default"; edges from a switch must use declared ports
+  (validated), case ports can't squat ""/default/error.
+- **merge** {mode all|any} — join: "any" runs on the first incoming token
+  (the M798 default), "all" waits for a token on EVERY incoming edge
+  (token counting in the engine); output = upstream outputs in edge order.
+- **approval** {description, capability?} — the HITL gate: blocks on the
+  approval registry (`agt approvals` / channels / console); grant
+  continues, deny/timeout fails the node.
+- **subworkflow** {workflow, payload?} — runs another stored workflow
+  (payload template → its {{trigger.payload}}, output = {executed,
+  outputs}); nesting depth-capped at 3 (a self-recursive workflow is
+  refused, not run forever).
+- **error port** — failable nodes (tool/llm/http/code/approval/subworkflow)
+  may wire port "error": on failure the run SURVIVES, the message lands in
+  {{node.output.error}}, and the error branch runs instead of the default
+  one. The workflow.node journal event carries ok=false + handled=true.
+
+Engine: token counting per node (merge-all readiness re-checked on every
+arriving token); invokeWorkflowTool shared by tool/http nodes (one policy
+gate, one dynamic-map lookup).
+
+## Tests (6 engine e2e + 14 validation cases, all packages green)
+
+- map+filter+switch+merge-all composition (untaken switch branch never
+  runs; merge collected both branches in edge order)
+- error port rescues the run; {{call.output.error}} flows; default branch
+  suppressed
+- code node via stub runner (interpolated input, structured output)
+- http node bridges the registered tool (method uppercased, url templated)
+- approval gate granted via the real registry (pending → Resolve →
+  "granted by tester" flows downstream)
+- subworkflow output bubbling + ouroboros depth-cap refusal
+- validation: per-type config rejects, switch undeclared-edge-port, error
+  port on non-failable nodes rejected
+
+## Smoke (isolated AGEZT_HOME, real daemon, real python sandbox)
+
+10-node "triage" pipeline in one run: filter kept sev>2 tickets, map
+shaped titles, switch took the "ops" port (dev/fallback never executed),
+merge-all combined both branches, then a deliberately broken python code
+node FAILED in the real sandbox and the error port rescued the run —
+"kurtarıldı: code failed: …SyntaxError…". 8/10 nodes executed, per-node
+outputs printed with the correlation.
+
+## Gate
+
+Full `GOMAXPROCS=3 go test -p 2 ./...` green; vet + staticcheck clean;
+linux cross-build OK; frontend untouched; go.mod unchanged; no new env
+vars. CI org-billing still blocked → local battery + arc-authority merge.
+
+## Next
+
+M801: the React Flow canvas editor — node palette, drag-and-connect,
+side-panel config, run with live node status from the workflow.* arc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **The workflow node library — branch, loop, join, gate, nest, and survive failures.** Eight new
+  node types make workflows genuinely n8n-class: **http** (rides the governed http tool — host
+  allowlist and GET/POST policy included), **code** (a script in the code-exec sandbox, input via
+  \`stdin.txt\`), **map** and **filter** (per-item \`{{item}}\`/\`{{index}}\` templates over arrays),
+  **switch** (multi-way branching on declared ports + \`default\`), **merge** (join branches —
+  \`any\` runs on the first arrival, \`all\` waits for every incoming edge), **approval** (a human
+  gate: the run blocks on the HITL registry until the operator grants or denies), and
+  **subworkflow** (run another stored workflow with its own payload; nesting depth-capped so a
+  self-recursive graph is refused, not run forever). And the **error port**: failable nodes may
+  wire an \`error\` branch — on failure the run survives, \`{{node.output.error}}\` carries the
+  message, and the error path runs instead of the happy path. Verified end-to-end in an isolated
+  daemon: a 10-node triage pipeline filtered severities, mapped titles, switched to the right team,
+  merged both branches, then a deliberately broken python node failed in the real sandbox and the
+  error port rescued the run. (M800)
 - **Workflows now start themselves — cron and event triggers.** A workflow's trigger node takes a
   `kind`: **manual** (run-on-demand, the default), **cron** (`interval_sec` or a daily `HH:MM`), or
   **event** (a journal-subject glob like `task.failed`, `board.dm.*`, or `memory.>`) — the matched

--- a/kernel/runtime/workflowrun.go
+++ b/kernel/runtime/workflowrun.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/approval"
 	"github.com/agezt/agezt/kernel/event"
 	"github.com/agezt/agezt/kernel/workflow"
 )
@@ -134,18 +135,21 @@ func (k *Kernel) RunWorkflow(ctx context.Context, corr, ref string, payload any)
 }
 
 func (k *Kernel) runWorkflowGraph(ctx context.Context, corr string, w workflow.Workflow, payload any) (RunWorkflowResult, error) {
-	// Outgoing edges grouped by (from, port).
+	// Outgoing edges grouped by (from, port); incoming counts for merge "all".
 	edges := map[string]map[string][]string{}
+	indegree := map[string]int{}
 	for _, e := range w.Edges {
 		if edges[e.From] == nil {
 			edges[e.From] = map[string][]string{}
 		}
 		edges[e.From][e.Port] = append(edges[e.From][e.Port], e.To)
+		indegree[e.To]++
 	}
 
 	data := map[string]any{"trigger": map[string]any{"payload": payload}}
 	res := RunWorkflowResult{Outputs: map[string]any{}}
 	executed := map[string]bool{}
+	tokens := map[string]int{} // incoming tokens received, for merge mode "all"
 
 	queue := []string{w.TriggerNode().ID}
 	steps := 0
@@ -162,10 +166,21 @@ func (k *Kernel) runWorkflowGraph(ctx context.Context, corr string, w workflow.W
 		if executed[id] {
 			continue // a node runs once: first token wins
 		}
-		executed[id] = true
 		node := w.NodeByID(id)
+		// A merge in "all" mode waits for a token on EVERY incoming edge —
+		// later tokens re-enqueue it, so skipping here is safe.
+		if node.Type == workflow.NodeMerge && mergeMode(node) == "all" && tokens[id] < indegree[id] {
+			continue
+		}
+		executed[id] = true
 
-		output, port, err := k.execWorkflowNode(ctx, corr, node, data, payload)
+		output, port, err := k.execWorkflowNode(ctx, corr, node, w, data, payload)
+		handled := false
+		if err != nil && len(edges[id]["error"]) > 0 {
+			// The node wired an error branch: the run survives, the error
+			// message becomes the node's output, and the error port fires.
+			output, port, handled = map[string]any{"error": err.Error()}, "error", true
+		}
 		nodePayload := map[string]any{
 			"workflow": w.Name, "node": id, "type": node.Type, "ok": err == nil,
 		}
@@ -177,27 +192,46 @@ func (k *Kernel) runWorkflowGraph(ctx context.Context, corr string, w workflow.W
 		}
 		if err != nil {
 			nodePayload["error"] = err.Error()
+			nodePayload["handled"] = handled
 		}
 		_, _ = k.bus.Publish(event.Spec{
 			Subject: "workflow." + w.Name, Kind: event.KindWorkflowNode, Actor: "workflow",
 			CorrelationID: corr,
 			Payload:       nodePayload,
 		})
-		if err != nil {
+		if err != nil && !handled {
 			return res, fmt.Errorf("node %s: %w", id, err)
 		}
 
 		data[id] = map[string]any{"output": output}
 		res.Outputs[id] = output
 		res.Executed = append(res.Executed, id)
-		queue = append(queue, edges[id][port]...)
+		for _, next := range edges[id][port] {
+			tokens[next]++
+			queue = append(queue, next)
+		}
 	}
 	return res, nil
 }
 
+func mergeMode(n *workflow.Node) string {
+	var c workflow.MergeConfig
+	_ = json.Unmarshal(n.Config, &c)
+	if c.Mode == "" {
+		return "any"
+	}
+	return c.Mode
+}
+
+// wfDepthKey carries subworkflow nesting depth through the run context.
+type wfDepthKey struct{}
+
+const maxSubflowDepth = 3
+
 // execWorkflowNode runs one node and returns (output, firedPort, error).
-// Every node except condition fires the default "" port.
-func (k *Kernel) execWorkflowNode(ctx context.Context, corr string, n *workflow.Node, data map[string]any, payload any) (any, string, error) {
+// Most nodes fire the default "" port; condition fires true/false, switch
+// fires a case port or "default".
+func (k *Kernel) execWorkflowNode(ctx context.Context, corr string, n *workflow.Node, w workflow.Workflow, data map[string]any, payload any) (any, string, error) {
 	switch n.Type {
 	case workflow.NodeTrigger:
 		return payload, "", nil
@@ -213,27 +247,7 @@ func (k *Kernel) execWorkflowNode(ctx context.Context, corr string, n *workflow.
 		}
 		// The exact policy gate agent-loop tool calls pass: deny refuses the
 		// node, ask blocks on the operator via the approval registry.
-		verdict := k.policyHook(ctx, agent.ToolCall{ID: "wf-" + n.ID, Name: c.Tool, Input: json.RawMessage(args)})
-		if !verdict.Allow {
-			reason := verdict.Reason
-			if reason == "" {
-				reason = "denied by policy"
-			}
-			return nil, "", fmt.Errorf("tool %s refused: %s", c.Tool, reason)
-		}
-		tools := k.mergeMCPTools(k.mergeScriptTools(k.tools))
-		tool, ok := tools[c.Tool]
-		if !ok {
-			return nil, "", fmt.Errorf("unknown tool %q", c.Tool)
-		}
-		out, err := tool.Invoke(ctx, json.RawMessage(args))
-		if err != nil {
-			return nil, "", err
-		}
-		if out.IsError {
-			return nil, "", fmt.Errorf("tool %s failed: %s", c.Tool, truncateForErr(out.Output))
-		}
-		return parseMaybeJSON(out.Output), "", nil
+		return k.invokeWorkflowTool(ctx, c.Tool, "wf-"+n.ID, json.RawMessage(args))
 
 	case workflow.NodeLLM:
 		var c workflow.LLMConfig
@@ -291,10 +305,230 @@ func (k *Kernel) execWorkflowNode(ctx context.Context, corr string, n *workflow.
 			return nil, "", ctx.Err()
 		}
 
+	case workflow.NodeHTTP:
+		var c workflow.HTTPConfig
+		if err := json.Unmarshal(n.Config, &c); err != nil {
+			return nil, "", err
+		}
+		// Ride the registered http tool — its host allowlist / egress guard
+		// and the CapHTTPGet/Post policy mapping apply exactly as they would
+		// to an agent's own call.
+		headers := make(map[string]string, len(c.Headers))
+		for hk, hv := range c.Headers {
+			headers[hk] = workflow.Interpolate(hv, data)
+		}
+		args, err := json.Marshal(map[string]any{
+			"method":       strings.ToUpper(strings.TrimSpace(c.Method)),
+			"url":          workflow.Interpolate(c.URL, data),
+			"headers":      headers,
+			"body":         workflow.Interpolate(c.Body, data),
+			"content_type": c.ContentType,
+		})
+		if err != nil {
+			return nil, "", err
+		}
+		return k.invokeWorkflowTool(ctx, "http", "wf-"+n.ID, args)
+
+	case workflow.NodeCode:
+		var c workflow.CodeConfig
+		if err := json.Unmarshal(n.Config, &c); err != nil {
+			return nil, "", err
+		}
+		if k.cfg.ScriptRunner == nil {
+			return nil, "", errors.New("code nodes need the code-exec sandbox (not available on this daemon)")
+		}
+		// The same code.exec policy gate a direct code_exec call passes.
+		probe, _ := json.Marshal(map[string]any{"language": c.Language, "code": c.Code})
+		verdict := k.policyHook(ctx, agent.ToolCall{ID: "wf-" + n.ID, Name: "code_exec", Input: probe})
+		if !verdict.Allow {
+			reason := verdict.Reason
+			if reason == "" {
+				reason = "denied by policy"
+			}
+			return nil, "", fmt.Errorf("code refused: %s", reason)
+		}
+		input := strings.TrimSpace(workflow.Interpolate(c.Input, data))
+		if input == "" {
+			input = "{}"
+		}
+		out, isErr, err := k.cfg.ScriptRunner.RunScript(ctx, c.Language, c.Code, input)
+		if err != nil {
+			return nil, "", err
+		}
+		if isErr {
+			return nil, "", fmt.Errorf("code failed: %s", truncateForErr(out))
+		}
+		return parseMaybeJSON(out), "", nil
+
+	case workflow.NodeMap:
+		var c workflow.MapConfig
+		if err := json.Unmarshal(n.Config, &c); err != nil {
+			return nil, "", err
+		}
+		items, err := workflowItems(c.Items, data)
+		if err != nil {
+			return nil, "", err
+		}
+		out := make([]any, 0, len(items))
+		for i, item := range items {
+			out = append(out, parseMaybeJSONValue(workflow.Interpolate(c.Template, withItem(data, item, i))))
+		}
+		return out, "", nil
+
+	case workflow.NodeFilter:
+		var c workflow.FilterConfig
+		if err := json.Unmarshal(n.Config, &c); err != nil {
+			return nil, "", err
+		}
+		items, err := workflowItems(c.Items, data)
+		if err != nil {
+			return nil, "", err
+		}
+		out := make([]any, 0, len(items))
+		for i, item := range items {
+			itemData := withItem(data, item, i)
+			keep, cerr := evalCondition(workflow.Interpolate(c.Left, itemData), c.Op, workflow.Interpolate(c.Right, itemData))
+			if cerr != nil {
+				return nil, "", cerr
+			}
+			if keep {
+				out = append(out, item)
+			}
+		}
+		return out, "", nil
+
+	case workflow.NodeSwitch:
+		var c workflow.SwitchConfig
+		if err := json.Unmarshal(n.Config, &c); err != nil {
+			return nil, "", err
+		}
+		val := workflow.Interpolate(c.Value, data)
+		for _, cs := range c.Cases {
+			if val == cs.Equals {
+				return val, cs.Port, nil
+			}
+		}
+		return val, "default", nil
+
+	case workflow.NodeMerge:
+		// Collect the outputs that arrived on incoming edges, in edge order.
+		var inputs []any
+		for _, e := range w.Edges {
+			if e.To != n.ID {
+				continue
+			}
+			if up, ok := data[e.From].(map[string]any); ok {
+				inputs = append(inputs, up["output"])
+			}
+		}
+		return inputs, "", nil
+
+	case workflow.NodeApproval:
+		var c workflow.ApprovalConfig
+		if err := json.Unmarshal(n.Config, &c); err != nil {
+			return nil, "", err
+		}
+		capability := strings.TrimSpace(c.Capability)
+		if capability == "" {
+			capability = "workflow.approve"
+		}
+		desc := workflow.Interpolate(c.Description, data)
+		out := k.approvals.Submit(ctx, approval.SubmitSpec{
+			Capability:    capability,
+			ToolName:      "workflow.approval",
+			Input:         desc,
+			Reason:        desc,
+			Actor:         "workflow",
+			CorrelationID: corr,
+		})
+		if out.Decision != approval.DecisionGrant {
+			return nil, "", fmt.Errorf("approval %s: %s", out.Decision, out.Reason)
+		}
+		return "granted by " + out.ResolvedBy, "", nil
+
+	case workflow.NodeSubflow:
+		var c workflow.SubflowConfig
+		if err := json.Unmarshal(n.Config, &c); err != nil {
+			return nil, "", err
+		}
+		depth, _ := ctx.Value(wfDepthKey{}).(int)
+		if depth+1 >= maxSubflowDepth {
+			return nil, "", fmt.Errorf("subworkflow nesting deeper than %d refused", maxSubflowDepth)
+		}
+		var subPayload any
+		if strings.TrimSpace(c.Payload) != "" {
+			subPayload = parseMaybeJSONValue(workflow.Interpolate(c.Payload, data))
+		}
+		subCtx := context.WithValue(ctx, wfDepthKey{}, depth+1)
+		subRes, err := k.RunWorkflow(subCtx, corr, c.Workflow, subPayload)
+		if err != nil {
+			return nil, "", fmt.Errorf("subworkflow %s: %w", c.Workflow, err)
+		}
+		return map[string]any{"executed": subRes.Executed, "outputs": subRes.Outputs}, "", nil
+
 	default:
 		return nil, "", fmt.Errorf("unknown node type %q", n.Type)
 	}
 }
+
+// invokeWorkflowTool runs one named tool through the policy gate — shared by
+// the tool and http nodes.
+func (k *Kernel) invokeWorkflowTool(ctx context.Context, toolName, callID string, args json.RawMessage) (any, string, error) {
+	verdict := k.policyHook(ctx, agent.ToolCall{ID: callID, Name: toolName, Input: args})
+	if !verdict.Allow {
+		reason := verdict.Reason
+		if reason == "" {
+			reason = "denied by policy"
+		}
+		return nil, "", fmt.Errorf("tool %s refused: %s", toolName, reason)
+	}
+	tools := k.mergeMCPTools(k.mergeScriptTools(k.tools))
+	tool, ok := tools[toolName]
+	if !ok {
+		return nil, "", fmt.Errorf("unknown tool %q", toolName)
+	}
+	out, err := tool.Invoke(ctx, args)
+	if err != nil {
+		return nil, "", err
+	}
+	if out.IsError {
+		return nil, "", fmt.Errorf("tool %s failed: %s", toolName, truncateForErr(out.Output))
+	}
+	return parseMaybeJSON(out.Output), "", nil
+}
+
+// workflowItems resolves a map/filter items reference — "{{a.output.list}}"
+// or the bare path "a.output.list" — to the array it names.
+func workflowItems(ref string, data map[string]any) ([]any, error) {
+	path := strings.TrimSpace(ref)
+	path = strings.TrimPrefix(path, "{{")
+	path = strings.TrimSuffix(path, "}}")
+	v := workflow.Lookup(data, strings.TrimSpace(path))
+	items, ok := v.([]any)
+	if !ok {
+		return nil, fmt.Errorf("items %q did not resolve to an array", ref)
+	}
+	const maxItems = 1000
+	if len(items) > maxItems {
+		return nil, fmt.Errorf("items %q has %d elements (max %d)", ref, len(items), maxItems)
+	}
+	return items, nil
+}
+
+// withItem extends the run context with the current element for per-item
+// templates ({{item}}, {{item.field}}, {{index}}).
+func withItem(data map[string]any, item any, index int) map[string]any {
+	out := make(map[string]any, len(data)+2)
+	for dk, dv := range data {
+		out[dk] = dv
+	}
+	out["item"] = item
+	out["index"] = index
+	return out
+}
+
+// parseMaybeJSONValue is parseMaybeJSON for already-trimmed template output.
+func parseMaybeJSONValue(s string) any { return parseMaybeJSON(s) }
 
 func evalCondition(left, op, right string) (bool, error) {
 	switch op {

--- a/kernel/runtime/workflowrun_m800_test.go
+++ b/kernel/runtime/workflowrun_m800_test.go
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: MIT
+
+package runtime_test
+
+// M800 node-library tests: map/filter/switch/merge data plumbing, the error
+// port, the code node (sandbox runner), the http node's tool bridging, the
+// approval gate, and the subworkflow depth cap.
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/approval"
+	"github.com/agezt/agezt/kernel/edict"
+	"github.com/agezt/agezt/kernel/runtime"
+	"github.com/agezt/agezt/kernel/toolforge"
+	"github.com/agezt/agezt/kernel/workflow"
+	"github.com/agezt/agezt/plugins/providers/mock"
+)
+
+// TestRunWorkflow_MapFilterSwitchMerge: the pure-data nodes compose — filter
+// keeps high scores, map shapes them, switch routes by a payload field, and
+// a merge in "all" mode waits for BOTH branches before combining.
+func TestRunWorkflow_MapFilterSwitchMerge(t *testing.T) {
+	k := openWorkflowKernel(t, mock.New(), &echoTool{})
+
+	saveFlow(t, k, workflow.Workflow{
+		Name: "data-pipes",
+		Nodes: []workflow.Node{
+			{ID: "start", Type: workflow.NodeTrigger},
+			{ID: "keep", Type: workflow.NodeFilter, Config: json.RawMessage(
+				`{"items":"{{trigger.payload.items}}","left":"{{item.score}}","op":"gt","right":"50"}`)},
+			{ID: "shape", Type: workflow.NodeMap, Config: json.RawMessage(
+				`{"items":"{{keep.output}}","template":"{{index}}:{{item.name}}!"}`)},
+			{ID: "route", Type: workflow.NodeSwitch, Config: json.RawMessage(
+				`{"value":"{{trigger.payload.mode}}","cases":[{"equals":"loud","port":"loud"},{"equals":"quiet","port":"quiet"}]}`)},
+			{ID: "yell", Type: workflow.NodeTransform, Config: json.RawMessage(`{"template":"YELLING"}`)},
+			{ID: "hush", Type: workflow.NodeTransform, Config: json.RawMessage(`{"template":"hushing"}`)},
+			{ID: "join", Type: workflow.NodeMerge, Config: json.RawMessage(`{"mode":"all"}`)},
+		},
+		Edges: []workflow.Edge{
+			{From: "start", To: "keep"},
+			{From: "keep", To: "shape"},
+			{From: "start", To: "route"},
+			{From: "route", To: "yell", Port: "loud"},
+			{From: "route", To: "hush", Port: "quiet"},
+			{From: "shape", To: "join"},
+			{From: "yell", To: "join"},
+		},
+	})
+
+	res, err := k.RunWorkflow(context.Background(), k.NewCorrelation(), "data-pipes", map[string]any{
+		"mode": "loud",
+		"items": []any{
+			map[string]any{"name": "a", "score": 80},
+			map[string]any{"name": "b", "score": 20},
+			map[string]any{"name": "c", "score": 55},
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunWorkflow: %v", err)
+	}
+	if kept, _ := res.Outputs["keep"].([]any); len(kept) != 2 {
+		t.Fatalf("filter kept %v", res.Outputs["keep"])
+	}
+	shaped, _ := res.Outputs["shape"].([]any)
+	if len(shaped) != 2 || shaped[0] != "0:a!" || shaped[1] != "1:c!" {
+		t.Fatalf("map output = %v", shaped)
+	}
+	if _, ran := res.Outputs["hush"]; ran {
+		t.Fatal("switch ran the unmatched branch")
+	}
+	// The merge waited for BOTH inputs (shape and yell) and collected them.
+	joined, _ := res.Outputs["join"].([]any)
+	if len(joined) != 2 {
+		t.Fatalf("merge-all collected %v", joined)
+	}
+	// Edge order: shape→join first, then yell→join.
+	if _, isList := joined[0].([]any); !isList || joined[1] != "YELLING" {
+		t.Fatalf("merge inputs out of order: %v", joined)
+	}
+}
+
+// TestRunWorkflow_ErrorPortBranches: a failing tool with an "error" edge
+// keeps the run alive — the message lands in {{call.output.error}} and the
+// error branch runs while the default branch never does.
+func TestRunWorkflow_ErrorPortBranches(t *testing.T) {
+	tool := &echoTool{out: "kaput", isErr: true}
+	k := openWorkflowKernel(t, mock.New(), tool)
+	k.Edict().SetLevel("echo", edict.LevelAllow)
+
+	saveFlow(t, k, workflow.Workflow{
+		Name: "rescued",
+		Nodes: []workflow.Node{
+			{ID: "start", Type: workflow.NodeTrigger},
+			{ID: "call", Type: workflow.NodeTool, Config: json.RawMessage(`{"tool":"echo","args":{}}`)},
+			{ID: "happy", Type: workflow.NodeTransform, Config: json.RawMessage(`{"template":"all good"}`)},
+			{ID: "rescue", Type: workflow.NodeTransform, Config: json.RawMessage(`{"template":"rescued: {{call.output.error}}"}`)},
+		},
+		Edges: []workflow.Edge{
+			{From: "start", To: "call"},
+			{From: "call", To: "happy"},
+			{From: "call", To: "rescue", Port: "error"},
+		},
+	})
+
+	res, err := k.RunWorkflow(context.Background(), k.NewCorrelation(), "rescued", nil)
+	if err != nil {
+		t.Fatalf("error port did not rescue the run: %v", err)
+	}
+	rescue, _ := res.Outputs["rescue"].(string)
+	if !strings.Contains(rescue, "rescued: ") || !strings.Contains(rescue, "kaput") {
+		t.Fatalf("rescue output = %q", rescue)
+	}
+	if _, ran := res.Outputs["happy"]; ran {
+		t.Fatal("default branch ran after a failure")
+	}
+}
+
+// TestRunWorkflow_CodeNode: the code node rides the M794 sandbox runner —
+// interpolated input in, stdout out, structured output stays structured.
+func TestRunWorkflow_CodeNode(t *testing.T) {
+	runner := &stubRunner{out: `{"doubled": 84}`}
+	prov := mock.New()
+	k, err := runtime.Open(runtime.Config{
+		BaseDir:      t.TempDir(),
+		Provider:     prov,
+		ScriptRunner: runner,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { k.Close() })
+
+	saveFlow(t, k, workflow.Workflow{
+		Name: "compute",
+		Nodes: []workflow.Node{
+			{ID: "start", Type: workflow.NodeTrigger},
+			{ID: "calc", Type: workflow.NodeCode, Config: json.RawMessage(
+				`{"language":"python","code":"print(42*2)","input":"{\"n\": {{trigger.payload.n}}}"}`)},
+			{ID: "read", Type: workflow.NodeTransform, Config: json.RawMessage(`{"template":"result={{calc.output.doubled}}"}`)},
+		},
+		Edges: []workflow.Edge{{From: "start", To: "calc"}, {From: "calc", To: "read"}},
+	})
+
+	res, err := k.RunWorkflow(context.Background(), k.NewCorrelation(), "compute", map[string]any{"n": 42})
+	if err != nil {
+		t.Fatalf("RunWorkflow: %v", err)
+	}
+	if runner.lang != "python" || !strings.Contains(runner.input, `"n": 42`) {
+		t.Fatalf("runner got %q / %q", runner.lang, runner.input)
+	}
+	if res.Outputs["read"] != "result=84" {
+		t.Fatalf("structured code output lost: %v", res.Outputs["read"])
+	}
+}
+
+// TestRunWorkflow_HTTPNodeBridgesTool: the http node maps its config onto
+// the registered http tool's input and passes the CapHTTPGet policy axis.
+func TestRunWorkflow_HTTPNodeBridgesTool(t *testing.T) {
+	tool := &echoTool{out: `{"ok":true}`}
+	prov := mock.New()
+	k, err := runtime.Open(runtime.Config{
+		BaseDir:  t.TempDir(),
+		Provider: prov,
+		Tools:    map[string]agent.Tool{"http": tool}, // stands in for the real guarded tool
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { k.Close() })
+
+	saveFlow(t, k, workflow.Workflow{
+		Name: "fetcher",
+		Nodes: []workflow.Node{
+			{ID: "start", Type: workflow.NodeTrigger},
+			{ID: "get", Type: workflow.NodeHTTP, Config: json.RawMessage(
+				`{"method":"get","url":"https://api.example.com/{{trigger.payload.path}}","headers":{"Accept":"application/json"}}`)},
+		},
+		Edges: []workflow.Edge{{From: "start", To: "get"}},
+	})
+
+	if _, err := k.RunWorkflow(context.Background(), k.NewCorrelation(), "fetcher", map[string]any{"path": "users/1"}); err != nil {
+		t.Fatalf("RunWorkflow: %v", err)
+	}
+	if len(tool.inputs) != 1 {
+		t.Fatalf("http tool calls = %d", len(tool.inputs))
+	}
+	got := tool.inputs[0]
+	if !strings.Contains(got, `"method":"GET"`) || !strings.Contains(got, "https://api.example.com/users/1") {
+		t.Fatalf("http args = %s", got)
+	}
+}
+
+// TestRunWorkflow_ApprovalGate: the approval node blocks on the HITL
+// registry; a grant lets the run continue, a deny fails the node.
+func TestRunWorkflow_ApprovalGate(t *testing.T) {
+	k := openWorkflowKernel(t, mock.New(), &echoTool{})
+
+	saveFlow(t, k, workflow.Workflow{
+		Name: "gated-flow",
+		Nodes: []workflow.Node{
+			{ID: "start", Type: workflow.NodeTrigger},
+			{ID: "ask", Type: workflow.NodeApproval, Config: json.RawMessage(
+				`{"description":"Proceed with {{trigger.payload.what}}?"}`)},
+			{ID: "go", Type: workflow.NodeTransform, Config: json.RawMessage(`{"template":"proceeded ({{ask.output}})"}`)},
+		},
+		Edges: []workflow.Edge{{From: "start", To: "ask"}, {From: "ask", To: "go"}},
+	})
+
+	// Resolve the pending approval as soon as it appears.
+	go func() {
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			for _, req := range k.Approvals().Pending() {
+				if req.ToolName == "workflow.approval" {
+					_ = k.Approvals().Resolve(req.ID, approval.DecisionGrant, "looks fine", "tester")
+					return
+				}
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	res, err := k.RunWorkflow(context.Background(), k.NewCorrelation(), "gated-flow", map[string]any{"what": "the deploy"})
+	if err != nil {
+		t.Fatalf("RunWorkflow: %v", err)
+	}
+	out, _ := res.Outputs["go"].(string)
+	if !strings.Contains(out, "granted by tester") {
+		t.Fatalf("approval output = %q", out)
+	}
+}
+
+// TestRunWorkflow_SubworkflowAndDepthCap: a parent runs a stored child and
+// reads its outputs; self-recursive nesting is refused at the cap.
+func TestRunWorkflow_SubworkflowAndDepthCap(t *testing.T) {
+	k := openWorkflowKernel(t, mock.New(), &echoTool{})
+
+	saveFlow(t, k, workflow.Workflow{
+		Name: "child",
+		Nodes: []workflow.Node{
+			{ID: "start", Type: workflow.NodeTrigger},
+			{ID: "greet", Type: workflow.NodeTransform, Config: json.RawMessage(`{"template":"hi {{trigger.payload.name}}"}`)},
+		},
+		Edges: []workflow.Edge{{From: "start", To: "greet"}},
+	})
+	saveFlow(t, k, workflow.Workflow{
+		Name: "parent",
+		Nodes: []workflow.Node{
+			{ID: "start", Type: workflow.NodeTrigger},
+			{ID: "sub", Type: workflow.NodeSubflow, Config: json.RawMessage(
+				`{"workflow":"child","payload":"{\"name\":\"{{trigger.payload.name}}\"}"}`)},
+			{ID: "read", Type: workflow.NodeTransform, Config: json.RawMessage(`{"template":"child said: {{sub.output.outputs.greet}}"}`)},
+		},
+		Edges: []workflow.Edge{{From: "start", To: "sub"}, {From: "sub", To: "read"}},
+	})
+
+	res, err := k.RunWorkflow(context.Background(), k.NewCorrelation(), "parent", map[string]any{"name": "ersin"})
+	if err != nil {
+		t.Fatalf("RunWorkflow: %v", err)
+	}
+	if res.Outputs["read"] != "child said: hi ersin" {
+		t.Fatalf("subworkflow output = %v", res.Outputs["read"])
+	}
+
+	// A workflow that calls ITSELF hits the depth cap instead of recursing
+	// forever.
+	saveFlow(t, k, workflow.Workflow{
+		Name: "ouroboros",
+		Nodes: []workflow.Node{
+			{ID: "start", Type: workflow.NodeTrigger},
+			{ID: "again", Type: workflow.NodeSubflow, Config: json.RawMessage(`{"workflow":"ouroboros"}`)},
+		},
+		Edges: []workflow.Edge{{From: "start", To: "again"}},
+	})
+	if _, err := k.RunWorkflow(context.Background(), k.NewCorrelation(), "ouroboros", nil); err == nil ||
+		!strings.Contains(err.Error(), "nesting") {
+		t.Fatalf("depth cap missing: %v", err)
+	}
+}
+
+// Silence the unused-import linter when toolforge types are only used by the
+// shared stubRunner from scripttool_test.go.
+var _ toolforge.Runner = (*stubRunner)(nil)

--- a/kernel/workflow/workflow.go
+++ b/kernel/workflow/workflow.go
@@ -31,19 +31,39 @@ import (
 // ErrNotFound is returned for an unknown workflow id/name.
 var ErrNotFound = errors.New("workflow: not found")
 
-// Node types the M798 engine executes. The set grows by arc (http, code,
-// forEach, parallel, approval, subworkflow... — M800).
+// Node types the engine executes.
 const (
-	NodeTrigger   = "trigger"   // the single entry point (manual in M798; cron/event in M799)
+	NodeTrigger   = "trigger"   // the single entry point: manual | cron | event (M799)
 	NodeTool      = "tool"      // one governed tool call: config {tool, args}
 	NodeLLM       = "llm"       // one completion: config {prompt, system?, model?}
 	NodeCondition = "condition" // branch: config {left, op, right} → "true"/"false" ports
 	NodeTransform = "transform" // pure template: config {template} → output
 	NodeDelay     = "delay"     // wait: config {seconds}
+
+	// The M800 library.
+	NodeHTTP     = "http"        // request via the governed http tool: {method, url, headers?, body?}
+	NodeCode     = "code"        // sandboxed script: {language, code, input?} (input → stdin.txt)
+	NodeMap      = "map"         // per-item template over an array: {items, template} ({{item}}, {{index}})
+	NodeFilter   = "filter"      // keep matching items: {items, left, op, right} ({{item}} in left/right)
+	NodeSwitch   = "switch"      // multi-way branch: {value, cases:[{equals, port}]} → case ports | "default"
+	NodeMerge    = "merge"       // join branches: {mode: "all"|"any"} (all = wait for every incoming edge)
+	NodeApproval = "approval"    // HITL gate: {description, capability?} — blocks on the operator
+	NodeSubflow  = "subworkflow" // run another stored workflow: {workflow, payload?} (depth-capped)
 )
 
 // knownTypes gates validation; ordered for error messages.
-var knownTypes = []string{NodeTrigger, NodeTool, NodeLLM, NodeCondition, NodeTransform, NodeDelay}
+var knownTypes = []string{
+	NodeTrigger, NodeTool, NodeLLM, NodeCondition, NodeTransform, NodeDelay,
+	NodeHTTP, NodeCode, NodeMap, NodeFilter, NodeSwitch, NodeMerge, NodeApproval, NodeSubflow,
+}
+
+// Failable nodes may wire an "error" port: when the node fails AND such an
+// edge exists, the run survives — {{node.output.error}} carries the message
+// and the error branch runs instead of the default one.
+var failable = map[string]bool{
+	NodeTool: true, NodeLLM: true, NodeHTTP: true, NodeCode: true,
+	NodeApproval: true, NodeSubflow: true,
+}
 
 // Node is one typed step on the canvas.
 type Node struct {
@@ -149,15 +169,8 @@ func Validate(w Workflow) error {
 		if e.From == e.To {
 			return fmt.Errorf("workflow: self-edge on %q", e.From)
 		}
-		switch from.Type {
-		case NodeCondition:
-			if e.Port != "true" && e.Port != "false" {
-				return fmt.Errorf("workflow: edge from condition %q needs port \"true\" or \"false\"", e.From)
-			}
-		default:
-			if e.Port != "" {
-				return fmt.Errorf("workflow: edge from %q (%s) must use the default port", e.From, from.Type)
-			}
+		if err := validateEdgePort(from, e.Port); err != nil {
+			return err
 		}
 		if from.Type == NodeTrigger && byID[e.To].Type == NodeTrigger {
 			return errors.New("workflow: trigger cannot feed a trigger")
@@ -292,9 +305,115 @@ type DelayConfig struct {
 	Seconds float64 `json:"seconds"`
 }
 
+// HTTPConfig rides the registered `http` tool — same egress guard and
+// CapHTTPGet/Post policy as an agent's own call. URL/headers/body are
+// templated.
+type HTTPConfig struct {
+	Method      string            `json:"method"` // GET | POST
+	URL         string            `json:"url"`
+	Headers     map[string]string `json:"headers,omitempty"`
+	Body        string            `json:"body,omitempty"`
+	ContentType string            `json:"content_type,omitempty"`
+}
+
+// CodeConfig runs a script in the code-exec sandbox (the M794 runner):
+// the interpolated Input lands as ./stdin.txt, stdout becomes the output.
+type CodeConfig struct {
+	Language string `json:"language"`
+	Code     string `json:"code"`
+	Input    string `json:"input,omitempty"` // templated; default "{}"
+}
+
+// MapConfig applies Template to every element of the array at Items
+// (a {{...}}-style path); inside the template {{item}} / {{item.field}} /
+// {{index}} address the current element.
+type MapConfig struct {
+	Items    string `json:"items"`
+	Template string `json:"template"`
+}
+
+// FilterConfig keeps the elements of Items for which left/op/right holds
+// ({{item}} / {{index}} usable in left and right).
+type FilterConfig struct {
+	Items string `json:"items"`
+	Left  string `json:"left"`
+	Op    string `json:"op"`
+	Right string `json:"right,omitempty"`
+}
+
+// SwitchConfig routes by value: the first case whose Equals matches fires
+// its Port; otherwise the "default" port fires.
+type SwitchCase struct {
+	Equals string `json:"equals"`
+	Port   string `json:"port"`
+}
+
+type SwitchConfig struct {
+	Value string       `json:"value"` // templated
+	Cases []SwitchCase `json:"cases"`
+}
+
+// MergeConfig joins branches: "any" (default) runs on the first incoming
+// token; "all" waits for a token on EVERY incoming edge — if an upstream
+// branch never fires (an untaken condition path), the merge never runs.
+type MergeConfig struct {
+	Mode string `json:"mode,omitempty"`
+}
+
+// ApprovalConfig blocks the run on a human decision via the HITL approval
+// registry (`agt approvals` / channels / console). Deny or timeout fails
+// the node (wire an "error" port to branch instead).
+type ApprovalConfig struct {
+	Description string `json:"description"` // templated; what the operator reads
+	Capability  string `json:"capability,omitempty"`
+}
+
+// SubflowConfig runs another stored workflow; the interpolated Payload
+// becomes its {{trigger.payload}}. Nesting is depth-capped by the engine.
+type SubflowConfig struct {
+	Workflow string `json:"workflow"`
+	Payload  string `json:"payload,omitempty"` // templated; JSON becomes structured
+}
+
+const maxSwitchCases = 16
+
 var conditionOps = map[string]bool{
 	"equals": true, "not_equals": true, "contains": true,
 	"not_empty": true, "empty": true, "gt": true, "lt": true,
+}
+
+// validateEdgePort enforces each node type's legal output ports: condition
+// fires true/false, switch fires its declared case ports or "default",
+// failable nodes may add an "error" branch, everything else uses the
+// default port only.
+func validateEdgePort(from *Node, port string) error {
+	switch from.Type {
+	case NodeCondition:
+		if port != "true" && port != "false" {
+			return fmt.Errorf("workflow: edge from condition %q needs port \"true\" or \"false\"", from.ID)
+		}
+		return nil
+	case NodeSwitch:
+		if port == "default" {
+			return nil
+		}
+		var c SwitchConfig
+		_ = json.Unmarshal(orEmpty(from.Config), &c)
+		for _, cs := range c.Cases {
+			if cs.Port == port {
+				return nil
+			}
+		}
+		return fmt.Errorf("workflow: edge from switch %q uses undeclared port %q", from.ID, port)
+	default:
+		if port == "" {
+			return nil
+		}
+		if port == "error" && failable[from.Type] {
+			return nil
+		}
+		return fmt.Errorf("workflow: edge from %q (%s) must use the default port", from.ID, from.Type)
+	}
 }
 
 func validateNodeConfig(n *Node) error {
@@ -344,6 +463,99 @@ func validateNodeConfig(n *Node) error {
 		}
 		if c.Seconds <= 0 || c.Seconds > maxDelaySeconds {
 			return fmt.Errorf("workflow: node %s: delay seconds must be in (0, %d]", n.ID, maxDelaySeconds)
+		}
+		return nil
+	case NodeHTTP:
+		var c HTTPConfig
+		if err := json.Unmarshal(orEmpty(n.Config), &c); err != nil {
+			return fmt.Errorf("workflow: node %s: http config: %w", n.ID, err)
+		}
+		m := strings.ToUpper(strings.TrimSpace(c.Method))
+		if m != "GET" && m != "POST" {
+			return fmt.Errorf("workflow: node %s: http method must be GET or POST", n.ID)
+		}
+		if strings.TrimSpace(c.URL) == "" {
+			return fmt.Errorf("workflow: node %s: http url is required", n.ID)
+		}
+		return nil
+	case NodeCode:
+		var c CodeConfig
+		if err := json.Unmarshal(orEmpty(n.Config), &c); err != nil {
+			return fmt.Errorf("workflow: node %s: code config: %w", n.ID, err)
+		}
+		if strings.TrimSpace(c.Language) == "" || strings.TrimSpace(c.Code) == "" {
+			return fmt.Errorf("workflow: node %s: code needs language and code", n.ID)
+		}
+		return nil
+	case NodeMap:
+		var c MapConfig
+		if err := json.Unmarshal(orEmpty(n.Config), &c); err != nil {
+			return fmt.Errorf("workflow: node %s: map config: %w", n.ID, err)
+		}
+		if strings.TrimSpace(c.Items) == "" || c.Template == "" {
+			return fmt.Errorf("workflow: node %s: map needs items and template", n.ID)
+		}
+		return nil
+	case NodeFilter:
+		var c FilterConfig
+		if err := json.Unmarshal(orEmpty(n.Config), &c); err != nil {
+			return fmt.Errorf("workflow: node %s: filter config: %w", n.ID, err)
+		}
+		if strings.TrimSpace(c.Items) == "" {
+			return fmt.Errorf("workflow: node %s: filter needs items", n.ID)
+		}
+		if !conditionOps[c.Op] {
+			return fmt.Errorf("workflow: node %s: filter op %q (want equals|not_equals|contains|not_empty|empty|gt|lt)", n.ID, c.Op)
+		}
+		return nil
+	case NodeSwitch:
+		var c SwitchConfig
+		if err := json.Unmarshal(orEmpty(n.Config), &c); err != nil {
+			return fmt.Errorf("workflow: node %s: switch config: %w", n.ID, err)
+		}
+		if strings.TrimSpace(c.Value) == "" {
+			return fmt.Errorf("workflow: node %s: switch needs a value", n.ID)
+		}
+		if len(c.Cases) == 0 || len(c.Cases) > maxSwitchCases {
+			return fmt.Errorf("workflow: node %s: switch needs 1..%d cases", n.ID, maxSwitchCases)
+		}
+		seen := map[string]bool{}
+		for _, cs := range c.Cases {
+			p := strings.TrimSpace(cs.Port)
+			if p == "" || p == "default" || p == "error" {
+				return fmt.Errorf("workflow: node %s: switch case ports must be named (not empty/default/error)", n.ID)
+			}
+			if seen[p] {
+				return fmt.Errorf("workflow: node %s: duplicate switch port %q", n.ID, p)
+			}
+			seen[p] = true
+		}
+		return nil
+	case NodeMerge:
+		var c MergeConfig
+		if err := json.Unmarshal(orEmpty(n.Config), &c); err != nil {
+			return fmt.Errorf("workflow: node %s: merge config: %w", n.ID, err)
+		}
+		if c.Mode != "" && c.Mode != "all" && c.Mode != "any" {
+			return fmt.Errorf("workflow: node %s: merge mode must be \"all\" or \"any\"", n.ID)
+		}
+		return nil
+	case NodeApproval:
+		var c ApprovalConfig
+		if err := json.Unmarshal(orEmpty(n.Config), &c); err != nil {
+			return fmt.Errorf("workflow: node %s: approval config: %w", n.ID, err)
+		}
+		if strings.TrimSpace(c.Description) == "" {
+			return fmt.Errorf("workflow: node %s: approval needs a description (what the operator reads)", n.ID)
+		}
+		return nil
+	case NodeSubflow:
+		var c SubflowConfig
+		if err := json.Unmarshal(orEmpty(n.Config), &c); err != nil {
+			return fmt.Errorf("workflow: node %s: subworkflow config: %w", n.ID, err)
+		}
+		if strings.TrimSpace(c.Workflow) == "" {
+			return fmt.Errorf("workflow: node %s: subworkflow needs a workflow name", n.ID)
 		}
 		return nil
 	default:

--- a/kernel/workflow/workflow_test.go
+++ b/kernel/workflow/workflow_test.go
@@ -77,6 +77,26 @@ func TestValidate_Rejects(t *testing.T) {
 		{"event on workflow.*", graph([]Node{{ID: "s", Type: NodeTrigger, Config: json.RawMessage(`{"kind":"event","subject":"workflow.x"}`)}}, nil), "self-referential"},
 		{"event on everything", graph([]Node{{ID: "s", Type: NodeTrigger, Config: json.RawMessage(`{"kind":"event","subject":">"}`)}}, nil), "too broad"},
 		{"unknown trigger kind", graph([]Node{{ID: "s", Type: NodeTrigger, Config: json.RawMessage(`{"kind":"vibes"}`)}}, nil), "trigger kind"},
+		// M800 node library.
+		{"http bad method", graph([]Node{trigger(), {ID: "a", Type: NodeHTTP, Config: json.RawMessage(`{"method":"DELETE","url":"https://x"}`)}}, nil), "GET or POST"},
+		{"http no url", graph([]Node{trigger(), {ID: "a", Type: NodeHTTP, Config: json.RawMessage(`{"method":"GET"}`)}}, nil), "url"},
+		{"code missing parts", graph([]Node{trigger(), {ID: "a", Type: NodeCode, Config: json.RawMessage(`{"language":"python"}`)}}, nil), "language and code"},
+		{"map missing template", graph([]Node{trigger(), {ID: "a", Type: NodeMap, Config: json.RawMessage(`{"items":"{{x}}"}`)}}, nil), "items and template"},
+		{"filter bad op", graph([]Node{trigger(), {ID: "a", Type: NodeFilter, Config: json.RawMessage(`{"items":"{{x}}","left":"{{item}}","op":"vibes"}`)}}, nil), "filter op"},
+		{"switch no cases", graph([]Node{trigger(), {ID: "a", Type: NodeSwitch, Config: json.RawMessage(`{"value":"{{x}}","cases":[]}`)}}, nil), "cases"},
+		{"switch reserved port", graph([]Node{trigger(), {ID: "a", Type: NodeSwitch, Config: json.RawMessage(`{"value":"{{x}}","cases":[{"equals":"a","port":"error"}]}`)}}, nil), "named"},
+		{"switch dup port", graph([]Node{trigger(), {ID: "a", Type: NodeSwitch, Config: json.RawMessage(`{"value":"{{x}}","cases":[{"equals":"a","port":"p"},{"equals":"b","port":"p"}]}`)}}, nil), "duplicate switch port"},
+		{"switch undeclared edge port", graph(
+			[]Node{trigger(),
+				{ID: "sw", Type: NodeSwitch, Config: json.RawMessage(`{"value":"{{x}}","cases":[{"equals":"a","port":"p"}]}`)},
+				toolNode("t")},
+			[]Edge{{From: "start", To: "sw"}, {From: "sw", To: "t", Port: "ghost"}}), "undeclared port"},
+		{"merge bad mode", graph([]Node{trigger(), {ID: "a", Type: NodeMerge, Config: json.RawMessage(`{"mode":"most"}`)}}, nil), "merge mode"},
+		{"approval no description", graph([]Node{trigger(), {ID: "a", Type: NodeApproval, Config: json.RawMessage(`{}`)}}, nil), "description"},
+		{"subworkflow no name", graph([]Node{trigger(), {ID: "a", Type: NodeSubflow, Config: json.RawMessage(`{}`)}}, nil), "workflow name"},
+		{"error port on non-failable", graph(
+			[]Node{trigger(), {ID: "a", Type: NodeTransform, Config: json.RawMessage(`{"template":"x"}`)}, toolNode("t")},
+			[]Edge{{From: "start", To: "a"}, {From: "a", To: "t", Port: "error"}}), "default port"},
 	}
 	for _, tc := range cases {
 		err := Validate(tc.w)


### PR DESCRIPTION
## What

**Workflow arc, step 3.** Eight new node types + failure branching make the engine genuinely n8n-class:

| node | config | governance |
|------|--------|------------|
| `http` | method/url/headers/body (templated) | rides the **registered http tool** — egress guard + CapHTTPGet/Post inherited |
| `code` | language/code/input | M794 sandbox runner, `code.exec` policy axis |
| `map` | items + per-item template (`{{item}}`, `{{index}}`) | pure data, 1000-element cap |
| `filter` | items + left/op/right per item | pure data |
| `switch` | value + declared case ports (+`default`) | edges validated against declared ports |
| `merge` | `any` (first token) / `all` (token-counted join on EVERY incoming edge) | output = upstream outputs in edge order |
| `approval` | description (+capability) | blocks on the **HITL registry**; grant continues, deny/timeout fails |
| `subworkflow` | workflow + payload template | child run with own journal arc; **depth cap 3** — self-recursion refused |

**Error port:** failable nodes may wire `port: "error"` — on failure the run **survives**, `{{node.output.error}}` carries the message, the error branch fires instead of the happy path (journal: `ok=false, handled=true`).

## Engine changes

Per-node token counting (merge-all readiness re-checked on each arriving token) · shared `invokeWorkflowTool` (one policy gate + dynamic tool-map lookup for tool/http nodes).

## Tests

6 new engine e2e (map+filter+switch+merge-all composition; error-port rescue; code via stub runner; http→tool bridging; approval grant via the real registry; subworkflow bubbling + ouroboros refusal) + 14 new validation cases. Full suite green.

## Smoke (isolated AGEZT_HOME, real daemon, **real python sandbox**)

10-node `triage` pipeline in one run: filter kept sev>2 → map shaped titles → switch took `ops` (dev/fallback never executed) → merge-all combined both branches → a deliberately broken python node **failed in the real sandbox** and the **error port rescued the run**. 8/10 nodes executed, per-node outputs + correlation printed.

## Local battery (CI org billing still blocked)

Full suite ✅ · vet ✅ · staticcheck ✅ · linux cross-build ✅ · gofmt sweep ✅ · go.mod unchanged · no new env vars · frontend untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)