### PR TITLE
Feat: stop the daemon console flooding with llm chunk events (M826)

### DIFF
--- a/.project/PHASE-M826-DAEMON-CONSOLE-NOISE-REPORT.md
+++ b/.project/PHASE-M826-DAEMON-CONSOLE-NOISE-REPORT.md
@@ -1,0 +1,31 @@
+# Phase M826 — quiet the daemon console event flood
+
+**Date:** 2026-06-11 · **Status:** DONE · **Trigger:** owner: "agezt çalışınca
+console bunlarla dolmasın artık [evt seq=0 kind=llm.reasoning subject=…]".
+
+## Why
+
+M819 silenced the per-token / per-reasoning-chunk flood in the `agt run`/`agt
+plan` CLI renderers, but the DAEMON itself also echoes events: `runDaemon`
+subscribes to `">"` (all bus events) and prints each to stdout so the operator
+sees activity. With autonomous agents running, the ephemeral high-rate
+`llm.token` / `llm.reasoning` events (seq=0, one per chunk, across several
+concurrent runs) buried the console.
+
+## Change (`cmd/agezt/main.go`)
+
+The daemon's `">"`-stream printer now skips `KindLLMToken` + `KindLLMReasoning`
+(same two kinds M819 filtered). All lifecycle events (task.received, llm.request,
+routing.decision, budget.consumed, llm.response, task.completed, tool.*, …) still
+print.
+
+## Verification
+
+Isolated daemon + real deepseek run "Say hi": daemon console shows the 6
+lifecycle lines (task.received → … → task.completed) and **zero**
+`kind=llm.reasoning` / `kind=llm.token` lines (grep count 0).
+
+## Gate
+
+`go test ./cmd/agezt/` green; vet + staticcheck + linux clean. No new env/schema;
+go.mod unchanged.

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -1435,11 +1435,18 @@ func runDaemon(stdout, stderr io.Writer) int {
 	fmt.Fprintf(stdout, "  client commands  : %s run | halt | resume | why <id> | journal verify\n", brand.CLI)
 	fmt.Fprintf(stdout, "Press Ctrl+C to stop.\n")
 
-	// Stream all events to stdout so the operator sees activity.
+	// Stream events to stdout so the operator sees activity — but SKIP the
+	// high-rate ephemeral chunks (llm.token, llm.reasoning). With autonomous
+	// agents running, those fire hundreds of times per run and bury the console
+	// in "[evt seq=0 kind=llm.reasoning …]" noise (M826; mirrors the CLI filter
+	// from M819). The meaningful lifecycle events (task/tool/run/…) still print.
 	sub, err := k.Bus().Subscribe(">", 256)
 	if err == nil {
 		go func() {
 			for ev := range sub.C {
+				if ev.Kind == event.KindLLMToken || ev.Kind == event.KindLLMReasoning {
+					continue
+				}
 				fmt.Fprintf(stdout, "  [evt seq=%d kind=%s subject=%s]\n", ev.Seq, ev.Kind, ev.Subject)
 			}
 		}()


### PR DESCRIPTION
## What

M819 silenced the per-token/per-reasoning flood in the `agt run`/`agt plan` CLI renderers, but the **daemon** itself also echoes events: `runDaemon` subscribes to `">"` (all bus events) and prints each to stdout so the operator sees activity. With autonomous agents running, the ephemeral high-rate `llm.token` / `llm.reasoning` events (seq=0, one per chunk, across several concurrent runs) buried the console — exactly the `[evt seq=0 kind=llm.reasoning subject=…]` the owner pasted.

Fix: the daemon's `">"`-stream printer skips `KindLLMToken` + `KindLLMReasoning` (the same two kinds M819 filtered). All lifecycle events still print.

## Verification
Isolated daemon + real deepseek run → console shows the 6 lifecycle lines (`task.received → llm.request → routing.decision → budget.consumed → llm.response → task.completed`) and **zero** reasoning/token lines.

`go test ./cmd/agezt/` green; vet + staticcheck + linux clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)