### PR TITLE
Feat: vision sidecar — auto-describe images on non-vision models (M821)

### DIFF
--- a/.project/PHASE-M821-VISION-SIDECAR-REPORT.md
+++ b/.project/PHASE-M821-VISION-SIDECAR-REPORT.md
@@ -1,0 +1,55 @@
+# Phase M821 — Vision sidecar (auto-describe images on non-vision models)
+
+**Date:** 2026-06-11 · **Status:** DONE · **Trigger:** owner: when an image
+arrives on a channel and the active model isn't vision-capable, analyze it
+internally with a keyed vision provider instead of failing. Owner chose the
+**sidecar** approach (keep the active model; a vision model captions the image;
+inject the caption).
+
+## Why
+
+A photo sent to the bot, or `agt run --image` on a non-vision model, hard-failed
+with `model does not support vision`. The owner has keyed providers; if any has a
+vision model, the system should use it transparently.
+
+## What shipped
+
+- **Catalog finder** `Catalog.VisionCapableAmong(providerEligible) (modelID, ok)`
+  (kernel/catalog/types.go) — first eligible+credentialed provider's
+  largest-context vision model (deterministic), mirroring the M37/M40
+  `ToolCapableAlternativeAmong` pattern + `pickBestVision`.
+- **Kernel sidecar** `Kernel.DescribeImages(ctx, corr, images, hint) (string,
+  error)` (kernel/runtime) — one-shot governor completion to the vision model
+  (req.Model = vision model, Messages[0].Images = images), returns the caption,
+  journals a `capability.rerouted` (capability="vision") event for `agt why`.
+  `ErrNoVisionModel` when none is configured. Picker injected via new
+  `Config.VisionModel func() (string, bool)`.
+- **Daemon wiring** (cmd/agezt/main.go): `cfg.VisionModel` resolves a keyed vision
+  model from the LIVE catalog (eligibility = supported family + credentialed, same
+  as buildGovernor's registered set), so a freshly synced vision provider is
+  picked up without a restart.
+- **Replace the hard reject at both image entry points:**
+  - `makeChannelHandler` (Telegram/Slack/Discord inbound): non-vision active model
+    + image → caption via the sidecar, inject `[Image description (analyzed by a
+    vision model): …]` into the intent, don't forward raw images. Vision-capable
+    model → unchanged pass-through. No keyed vision model → the clear gate error.
+  - controlplane run handler (`agt run --image` / API): same logic; corr is now
+    pre-generated before the gate so the sidecar event links to the run.
+
+## Tests
+
+- catalog: `VisionCapableAmong` picks largest-context vision model (repeated for
+  map-order determinism), skips ineligible/text-only providers, returns false
+  when none.
+- runtime: `DescribeImages` routes to the vision model with the images and
+  returns the caption; `ErrNoVisionModel` when unset.
+- Full suite green (all packages; cmd/agt verified in isolation — 238s — the
+  capped parallel run merely exceeded the default 10m wall, no regression);
+  vet + staticcheck + linux cross-build clean.
+
+## Note
+
+A live positive smoke needs a keyed *vision-capable* provider; the unit tests
+cover the routing + caption path deterministically. The channel path (the owner's
+actual use) and the CLI path both now degrade to the sidecar instead of erroring.
+M822 will persist these inbound images as browsable artifacts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
   posture. (M818)
 
 ### Added
+- **Vision sidecar: images on a non-vision model just work.** When a message brings an image but
+  the active model can't see images, AGEZT no longer fails with `model does not support vision` — it
+  asks a keyed vision-capable provider to describe the image and injects that description into the
+  run, so the active model still "reads" the photo. Works for inbound channel images (Telegram/Slack/
+  Discord) and `agt run --image`; falls back to a clear error only when no vision provider is keyed.
+  The pick uses the live catalog (a freshly synced vision provider needs no restart). (M821)
+
+### Added
 - **Web UI on by default + optional password.** A bare `agezt` now serves the console at
   `127.0.0.1:8787` (tokenized URL in the banner) — no `AGEZT_WEB_ADDR` needed. The default port
   being busy falls back to a free port so a console always comes up; disable with

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -24,6 +24,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -677,6 +678,27 @@ func runDaemon(stdout, stderr io.Writer) int {
 			k.SetModel(model2)
 		}
 		return nil
+	}
+
+	// Vision sidecar picker (M821): returns a keyed vision-capable model id the
+	// governor can route to, or ("", false) if none. Eligibility mirrors
+	// buildGovernor's registered set (supported family + credentialed) so the
+	// pick is always routable. Uses the LIVE catalog (k.Catalog()) so a freshly
+	// synced/credentialed vision provider is picked up without a restart. Injected
+	// into the runtime so DescribeImages can caption images for non-vision models.
+	cfg.VisionModel = func() (string, bool) {
+		if k == nil {
+			return "", false
+		}
+		cat := k.Catalog()
+		if cat == nil {
+			return "", false
+		}
+		lookup, _ := buildAWSCredChain(credStore.Lookup)
+		return cat.VisionCapableAmong(func(provID string) bool {
+			e := cat.Providers[provID]
+			return e != nil && compat.IsSupportedFamily(e.Family()) && e.HasCredentials(lookup)
+		})
 	}
 
 	var openErr error
@@ -1561,14 +1583,28 @@ func makeChannelHandler(k *kernelruntime.Kernel) channel.InboundHandler {
 		// the control plane and OpenAI API do, so a photo sent to the bot reaches
 		// a vision model. An image with no caption gets a default instruction.
 		if len(msg.Images) > 0 {
-			// Pre-gate vision capability (M255) so a non-vision model gives a clear
-			// reply instead of a downstream provider error.
 			if err := visionGate(k, "", msg.Images); err != nil {
-				return "", err
-			}
-			hctx = kernelruntime.WithImages(hctx, msg.Images)
-			if strings.TrimSpace(intent) == "" {
-				intent = "Describe the attached image(s)."
+				// The active model can't see images. Vision SIDECAR (M821): a keyed
+				// vision model describes the image and we inject that text into the
+				// run, so a non-vision primary still "reads" the photo instead of
+				// failing. If NO vision model is keyed, fall back to the clear gate
+				// error so the operator knows to add one.
+				caption, derr := k.DescribeImages(hctx, corr, msg.Images, "")
+				if derr != nil {
+					if errors.Is(derr, kernelruntime.ErrNoVisionModel) {
+						return "", err
+					}
+					return "", derr
+				}
+				if strings.TrimSpace(intent) == "" {
+					intent = "Describe the attached image(s)."
+				}
+				intent += "\n\n[Image description (analyzed by a vision model):\n" + caption + "\n]"
+			} else {
+				hctx = kernelruntime.WithImages(hctx, msg.Images)
+				if strings.TrimSpace(intent) == "" {
+					intent = "Describe the attached image(s)."
+				}
 			}
 		}
 		return k.RunWith(hctx, corr, intent)

--- a/kernel/catalog/downroute_test.go
+++ b/kernel/catalog/downroute_test.go
@@ -194,3 +194,51 @@ func TestToolCapableAlternativeAmong_TieBreaksByIDAcrossProviders(t *testing.T) 
 		})
 	}
 }
+
+// vis builds a vision-capable model.
+func vis(id string, ctx int) *catalog.Model {
+	return &catalog.Model{ID: id, Modalities: catalog.Modalities{Input: []string{"text", "image"}}, Limit: catalog.Limit{Context: ctx}}
+}
+
+// txt builds a text-only model.
+func txt(id string, ctx int) *catalog.Model {
+	return &catalog.Model{ID: id, Modalities: catalog.Modalities{Input: []string{"text"}}, Limit: catalog.Limit{Context: ctx}}
+}
+
+// TestVisionCapableAmong_PicksLargestVisionModel (M821) — among eligible
+// providers, the first (sorted) with a vision model returns its largest-context
+// vision model.
+func TestVisionCapableAmong_PicksLargestVisionModel(t *testing.T) {
+	c := catalog.NewEmpty()
+	c.Providers["acme"] = &catalog.Provider{ID: "acme", Models: map[string]*catalog.Model{
+		"a-text": txt("a-text", 99999),
+		"a-vis":  vis("a-vis", 8000),
+		"a-vbig": vis("a-vbig", 200000),
+	}}
+	for i := 0; i < 20; i++ { // map order randomised
+		id, ok := c.VisionCapableAmong(allEligible)
+		if !ok || id != "a-vbig" {
+			t.Fatalf("VisionCapableAmong = %q,%v want a-vbig,true", id, ok)
+		}
+	}
+}
+
+// TestVisionCapableAmong_SkipsIneligibleAndTextOnly — only eligible providers
+// with an actual vision model qualify; a provider filtered out by the predicate
+// (e.g. uncredentialed) is skipped even if it has a vision model.
+func TestVisionCapableAmong_SkipsIneligibleAndTextOnly(t *testing.T) {
+	c := catalog.NewEmpty()
+	c.Providers["aaa"] = &catalog.Provider{ID: "aaa", Models: map[string]*catalog.Model{"t": txt("t", 1000)}} // text only
+	c.Providers["bbb"] = &catalog.Provider{ID: "bbb", Models: map[string]*catalog.Model{"v": vis("v", 1000)}} // vision but ineligible
+	c.Providers["ccc"] = &catalog.Provider{ID: "ccc", Models: map[string]*catalog.Model{"cv": vis("cv", 1000)}}
+
+	id, ok := c.VisionCapableAmong(func(p string) bool { return p != "bbb" })
+	if !ok || id != "cv" {
+		t.Fatalf("VisionCapableAmong = %q,%v want cv,true (aaa text-only, bbb ineligible)", id, ok)
+	}
+
+	// No eligible provider has a vision model → (\"\", false).
+	if id, ok := c.VisionCapableAmong(func(p string) bool { return p == "aaa" }); ok {
+		t.Errorf("VisionCapableAmong over text-only provider = %q,true want \"\",false", id)
+	}
+}

--- a/kernel/catalog/types.go
+++ b/kernel/catalog/types.go
@@ -455,6 +455,42 @@ func pickBestToolCapable(p *Provider, excludeID string) (string, int, bool) {
 	return best, bestCtx, true
 }
 
+// VisionCapableAmong finds a vision-capable model among the providers for which
+// providerEligible returns true (the daemon passes registered+credentialed
+// providers, so the result is one the governor can actually route to). It walks
+// ProviderList() (sorted by id) and returns the first eligible provider's
+// largest-context vision model (tie-broken by id ascending) — deterministic
+// despite random map iteration. Returns (modelID, true) or ("", false) when no
+// eligible provider has a vision model. Used by the vision sidecar (M821) to
+// caption images when the active model can't see them.
+func (c *Catalog) VisionCapableAmong(providerEligible func(provID string) bool) (string, bool) {
+	for _, p := range c.ProviderList() {
+		if !providerEligible(p.ID) {
+			continue
+		}
+		if id, ok := pickBestVision(p); ok {
+			return id, true
+		}
+	}
+	return "", false
+}
+
+// pickBestVision returns the largest-context vision-capable model in p, tie-broken
+// by id ascending, or ("", false) if none. Mirrors pickBestToolCapable.
+func pickBestVision(p *Provider) (string, bool) {
+	best := ""
+	bestCtx := -1
+	for id, m := range p.Models {
+		if !m.SupportsVision() {
+			continue
+		}
+		if m.Limit.Context > bestCtx || (m.Limit.Context == bestCtx && id < best) {
+			best, bestCtx = id, m.Limit.Context
+		}
+	}
+	return best, best != ""
+}
+
 // Merge folds src into dst with src winning on key conflict. Mutates
 // dst.Providers in place; per-provider Models maps are also merged
 // (src model wins). Used by the loader to apply local/custom on top

--- a/kernel/controlplane/server.go
+++ b/kernel/controlplane/server.go
@@ -1309,6 +1309,10 @@ func (s *Server) handleRun(ctx context.Context, conn net.Conn, req Request) {
 		effModel = modelOverride
 	}
 
+	// Pre-generate the correlation id here (it was minted just before Subscribe
+	// below) so the vision sidecar's journaled event links to this run.
+	corr := k.NewCorrelation()
+
 	// Vision capability gate (M91): a run carrying image attachments requires a
 	// model confirmed to accept image input. Unlike the M25 tool gate (which
 	// allows unknown models because many tolerate tool schemas), an image sent to
@@ -1329,24 +1333,36 @@ func (s *Server) handleRun(ctx context.Context, conn net.Conn, req Request) {
 			}
 		}
 		if !visionOK {
-			_, _ = k.Bus().Publish(event.Spec{
-				Subject: "governor.capability",
-				Kind:    event.KindCapabilityRejected,
-				Actor:   "controlplane",
-				Payload: map[string]any{
-					"model":            effModel,
-					"capability":       "vision",
-					"images_requested": len(imageRefs),
-				},
-			})
-			s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: fmt.Sprintf(
-				"model %q does not support vision (image input); attach images only to a vision-capable model (see `agt provider check --caps`)",
-				effModel)})
-			return
+			// Vision SIDECAR (M821): rather than rejecting, ask a keyed vision model
+			// to describe the image(s) and inject that text into the intent, so a
+			// non-vision active model still "reads" the photo. Fall back to the hard
+			// rejection only when no vision model is configured.
+			caption, derr := k.DescribeImages(ctx, corr, imageRefs, "")
+			if derr == nil && strings.TrimSpace(caption) != "" {
+				intent += "\n\n[Image description (analyzed by a vision model):\n" + caption + "\n]"
+				imageRefs = nil // consumed by the sidecar; don't send raw images downstream
+			} else {
+				_, _ = k.Bus().Publish(event.Spec{
+					Subject: "governor.capability",
+					Kind:    event.KindCapabilityRejected,
+					Actor:   "controlplane",
+					Payload: map[string]any{
+						"model":            effModel,
+						"capability":       "vision",
+						"images_requested": len(imageRefs),
+					},
+				})
+				s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: fmt.Sprintf(
+					"model %q does not support vision (image input); add a vision-capable provider key or attach images only to a vision-capable model (see `agt provider check --caps`)",
+					effModel)})
+				return
+			}
 		}
-		// Gate passed (M93): carry the image refs into the run so they reach the
-		// initial user message and, in turn, the provider.
-		ctx = runtime.WithImages(ctx, imageRefs)
+		// Gate passed or sidecar consumed the images (M93/M821): carry any remaining
+		// image refs into the run so they reach the initial user message.
+		if len(imageRefs) > 0 {
+			ctx = runtime.WithImages(ctx, imageRefs)
+		}
 	}
 	// Route this run to the override model when given (M148); the loop reads it
 	// via modelFromCtx, the same path the OpenAI API uses.
@@ -1463,9 +1479,8 @@ func (s *Server) handleRun(ctx context.Context, conn net.Conn, req Request) {
 		return
 	}
 
-	// Pre-generate the correlation ID so we can subscribe to this run's
-	// subject *before* starting it. No race; no missed events.
-	corr := k.NewCorrelation()
+	// corr was pre-generated above (before the vision gate) so we can subscribe to
+	// this run's subject *before* starting it. No race; no missed events.
 	sub, err := k.Bus().Subscribe(k.SubjectForRun(corr), 1024)
 	if err != nil {
 		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})

--- a/kernel/runtime/runtime.go
+++ b/kernel/runtime/runtime.go
@@ -322,6 +322,13 @@ type Config struct {
 	// provider-agnostic; cmd/agezt owns the build logic. Nil is
 	// allowed — Kernel.Reload then refreshes only the catalog snapshot.
 	OnReload func() error
+
+	// VisionModel, when set, returns a vision-capable model id the governor can
+	// route to (among the registered+credentialed providers), or ("", false) if
+	// none is keyed. Injected by the daemon (cmd/agezt) which owns the registered
+	// set. Used by DescribeImages (M821) to caption images for a run whose active
+	// model can't see them. Nil disables the vision sidecar.
+	VisionModel func() (modelID string, ok bool)
 }
 
 // Kernel is the running Agezt instance.
@@ -1543,6 +1550,61 @@ func (k *Kernel) verifyCompletion(ctx context.Context, corr, task, answer string
 		Payload:       map[string]any{"complete": v.Complete, "gap": v.Gap},
 	})
 	return v, nil
+}
+
+// visionDescribeMaxTokens bounds the sidecar caption — a description, not an essay.
+const visionDescribeMaxTokens = 1024
+
+// ErrNoVisionModel is returned by DescribeImages when no vision-capable model is
+// available (the sidecar is disabled or no keyed provider has one).
+var ErrNoVisionModel = errors.New("runtime: no vision-capable model available")
+
+// DescribeImages runs the vision SIDECAR (M821): it sends the images to a keyed
+// vision-capable model and returns a text description, so a run whose active
+// model can't see images can still "read" them (the caller injects the returned
+// text into the run). One-shot governor completion — no agent loop — routed to
+// the vision model via per-request model routing. hint, if non-empty, replaces
+// the default instruction. Returns ErrNoVisionModel when none is configured.
+func (k *Kernel) DescribeImages(ctx context.Context, corr string, images []string, hint string) (string, error) {
+	if len(images) == 0 {
+		return "", nil
+	}
+	if k.cfg.VisionModel == nil {
+		return "", ErrNoVisionModel
+	}
+	model, ok := k.cfg.VisionModel()
+	if !ok || model == "" {
+		return "", ErrNoVisionModel
+	}
+	prompt := hint
+	if strings.TrimSpace(prompt) == "" {
+		prompt = "Describe the attached image(s) in detail and transcribe any visible text. Be thorough and factual."
+	}
+	resp, err := k.cfg.Provider.Complete(ctx, agent.CompletionRequest{
+		Model:         model,
+		CorrelationID: corr,
+		TaskType:      "vision",
+		MaxTokens:     visionDescribeMaxTokens,
+		Messages:      []agent.Message{{Role: agent.RoleUser, Content: prompt, Images: images}},
+	})
+	if err != nil {
+		return "", err
+	}
+	// Journal the sidecar so `agt why` shows the active model was supplemented by
+	// a vision model (reuse capability.rerouted; capability="vision").
+	_, _ = k.bus.Publish(event.Spec{
+		Subject:       "agent.agent-" + corr + ".vision",
+		Kind:          event.KindCapabilityRerouted,
+		Actor:         "vision",
+		CorrelationID: corr,
+		Payload: map[string]any{
+			"from_model": k.Model(),
+			"to_model":   model,
+			"capability": "vision",
+			"images":     len(images),
+		},
+	})
+	return resp.Message.Content, nil
 }
 
 // RunWith executes one tool-loop using the supplied correlation ID.

--- a/kernel/runtime/runtime_test.go
+++ b/kernel/runtime/runtime_test.go
@@ -533,6 +533,68 @@ func TestKernel_Model_LiveSwap(t *testing.T) {
 	}
 }
 
+// TestKernel_DescribeImages_RoutesToVisionModel (M821) — the vision sidecar
+// sends the images to the injected vision model and returns its description; the
+// request carries the images and is routed to the vision model id.
+func TestKernel_DescribeImages_RoutesToVisionModel(t *testing.T) {
+	prov := mock.New()
+	var gotModel string
+	var gotImages []string
+	prov.OnRequest = func(req agent.CompletionRequest) {
+		gotModel = req.Model
+		if len(req.Messages) > 0 {
+			gotImages = req.Messages[0].Images
+		}
+	}
+	prov.Responder = func(agent.CompletionRequest) agent.CompletionResponse {
+		return mock.FinalText("a photo of a cat on a sofa")
+	}
+	k, err := runtime.Open(runtime.Config{
+		BaseDir:     t.TempDir(),
+		Provider:    prov,
+		Model:       "text-only-model",
+		Tools:       map[string]agent.Tool{},
+		VisionModel: func() (string, bool) { return "vision-model", true },
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer k.Close()
+
+	caption, err := k.DescribeImages(context.Background(), "corr-vis", []string{"data:image/png;base64,AAAA"}, "")
+	if err != nil {
+		t.Fatalf("DescribeImages: %v", err)
+	}
+	if caption != "a photo of a cat on a sofa" {
+		t.Errorf("caption = %q", caption)
+	}
+	if gotModel != "vision-model" {
+		t.Errorf("request model = %q, want vision-model (not the text-only default)", gotModel)
+	}
+	if len(gotImages) != 1 {
+		t.Errorf("vision request carried %d images, want 1", len(gotImages))
+	}
+}
+
+// TestKernel_DescribeImages_NoVisionModel — with no vision model configured the
+// sidecar reports ErrNoVisionModel so the caller can fall back to a clear error.
+func TestKernel_DescribeImages_NoVisionModel(t *testing.T) {
+	k, err := runtime.Open(runtime.Config{
+		BaseDir:  t.TempDir(),
+		Provider: mock.New(mock.FinalText("x")),
+		Tools:    map[string]agent.Tool{},
+		// VisionModel nil → sidecar disabled.
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer k.Close()
+
+	if _, err := k.DescribeImages(context.Background(), "c", []string{"data:image/png;base64,AAAA"}, ""); !errors.Is(err, runtime.ErrNoVisionModel) {
+		t.Fatalf("err = %v, want ErrNoVisionModel", err)
+	}
+}
+
 func TestKernel_Reload_NilOnReloadIsCatalogOnly(t *testing.T) {
 	k, err := runtime.Open(runtime.Config{
 		BaseDir:  t.TempDir(),


### PR DESCRIPTION
## What

A photo sent to the bot (or `agt run --image`) on a **non-vision** model hard-failed with `model does not support vision`. Now, if any **keyed** provider has a vision model, AGEZT describes the image with it and injects that description into the run — the owner-chosen **sidecar** approach: the active model keeps running and "reads" the photo via the caption.

- **`catalog.VisionCapableAmong(providerEligible)`** — first eligible+credentialed provider's largest-context vision model (mirrors the M37/M40 `ToolCapableAlternativeAmong` pattern).
- **`Kernel.DescribeImages(ctx, corr, images, hint)`** — one-shot governor completion to the vision model (`req.Model` = vision model, `Messages[0].Images` = images); returns the caption, journals `capability.rerouted` (capability="vision") for `agt why`; `ErrNoVisionModel` when none. Picker injected via new `Config.VisionModel`, wired from the **live** catalog (a freshly synced vision key needs no restart).
- **Both image entry points** replace the hard reject with the sidecar: `makeChannelHandler` (Telegram/Slack/Discord inbound) and the controlplane run gate (`agt run --image` / API). Raw images are dropped so the non-vision model never receives unsupported input; a clear error remains only when no vision provider is keyed.

## Tests
- catalog: `VisionCapableAmong` picks the largest-context vision model (repeated for map-order determinism), skips ineligible/text-only providers, returns false when none.
- runtime: `DescribeImages` routes to the vision model with the images and returns the caption; `ErrNoVisionModel` when unset.
- Full suite green across all packages; vet + staticcheck + linux clean. (cmd/agt's heavy integration suite verified green in isolation — 238s — the capped parallel run merely exceeded the default 10m wall; no regression.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)