### PR TITLE
Feat: vector memory — local hybrid recall (M803)

### DIFF
--- a/.project/PHASE-M803-VECTOR-MEMORY-REPORT.md
+++ b/.project/PHASE-M803-VECTOR-MEMORY-REPORT.md
@@ -1,0 +1,78 @@
+# Phase M803 — vector memory (local hybrid recall)
+
+**Date:** 2026-06-10 · **Status:** DONE · **Arc:** vision gap #5.
+
+## What — typo/morphology-tolerant recall, zero marginal cost
+
+DECISIONS C5 said "local embeddings by default (zero marginal cost);
+provider embeddings opt-in". This ships the default.
+
+**kernel/memory/vector.go**:
+- `Embed(text)` — signed feature hashing of word tokens + per-token
+  character 3-grams (boundary-marked, over RUNES so ç/ğ/ş hash
+  correctly) into an L2-normalized 256-dim vector. Pure Go (stdlib FNV),
+  deterministic, no model download, no network, microseconds per record.
+- `Cosine(a,b)` — dot of normalized vectors.
+- `SearchSemantic` — cosine × the SAME confidence/recency weights as
+  keyword Search, noise floor 0.2. Similarity is the better of the
+  whole-query cosine and the best **damped per-token cosine** (×0.85,
+  tokens ≥4 runes) — a salient term buried in a chatty question ("what
+  do you remember about kubenetes?") isn't diluted below the floor by
+  function words.
+- `SearchHybrid` — keyword + semantic blended by record: both-signal
+  records sum both scores; a record only one signal sees still surfaces.
+  This is what `Manager.Recall*` and `Manager.Search` now use — the
+  agent's pre-run recall, the memory tool, `agt memory search`, and the
+  console all get it for free.
+- Embeddings are recomputed on demand (pure functions, no cache, no
+  schema change, nothing new in memory.json) — at recall scale
+  (hundreds of records, one recall per run) hashing cost is noise.
+- `searchText(r)` extracted so keyword overlap and the embedder always
+  look at the same record surface.
+
+What it gives: typo tolerance ("kubenetes" finds the kubernetes record
+with ZERO keyword overlap) and morphology tolerance (Turkish
+inflections: "servisinin yeniden başlatılması" finds "servisi …
+yeniden başlatılıyor"). What it doesn't: true synonym semantics — that
+is exactly the provider-embeddings opt-in, left as the documented
+follow-up; hybrid keeps the keyword signal first-class for that reason.
+
+## Tests (6 new suites; memory + full battery green)
+
+- Embed determinism + L2 norm + nil for empty/noise text
+- Cosine: self=1, related (typo/morph incl. Turkish) ≥ floor, unrelated
+  < floor, nil→0
+- SearchSemantic: typo query finds the record keyword Search misses;
+  tombstoned/unrelated stay out
+- ChattyQueryNotDiluted: per-token rescue finds it, unrelated chatty
+  query stays empty (the probe that motivated the fix, regression-pinned)
+- SearchHybrid: superset of keyword hits, both-signal outranks
+  single-signal, limit after merge
+- Determinism: identical calls → identical ordering (LastSeenMS/ID ties)
+
+## Smoke (isolated AGEZT_HOME, real daemon)
+
+Seeded EN + TR memories. `agt memory search "kubenetes clstr"` → found
+the kubernetes record (0.53, pure semantic — keyword finds nothing);
+`"ödeme servisinin yeniden başlatılması"` → found "ödeme servisi her
+gece 03:00'te yeniden başlatılıyor" (3.82, hybrid); negative control
+("uzay roketi yakıt formülü") → no records. Run-time path: `agt run
+"what do you remember about kubenetes?"` → memory.retrieved journaled,
+the model answered FROM MEMORY ("the cluster runs in Frankfurt").
+
+Mid-smoke find: the first daemon run journaled NO memory.retrieved for
+the chatty query — whole-query cosine was 0.143, under the floor. A
+go-run probe confirmed the dilution; the per-token rescue fixed it and
+the regression test pins it.
+
+## Gate
+
+Full `GOMAXPROCS=3 go test -p 2 ./...` green; vet + staticcheck clean;
+linux cross-build OK; frontend untouched (recall shape unchanged);
+go.mod unchanged (stdlib FNV only); no new env vars.
+
+## Next
+
+Vision gap #6: brain distiller standing surface. Memory polish backlog:
+provider embeddings opt-in (C5's second half), HNSW if corpora outgrow
+the exact scan, IDF weighting if tag noise ever shows up in ranking.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **Vector memory — recall that survives typos and inflections, at zero marginal cost.** Memory
+  retrieval is now hybrid: exact keyword overlap blended with **local embeddings** (signed
+  feature hashing of words + character n-grams, pure Go, no model download, no network, no
+  per-call cost — DECISIONS C5's default). "kubenetes clstr" now finds the kubernetes record
+  keyword search misses entirely, and Turkish morphology works: "ödeme servisinin yeniden
+  başlatılması" finds "ödeme servisi … yeniden başlatılıyor". A salient term buried in a chatty
+  question isn't diluted away (per-token matching with a damping factor), unrelated queries stay
+  under the noise floor, and every surface — the agent's pre-run recall, the memory tool,
+  `agt memory search`, the console — gets it with no schema change and nothing new persisted.
+  True synonym semantics remain the documented provider-embeddings opt-in. (M803)
 - **The workflow copilot — describe it, see it on the canvas — and agents that author workflows.**
   Tell the copilot what you want in plain language and it designs a validated workflow graph:
   the daemon's provider sees the full node-type contract, the kernel extracts strict JSON,

--- a/kernel/memory/manager.go
+++ b/kernel/memory/manager.go
@@ -160,7 +160,10 @@ func (m *Manager) RecallScoped(corr, query string, limit int, scope string) ([]S
 		return nil, err
 	}
 	all = filterScope(all, scope)
-	hits := Search(all, query, limit, m.now().UnixMilli())
+	// Hybrid (M803): exact-keyword precision + local-embedding cosine for
+	// typo/morphology recall — a misspelled or inflected query still
+	// surfaces the right record.
+	hits := SearchHybrid(all, query, limit, m.now().UnixMilli())
 	if len(hits) > 0 {
 		ids := make([]string, 0, len(hits))
 		for _, h := range hits {
@@ -269,7 +272,7 @@ func (m *Manager) Search(query string, limit int) ([]Scored, error) {
 	if err != nil {
 		return nil, err
 	}
-	return Search(all, query, limit, m.now().UnixMilli()), nil
+	return SearchHybrid(all, query, limit, m.now().UnixMilli()), nil
 }
 
 // publish writes one event through the bus, returning the persisted event (or

--- a/kernel/memory/memory.go
+++ b/kernel/memory/memory.go
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MIT
 
-// Package memory implements "memory-lite" (ROADMAP §2.3): a journaled,
+// Package memory implements the memory store (ROADMAP §2.3): a journaled,
 // content-addressed knowledge store that the agent loop reads as injected
 // context and that the operator, the agent, and an auto-distiller can write
-// to. It is the smallest slice of SPEC-05 that makes Agezt *remember*
-// without yet building the world-model graph, the skill/Forge lifecycle, or
-// vector retrieval (those land in the full Memory & Forge milestone).
+// to. Retrieval is hybrid (M803): exact keyword overlap blended with local
+// hashed-n-gram embeddings (vector.go) for typo/morphology recall —
+// DECISIONS C5's "local embeddings by default"; provider embeddings remain
+// the documented opt-in.
 //
 // Two layers, mirroring how kernel/state and kernel/runtime split:
 //
@@ -284,15 +285,7 @@ func Search(rs []Record, query string, limit int, nowMS int64) []Scored {
 		score := float64(overlap) * (0.5 + conf) * recencyFactor(r.LastSeenMS, nowMS)
 		out = append(out, Scored{Record: r, Score: score})
 	}
-	sort.SliceStable(out, func(i, j int) bool {
-		if out[i].Score != out[j].Score {
-			return out[i].Score > out[j].Score
-		}
-		if out[i].Record.LastSeenMS != out[j].Record.LastSeenMS {
-			return out[i].Record.LastSeenMS > out[j].Record.LastSeenMS
-		}
-		return out[i].Record.ID < out[j].Record.ID
-	})
+	sortScored(out)
 	if limit > 0 && len(out) > limit {
 		out = out[:limit]
 	}
@@ -300,20 +293,11 @@ func Search(rs []Record, query string, limit int, nowMS int64) []Scored {
 }
 
 // keywordOverlap counts how many distinct query tokens appear anywhere in the
-// record's searchable text (subject + content + tag keys/values).
+// record's searchable text (subject + content + tag keys/values — searchText,
+// shared with the embedder so both signals see the same surface).
 func keywordOverlap(qTokens []string, r Record) int {
-	var b strings.Builder
-	b.WriteString(r.Subject)
-	b.WriteByte(' ')
-	b.WriteString(r.Content)
-	for k, v := range r.Tags {
-		b.WriteByte(' ')
-		b.WriteString(k)
-		b.WriteByte(' ')
-		b.WriteString(v)
-	}
 	haystack := make(map[string]struct{})
-	for _, t := range tokenize(b.String()) {
+	for _, t := range tokenize(searchText(r)) {
 		haystack[t] = struct{}{}
 	}
 	n := 0

--- a/kernel/memory/vector.go
+++ b/kernel/memory/vector.go
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: MIT
+
+package memory
+
+// Vector retrieval (M803, DECISIONS C5: "local embeddings by default — zero
+// marginal cost; provider embeddings opt-in"). The local embedder is a
+// feature-hashed bag of word tokens + character n-grams: deterministic, pure
+// Go (stdlib FNV), no model download, no network, no marginal cost — and
+// language-agnostic, which matters for an owner who writes memories in
+// Turkish and queries them in English-mixed shorthand. Character n-grams
+// give what keyword overlap can't: typo tolerance ("kubenetes" still finds
+// the kubernetes record) and morphology tolerance ("servisler" still finds
+// "servis"). It does NOT give true synonym semantics — that is exactly the
+// provider-embeddings opt-in (a future milestone), and the reason hybrid
+// search keeps the keyword signal as a first-class term instead of replacing
+// it.
+//
+// Embeddings are recomputed on demand: at recall scale (hundreds of records,
+// one recall per run) hashing is microseconds per record, and recomputing
+// keeps Search* pure functions of their inputs — no cache invalidation, no
+// schema change, nothing new persisted in memory.json.
+
+import (
+	"hash/fnv"
+	"math"
+	"sort"
+	"strings"
+)
+
+// EmbedDim is the embedding dimensionality. 256 signed-hash buckets keep
+// collision noise low at this corpus size while staying cheap to dot.
+const EmbedDim = 256
+
+// minSemanticCosine is the noise floor: unrelated texts under feature
+// hashing land well below it, morphology/typo neighbours well above.
+const minSemanticCosine = 0.2
+
+// tokenCosineDamp discounts per-token matches relative to whole-query
+// cosine: a single salient token ("kubenetes" inside "what do you remember
+// about kubenetes?") may carry the match, but never quite as strongly as a
+// query that is ABOUT the record end to end.
+const tokenCosineDamp = 0.85
+
+// minTokenLen keeps per-token matching to salient words; the noise floor
+// does the rest (a 4-letter function word rarely clears it against a whole
+// record).
+const minTokenLen = 4
+
+// Embed maps text to an L2-normalized EmbedDim vector via signed feature
+// hashing of its word tokens and per-token character 3-grams (with boundary
+// markers, over runes so UTF-8 — ç/ğ/ş — hashes correctly). Deterministic;
+// returns nil for text with no tokens.
+func Embed(text string) []float32 {
+	tokens := tokenize(text)
+	if len(tokens) == 0 {
+		return nil
+	}
+	vec := make([]float32, EmbedDim)
+	for _, tok := range tokens {
+		addFeature(vec, tok)
+		runes := []rune("^" + tok + "$")
+		for i := 0; i+3 <= len(runes); i++ {
+			addFeature(vec, string(runes[i:i+3]))
+		}
+	}
+	var norm float64
+	for _, v := range vec {
+		norm += float64(v) * float64(v)
+	}
+	if norm == 0 {
+		return nil
+	}
+	scale := float32(1 / math.Sqrt(norm))
+	for i := range vec {
+		vec[i] *= scale
+	}
+	return vec
+}
+
+// addFeature hashes one feature into its bucket with a ±1 sign drawn from an
+// independent hash bit — signed hashing keeps E[a·b]=0 for unrelated texts.
+func addFeature(vec []float32, feature string) {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(feature))
+	sum := h.Sum64()
+	bucket := sum % EmbedDim
+	if (sum>>32)&1 == 1 {
+		vec[bucket]++
+	} else {
+		vec[bucket]--
+	}
+}
+
+// Cosine returns the cosine similarity of two Embed outputs. Both are
+// already L2-normalized, so this is a plain dot product; mismatched or nil
+// vectors score 0.
+func Cosine(a, b []float32) float64 {
+	if len(a) == 0 || len(a) != len(b) {
+		return 0
+	}
+	var dot float64
+	for i := range a {
+		dot += float64(a[i]) * float64(b[i])
+	}
+	return dot
+}
+
+// searchText is the record's retrieval surface — subject + content + tags —
+// shared by keyword overlap and the embedder so the two signals always look
+// at the same text.
+func searchText(r Record) string {
+	var b strings.Builder
+	b.WriteString(r.Subject)
+	b.WriteByte(' ')
+	b.WriteString(r.Content)
+	for k, v := range r.Tags {
+		b.WriteByte(' ')
+		b.WriteString(k)
+		b.WriteByte(' ')
+		b.WriteString(v)
+	}
+	return b.String()
+}
+
+// SearchSemantic ranks active records by embedding cosine against the query,
+// weighted by the same confidence and recency factors as keyword Search.
+// The similarity is the better of (a) the whole-query cosine and (b) the
+// best damped per-token cosine — so a salient term buried in a chatty
+// question ("what do you remember about kubenetes?") still finds its record
+// instead of being diluted below the noise floor by function words.
+// Records under the floor are excluded. Pure function; same tie rules as
+// Search.
+func SearchSemantic(rs []Record, query string, limit int, nowMS int64) []Scored {
+	qv := Embed(query)
+	out := make([]Scored, 0, len(rs))
+	if qv == nil {
+		return out
+	}
+	var tokVecs [][]float32
+	for _, tok := range tokenize(query) {
+		if len([]rune(tok)) >= minTokenLen {
+			if tv := Embed(tok); tv != nil {
+				tokVecs = append(tokVecs, tv)
+			}
+		}
+	}
+	for _, r := range rs {
+		if !r.Active() {
+			continue
+		}
+		rv := Embed(searchText(r))
+		cos := Cosine(qv, rv)
+		for _, tv := range tokVecs {
+			if c := Cosine(tv, rv) * tokenCosineDamp; c > cos {
+				cos = c
+			}
+		}
+		if cos < minSemanticCosine {
+			continue
+		}
+		conf := r.Confidence
+		if conf <= 0 {
+			conf = 0.5
+		}
+		score := cos * (0.5 + conf) * recencyFactor(r.LastSeenMS, nowMS)
+		out = append(out, Scored{Record: r, Score: score})
+	}
+	sortScored(out)
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+// SearchHybrid blends both signals: keyword overlap (exact-term precision)
+// plus embedding cosine (typo/morphology recall). A record matching both
+// sums both scores; a record only one signal sees still surfaces — which is
+// the point: "kubenetes" has zero keyword overlap with the kubernetes
+// record, and "izmir hava" should still rank the exact-keyword record first.
+// Pure function; this is what Manager recall uses.
+func SearchHybrid(rs []Record, query string, limit int, nowMS int64) []Scored {
+	byID := make(map[string]Scored)
+	for _, s := range Search(rs, query, 0, nowMS) {
+		byID[s.Record.ID] = s
+	}
+	for _, s := range SearchSemantic(rs, query, 0, nowMS) {
+		if prev, ok := byID[s.Record.ID]; ok {
+			prev.Score += s.Score
+			byID[s.Record.ID] = prev
+		} else {
+			byID[s.Record.ID] = s
+		}
+	}
+	out := make([]Scored, 0, len(byID))
+	for _, s := range byID {
+		out = append(out, s)
+	}
+	sortScored(out)
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+// sortScored applies the retrieval ordering shared by every Search variant:
+// score desc, then LastSeenMS desc, then ID asc — stable, deterministic.
+func sortScored(out []Scored) {
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Score != out[j].Score {
+			return out[i].Score > out[j].Score
+		}
+		if out[i].Record.LastSeenMS != out[j].Record.LastSeenMS {
+			return out[i].Record.LastSeenMS > out[j].Record.LastSeenMS
+		}
+		return out[i].Record.ID < out[j].Record.ID
+	})
+}

--- a/kernel/memory/vector_test.go
+++ b/kernel/memory/vector_test.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: MIT
+
+package memory
+
+import (
+	"math"
+	"testing"
+)
+
+func TestEmbed_DeterministicAndNormalized(t *testing.T) {
+	a := Embed("the kubernetes cluster runs in frankfurt")
+	b := Embed("the kubernetes cluster runs in frankfurt")
+	if len(a) != EmbedDim || len(b) != EmbedDim {
+		t.Fatalf("dim = %d/%d", len(a), len(b))
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			t.Fatalf("not deterministic at %d: %v vs %v", i, a[i], b[i])
+		}
+	}
+	var norm float64
+	for _, v := range a {
+		norm += float64(v) * float64(v)
+	}
+	if math.Abs(norm-1) > 1e-5 {
+		t.Fatalf("not L2-normalized: %v", norm)
+	}
+	if Embed("") != nil || Embed("a .!") != nil { // no tokens (1-char dropped)
+		t.Fatal("empty/noise text must embed to nil")
+	}
+}
+
+func TestCosine_RelatedVsUnrelated(t *testing.T) {
+	base := Embed("the kubernetes cluster needs a node upgrade")
+	typo := Embed("kubenetes cluster upgrade")               // misspelled
+	morph := Embed("kubernetes clusters upgrades")           // inflected
+	other := Embed("pizza dough requires slow fermentation") // unrelated
+
+	if got := Cosine(base, base); math.Abs(got-1) > 1e-5 {
+		t.Fatalf("self cosine = %v", got)
+	}
+	ct, cm, co := Cosine(base, typo), Cosine(base, morph), Cosine(base, other)
+	if ct <= co || cm <= co {
+		t.Fatalf("related must beat unrelated: typo=%v morph=%v other=%v", ct, cm, co)
+	}
+	if ct < minSemanticCosine || cm < minSemanticCosine {
+		t.Fatalf("related pairs under the noise floor: typo=%v morph=%v", ct, cm)
+	}
+	if co >= minSemanticCosine {
+		t.Fatalf("unrelated pair above the noise floor: %v", co)
+	}
+	// Turkish morphology: an inflected query still lands on the base record.
+	srv := Cosine(Embed("servis çalışıyor ve sağlıklı"), Embed("servisler çalışmıyor"))
+	if srv < minSemanticCosine {
+		t.Fatalf("turkish morphology cosine = %v", srv)
+	}
+	if Cosine(nil, base) != 0 || Cosine(base, nil) != 0 {
+		t.Fatal("nil vectors must score 0")
+	}
+}
+
+func semRecords() []Record {
+	return []Record{
+		{ID: "k8s", Subject: "kubernetes", Content: "the kubernetes cluster runs in frankfurt", Confidence: 1, LastSeenMS: 1000},
+		{ID: "pizza", Subject: "cooking", Content: "pizza dough requires slow fermentation", Confidence: 1, LastSeenMS: 1000},
+		{ID: "dead", Subject: "kubernetes", Content: "kubernetes node pool was resized", Confidence: 1, LastSeenMS: 1000, Tombstoned: true},
+	}
+}
+
+// TestSearchSemantic_TypoFindsRecord is the headline capability: zero
+// keyword overlap, the embedding still finds it.
+func TestSearchSemantic_TypoFindsRecord(t *testing.T) {
+	rs := semRecords()
+	if hits := Search(rs, "kubenetes clstr", 5, 2000); len(hits) != 0 {
+		t.Fatalf("keyword search unexpectedly matched: %v", hits)
+	}
+	hits := SearchSemantic(rs, "kubenetes clstr", 5, 2000)
+	if len(hits) != 1 || hits[0].Record.ID != "k8s" {
+		t.Fatalf("semantic hits = %+v", hits)
+	}
+	// Tombstoned and unrelated records stay out.
+	for _, h := range hits {
+		if h.Record.ID == "dead" || h.Record.ID == "pizza" {
+			t.Fatalf("unwanted hit %s", h.Record.ID)
+		}
+	}
+}
+
+// TestSearchSemantic_ChattyQueryNotDiluted: a salient (misspelled) term
+// buried in a conversational question still finds its record — per-token
+// cosine rescues what whole-query dilution would drop below the floor.
+func TestSearchSemantic_ChattyQueryNotDiluted(t *testing.T) {
+	rs := semRecords()
+	hits := SearchSemantic(rs, "what do you remember about kubenetes?", 5, 2000)
+	if len(hits) != 1 || hits[0].Record.ID != "k8s" {
+		t.Fatalf("chatty-query hits = %+v", hits)
+	}
+	// And the per-token path must not drag in unrelated records.
+	if hits := SearchSemantic(rs, "what do you remember about quantum entanglement?", 5, 2000); len(hits) != 0 {
+		t.Fatalf("unrelated chatty query matched: %+v", hits)
+	}
+}
+
+// TestSearchHybrid_SupersetAndOrdering: every keyword hit survives hybrid,
+// both-signal records outrank single-signal ones, and the typo case rides in.
+func TestSearchHybrid_SupersetAndOrdering(t *testing.T) {
+	rs := semRecords()
+
+	// Exact query: the kubernetes record matches BOTH signals and must rank
+	// above anything matching one.
+	hy := SearchHybrid(rs, "kubernetes cluster", 5, 2000)
+	if len(hy) == 0 || hy[0].Record.ID != "k8s" {
+		t.Fatalf("hybrid top = %+v", hy)
+	}
+	kw := Search(rs, "kubernetes cluster", 5, 2000)
+	if len(kw) == 0 {
+		t.Fatal("keyword baseline empty")
+	}
+	if hy[0].Score <= kw[0].Score {
+		t.Fatalf("both-signal score %v must exceed keyword-only %v", hy[0].Score, kw[0].Score)
+	}
+	// Every keyword hit appears in the hybrid result (superset property).
+	hybridIDs := map[string]bool{}
+	for _, h := range hy {
+		hybridIDs[h.Record.ID] = true
+	}
+	for _, h := range kw {
+		if !hybridIDs[h.Record.ID] {
+			t.Fatalf("keyword hit %s lost in hybrid", h.Record.ID)
+		}
+	}
+
+	// Typo query: keyword finds nothing, hybrid still surfaces the record.
+	hy = SearchHybrid(rs, "kubenetes clstr", 5, 2000)
+	if len(hy) != 1 || hy[0].Record.ID != "k8s" {
+		t.Fatalf("hybrid typo hits = %+v", hy)
+	}
+
+	// Limit applies after the merge.
+	if got := SearchHybrid(rs, "kubernetes pizza fermentation", 1, 2000); len(got) != 1 {
+		t.Fatalf("limit ignored: %d hits", len(got))
+	}
+}
+
+// TestSearchSemantic_Determinism: two identical calls produce identical
+// ordering (the sort ties on LastSeenMS then ID).
+func TestSearchSemantic_Determinism(t *testing.T) {
+	rs := []Record{
+		{ID: "a", Subject: "deploy", Content: "deploy service to prod", Confidence: 1, LastSeenMS: 100},
+		{ID: "b", Subject: "deploy", Content: "deploy service to prod", Confidence: 1, LastSeenMS: 100},
+	}
+	x := SearchSemantic(rs, "deploying services", 5, 200)
+	y := SearchSemantic(rs, "deploying services", 5, 200)
+	if len(x) != 2 || len(y) != 2 || x[0].Record.ID != y[0].Record.ID || x[0].Record.ID != "a" {
+		t.Fatalf("non-deterministic: %+v vs %+v", x, y)
+	}
+}


### PR DESCRIPTION
## Summary
- Memory retrieval is now **hybrid**: exact keyword overlap + **local embeddings** (signed feature hashing of words + rune-correct character 3-grams → L2-normalized 256-dim vectors; pure Go stdlib FNV; zero marginal cost — DECISIONS C5's default)
- `SearchSemantic`: cosine × the same confidence/recency weights, 0.2 noise floor; whole-query OR best damped per-token cosine, so chatty questions aren't diluted away
- `SearchHybrid` wired into `Manager.Recall*`/`Search` → pre-run recall, memory tool, `agt memory search`, console all gain typo + morphology tolerance with no surface/schema change
- Synonym-level semantics remain the documented provider-embeddings opt-in

## Test plan
- [x] 6 new suites: embed determinism/norm, related-vs-unrelated cosine (incl. Turkish morphology), typo-finds-what-keyword-misses, chatty-query rescue (regression for a live-found dilution bug), hybrid superset+ordering, tie determinism
- [x] Full `GOMAXPROCS=3 go test -p 2 ./...` green; vet + staticcheck clean; linux cross-build OK; go.mod unchanged (stdlib only)
- [x] Smoke vs isolated daemon: `agt memory search "kubenetes clstr"` → hit (keyword: nothing); `"ödeme servisinin yeniden başlatılması"` → hit; negative control clean; real run answered "Frankfurt" from memory with `memory.retrieved` journaled

🤖 Generated with [Claude Code](https://claude.com/claude-code)