### PR TITLE
Change: allow-by-default policy posture (M814)

### DIFF
--- a/.project/PHASE-M814-ALLOW-BY-DEFAULT-REPORT.md
+++ b/.project/PHASE-M814-ALLOW-BY-DEFAULT-REPORT.md
@@ -1,0 +1,62 @@
+# Phase M814 — allow-by-default policy posture
+
+**Date:** 2026-06-10 · **Status:** DONE · **Trigger:** owner law —
+"default olarak kapatmadıkça her şeye izni var bu agezt içinde her şeyin"
+(everything is allowed unless you turn it off).
+
+## What
+
+`edict.DefaultLevels()` now returns **LevelAllow for every capability**
+(built from `AllCapabilities()`, so a new capability is allow-by-default
+automatically and a forgotten entry can't silently land somewhere
+stricter). The pre-M814 ladder mixed Allow/AskFirst/Ask per DECISIONS
+F3, but the owner already ran AskPolicy=AskAllow — which folded every
+ask to allow in practice; this makes the real posture the explicit,
+durable one.
+
+**Restriction is the operator's opt-OUT**, unchanged and fully working:
+the Policy center, `agt edict level <cap> <L0..L4>`, `AGEZT_EDICT_DENY`,
+and durable overlays all still bind on top of the allow defaults.
+
+**Deliberately NOT relaxed** (these are guards, not permission levels):
+- the F4 hard-deny strings (fork bombs, `rm -rf /`, raw-device writes) —
+  they bite even when the capability is L4;
+- the http/browser SSRF guards (loopback/private-net egress);
+- Governor budget ceilings + per-agent daily caps;
+- EXPLICIT HITL surfaces the operator wires on purpose — the workflow
+  approval node and the forge promotion queue (M813) block on the
+  approval registry regardless of capability level.
+
+Banner now reads "edict (allow-by-default — every capability on unless
+you opt out; …)".
+
+## Tests (edict + controlplane; full battery green)
+
+- `TestDefaultLevels_MaxAutonomy`: EVERY capability in `AllCapabilities()`
+  defaults to LevelAllow (a new/forgotten cap fails here), and an
+  explicit override still beats the default
+- Updated the three posture-pinned control-plane tests (edict show /
+  set-level / set-mode) from the old F3 shell=L2 expectation to the
+  L4 default; the set-mode test now opts shell INTO ask-first first to
+  exercise AskDeny folding (nothing is ask-class out of the box anymore)
+- Full Go suite, vet, staticcheck, linux cross-build green; frontend
+  untouched (492 vitest)
+
+## Smoke (isolated AGEZT_HOME, real daemon)
+
+`agt edict test` on shell / file.write / file.delete / http.post /
+mcp.install / workflow.manage / config.write → **all allow** out of the
+box. Opt-OUT proven: `agt edict level shell L0` → "shell: L4 → L0",
+and a probe then **denied**. Hard-deny proven: `rm -rf /` on shell
+**denied even at L4**. Banner shows the new posture line.
+
+## Gate
+
+Full `GOMAXPROCS=3 go test -p 2 ./...` green; vet + staticcheck clean;
+linux cross-build OK; vitest 492; go.mod unchanged; no new env vars.
+Memory recorded: [[default-allow-posture]].
+
+## Next
+
+Remaining optional backlog: alert per-channel routing + mute window.
+Owner-gated: CI billing → v1.0.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 
 ## [Unreleased]
 
+### Changed
+- **Allow-by-default policy posture.** Every capability now ships at the allow level — AGEZT
+  is full-autonomy out of the box, and restriction is your explicit opt-out (`agt edict level
+  <cap> <L0..L4>`, the Policy center, `AGEZT_EDICT_DENY`, durable overlays) rather than the
+  default. This makes the real posture explicit: the previous mixed ladder was already folded
+  to allow in practice by the AskAllow approval mode. The guardrails that are *not* permission
+  levels stay exactly as they were — the hard-deny strings (`rm -rf /`, fork bombs, raw-device
+  writes) bite even at the allow level, the SSRF/egress guards hold, budget ceilings apply, and
+  the deliberate human-approval gates (workflow approval node, forge promotion queue) still
+  block on the approval registry. (M814)
+
 ### Added
 - **Forge promotion queue — agents ask, you decide.** A forged tool's author can now request
   promotion (`tool_forge op=request_promotion`): the call blocks on the same HITL approval

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -857,7 +857,7 @@ func runDaemon(stdout, stderr io.Writer) int {
 	fmt.Fprintf(stdout, "  credentials      : %s\n", credDesc)
 	fmt.Fprintf(stdout, "  redaction        : %s\n", redactDesc)
 	fmt.Fprintf(stdout, "  tools            : %s\n", toolsDesc)
-	fmt.Fprintf(stdout, "  policy engine    : edict (defaults from DECISIONS F3; %s)\n", askPolicyDesc)
+	fmt.Fprintf(stdout, "  policy engine    : edict (allow-by-default — every capability on unless you opt out; %s)\n", askPolicyDesc)
 	fmt.Fprintf(stdout, "  delegation       : %s\n", delegationBanner(k))
 	fmt.Fprintf(stdout, "  run timeout      : %s\n", runTimeoutDesc)
 	fmt.Fprintf(stdout, "  tool timeout     : %s\n", toolTimeoutDesc)

--- a/kernel/controlplane/edict_test.go
+++ b/kernel/controlplane/edict_test.go
@@ -71,12 +71,11 @@ func TestEdictShow_ReturnsDefaultPolicy(t *testing.T) {
 	if len(levels) < 8 {
 		t.Errorf("levels len = %d, want at least 8 (DefaultLevels count)", len(levels))
 	}
-	// Spot-check a high-value entry — shell is operator-critical;
-	// regressions on its default would be a security event.
-	// DECISIONS F3 vocabulary: TrustLevel.String() emits "L0".."L4"
-	// (where L2 = ask-first; see kernel/edict/edict.go).
-	if lvl, _ := levels["shell"].(string); lvl != "L2" {
-		t.Errorf("shell level = %q want %q (DECISIONS F3, L2 = ask-first)", lvl, "L2")
+	// Spot-check a high-value entry — under the M814 owner posture every
+	// capability defaults to L4 (allow); restriction is the operator's
+	// opt-OUT. TrustLevel.String() emits "L0".."L4".
+	if lvl, _ := levels["shell"].(string); lvl != "L4" {
+		t.Errorf("shell level = %q want %q (M814 allow-by-default)", lvl, "L4")
 	}
 
 	rules, ok := res["hard_deny"].([]any)
@@ -208,9 +207,9 @@ func TestEdictSetLevel_RuntimeChange(t *testing.T) {
 	if to, _ := set["to"].(string); to != "L0" {
 		t.Errorf("to = %q want L0", to)
 	}
-	// from must be the F3 default for shell (L2), proving we captured it.
-	if from, _ := set["from"].(string); from != "L2" {
-		t.Errorf("from = %q want L2 (shell default)", from)
+	// from must be the M814 default for shell (L4 allow), proving we captured it.
+	if from, _ := set["from"].(string); from != "L4" {
+		t.Errorf("from = %q want L4 (shell default, allow-by-default)", from)
 	}
 
 	probe, _ := c.Call(ctx, controlplane.CmdEdictTest, map[string]any{
@@ -276,6 +275,12 @@ func TestEdictSetLevel_FloorStillFires(t *testing.T) {
 func TestEdictSetMode_RuntimeChange(t *testing.T) {
 	_, _, c, _ := startPair(t, mock.New(mock.FinalText("ok")))
 	ctx := context.Background()
+
+	// M814: every capability is allow-by-default, so nothing is ask-class
+	// out of the box — opt shell INTO ask-first to exercise mode folding.
+	if _, err := c.Call(ctx, controlplane.CmdEdictSetLevel, map[string]any{"capability": "shell", "level": "L2"}); err != nil {
+		t.Fatalf("opt shell into ask-first: %v", err)
+	}
 
 	set, err := c.Call(ctx, controlplane.CmdEdictSetMode, map[string]any{"mode": "deny"})
 	if err != nil {

--- a/kernel/edict/edict.go
+++ b/kernel/edict/edict.go
@@ -577,46 +577,30 @@ func New(opt Options) *Engine {
 	}
 }
 
-// DefaultLevels are the per-capability defaults from DECISIONS F3, adapted
-// to the M1 capability set. Approval routing isn't wired yet, so anything
-// at L1..L3 will be folded by AskPolicy (default AskAllow + journal note).
+// DefaultLevels is the MAX-AUTONOMY posture (M814, owner's law: "default
+// olarak kapatmadıkça her şeye izni var" — everything is allowed unless the
+// operator turns it off). Every capability defaults to LevelAllow;
+// restriction is the operator's opt-OUT, applied per capability through the
+// Policy center, `agt edict`, AGEZT_EDICT_DENY, or a durable overlay.
+//
+// What this deliberately does NOT relax (they are guards, not permissions):
+//   - the F4 hard-deny strings (fork bombs, rm -rf /, raw-device writes);
+//   - the http/browser SSRF guards (loopback/private-net egress);
+//   - Governor budget ceilings and per-agent daily caps;
+//   - EXPLICIT HITL surfaces the operator wires on purpose (the workflow
+//     approval node, the forge promotion queue) — those block on the
+//     approval registry regardless of capability levels.
+//
+// History: the pre-M814 ladder mixed Allow/AskFirst/Ask per DECISIONS F3,
+// but the owner ran AskPolicy=AskAllow, which folded every ask to allow in
+// practice — this makes the real posture the explicit one. New capabilities
+// ship at LevelAllow unless the owner says otherwise.
 func DefaultLevels() map[Capability]TrustLevel {
-	return map[Capability]TrustLevel{
-		CapShell:        LevelAskFirst, // L2 per F3
-		CapFileRead:     LevelAllow,    // very common, low risk
-		CapFileList:     LevelAllow,
-		CapFileWrite:    LevelAskFirst, // L2
-		CapFileDelete:   LevelAsk,      // L1 — always ask
-		CapHTTPGet:      LevelAskFirst, // L2 (more permissive than F3's L1)
-		CapHTTPPost:     LevelAsk,      // L1
-		CapProviderCall: LevelAllow,    // governed by budget, not Edict
-		CapDelegate:     LevelAllow,    // sub-agent spawn; its tool calls are gated individually
-		CapCoding:       LevelAskFirst, // external coding agent; isolated to a worktree, returns a diff
-		CapACPAgent:     LevelAskFirst, // external ACP agent; runs in its own sandbox, returns its answer
-		CapRemoteRun:    LevelAskFirst, // peer Agezt node; ships a task to an external node over REST
-		CapNotify:       LevelAllow,    // message the operator's own configured chats; recipient is config-pinned
-
-		CapHomeAssistantRead: LevelAllow,    // read entity state; low risk, allowlist-filtered
-		CapHomeAssistantCall: LevelAskFirst, // actuate the physical world; confirm before acting
-
-		CapBrowserRead: LevelAskFirst, // L2 network read, symmetric with http.get; host allowlist is the 2nd gate
-		CapMemory:      LevelAllow,    // local knowledge store; low risk
-		CapWorld:       LevelAllow,    // local world-model graph; low risk
-		CapWebSearch:   LevelAskFirst, // L2 network read; engine host is fixed, query is the only operator input
-		CapSchedule:    LevelAskFirst, // L2 autonomy grant; a scheduled intent runs later through the governed loop
-		CapRunsRead:    LevelAllow,    // local read of the agent's own run history; low risk
-		CapStanding:    LevelAskFirst, // L2 strongest autonomy grant; the agent sets up unattended trigger-driven behaviour
-		CapBoard:       LevelAllow,    // local shared message board between agents; low risk
-		CapSkill:       LevelAskFirst, // self-modification: the agent authoring/promoting its own skills
-		CapIntrospect:  LevelAllow,    // local read of the daemon's own live state; no mutation, no network — low risk
-		CapCodeExec:    LevelAllow,    // write+run code; sandboxed (scrubbed env, confined dir, capped) and journaled — owner's choice for full autonomy
-		CapToolForge:   LevelAskFirst, // self-modification: the agent authoring its own script tools (going live still needs an operator promote)
-		CapMCPInstall:  LevelAsk,      // self-install: registering/attaching an MCP server spawns an arbitrary process — approve every one
-		CapMCP:         LevelAskFirst, // calling a bridged MCP tool: external, unvetted surface — vet first use per session
-		CapWorkflow:    LevelAskFirst, // L2 autonomy grant like standing: saving/arming durable automation — vet first use; nodes re-gate per call
-		CapConfigRead:  LevelAllow,    // read Config Center schema/values; no mutation, secrets presence-only
-		CapConfigWrite: LevelAskFirst, // mutate settings / register schema; can reach built-in security fields — confirm first
+	levels := make(map[Capability]TrustLevel, len(AllCapabilities()))
+	for _, c := range AllCapabilities() {
+		levels[c] = LevelAllow
 	}
+	return levels
 }
 
 // DefaultHardDeny is the immutable hard-deny set from DECISIONS F4. The

--- a/kernel/edict/edict_test.go
+++ b/kernel/edict/edict_test.go
@@ -283,25 +283,26 @@ func TestApplyOverlay_RestoresOntoEngine(t *testing.T) {
 	}
 }
 
-func TestDefaultLevels_RespectF3(t *testing.T) {
+// TestDefaultLevels_MaxAutonomy pins the M814 owner posture: EVERY known
+// capability defaults to LevelAllow ("default olarak kapatmadıkça her şeye
+// izni var"). Restriction is the operator's opt-OUT, not the default — a
+// new capability missing from the map, or any non-Allow default, fails here.
+func TestDefaultLevels_MaxAutonomy(t *testing.T) {
 	e := New(Options{})
-	checks := map[Capability]TrustLevel{
-		CapShell:      LevelAskFirst,
-		CapFileRead:   LevelAllow,
-		CapFileWrite:  LevelAskFirst,
-		CapFileDelete: LevelAsk,
-		CapHTTPGet:    LevelAskFirst,
-		CapHTTPPost:   LevelAsk,
-	}
-	for cap, want := range checks {
+	for _, cap := range AllCapabilities() {
 		got, ok := e.Level(cap)
 		if !ok {
 			t.Errorf("%s missing from default levels", cap)
 			continue
 		}
-		if got != want {
-			t.Errorf("%s: level=%s want %s", cap, got, want)
+		if got != LevelAllow {
+			t.Errorf("%s: level=%s want L4 (allow-by-default is the owner's law)", cap, got)
 		}
+	}
+	// The opt-OUT still works: an explicit override beats the default.
+	e2 := New(Options{Levels: map[Capability]TrustLevel{CapShell: LevelAsk}})
+	if got, _ := e2.Level(CapShell); got != LevelAsk {
+		t.Errorf("override ignored: %s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- **Every capability defaults to allow** — full autonomy out of the box; restriction is the operator's explicit opt-out, not the default
- Built from `AllCapabilities()` so new capabilities are allow-by-default automatically (and pinned by test)
- Makes the real posture explicit: the old mixed ladder was already folded to allow by `AskPolicy=AskAllow`
- **Unchanged guards** (not permission levels): F4 hard-deny strings (bite even at L4), SSRF/egress guards, budget ceilings, and the deliberate HITL gates (workflow approval node, forge promotion queue)

## Test plan
- [x] `TestDefaultLevels_MaxAutonomy`: every `AllCapabilities()` entry = LevelAllow; explicit override still wins
- [x] Three control-plane posture tests updated (show/set-level/set-mode); set-mode opts shell into ask-first to exercise AskDeny folding
- [x] Full `GOMAXPROCS=3 go test -p 2 ./...` green; vet + staticcheck clean; linux cross-build OK; 492 vitest
- [x] Smoke: shell/file.write/file.delete/http.post/mcp.install/workflow.manage/config.write all allow; `agt edict level shell L0` → denied; `rm -rf /` denied even at L4

🤖 Generated with [Claude Code](https://claude.com/claude-code)