### PR TITLE
Feat: forge promotion queue — agents request, the operator decides (M813)

### DIFF
--- a/.project/PHASE-M813-FORGE-PROMOTION-QUEUE-REPORT.md
+++ b/.project/PHASE-M813-FORGE-PROMOTION-QUEUE-REPORT.md
@@ -1,0 +1,63 @@
+# Phase M813 — forge promotion queue
+
+**Date:** 2026-06-10 · **Status:** DONE · **Arc:** forge polish — the
+agent can now ASK for its tool to go live; the operator decides from the
+same approval surface as everything else.
+
+## What
+
+M794 deliberately made promotion operator-only (CLI/console) — but the
+agent couldn't even request it; the loop ended with "ask the operator"
+prose. M813 closes the loop with the HITL registry:
+
+- **kernel/runtime `RequestToolPromotion(ctx, corr, ref)`** — checks the
+  invariants UP FRONT (exists, not already active, **TestedOK** — an
+  untested draft never reaches the operator's queue, preserving "only
+  tested code goes live"), then blocks on `approvals.Submit` (capability
+  `toolforge.promote`, input carries name/language/description). A grant
+  promotes through the EXACT path the operator CLI uses
+  (PromoteScriptTool → scripttool.promoted journaled); a deny/timeout
+  returns the decision + reason as a verdict, not an error.
+- **tool_forge `op=request_promotion {ref}`** — granted → "promoted —
+  callable as forge_<name> from the next run"; denied → an error result
+  carrying the operator's reason ("improve the tool or move on");
+  timeout → "the operator did not decide in time". The op=test verdict
+  now points at request_promotion. Edict: rides the existing
+  CapToolForge mapping (the registry is the real gate).
+- The request appears in `agt approvals` and the console's Approvals
+  view automatically — zero new surfaces, the queue IS the registry.
+
+## Tests (runtime e2e + tool suite; full battery green)
+
+- Runtime, REAL registry: deny → verdict+reason back, draft stays draft;
+  grant → ACTIVE via the operator path; untested refused with
+  ErrUntested BEFORE any registry submit; already-active and ghost
+  refused up front
+- forgetool: denied → IsError with the operator's reason; granted →
+  forge_<name> message + ACTIVE; untested → "no passing test"; missing
+  ref refused
+- 492 vitest; full Go suite, vet, staticcheck, linux cross-build green
+
+## Smoke (isolated AGEZT_HOME, real daemon, REAL provider MiniMax-M2)
+
+One `agt run`: the real agent drafted a python `slugify` tool, tested it
+in the real sandbox ("Merhaba Dunya 42"), then requested promotion and
+BLOCKED. `agt approvals` showed "promote slugify (python): Convert a
+text string into a URL-friendly slug format"; `agt approve … "test
+gecti, lgtm"` released it; the agent reported "The tool is now active
+and callable as forge_slugify". `agt toolforge list` → ACTIVE; a FRESH
+run then called `forge_slugify` successfully. The whole loop — author,
+test, request, human gate, go-live, use — in one session.
+
+## Gate
+
+Full `GOMAXPROCS=3 go test -p 2 ./...` green; vet + staticcheck clean;
+linux cross-build OK; vitest 492 (frontend untouched); go.mod unchanged;
+no new env vars; no new event kinds (the registry's approval.* arc
+already covers the queue).
+
+## Next
+
+Remaining optional backlog: alert per-channel routing + mute window;
+provider embeddings opt-in (needs an embeddings-capable keyed provider —
+verify before building). Owner-gated: CI billing → v1.0.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **Forge promotion queue — agents ask, you decide.** A forged tool's author can now request
+  promotion (`tool_forge op=request_promotion`): the call blocks on the same HITL approval
+  queue as everything else (`agt approvals` / the console's Approvals view), a grant takes the
+  tool live through the exact operator path, and a denial returns your reason to the agent so
+  it can improve and retry. The "only tested code goes live" invariant holds at the gate — an
+  untested draft never even reaches your queue. Proven in one live session: a real agent
+  drafted and sandbox-tested a slugify tool, requested promotion, waited; `agt approve` took it
+  live; a fresh run called `forge_slugify` successfully. (M813)
 - **Webhook reply mode — request/response workflows.** Set `"reply": true` on a webhook
   trigger and the caller's POST waits for the run and receives its outputs: a branching
   workflow answered `curl -d '{"n":9}'` with the BIG branch's result and `'{"n":2}'` with the

--- a/kernel/runtime/scripttool.go
+++ b/kernel/runtime/scripttool.go
@@ -15,9 +15,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/approval"
 	"github.com/agezt/agezt/kernel/event"
 	"github.com/agezt/agezt/kernel/toolforge"
 )
@@ -109,6 +111,42 @@ func (k *Kernel) PromoteScriptTool(corr, ref string) (toolforge.ScriptTool, erro
 		Payload:       map[string]any{"id": st.ID, "name": st.Name, "language": st.Language},
 	})
 	return st, nil
+}
+
+// RequestToolPromotion (M813): the agent ASKS for its tool to go live — the
+// promotion queue. The request blocks on the HITL approval registry (it
+// shows up in `agt approvals` and the console's Approvals view); a grant
+// promotes through the exact path the operator CLI uses, a deny/timeout
+// comes back as the decision, not an error. The "only tested code goes
+// live" invariant is checked up front so an untested draft never even
+// reaches the operator's queue.
+func (k *Kernel) RequestToolPromotion(ctx context.Context, corr, ref string) (toolforge.ScriptTool, approval.Decision, string, error) {
+	st, found := k.toolForge.Get(strings.TrimSpace(ref))
+	if !found {
+		return toolforge.ScriptTool{}, "", "", fmt.Errorf("toolforge: no script tool %q", ref)
+	}
+	if st.Status == toolforge.StatusActive {
+		return st, "", "", fmt.Errorf("toolforge: %s is already active", st.Name)
+	}
+	if !st.TestedOK {
+		return toolforge.ScriptTool{}, "", "", toolforge.ErrUntested
+	}
+	out := k.approvals.Submit(ctx, approval.SubmitSpec{
+		Capability:    "toolforge.promote",
+		ToolName:      "toolforge.promote",
+		Input:         fmt.Sprintf("promote %s (%s): %s", st.Name, st.Language, st.Description),
+		Reason:        "agent requested promotion of forge tool " + st.Name,
+		Actor:         "toolforge",
+		CorrelationID: corr,
+	})
+	if out.Decision != approval.DecisionGrant {
+		return st, out.Decision, out.Reason, nil // a verdict, not a failure
+	}
+	promoted, err := k.PromoteScriptTool(corr, st.Name)
+	if err != nil {
+		return st, out.Decision, out.Reason, err
+	}
+	return promoted, out.Decision, out.Reason, nil
 }
 
 // QuarantineScriptTool pulls an active tool from production — the kill

--- a/kernel/runtime/scripttool_test.go
+++ b/kernel/runtime/scripttool_test.go
@@ -4,10 +4,13 @@ package runtime_test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/approval"
 	"github.com/agezt/agezt/kernel/runtime"
 	"github.com/agezt/agezt/kernel/toolforge"
 	"github.com/agezt/agezt/plugins/providers/mock"
@@ -228,4 +231,72 @@ func contains(names []string, want string) bool {
 		}
 	}
 	return false
+}
+
+// TestRequestToolPromotion (M813): the agent's promotion request blocks on
+// the REAL approval registry; a grant promotes through the operator path, a
+// deny comes back as the decision, and untested/active/ghost are refused
+// before the operator ever sees a request.
+func TestRequestToolPromotion(t *testing.T) {
+	runner := &stubRunner{}
+	k := openForgeKernel(t, mock.New(mock.FinalText("unused")), runner)
+
+	st, err := k.DraftScriptTool("", toolforge.ScriptTool{
+		Name: "greet", Description: "says hi", Language: "python", Code: "print('hi')",
+	})
+	if err != nil {
+		t.Fatalf("draft: %v", err)
+	}
+
+	// Untested → refused without touching the registry.
+	if _, _, _, err := k.RequestToolPromotion(context.Background(), "", st.Name); !errors.Is(err, toolforge.ErrUntested) {
+		t.Fatalf("untested err = %v", err)
+	}
+	runner.out = "ok"
+	if _, _, err := k.TestScriptTool(context.Background(), "", st.Name, "{}"); err != nil {
+		t.Fatalf("test: %v", err)
+	}
+
+	// The operator resolves the pending request from another goroutine.
+	resolve := func(decision approval.Decision, reason string) {
+		deadline := time.After(5 * time.Second)
+		for {
+			for _, req := range k.Approvals().Pending() {
+				if req.Capability == "toolforge.promote" {
+					_ = k.Approvals().Resolve(req.ID, decision, reason, "tester")
+					return
+				}
+			}
+			select {
+			case <-deadline:
+				return
+			case <-time.After(10 * time.Millisecond):
+			}
+		}
+	}
+
+	// Denied: the verdict rides back, the draft stays a draft.
+	go resolve(approval.DecisionDeny, "needs validation")
+	_, decision, reason, err := k.RequestToolPromotion(context.Background(), "", "greet")
+	if err != nil || decision != approval.DecisionDeny || reason != "needs validation" {
+		t.Fatalf("deny: %v/%v/%v", decision, reason, err)
+	}
+	if got, _ := k.ToolForge().Get("greet"); got.Status == toolforge.StatusActive {
+		t.Fatal("denied tool went active")
+	}
+
+	// Granted: ACTIVE via the same path the operator CLI uses.
+	go resolve(approval.DecisionGrant, "lgtm")
+	promoted, decision, _, err := k.RequestToolPromotion(context.Background(), "", "greet")
+	if err != nil || decision != approval.DecisionGrant || promoted.Status != toolforge.StatusActive {
+		t.Fatalf("grant: %+v %v %v", promoted, decision, err)
+	}
+
+	// Already active / ghost → refused up front.
+	if _, _, _, err := k.RequestToolPromotion(context.Background(), "", "greet"); err == nil {
+		t.Fatal("re-promoting an active tool accepted")
+	}
+	if _, _, _, err := k.RequestToolPromotion(context.Background(), "", "ghost"); err == nil {
+		t.Fatal("ghost accepted")
+	}
 }

--- a/plugins/tools/forgetool/tool.go
+++ b/plugins/tools/forgetool/tool.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 
 	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/approval"
 	"github.com/agezt/agezt/kernel/toolforge"
 )
 
@@ -27,6 +28,7 @@ type Kernel interface {
 	DraftScriptTool(corr string, st toolforge.ScriptTool) (toolforge.ScriptTool, error)
 	UpdateScriptTool(corr, ref string, mutate func(*toolforge.ScriptTool)) (toolforge.ScriptTool, bool, error)
 	TestScriptTool(ctx context.Context, corr, ref, input string) (toolforge.ScriptTool, string, error)
+	RequestToolPromotion(ctx context.Context, corr, ref string) (toolforge.ScriptTool, approval.Decision, string, error)
 	ToolForge() *toolforge.Store
 }
 
@@ -62,14 +64,15 @@ func (t *Tool) Definition() agent.ToolDef {
 			"op=draft saves a named script (python/node/deno) as a DRAFT tool; " +
 			"op=test runs the draft once in the sandbox with a sample JSON input (your script reads it from ./stdin.txt and must print its result to stdout); " +
 			"op=update edits a draft (changing the code clears its test record and demotes an active tool back to draft); " +
+			"op=request_promotion asks the human operator to take a TESTED draft live — the call waits for their decision; " +
 			"op=list and op=show inspect your tools. " +
-			"A draft only goes LIVE when the operator promotes it — after a passing test — and is then callable by every agent as forge_<name>. " +
+			"A draft only goes LIVE when the operator approves — after a passing test — and is then callable by every agent as forge_<name>. " +
 			"Use this when you've written code worth keeping: turn it into a tool instead of rewriting it every run.",
 		InputSchema: json.RawMessage(`{
   "type": "object",
   "required": ["op"],
   "properties": {
-    "op":           {"type":"string", "enum":["draft","update","test","list","show"]},
+    "op":           {"type":"string", "enum":["draft","update","test","request_promotion","list","show"]},
     "name":         {"type":"string", "description":"For op=draft: the tool's handle (lowercase letters/digits/underscore, e.g. \"fetch_weather\"); callable as forge_<name> once promoted."},
     "description":  {"type":"string", "description":"For op=draft/update: what the tool does and when to call it — the model-facing description."},
     "language":     {"type":"string", "description":"For op=draft/update: the sandbox runtime, e.g. \"python\", \"node\", or \"deno\"."},
@@ -161,11 +164,34 @@ func (t *Tool) Invoke(ctx context.Context, raw json.RawMessage) (agent.Result, e
 		if err != nil {
 			return errResult(err.Error()), nil
 		}
-		verdict := "PASSED — ask the operator to promote it (agt toolforge promote " + st.Name + ")"
+		verdict := "PASSED — request promotion (op=request_promotion) or ask the operator (agt toolforge promote " + st.Name + ")"
 		if !st.TestedOK {
 			verdict = "FAILED — fix the code (op=update) and test again"
 		}
 		return agent.Result{Output: "test " + verdict + "\n\n" + out, IsError: !st.TestedOK}, nil
+
+	case "request_promotion":
+		if strings.TrimSpace(in.Ref) == "" {
+			return errResult(`op=request_promotion needs a "ref" (the tool's id or name)`), nil
+		}
+		st, decision, reason, err := k.RequestToolPromotion(ctx, corr, in.Ref)
+		if err != nil {
+			return errResult(err.Error()), nil
+		}
+		switch decision {
+		case approval.DecisionGrant:
+			v := view(st)
+			v["message"] = "promoted by the operator — callable as forge_" + st.Name + " from the next run"
+			return okJSON(v), nil
+		case approval.DecisionDeny:
+			msg := "promotion denied by the operator"
+			if reason != "" {
+				msg += ": " + reason
+			}
+			return errResult(msg + " — improve the tool or move on"), nil
+		default:
+			return errResult("promotion request " + string(decision) + " — the operator did not decide in time"), nil
+		}
 
 	case "list":
 		all := k.ToolForge().List()
@@ -191,9 +217,9 @@ func (t *Tool) Invoke(ctx context.Context, raw json.RawMessage) (agent.Result, e
 		return okJSON(v), nil
 
 	case "":
-		return errResult("op required (draft|update|test|list|show)"), nil
+		return errResult("op required (draft|update|test|request_promotion|list|show)"), nil
 	default:
-		return errResult("unknown op " + in.Op + " (draft|update|test|list|show)"), nil
+		return errResult("unknown op " + in.Op + " (draft|update|test|request_promotion|list|show)"), nil
 	}
 }
 

--- a/plugins/tools/forgetool/tool_test.go
+++ b/plugins/tools/forgetool/tool_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/agezt/agezt/kernel/approval"
 	"github.com/agezt/agezt/kernel/toolforge"
 )
 
@@ -18,6 +19,9 @@ type fakeKernel struct {
 	store   *toolforge.Store
 	testOut string
 	testOK  bool
+	// promotion-queue double (M813): the operator's canned verdict.
+	decision approval.Decision
+	reason   string
 }
 
 func (f *fakeKernel) DraftScriptTool(_ string, st toolforge.ScriptTool) (toolforge.ScriptTool, error) {
@@ -38,6 +42,21 @@ func (f *fakeKernel) UpdateScriptTool(_, ref string, mutate func(*toolforge.Scri
 func (f *fakeKernel) TestScriptTool(_ context.Context, _, ref, _ string) (toolforge.ScriptTool, string, error) {
 	st, err := f.store.RecordTest(ref, f.testOK)
 	return st, f.testOut, err
+}
+
+func (f *fakeKernel) RequestToolPromotion(_ context.Context, _, ref string) (toolforge.ScriptTool, approval.Decision, string, error) {
+	st, found := f.store.Get(ref)
+	if !found {
+		return toolforge.ScriptTool{}, "", "", errors.New("toolforge: no script tool " + ref)
+	}
+	if !st.TestedOK {
+		return toolforge.ScriptTool{}, "", "", toolforge.ErrUntested
+	}
+	if f.decision == approval.DecisionGrant {
+		st, err := f.store.Promote(ref)
+		return st, f.decision, f.reason, err
+	}
+	return st, f.decision, f.reason, nil
 }
 
 func (f *fakeKernel) ToolForge() *toolforge.Store { return f.store }
@@ -126,5 +145,45 @@ func TestUnbound(t *testing.T) {
 	out, isErr := invoke(t, New(), map[string]any{"op": "list"})
 	if !isErr || !strings.Contains(out, "not available") {
 		t.Fatalf("unbound: err=%v out=%s", isErr, out)
+	}
+}
+
+// TestRequestPromotion (M813): the agent's promotion queue — granted goes
+// live, denied is an actionable error, untested never reaches the operator.
+func TestRequestPromotion(t *testing.T) {
+	tool, fk := newBound(t)
+	fk.testOK = true
+	invoke(t, tool, map[string]any{"op": "draft", "name": "greet", "language": "python", "code": "print(1)", "description": "says hi"})
+	invoke(t, tool, map[string]any{"op": "test", "ref": "greet"})
+
+	// Denied: an error result carrying the operator's reason.
+	fk.decision, fk.reason = approval.DecisionDeny, "needs input validation"
+	res, err := tool.Invoke(context.Background(), json.RawMessage(`{"op":"request_promotion","ref":"greet"}`))
+	if err != nil || !res.IsError || !strings.Contains(res.Output, "needs input validation") {
+		t.Fatalf("denied: %+v err=%v", res, err)
+	}
+	if st, _ := fk.store.Get("greet"); st.Status == toolforge.StatusActive {
+		t.Fatal("a denied tool went active")
+	}
+
+	// Granted: promoted, callable as forge_greet.
+	fk.decision = approval.DecisionGrant
+	res, err = tool.Invoke(context.Background(), json.RawMessage(`{"op":"request_promotion","ref":"greet"}`))
+	if err != nil || res.IsError || !strings.Contains(res.Output, "forge_greet") {
+		t.Fatalf("granted: %+v err=%v", res, err)
+	}
+	if st, _ := fk.store.Get("greet"); st.Status != toolforge.StatusActive {
+		t.Fatalf("status = %s", st.Status)
+	}
+
+	// Untested drafts never reach the queue; missing ref is refused.
+	invoke(t, tool, map[string]any{"op": "draft", "name": "raw", "language": "python", "code": "print(2)", "description": "untested"})
+	res, _ = tool.Invoke(context.Background(), json.RawMessage(`{"op":"request_promotion","ref":"raw"}`))
+	if !res.IsError || !strings.Contains(res.Output, "no passing test") {
+		t.Fatalf("untested: %+v", res)
+	}
+	res, _ = tool.Invoke(context.Background(), json.RawMessage(`{"op":"request_promotion"}`))
+	if !res.IsError || !strings.Contains(res.Output, `"ref"`) {
+		t.Fatalf("missing ref: %+v", res)
 	}
 }


### PR DESCRIPTION
## Summary
- **`tool_forge op=request_promotion`**: the agent asks for its TESTED tool to go live; the call blocks on the standard HITL approval queue (`agt approvals` / console Approvals — zero new surfaces)
- Grant → promoted through the exact operator path; deny → the operator's reason returns to the agent as an actionable error; timeout named
- "Only tested code goes live" holds at the gate: untested drafts are refused before reaching the queue

## Test plan
- [x] Runtime e2e on the REAL registry: deny verdict (draft stays draft), grant → ACTIVE, untested refused pre-queue, active/ghost refused up front
- [x] forgetool suite: denied/granted/untested/missing-ref shapes
- [x] Full `GOMAXPROCS=3 go test -p 2 ./...` green; vet + staticcheck clean; linux cross-build OK; 492 vitest
- [x] Live smoke (real provider + real sandbox): agent drafted slugify → tested → requested → BLOCKED → `agt approve` → active → a fresh run called `forge_slugify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)