### PR TITLE
Feat: artifact index + persist inbound channel images (M822)

### DIFF
--- a/.project/PHASE-M822-ARTIFACT-INDEX-INBOUND-IMAGES-REPORT.md
+++ b/.project/PHASE-M822-ARTIFACT-INDEX-INBOUND-IMAGES-REPORT.md
@@ -1,0 +1,49 @@
+# Phase M822 — artifact index + persist inbound channel images
+
+**Date:** 2026-06-11 · **Status:** DONE · **Trigger:** owner: "mesajlaşma ile
+gelen tüm resimleri saklayıp gösterebilsek… resim dışındaki artifactları da
+saklayıp file manager mantığı getirelim." This is the backend foundation; M823
+adds the file-manager UI + Inbox thumbnails.
+
+## Why
+
+Inbound channel images were ephemeral data-URLs, used for one run and discarded.
+The blob artifact store had no metadata and no list/delete — only point-lookup by
+content ref. To save + browse + delete media, we need a queryable index.
+
+## What shipped (backend)
+
+- **Artifact index** (`kernel/artifact/index.go`): a metadata sidecar over the
+  pure blob `Store`. `Entry{ID,Ref,Name,Mime,Kind,Source,Sender,Corr,Size,
+  CreatedMs,Caption}` persisted one JSON file each under `artifacts/index/`; blobs
+  stay content-addressed/deduped. Methods: `OpenIndex`, `PutEntry`, `List(Filter)`
+  (newest-first, kind/source/corr filters), `Get`, `Bytes`, `Count`, `Delete`
+  (GCs the blob only when no other entry references the ref). Wired into the
+  kernel (`k.ArtifactIndex()`).
+- **Persist inbound images** (`cmd/agezt/main.go`): `makeChannelHandler` now
+  decodes each `msg.Images` data-URL and `PutEntry`s it as `kind=image,
+  source=<channel>, sender, corr`, with the M821 vision caption attached. Even
+  when no vision model is keyed (run can't proceed), the image is still saved.
+  Helpers `decodeDataURL` + `extForMime`.
+- **Control plane**: `CmdArtifactList` (filtered, metadata only) + `CmdArtifactDelete`
+  (by id) added; `CmdArtifactGet` unchanged.
+- **Web UI routes**: `/api/artifacts` (list), `/api/artifact/delete` (POST), and a
+  binary `/api/artifact/raw?ref=&mime=&download=&name=` that proxies CmdArtifactGet,
+  decodes, and serves bytes with a **sanitized** Content-Type (image/doc allowlist
+  → else octet-stream; nosniff is set globally) for `<img src>`/downloads.
+
+## Tests
+
+- index: put/list(filter)/get/bytes; delete GCs an orphan blob but keeps a shared
+  one; entries persist across reopen.
+- raw route: token-gated (401), serves bytes with the right Content-Type, hostile
+  mime → octet-stream, missing ref → 400.
+- decodeDataURL / extForMime parsing table.
+- Live: daemon boots with the index; `/api/artifacts` → `{count:0,entries:[]}`.
+
+## Gate
+
+`go test` on artifact/runtime/controlplane/webui/cmd-agezt green; vet +
+staticcheck + linux clean. Two new control-plane commands; no new env var.
+Frontend untouched (no dist change) — M823 adds the Files view + Inbox thumbnails
+and indexes tool outputs too.

--- a/cmd/agezt/dataurl_test.go
+++ b/cmd/agezt/dataurl_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+func TestDecodeDataURL(t *testing.T) {
+	b64 := base64.StdEncoding.EncodeToString([]byte("PNGDATA"))
+
+	mime, data, ok := decodeDataURL("data:image/png;base64," + b64)
+	if !ok || mime != "image/png" || string(data) != "PNGDATA" {
+		t.Fatalf("base64 png = %q,%q,%v", mime, data, ok)
+	}
+
+	// No mime → empty mime, still decodes.
+	if _, d, ok := decodeDataURL("data:;base64," + b64); !ok || string(d) != "PNGDATA" {
+		t.Errorf("no-mime base64 failed: %q,%v", d, ok)
+	}
+
+	// Not a data URL.
+	if _, _, ok := decodeDataURL("https://x/y.png"); ok {
+		t.Error("non-data URL should be rejected")
+	}
+	// No comma.
+	if _, _, ok := decodeDataURL("data:image/png;base64"); ok {
+		t.Error("missing comma should be rejected")
+	}
+	// Bad base64.
+	if _, _, ok := decodeDataURL("data:image/png;base64,!!!notb64!!!"); ok {
+		t.Error("invalid base64 should be rejected")
+	}
+}
+
+func TestExtForMime(t *testing.T) {
+	cases := map[string]string{
+		"image/jpeg": ".jpg", "image/jpg": ".jpg", "image/png": ".png",
+		"image/gif": ".gif", "image/webp": ".webp", "application/zip": "",
+	}
+	for mime, want := range cases {
+		if got := extForMime(mime); got != want {
+			t.Errorf("extForMime(%q) = %q, want %q", mime, got, want)
+		}
+	}
+}

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -22,6 +22,7 @@ package main
 import (
 	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -45,6 +46,7 @@ import (
 	"github.com/agezt/agezt/kernel/agent"
 	"github.com/agezt/agezt/kernel/alerter"
 	"github.com/agezt/agezt/kernel/anomaly"
+	"github.com/agezt/agezt/kernel/artifact"
 	"github.com/agezt/agezt/kernel/board"
 	"github.com/agezt/agezt/kernel/bus"
 	"github.com/agezt/agezt/kernel/cadence"
@@ -1607,19 +1609,22 @@ func makeChannelHandler(k *kernelruntime.Kernel) channel.InboundHandler {
 		// the control plane and OpenAI API do, so a photo sent to the bot reaches
 		// a vision model. An image with no caption gets a default instruction.
 		if len(msg.Images) > 0 {
+			var caption string
 			if err := visionGate(k, "", msg.Images); err != nil {
 				// The active model can't see images. Vision SIDECAR (M821): a keyed
 				// vision model describes the image and we inject that text into the
 				// run, so a non-vision primary still "reads" the photo instead of
-				// failing. If NO vision model is keyed, fall back to the clear gate
-				// error so the operator knows to add one.
-				caption, derr := k.DescribeImages(hctx, corr, msg.Images, "")
+				// failing. If NO vision model is keyed, persist the image anyway
+				// (so it's not lost) and surface the clear gate error.
+				c, derr := k.DescribeImages(hctx, corr, msg.Images, "")
 				if derr != nil {
 					if errors.Is(derr, kernelruntime.ErrNoVisionModel) {
+						persistInboundImages(k, msg, corr, "")
 						return "", err
 					}
 					return "", derr
 				}
+				caption = c
 				if strings.TrimSpace(intent) == "" {
 					intent = "Describe the attached image(s)."
 				}
@@ -1630,8 +1635,89 @@ func makeChannelHandler(k *kernelruntime.Kernel) channel.InboundHandler {
 					intent = "Describe the attached image(s)."
 				}
 			}
+			// Persist the inbound image(s) as browsable artifacts (M822) — keyed to
+			// this run's correlation, with the vision caption (if any) attached.
+			persistInboundImages(k, msg, corr, caption)
 		}
 		return k.RunWith(hctx, corr, intent)
+	}
+}
+
+// persistInboundImages saves each inbound channel image as a browsable artifact
+// entry (M822), keyed to the run correlation, with the vision caption (if the
+// sidecar ran) attached. Best-effort: a decode/store failure for one image is
+// logged-by-omission, never fatal to the run. Returns the new entry ids.
+func persistInboundImages(k *kernelruntime.Kernel, msg channel.UnifiedMessage, corr, caption string) []string {
+	idx := k.ArtifactIndex()
+	if idx == nil || len(msg.Images) == 0 {
+		return nil
+	}
+	now := time.Now().UnixMilli()
+	var ids []string
+	for n, du := range msg.Images {
+		mime, data, ok := decodeDataURL(du)
+		if !ok || len(data) == 0 {
+			continue
+		}
+		e, err := idx.PutEntry(artifact.Entry{
+			Kind:    "image",
+			Source:  msg.ChannelKind,
+			Sender:  msg.Sender,
+			Corr:    corr,
+			Mime:    mime,
+			Name:    fmt.Sprintf("%s-image-%d%s", msg.ChannelKind, n+1, extForMime(mime)),
+			Caption: caption,
+		}, data, now)
+		if err == nil {
+			ids = append(ids, e.ID)
+		}
+	}
+	return ids
+}
+
+// decodeDataURL parses a data: URL (data:<mime>[;base64],<payload>) into its mime
+// and decoded bytes. ok=false for anything that isn't a data URL. Base64 is the
+// only encoding channels produce for images; a non-base64 payload is returned raw.
+func decodeDataURL(s string) (mime string, data []byte, ok bool) {
+	if !strings.HasPrefix(s, "data:") {
+		return "", nil, false
+	}
+	rest := s[len("data:"):]
+	comma := strings.IndexByte(rest, ',')
+	if comma < 0 {
+		return "", nil, false
+	}
+	meta, payload := rest[:comma], rest[comma+1:]
+	mime = meta
+	base64Encoded := false
+	if i := strings.IndexByte(meta, ';'); i >= 0 {
+		mime = meta[:i]
+		base64Encoded = strings.Contains(meta[i:], "base64")
+	}
+	if base64Encoded {
+		b, err := base64.StdEncoding.DecodeString(payload)
+		if err != nil {
+			return "", nil, false
+		}
+		return mime, b, true
+	}
+	return mime, []byte(payload), true
+}
+
+// extForMime maps the common image mimes to a file extension for the artifact's
+// display name; unknown types get no extension.
+func extForMime(mime string) string {
+	switch strings.ToLower(strings.TrimSpace(mime)) {
+	case "image/jpeg", "image/jpg":
+		return ".jpg"
+	case "image/png":
+		return ".png"
+	case "image/gif":
+		return ".gif"
+	case "image/webp":
+		return ".webp"
+	default:
+		return ""
 	}
 }
 

--- a/kernel/artifact/index.go
+++ b/kernel/artifact/index.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: MIT
+
+package artifact
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/agezt/agezt/kernel/ulid"
+)
+
+// Entry is one stored artifact's metadata — a single ARRIVAL. The bytes live in
+// the content-addressed blob Store under Ref (deduped across arrivals); an Entry
+// is per-arrival, so the same image sent twice is two Entries pointing at one
+// blob. This is the queryable, deletable layer the file-manager (M823) and the
+// inbound-image persistence (M822) build on, while Store stays a pure blob store.
+type Entry struct {
+	ID        string `json:"id"`
+	Ref       string `json:"ref"`
+	Name      string `json:"name,omitempty"`
+	Mime      string `json:"mime,omitempty"`
+	Kind      string `json:"kind,omitempty"`   // image | tool-output | file | …
+	Source    string `json:"source,omitempty"` // telegram | slack | discord | run | …
+	Sender    string `json:"sender,omitempty"`
+	Corr      string `json:"corr,omitempty"`
+	Size      int64  `json:"size"`
+	CreatedMs int64  `json:"created_ms"`
+	Caption   string `json:"caption,omitempty"`
+}
+
+// Filter narrows List; empty fields impose no constraint (exact match otherwise).
+type Filter struct {
+	Kind   string
+	Source string
+	Corr   string
+}
+
+// Index is a metadata sidecar over a blob Store. Entries persist as one JSON file
+// each under <baseDir>/index/<id>.json; the blob shards (<aa>/<ref>) are
+// untouched. An in-memory map (loaded at Open) backs queries; all access is
+// mutex-guarded. Deleting an Entry garbage-collects its blob only when no other
+// Entry still references that ref.
+type Index struct {
+	store   *Store
+	dir     string
+	mu      sync.Mutex
+	entries map[string]Entry
+}
+
+// OpenIndex opens (creating if needed) the metadata index for store, rooted at
+// <baseDir>/index. baseDir is normally the same artifacts dir the Store uses.
+func OpenIndex(store *Store, baseDir string) (*Index, error) {
+	dir := filepath.Join(baseDir, "index")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("artifact index: open %s: %w", dir, err)
+	}
+	idx := &Index{store: store, dir: dir, entries: map[string]Entry{}}
+	des, _ := os.ReadDir(dir)
+	for _, de := range des {
+		if de.IsDir() || !strings.HasSuffix(de.Name(), ".json") {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(dir, de.Name()))
+		if err != nil {
+			continue
+		}
+		var e Entry
+		if json.Unmarshal(b, &e) == nil && e.ID != "" {
+			idx.entries[e.ID] = e
+		}
+	}
+	return idx, nil
+}
+
+// PutEntry stores data in the blob store and records a metadata Entry. The caller
+// supplies createdMs (the daemon stamps wall-clock; tests pass a fixed value) so
+// the entry's sort key is explicit. The Entry's ID/Ref/Size are filled in here.
+func (i *Index) PutEntry(meta Entry, data []byte, createdMs int64) (Entry, error) {
+	ref, err := i.store.Put(data)
+	if err != nil {
+		return Entry{}, err
+	}
+	meta.ID = "art-" + ulid.New()
+	meta.Ref = ref
+	meta.Size = int64(len(data))
+	meta.CreatedMs = createdMs
+	i.mu.Lock()
+	i.entries[meta.ID] = meta
+	i.mu.Unlock()
+	if err := i.writeMeta(meta); err != nil {
+		return Entry{}, err
+	}
+	return meta, nil
+}
+
+func (i *Index) writeMeta(e Entry) error {
+	b, err := json.MarshalIndent(e, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := filepath.Join(i.dir, ".tmp-"+e.ID)
+	if err := os.WriteFile(tmp, b, 0o600); err != nil {
+		return fmt.Errorf("artifact index: write: %w", err)
+	}
+	if err := os.Rename(tmp, filepath.Join(i.dir, e.ID+".json")); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("artifact index: write: %w", err)
+	}
+	return nil
+}
+
+// List returns the entries matching f, newest first (tie-broken by id desc).
+func (i *Index) List(f Filter) []Entry {
+	i.mu.Lock()
+	out := make([]Entry, 0, len(i.entries))
+	for _, e := range i.entries {
+		if f.Kind != "" && e.Kind != f.Kind {
+			continue
+		}
+		if f.Source != "" && e.Source != f.Source {
+			continue
+		}
+		if f.Corr != "" && e.Corr != f.Corr {
+			continue
+		}
+		out = append(out, e)
+	}
+	i.mu.Unlock()
+	sort.Slice(out, func(a, b int) bool {
+		if out[a].CreatedMs != out[b].CreatedMs {
+			return out[a].CreatedMs > out[b].CreatedMs
+		}
+		return out[a].ID > out[b].ID
+	})
+	return out
+}
+
+// Get returns the Entry for id.
+func (i *Index) Get(id string) (Entry, bool) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	e, ok := i.entries[id]
+	return e, ok
+}
+
+// Bytes returns the blob bytes (and Entry) for an entry id, re-verified by the
+// store against the content ref.
+func (i *Index) Bytes(id string) ([]byte, Entry, error) {
+	e, ok := i.Get(id)
+	if !ok {
+		return nil, Entry{}, ErrNotFound
+	}
+	b, err := i.store.Get(e.Ref)
+	return b, e, err
+}
+
+// Count returns how many entries are indexed.
+func (i *Index) Count() int {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return len(i.entries)
+}
+
+// Delete removes the entry and its metadata file. The underlying blob is
+// garbage-collected only when no remaining entry references the same ref (the
+// content-address dedup means one blob may back several arrivals).
+func (i *Index) Delete(id string) error {
+	i.mu.Lock()
+	e, ok := i.entries[id]
+	if !ok {
+		i.mu.Unlock()
+		return ErrNotFound
+	}
+	delete(i.entries, id)
+	stillUsed := false
+	for _, other := range i.entries {
+		if other.Ref == e.Ref {
+			stillUsed = true
+			break
+		}
+	}
+	i.mu.Unlock()
+
+	_ = os.Remove(filepath.Join(i.dir, id+".json"))
+	if !stillUsed {
+		_ = os.Remove(i.store.pathFor(e.Ref)) // GC the now-orphaned blob
+	}
+	return nil
+}

--- a/kernel/artifact/index_test.go
+++ b/kernel/artifact/index_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+
+package artifact_test
+
+import (
+	"testing"
+
+	"github.com/agezt/agezt/kernel/artifact"
+)
+
+func openIdx(t *testing.T) (*artifact.Index, string) {
+	t.Helper()
+	dir := t.TempDir()
+	st, err := artifact.Open(dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	idx, err := artifact.OpenIndex(st, dir)
+	if err != nil {
+		t.Fatalf("OpenIndex: %v", err)
+	}
+	return idx, dir
+}
+
+func TestIndex_PutListGetBytes(t *testing.T) {
+	idx, _ := openIdx(t)
+
+	e1, err := idx.PutEntry(artifact.Entry{Kind: "image", Source: "telegram", Mime: "image/png", Caption: "a cat"}, []byte("PNGDATA"), 100)
+	if err != nil {
+		t.Fatalf("PutEntry: %v", err)
+	}
+	if e1.ID == "" || e1.Ref == "" || e1.Size != 7 || e1.CreatedMs != 100 {
+		t.Fatalf("entry not filled in: %+v", e1)
+	}
+	_, err = idx.PutEntry(artifact.Entry{Kind: "tool-output", Source: "run"}, []byte("log output"), 200)
+	if err != nil {
+		t.Fatalf("PutEntry 2: %v", err)
+	}
+
+	// List newest-first.
+	all := idx.List(artifact.Filter{})
+	if len(all) != 2 || all[0].CreatedMs != 200 {
+		t.Fatalf("List = %d entries, newest-first broken: %+v", len(all), all)
+	}
+	// Filter by kind.
+	imgs := idx.List(artifact.Filter{Kind: "image"})
+	if len(imgs) != 1 || imgs[0].ID != e1.ID {
+		t.Fatalf("kind filter = %+v", imgs)
+	}
+
+	// Bytes round-trips through the blob store.
+	b, e, err := idx.Bytes(e1.ID)
+	if err != nil || string(b) != "PNGDATA" || e.Caption != "a cat" {
+		t.Fatalf("Bytes = %q,%+v,%v", b, e, err)
+	}
+}
+
+func TestIndex_DeleteGCsOrphanBlobButKeepsShared(t *testing.T) {
+	idx, _ := openIdx(t)
+
+	// Two arrivals of the SAME bytes → two entries, one blob (content dedup).
+	a, _ := idx.PutEntry(artifact.Entry{Kind: "image", Source: "telegram"}, []byte("SAME"), 1)
+	bEnt, _ := idx.PutEntry(artifact.Entry{Kind: "image", Source: "slack"}, []byte("SAME"), 2)
+	if a.Ref != bEnt.Ref {
+		t.Fatalf("identical bytes should share a ref: %s vs %s", a.Ref, bEnt.Ref)
+	}
+
+	// Delete one — the blob must survive because the other entry still uses it.
+	if err := idx.Delete(a.ID); err != nil {
+		t.Fatalf("Delete a: %v", err)
+	}
+	if _, _, err := idx.Bytes(bEnt.ID); err != nil {
+		t.Fatalf("shared blob GC'd too early: %v", err)
+	}
+	if idx.Count() != 1 {
+		t.Fatalf("Count after one delete = %d, want 1", idx.Count())
+	}
+
+	// Delete the last referrer — now the blob is orphaned and GC'd.
+	if err := idx.Delete(bEnt.ID); err != nil {
+		t.Fatalf("Delete b: %v", err)
+	}
+	if idx.Count() != 0 {
+		t.Fatalf("Count = %d, want 0", idx.Count())
+	}
+}
+
+func TestIndex_PersistsAcrossReopen(t *testing.T) {
+	idx, dir := openIdx(t)
+	e, _ := idx.PutEntry(artifact.Entry{Kind: "image", Source: "telegram", Caption: "kept"}, []byte("X"), 5)
+
+	// Reopen against the same dir — the entry must reload from its sidecar file.
+	st, _ := artifact.Open(dir)
+	idx2, err := artifact.OpenIndex(st, dir)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	got, ok := idx2.Get(e.ID)
+	if !ok || got.Caption != "kept" {
+		t.Fatalf("entry not persisted across reopen: %+v ok=%v", got, ok)
+	}
+}

--- a/kernel/controlplane/artifact.go
+++ b/kernel/controlplane/artifact.go
@@ -53,3 +53,55 @@ func (s *Server) handleArtifactGet(conn net.Conn, req Request) {
 		},
 	})
 }
+
+// handleArtifactList returns the artifact INDEX entries (M822), newest first,
+// optionally filtered by kind/source/corr — metadata only, no bytes. The file
+// manager and Inbox use this to enumerate stored artifacts.
+func (s *Server) handleArtifactList(conn net.Conn, req Request) {
+	idx := s.k.ArtifactIndex()
+	if idx == nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "artifact index unavailable"})
+		return
+	}
+	kind, _ := req.Args["kind"].(string)
+	source, _ := req.Args["source"].(string)
+	corr, _ := req.Args["corr"].(string)
+	ents := idx.List(artifact.Filter{Kind: kind, Source: source, Corr: corr})
+	out := make([]map[string]any, 0, len(ents))
+	for _, e := range ents {
+		out = append(out, map[string]any{
+			"id": e.ID, "ref": e.Ref, "name": e.Name, "mime": e.Mime,
+			"kind": e.Kind, "source": e.Source, "sender": e.Sender,
+			"corr": e.Corr, "size": e.Size, "created_ms": e.CreatedMs,
+			"caption": e.Caption,
+		})
+	}
+	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{
+		"count":   len(out),
+		"entries": out,
+	}})
+}
+
+// handleArtifactDelete removes an index entry by id (M822); the blob is GC'd when
+// no other entry references it.
+func (s *Server) handleArtifactDelete(conn net.Conn, req Request) {
+	id, _ := req.Args["id"].(string)
+	if id == "" {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.id required"})
+		return
+	}
+	idx := s.k.ArtifactIndex()
+	if idx == nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "artifact index unavailable"})
+		return
+	}
+	if err := idx.Delete(id); err != nil {
+		if errors.Is(err, artifact.ErrNotFound) {
+			s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "artifact not found: " + id})
+			return
+		}
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
+		return
+	}
+	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{"deleted": true, "id": id}})
+}

--- a/kernel/controlplane/protocol.go
+++ b/kernel/controlplane/protocol.go
@@ -479,6 +479,17 @@ const (
 	//   - data  : string — base64-encoded bytes.
 	CmdArtifactGet = "artifact_get"
 
+	// CmdArtifactList lists the artifact INDEX entries (M822) — browsable metadata
+	// for stored artifacts (inbound images, tool outputs), newest first. No bytes.
+	// Args (all optional, exact-match filters): kind, source, corr.
+	// Returns: entries — []object{id,ref,name,mime,kind,source,sender,corr,size,created_ms,caption}.
+	CmdArtifactList = "artifact_list"
+
+	// CmdArtifactDelete removes an artifact index entry by id (M822); the blob is
+	// garbage-collected when no other entry references it.
+	// Args: id : string. Returns: deleted : bool.
+	CmdArtifactDelete = "artifact_delete"
+
 	// CmdJournalGrep is the server-side filter sibling of
 	// CmdJournalTail. Today operators run `agt journal tail 10000
 	// --json | jq 'select(...)'` which loads the entire tail into

--- a/kernel/controlplane/server.go
+++ b/kernel/controlplane/server.go
@@ -472,6 +472,10 @@ func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
 		s.handleVerify(conn, req)
 	case CmdArtifactGet:
 		s.handleArtifactGet(conn, req)
+	case CmdArtifactList:
+		s.handleArtifactList(conn, req)
+	case CmdArtifactDelete:
+		s.handleArtifactDelete(conn, req)
 	case CmdApprovals:
 		s.handleApprovals(conn, req)
 	case CmdApprovalsLog:

--- a/kernel/runtime/runtime.go
+++ b/kernel/runtime/runtime.go
@@ -355,6 +355,7 @@ type Kernel struct {
 	mcpStore  *mcp.Store
 	workflows *workflow.Store
 	artifacts *artifact.Store
+	artIndex  *artifact.Index // metadata sidecar over artifacts (M822): browsable/deletable entries
 	reflect   *reflect.Engine
 	schedules *cadence.Store        // persistent scheduled-intents store (autonomy)
 	tools     map[string]agent.Tool // cfg.Tools + the memory/world tools (when enabled)
@@ -465,6 +466,18 @@ func Open(cfg Config) (*Kernel, error) {
 		wstore.Close()
 		skstore.Close()
 		return nil, fmt.Errorf("runtime: artifacts: %w", err)
+	}
+	// Metadata index over the blob store (M822) — browsable/deletable entries
+	// (inbound images, tool outputs). Failure here is non-fatal to the blob store
+	// but we surface it so the operator knows the file-manager won't populate.
+	artIndex, err := artifact.OpenIndex(artStore, filepath.Join(cfg.BaseDir, "artifacts"))
+	if err != nil {
+		j.Close()
+		st.Close()
+		mstore.Close()
+		wstore.Close()
+		skstore.Close()
+		return nil, fmt.Errorf("runtime: artifact index: %w", err)
 	}
 
 	ststore, err := standing.Open(filepath.Join(cfg.BaseDir, "standing"))
@@ -582,6 +595,7 @@ func Open(cfg Config) (*Kernel, error) {
 		mcpConns:     make(map[string]mcp.Conn),
 		workflows:    wfstore,
 		artifacts:    artStore,
+		artIndex:     artIndex,
 		reflect:      reflectEng,
 		schedules:    schedStore,
 		tools:        effTools,
@@ -692,6 +706,11 @@ func (k *Kernel) Forge() *skill.Forge { return k.forge }
 // Artifacts returns the content-addressed artifact store (SPEC-04 §3.6), where
 // the loop offloads oversized tool outputs. Used by retrieval surfaces.
 func (k *Kernel) Artifacts() *artifact.Store { return k.artifacts }
+
+// ArtifactIndex returns the metadata index over the blob store (M822) — the
+// browsable/deletable per-arrival entries (inbound images, tool outputs) the
+// file manager and inbound-image persistence use.
+func (k *Kernel) ArtifactIndex() *artifact.Index { return k.artIndex }
 
 // Standing returns the Chronos standing-order store (SPEC-16 §4), backing
 // `agt standing`. Always non-nil after Open.

--- a/kernel/webui/artifact_route.go
+++ b/kernel/webui/artifact_route.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+
+package webui
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/agezt/agezt/kernel/controlplane"
+)
+
+// handleArtifactRaw streams a stored artifact's raw bytes (M822) so an <img src>
+// or a download link can render it. It proxies CmdArtifactGet (which re-verifies
+// the bytes against the content ref) and serves them with a SANITIZED
+// Content-Type — the stored mime is attacker-influenceable (it came off a channel
+// message), so only a safe allowlist is honored; everything else is served as
+// application/octet-stream. X-Content-Type-Options: nosniff (set globally) blocks
+// type sniffing regardless. ?download=1 forces a save dialog.
+func (s *Server) handleArtifactRaw(w http.ResponseWriter, r *http.Request) {
+	ref := r.URL.Query().Get("ref")
+	if ref == "" {
+		http.Error(w, "ref required", http.StatusBadRequest)
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+	res, err := s.client.Call(ctx, controlplane.CmdArtifactGet, map[string]any{"ref": ref})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	b64, _ := res["data"].(string)
+	data, derr := base64.StdEncoding.DecodeString(b64)
+	if derr != nil {
+		http.Error(w, "artifact decode failed", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", safeContentType(r.URL.Query().Get("mime")))
+	if r.URL.Query().Get("download") == "1" {
+		name := sanitizeFilename(r.URL.Query().Get("name"))
+		w.Header().Set("Content-Disposition", "attachment; filename=\""+name+"\"")
+	}
+	// Content-addressed bytes are immutable; let the browser cache them privately.
+	w.Header().Set("Cache-Control", "private, max-age=86400")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}
+
+// safeContentType allows only a known image/document allowlist; anything else
+// becomes application/octet-stream so a hostile stored mime can't coax the
+// browser into an unexpected rendering.
+func safeContentType(mime string) string {
+	switch strings.ToLower(strings.TrimSpace(mime)) {
+	case "image/png", "image/jpeg", "image/jpg", "image/gif", "image/webp", "image/svg+xml",
+		"application/pdf", "text/plain":
+		if mime == "image/jpg" {
+			return "image/jpeg"
+		}
+		return strings.ToLower(strings.TrimSpace(mime))
+	default:
+		return "application/octet-stream"
+	}
+}
+
+// sanitizeFilename keeps a download filename to a safe single path segment.
+func sanitizeFilename(name string) string {
+	name = strings.TrimSpace(name)
+	name = strings.ReplaceAll(name, "\\", "_")
+	name = strings.ReplaceAll(name, "/", "_")
+	name = strings.ReplaceAll(name, "\"", "_")
+	name = strings.ReplaceAll(name, "\n", "_")
+	name = strings.ReplaceAll(name, "\r", "_")
+	if name == "" {
+		return "artifact"
+	}
+	return name
+}

--- a/kernel/webui/artifact_route_test.go
+++ b/kernel/webui/artifact_route_test.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+
+package webui
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestArtifactRaw_ServesBytesWithSanitizedMime(t *testing.T) {
+	fc := &fakeCaller{result: map[string]any{"data": base64.StdEncoding.EncodeToString([]byte("PNGDATA"))}}
+	s, _ := newServer(t, fc, "secret")
+
+	// Token required.
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/artifact/raw?ref=abc", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("no token: code=%d, want 401", rec.Code)
+	}
+
+	// With token + a known mime → bytes + that Content-Type.
+	rec = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/artifact/raw?token=secret&ref=abc&mime=image/png", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("code=%d, want 200", rec.Code)
+	}
+	if rec.Body.String() != "PNGDATA" {
+		t.Fatalf("body=%q, want PNGDATA", rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "image/png" {
+		t.Fatalf("content-type=%q, want image/png", ct)
+	}
+
+	// A hostile/unknown mime is downgraded to octet-stream (nosniff blocks the rest).
+	rec = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/artifact/raw?token=secret&ref=abc&mime=text/html", nil))
+	if ct := rec.Header().Get("Content-Type"); ct != "application/octet-stream" {
+		t.Fatalf("hostile mime content-type=%q, want application/octet-stream", ct)
+	}
+
+	// Missing ref → 400.
+	rec = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/artifact/raw?token=secret", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("no ref: code=%d, want 400", rec.Code)
+	}
+}

--- a/kernel/webui/webui.go
+++ b/kernel/webui/webui.go
@@ -163,7 +163,11 @@ var readArgsRoutes = map[string]writeRoute{
 	"/api/tool_log":       {controlplane.CmdToolLog, []string{"limit", "tool", "errors"}},
 	// Read one sandbox project file's content (M686), path-confined server-side.
 	"/api/sandbox_file": {controlplane.CmdSandboxFile, []string{"project", "file"}},
-	"/api/policy_log":   {controlplane.CmdEdictLog, []string{"limit", "denied"}},
+	// Artifact index listing (M822): browsable metadata for stored artifacts
+	// (inbound images, tool outputs), optionally filtered. No bytes — the raw
+	// route below serves those.
+	"/api/artifacts":  {controlplane.CmdArtifactList, []string{"kind", "source", "corr"}},
+	"/api/policy_log": {controlplane.CmdEdictLog, []string{"limit", "denied"}},
 	// Resolved HITL approval history (M773): a timeline of past approval requests
 	// joined with their granted/denied/timeout outcome. Read-only.
 	"/api/approvals_log": {controlplane.CmdApprovalsLog, []string{"limit", "denied"}},
@@ -234,6 +238,8 @@ var writeRoutes = map[string]writeRoute{
 	"/api/run/steer":     {controlplane.CmdRunSteer, []string{"correlation", "directive"}},
 	"/api/decide":        {controlplane.CmdDecide, []string{"id", "decision", "reason"}},
 	"/api/memory/forget": {controlplane.CmdMemoryForget, []string{"id"}},
+	// Delete a stored artifact by index id (M822); the blob is GC'd when unreferenced.
+	"/api/artifact/delete": {controlplane.CmdArtifactDelete, []string{"id"}},
 	// One brain-distillation pass (M804): merge related records, supersede
 	// the originals. No args; mirrors /api/reflect/run.
 	"/api/memory/consolidate": {controlplane.CmdMemoryConsolidate, nil},
@@ -420,6 +426,10 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/api/plan/run", s.auth(s.planRunProxy()))
 	mux.HandleFunc("/api/run", s.auth(s.runStreamProxy()))
 	mux.HandleFunc("/api/transcribe", s.auth(s.handleTranscribe))
+	// Binary artifact serving (M822): streams the raw bytes for a content ref with
+	// a sanitized Content-Type, so an <img src> / download link can render stored
+	// images and files. Proxies CmdArtifactGet (which re-verifies the bytes).
+	mux.HandleFunc("/api/artifact/raw", s.auth(s.handleArtifactRaw))
 	// Workflow webhooks (M809): the ONE deliberately console-token-free
 	// path. Authentication is the per-workflow secret, verified by the
 	// control plane (constant-time); all this handler can ever do is ask


### PR DESCRIPTION
## What

Backend foundation for "save + browse + delete all media that arrives over channels." Inbound channel images were ephemeral data-URLs, discarded after one run; the blob artifact store had no metadata and no list/delete. (M823 adds the file-manager UI + Inbox thumbnails.)

- **`kernel/artifact/index.go`** — a metadata sidecar over the pure blob `Store`. `Entry{id,ref,name,mime,kind,source,sender,corr,size,created_ms,caption}`, one JSON file each under `artifacts/index/`; blobs stay content-addressed/deduped. `OpenIndex`/`PutEntry`/`List(filter)`/`Get`/`Bytes`/`Count`/`Delete` (GCs the blob only when no other entry references the ref). Exposed via `k.ArtifactIndex()`.
- **Persist inbound images** — `makeChannelHandler` decodes each `msg.Images` data-URL and `PutEntry`s it (`kind=image, source=<channel>, sender, corr`, with the M821 vision caption). Saved even when no vision model is keyed.
- **Control plane** — `CmdArtifactList` (filtered, metadata only) + `CmdArtifactDelete` (by id).
- **Web UI routes** — `/api/artifacts` (list), `/api/artifact/delete` (POST), and a binary `/api/artifact/raw?ref=&mime=&download=&name=` proxying CmdArtifactGet with a **sanitized** Content-Type (image/doc allowlist → else octet-stream; nosniff global) for `<img src>`/downloads.

## Tests
index put/list/get/bytes + delete-GCs-orphan-keeps-shared + persist-across-reopen; raw route token-gate/mime-sanitize/400; `decodeDataURL`/`extForMime` table. Live: daemon boots with the index, `/api/artifacts` → `{count:0,entries:[]}`. `go test` on artifact/runtime/controlplane/webui/cmd-agezt green; vet + staticcheck + linux clean. Frontend untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)