### PR TITLE
Feat: http/browser.read allow-by-default (owner law) (M818)

### DIFF
--- a/.project/PHASE-M818-NET-TOOLS-DEFAULT-ALLOW-REPORT.md
+++ b/.project/PHASE-M818-NET-TOOLS-DEFAULT-ALLOW-REPORT.md
@@ -1,0 +1,59 @@
+# Phase M818 — http / browser.read default-ALLOW (owner law)
+
+**Date:** 2026-06-11 · **Status:** DONE · **Trigger:** owner: "browser.read ve
+http.get için sürekli `http: host not in allowlist` … her şey yasak bu ne" — the
+network tools refused every host out of the box.
+
+## Why
+
+The `http` and `browser.read` tools shipped **default-DENY**: an empty host
+allowlist meant *no host allowed*, and the daemon only flipped `AllowAll` on with
+`AGEZT_HTTP_ALLOW_ALL=1` / `AGEZT_ALLOW_ALL=1`. So a fresh daemon answered every
+`http.get`/`browser.read` with `host not in allowlist`. That is the exact
+opposite of the owner's standing law (memory `default-allow-posture`): *every
+capability is allowed by default; restriction is the opt-OUT*. The banner even
+read `http(hosts=0, egress=guarded)` — zero hosts, everything blocked.
+
+## What changed (`cmd/agezt/main.go` tool wiring only)
+
+The tool LIBRARY defaults stay safe (`httptool.New()` is still default-deny — a
+good library default); the DAEMON now opts into the open posture:
+
+- **http:** empty `AGEZT_HTTP_ALLOWED_HOSTS` ⇒ `AllowAll = true` (any public
+  host). A non-empty list is the opt-OUT that RESTRICTS to those hosts.
+- **browser.read:** identical rule with `AGEZT_BROWSER_ALLOWED_HOSTS`.
+- `AGEZT_ALLOW_ALL=1` / the per-tool `*_ALLOW_ALL=1` still force open and now also
+  override a pinned allowlist back to open.
+
+**The SSRF egress guard is untouched and stays the hard floor**: even with any
+host allowed, netguard still refuses loopback (127.0.0.0/8, ::1), the private
+network (RFC1918 / ULA), and cloud metadata (169.254.169.254) on every hop —
+relaxed only by the explicit `AGEZT_HTTP_ALLOW_LOOPBACK` / `_ALLOW_PRIVATE`
+flags. "Open" means the public internet, not a pivot into co-located admin
+surfaces. This is the F4/SSRF carve-out the owner law preserves.
+
+Banner now reads `http(any host, egress=guarded), browser.read(any host)`; a
+pinned allowlist shows `http(hosts=N, …)`.
+
+## Tests / verification
+
+- Full `GOMAXPROCS=3 go test -p 2 ./...` green; vet + staticcheck clean. The
+  httptool/browser/netguard unit suites (AllowAll + egress-guard behaviour) are
+  unchanged and pass — no test pinned the old default-deny daemon banner.
+- **Live smoke** (isolated home, real deepseek provider): banner shows
+  `http(any host, egress=guarded)`. An agent run — "GET https://example.com and
+  report the title" — returned **"Example Domain … No blocking occurred — 200
+  OK"** (`$0.0068`). Pre-M818 this failed with `host not in allowlist`.
+
+## Gate
+
+Go suite + vet + staticcheck clean; linux cross-build unaffected; no schema /
+env-var additions (behaviour change only — the same `AGEZT_*_ALLOWED_HOSTS`
+vars now mean "restrict" instead of "the only thing allowed"); go.mod unchanged.
+
+## Note
+
+Existing operators who had RELIED on default-deny + an allowlist are unaffected:
+a pinned `AGEZT_HTTP_ALLOWED_HOSTS` still restricts exactly as before. Only the
+*empty* (unconfigured) case flipped from deny-all to allow-all, matching the
+owner's allow-by-default posture.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 
 ## [Unreleased]
 
+### Changed
+- **`http` and `browser.read` are allow-by-default.** Out of the box the network tools now reach
+  **any public host** — an empty allowlist no longer means "deny everything" (the old behaviour that
+  made every `http.get`/`browser.read` fail with `host not in allowlist`). Setting
+  `AGEZT_HTTP_ALLOWED_HOSTS` / `AGEZT_BROWSER_ALLOWED_HOSTS` is now the opt-OUT that **restricts** to
+  those hosts. The SSRF egress guard still refuses loopback, the private network, and cloud-metadata
+  on every hop — "open" means the public internet, not a pivot inward. Matches the allow-by-default
+  posture. (M818)
+
 ### Added
 - **Web UI on by default + optional password.** A bare `agezt` now serves the console at
   `127.0.0.1:8787` (tokenized URL in the banner) — no `AGEZT_WEB_ADDR` needed. The default port

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -4158,25 +4158,34 @@ func buildTools(baseDir string, stderr io.Writer, ward warden.Engine) (map[strin
 	out["config"] = configtool.New(baseDir)
 	registered = append(registered, "config()")
 
-	// http — default-deny; allowed hosts via $AGEZT_HTTP_ALLOWED_HOSTS
-	// (comma-separated). $AGEZT_HTTP_ALLOW_ALL=1 bypasses (DANGEROUS).
+	// http — default-ALLOW (M818, owner law: every capability open unless you opt
+	// out). Any PUBLIC host is reachable out of the box; the opt-OUT is a non-empty
+	// $AGEZT_HTTP_ALLOWED_HOSTS (comma-separated), which RESTRICTS the tool to just
+	// those hosts. The SSRF egress guard (loopback / private / cloud-metadata
+	// refused) is the hard floor and stays on regardless — relaxed only by the
+	// explicit AGEZT_HTTP_ALLOW_* flags below. So "open" means the public internet,
+	// not a pivot into co-located admin surfaces.
 	ht := httptool.New()
-	if hostsCSV := os.Getenv(brand.EnvPrefix + "HTTP_ALLOWED_HOSTS"); hostsCSV != "" {
+	httpRestricted := false
+	if hostsCSV := os.Getenv(brand.EnvPrefix + "HTTP_ALLOWED_HOSTS"); strings.TrimSpace(hostsCSV) != "" {
 		for h := range strings.SplitSeq(hostsCSV, ",") {
 			if h = strings.TrimSpace(h); h != "" {
 				ht.AllowedHosts = append(ht.AllowedHosts, h)
 			}
 		}
+		httpRestricted = len(ht.AllowedHosts) > 0
+	}
+	if !httpRestricted {
+		ht.AllowAll = true // default-allow: no allowlist pinned ⇒ any public host
 	}
 	// Master permissive switch (M611): AGEZT_ALLOW_ALL=1 implies the full open
 	// posture for the network tools too — any host, including loopback and the
-	// private network — so "everything allowed" really means everything.
+	// private network — so "everything allowed" really means everything. It also
+	// overrides a pinned allowlist back to open.
 	allowAll := os.Getenv(brand.EnvPrefix+"ALLOW_ALL") == "1"
 	if allowAll || os.Getenv(brand.EnvPrefix+"HTTP_ALLOW_ALL") == "1" {
 		ht.AllowAll = true
-		if !allowAll {
-			fmt.Fprintln(stderr, "WARNING: AGEZT_HTTP_ALLOW_ALL=1 disables the http host allowlist.")
-		}
+		httpRestricted = false
 	}
 	// Egress guard (M16): by default the http tool refuses internal/metadata
 	// addresses even for allowlisted/AllowAll hosts. Relax per range for local use.
@@ -4195,28 +4204,33 @@ func buildTools(baseDir string, stderr io.Writer, ward warden.Engine) (map[strin
 		fmt.Fprintln(stderr, "WARNING: AGEZT_HTTP_ALLOW_PRIVATE=1 lets the http tool reach the private network.")
 	}
 	out["http"] = ht
-	if ht.AllowAll {
-		registered = append(registered, fmt.Sprintf("http(allow_all=true, egress=%s)", egress))
-	} else {
+	if httpRestricted {
 		registered = append(registered, fmt.Sprintf("http(hosts=%d, egress=%s)", len(ht.AllowedHosts), egress))
+	} else {
+		registered = append(registered, fmt.Sprintf("http(any host, egress=%s)", egress))
 	}
 
 	// browser.read — same allowlist pattern as http (uses AGEZT_BROWSER_*
 	// env vars; deliberately separate from http's allowlist so operators
 	// can grant browser-read access to a wider domain set than POSTs).
+	// Same default-ALLOW posture as http (M818): any public host out of the box;
+	// a non-empty AGEZT_BROWSER_ALLOWED_HOSTS is the opt-OUT that restricts it.
 	br := browser.New()
-	if hostsCSV := os.Getenv(brand.EnvPrefix + "BROWSER_ALLOWED_HOSTS"); hostsCSV != "" {
+	browserRestricted := false
+	if hostsCSV := os.Getenv(brand.EnvPrefix + "BROWSER_ALLOWED_HOSTS"); strings.TrimSpace(hostsCSV) != "" {
 		for h := range strings.SplitSeq(hostsCSV, ",") {
 			if h = strings.TrimSpace(h); h != "" {
 				br.AllowedHosts = append(br.AllowedHosts, h)
 			}
 		}
+		browserRestricted = len(br.AllowedHosts) > 0
+	}
+	if !browserRestricted {
+		br.AllowAll = true // default-allow
 	}
 	if allowAll || os.Getenv(brand.EnvPrefix+"BROWSER_ALLOW_ALL") == "1" {
 		br.AllowAll = true
-		if !allowAll {
-			fmt.Fprintln(stderr, "WARNING: AGEZT_BROWSER_ALLOW_ALL=1 disables the browser host allowlist.")
-		}
+		browserRestricted = false
 	}
 	// Egress guard (M16): browser.read refuses internal/metadata addresses by
 	// default, even for allowlisted/AllowAll hosts. Relax per range for local use.
@@ -4236,10 +4250,10 @@ func buildTools(baseDir string, stderr io.Writer, ward warden.Engine) (map[strin
 		}
 	}
 	out["browser.read"] = br
-	if br.AllowAll {
-		registered = append(registered, "browser.read(allow_all=true)")
-	} else {
+	if browserRestricted {
 		registered = append(registered, fmt.Sprintf("browser.read(hosts=%d)", len(br.AllowedHosts)))
+	} else {
+		registered = append(registered, "browser.read(any host)")
 	}
 
 	// web_search — keyword search against a public engine, returning result


### PR DESCRIPTION
## What

The `http` and `browser.read` tools shipped **default-DENY** — an empty host allowlist meant *no host allowed*, so a fresh daemon refused every `http.get`/`browser.read` with `host not in allowlist`. That contradicts the standing **allow-by-default** posture (you opt OUT, you don't opt in).

Now (daemon tool wiring only, `cmd/agezt/main.go`):
- empty `AGEZT_HTTP_ALLOWED_HOSTS` / `AGEZT_BROWSER_ALLOWED_HOSTS` → `AllowAll` = any **public** host;
- a non-empty list is the **opt-OUT** that restricts to those hosts;
- `AGEZT_ALLOW_ALL=1` and the per-tool `*_ALLOW_ALL=1` still force open (and override a pinned allowlist).

**The SSRF egress guard is untouched** and stays the hard floor: loopback, the private network, and cloud-metadata (169.254.169.254) are refused on every hop regardless — relaxed only by the explicit `*_ALLOW_LOOPBACK`/`*_ALLOW_PRIVATE` flags. "Open" = the public internet, not a pivot inward. The tool **library** default (`httptool.New`) stays default-deny.

Banner now reads `http(any host, egress=guarded), browser.read(any host)`; a pinned allowlist shows `http(hosts=N, …)`.

## Verification
- **Live** (real deepseek provider, isolated home): agent run *"GET https://example.com and report the title"* → **"Example Domain … No blocking occurred — 200 OK"** (`$0.0068`). Pre-M818 this failed with `host not in allowlist`.
- Full `GOMAXPROCS=3 go test -p 2 ./...` green; vet + staticcheck clean. netguard/httptool/browser suites unchanged (the library defaults and egress guard are unchanged).

## Compatibility
Operators who relied on default-deny + an allowlist are unaffected — a pinned `AGEZT_*_ALLOWED_HOSTS` still restricts exactly as before. Only the *empty/unconfigured* case flipped from deny-all to allow-all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)