### PR TITLE
Feat: quiet the llm.token/llm.reasoning CLI stream flood (M819)

### DIFF
--- a/.project/PHASE-M819-STREAM-NOISE-REPORT.md
+++ b/.project/PHASE-M819-STREAM-NOISE-REPORT.md
@@ -1,0 +1,41 @@
+# Phase M819 — quiet the llm.token / llm.reasoning stream flood
+
+**Date:** 2026-06-11 · **Status:** DONE · **Trigger:** owner: "su nedir yahu
+sürekli bundan görüyorum [evt seq=0 kind=llm.reasoning …]" — the CLI spammed a
+line per streamed token / reasoning chunk.
+
+## Why
+
+`llm.token` (each output token) and `llm.reasoning` (each chain-of-thought delta
+from a reasoning model like deepseek-v4-pro) are EPHEMERAL, high-rate bus events
+(seq=0, never journaled). The CLI streamers dumped them raw:
+
+- `agt run` special-cased `llm.token` (inline) but let `llm.reasoning` fall
+  through to the `[evt seq=0 kind=llm.reasoning]` summary line — hundreds per run.
+- `agt plan` / `agt plan run` dumped EVERY event including both — and with
+  concurrent plan nodes they interleaved into an unreadable wall.
+
+## What changed (`cmd/agt/main.go` only)
+
+- **`agt run`:** answer tokens still stream inline; reasoning is now HIDDEN by
+  default (no per-chunk line). `AGEZT_SHOW_REASONING=1` streams it inline,
+  demarcated with `💭`, on its own line group. A small streamMode helper emits a
+  clean newline when switching between thinking, answer, and per-event lines.
+- **`agt plan` (`runPlanJSON`):** skips `llm.token` + `llm.reasoning` in the
+  event dump — the structural events (node transitions, tool calls) and the
+  per-node outputs at the end carry the signal.
+
+`-q`/`--quiet` is unchanged (answer-only).
+
+## Verification
+
+Live run (real deepseek-v4-pro, isolated home), `agt run "What is 17*23?"`:
+output is now `task.received → llm.request → 391 (inline) → llm.response →
+task.completed`, **zero** `kind=llm.reasoning`/`kind=llm.token` lines (grep
+count 0). The answer `391` streams inline as before.
+
+## Gate
+
+`GOMAXPROCS=3 go test -p 2 ./cmd/... ./kernel/...` green; vet + staticcheck
+clean; linux cross-build OK; gofmt clean. No schema / behaviour changes beyond
+CLI rendering; go.mod unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Changed
+- **CLI no longer floods with per-token/reasoning event lines.** `agt run` and `agt plan` were
+  printing a `[evt seq=0 kind=llm.token]` / `kind=llm.reasoning` line for every streamed chunk — a
+  reasoning model (e.g. deepseek-v4-pro) buried the output. Now the answer streams inline, reasoning
+  is hidden by default (`AGEZT_SHOW_REASONING=1` shows it, demarcated with 💭), and `agt plan` skips
+  the ephemeral chunks entirely. (M819)
+
+### Changed
 - **`http` and `browser.read` are allow-by-default.** Out of the box the network tools now reach
   **any public host** — an empty allowlist no longer means "deny everything" (the old behaviour that
   made every `http.get`/`browser.read` fail with `host not in allowlist`). Setting

--- a/cmd/agt/main.go
+++ b/cmd/agt/main.go
@@ -586,12 +586,33 @@ func cmdRun(args []string, stdout, stderr io.Writer) int {
 	// bus.PublishStreaming). Render those inline so the operator sees
 	// progress instead of a frozen prompt. Every other event keeps
 	// the existing `[evt seq=...]` summary line.
-	inStream := false
+	// Stream renderer state. The answer tokens (KindLLMToken) stream inline; a
+	// reasoning model's chain-of-thought (KindLLMReasoning) is HIDDEN by default —
+	// it's high-rate ephemeral noise (the "[evt seq=0 kind=llm.reasoning]" flood)
+	// that the operator rarely wants — and shown, demarcated with 💭, only when
+	// AGEZT_SHOW_REASONING=1. streamMode tracks which inline stream is open so we
+	// emit a clean newline when switching between thinking, answer, and the
+	// per-event summary lines.
+	showReasoning := os.Getenv(brand.EnvPrefix+"SHOW_REASONING") == "1"
+	streamMode := "" // "", "answer", "reason"
 	closeStream := func() {
-		if inStream {
+		if streamMode != "" {
 			fmt.Fprintln(stdout)
-			inStream = false
+			streamMode = ""
 		}
+	}
+	streamText := func(mode, prefix, text string) {
+		if text == "" {
+			return
+		}
+		if streamMode != mode {
+			if streamMode != "" {
+				fmt.Fprintln(stdout)
+			}
+			fmt.Fprint(stdout, prefix)
+			streamMode = mode
+		}
+		fmt.Fprint(stdout, text)
 	}
 	// --quiet (M156): suppress the live token stream + per-event lines + the
 	// usage/correlation footer, printing ONLY the final answer — so scripts can
@@ -600,18 +621,23 @@ func cmdRun(args []string, stdout, stderr io.Writer) int {
 		if quiet {
 			return
 		}
-		if ev.Kind == event.KindLLMToken {
+		switch ev.Kind {
+		case event.KindLLMToken:
 			var p struct {
 				Text string `json:"text"`
 			}
 			_ = json.Unmarshal(ev.Payload, &p)
-			if p.Text != "" {
-				if !inStream {
-					fmt.Fprint(stdout, "  ")
-					inStream = true
-				}
-				fmt.Fprint(stdout, p.Text)
+			streamText("answer", "  ", p.Text)
+			return
+		case event.KindLLMReasoning:
+			if !showReasoning {
+				return // ephemeral thinking; opt in with AGEZT_SHOW_REASONING=1
 			}
+			var p struct {
+				Text string `json:"text"`
+			}
+			_ = json.Unmarshal(ev.Payload, &p)
+			streamText("reason", "  💭 ", p.Text)
 			return
 		}
 		closeStream()
@@ -1090,6 +1116,13 @@ func runPlanJSON(planJSON string, stdout, stderr io.Writer) int {
 	result, err := c.Stream(ctx, controlplane.CmdPlan,
 		map[string]any{"plan_json": planJSON},
 		func(ev *event.Event) {
+			// Skip the high-rate ephemeral token/reasoning chunks — with concurrent
+			// plan nodes they interleave into an unreadable "[evt seq=0]" flood. The
+			// structural events (node transitions, tool calls) and the per-node
+			// outputs at the end carry the signal.
+			if ev.Kind == event.KindLLMToken || ev.Kind == event.KindLLMReasoning {
+				return
+			}
 			fmt.Fprintf(stdout, "  [evt seq=%d kind=%s subject=%s]\n", ev.Seq, ev.Kind, ev.Subject)
 		})
 	if err != nil {


### PR DESCRIPTION
## What

`llm.token` (each output token) and `llm.reasoning` (each chain-of-thought delta from a reasoning model like deepseek-v4-pro) are ephemeral, high-rate bus events (seq=0, never journaled). The CLI dumped them raw:
- `agt run` streamed `llm.token` inline but let `llm.reasoning` fall through to a `[evt seq=0 kind=llm.reasoning]` line **per chunk** — hundreds per run;
- `agt plan` dumped **every** event including both, and with concurrent plan nodes they interleaved into an unreadable wall.

The owner saw a screen full of `[evt seq=0 kind=llm.reasoning …]` and asked what it was.

## Change (`cmd/agt/main.go`)
- **`agt run`:** answer tokens still stream inline; reasoning is **hidden by default** (no per-chunk line). `AGEZT_SHOW_REASONING=1` streams it inline, demarcated with 💭.
- **`agt plan`:** skips `llm.token` + `llm.reasoning`; structural events + per-node outputs carry the signal.
- `-q`/`--quiet` unchanged.

## Verification
Live (real deepseek-v4-pro): `agt run "What is 17*23?"` →
```
[evt seq=0 kind=task.received]
[evt seq=1 kind=llm.request]
391
[evt seq=4 kind=llm.response]
[evt seq=5 kind=task.completed]
```
**Zero** `kind=llm.reasoning`/`kind=llm.token` lines (grep count 0); the answer `391` streams inline.

Full `go test ./cmd/... ./kernel/...` green; vet + staticcheck clean; linux cross-build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)