### PR TITLE
Chore: untrack accidentally-committed agezt.exe~ backup binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ creds.json
 # Local demo artifacts (Playwright screenshots, browser MCP)
 .playwright-mcp/
 webui-*.png
+
+# editor/build backup files
+*~
+*.exe~


### PR DESCRIPTION
A stray `agezt.exe~` (17MB build/editor backup) was swept into #271's `git add -A` — `.gitignore` had `*.exe` but not the `~` variant. Untrack it and gitignore `*~`/`*.exe~`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)