### PR TITLE
Feat: index offloaded tool outputs in the file manager (M827)

### DIFF
--- a/.project/PHASE-M827-INDEX-TOOL-OUTPUTS-REPORT.md
+++ b/.project/PHASE-M827-INDEX-TOOL-OUTPUTS-REPORT.md
@@ -1,0 +1,30 @@
+# Phase M827 — index offloaded tool outputs (file manager shows run outputs)
+
+**Date:** 2026-06-11 · **Status:** DONE · **Trigger:** the M823 backlog item —
+the file manager only listed inbound images; the owner wanted non-image
+artifacts (run outputs) too.
+
+## What shipped
+
+- `artifact.Index.IndexRef(ref, meta, createdMs)` — records a metadata Entry for
+  an ALREADY-stored blob (no re-Put), filling Size from the store. For outputs the
+  agent offloaded itself.
+- `wireArtifactIndexer(ctx, k)` in cmd/agezt: a bus subscriber that watches
+  `tool.result` events carrying a `raw_ref` (the agent offloaded a large output to
+  the blob store) and `IndexRef`s it as `kind=tool-output, source=run`, name
+  `<tool>-output.txt`, with the run correlation and output_bytes. Best-effort,
+  on the daemon ctx. Decoupled — the agent loop is untouched.
+
+## Tests
+
+- `IndexRef`: records an entry for a pre-stored ref (Size from store), lists under
+  tool-output, rejects an absent ref.
+- **Live** (real deepseek): an agent run that printed 9000 chars via `code_exec`
+  (> the 8 KiB offload threshold) → `/api/artifacts?kind=tool-output` shows
+  `code_exec-output.txt` (tool-output, run, 9091 bytes). The file manager now
+  lists run outputs alongside inbound images.
+
+## Gate
+
+`go test` artifact + cmd/agezt green; vet + staticcheck + linux clean. No new env
+var; frontend untouched (Files already renders non-image entries as a list).

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -818,6 +818,12 @@ func runDaemon(stdout, stderr io.Writer) int {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	// Index offloaded tool outputs (M827): watch tool.result events carrying a
+	// raw_ref (the agent stored a large output in the blob store) and add a
+	// browsable artifact-index entry, so the file manager lists run outputs
+	// alongside inbound images. Best-effort; lives on the daemon ctx.
+	wireArtifactIndexer(ctx, k)
+
 	srv := controlplane.NewServer(k, baseDir)
 	srv.SetConfigEnvPinned(configPinned) // M693: Config Center marks env-pinned fields read-only
 	// Cancel-on-disconnect (M35): when AGEZT_CANCEL_ON_DISCONNECT=on, a
@@ -4112,6 +4118,60 @@ func buildFromCatalog(entry *catalog.Provider, modelOverride string, lookup func
 	}
 	desc := fmt.Sprintf("%s(catalog; family=%s, model=%s)", entry.ID, entry.Family(), modelID)
 	return prov, desc, modelID, auth, nil
+}
+
+// wireArtifactIndexer subscribes to the bus and indexes every offloaded tool
+// output (M827): a tool.result event with a raw_ref means the agent stored a
+// large output in the blob store, so we add a metadata index entry pointing at
+// that ref (kind=tool-output, source=run, the tool name, the run correlation).
+// The file manager then lists run outputs alongside inbound images. Best-effort:
+// an index failure is silently skipped — it must never disturb a run. The
+// subscription lives on the daemon ctx and ends when the daemon stops.
+func wireArtifactIndexer(ctx context.Context, k *kernelruntime.Kernel) {
+	idx := k.ArtifactIndex()
+	if idx == nil {
+		return
+	}
+	sub, err := k.Bus().Subscribe(">", 256)
+	if err != nil {
+		return
+	}
+	go func() {
+		defer sub.Cancel()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case ev, ok := <-sub.C:
+				if !ok {
+					return
+				}
+				if ev.Kind != event.KindToolResult {
+					continue
+				}
+				var p struct {
+					RawRef      string `json:"raw_ref"`
+					Tool        string `json:"tool"`
+					OutputBytes int64  `json:"output_bytes"`
+				}
+				if json.Unmarshal(ev.Payload, &p) != nil || p.RawRef == "" {
+					continue
+				}
+				name := p.Tool
+				if name == "" {
+					name = "tool"
+				}
+				_, _ = idx.IndexRef(p.RawRef, artifact.Entry{
+					Kind:   "tool-output",
+					Source: "run",
+					Name:   fmt.Sprintf("%s-output.txt", name),
+					Mime:   "text/plain",
+					Corr:   ev.CorrelationID,
+					Size:   p.OutputBytes,
+				}, time.Now().UnixMilli())
+			}
+		}
+	}()
 }
 
 // wireNetguardAudit points the http/browser tools' egress-guard OnBlock at the

--- a/kernel/artifact/index.go
+++ b/kernel/artifact/index.go
@@ -98,6 +98,35 @@ func (i *Index) PutEntry(meta Entry, data []byte, createdMs int64) (Entry, error
 	return meta, nil
 }
 
+// IndexRef records a metadata Entry for an ALREADY-stored blob (by content ref),
+// without re-storing the bytes — used to index outputs the agent offloaded itself
+// (the tool.result raw_ref). The ref must exist in the blob store. Size is filled
+// from the store when meta.Size is 0.
+func (i *Index) IndexRef(ref string, meta Entry, createdMs int64) (Entry, error) {
+	ok, err := i.store.Has(ref)
+	if err != nil {
+		return Entry{}, err
+	}
+	if !ok {
+		return Entry{}, ErrNotFound
+	}
+	meta.ID = "art-" + ulid.New()
+	meta.Ref = ref
+	meta.CreatedMs = createdMs
+	if meta.Size == 0 {
+		if sz, serr := i.store.Size(ref); serr == nil {
+			meta.Size = sz
+		}
+	}
+	i.mu.Lock()
+	i.entries[meta.ID] = meta
+	i.mu.Unlock()
+	if err := i.writeMeta(meta); err != nil {
+		return Entry{}, err
+	}
+	return meta, nil
+}
+
 func (i *Index) writeMeta(e Entry) error {
 	b, err := json.MarshalIndent(e, "", "  ")
 	if err != nil {

--- a/kernel/artifact/index_test.go
+++ b/kernel/artifact/index_test.go
@@ -85,6 +85,35 @@ func TestIndex_DeleteGCsOrphanBlobButKeepsShared(t *testing.T) {
 	}
 }
 
+func TestIndex_IndexRefForAlreadyStoredBlob(t *testing.T) {
+	dir := t.TempDir()
+	st, _ := artifact.Open(dir)
+	idx, _ := artifact.OpenIndex(st, dir)
+
+	// Simulate the agent's offload: bytes are already in the blob store by ref.
+	ref, err := st.Put([]byte("a big tool output …"))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	e, err := idx.IndexRef(ref, artifact.Entry{Kind: "tool-output", Source: "run", Name: "shell-output.txt", Corr: "run-1"}, 42)
+	if err != nil {
+		t.Fatalf("IndexRef: %v", err)
+	}
+	if e.Ref != ref || e.Size == 0 || e.CreatedMs != 42 || e.Corr != "run-1" {
+		t.Fatalf("entry not filled from store: %+v", e)
+	}
+	got := idx.List(artifact.Filter{Kind: "tool-output"})
+	if len(got) != 1 || got[0].ID != e.ID {
+		t.Fatalf("tool-output not listed: %+v", got)
+	}
+
+	// A ref that isn't in the store is rejected (no phantom entry).
+	if _, err := idx.IndexRef("00ff", artifact.Entry{Kind: "tool-output"}, 1); err == nil {
+		t.Error("IndexRef of an absent ref should fail")
+	}
+}
+
 func TestIndex_PersistsAcrossReopen(t *testing.T) {
 	idx, dir := openIdx(t)
 	e, _ := idx.PutEntry(artifact.Entry{Kind: "image", Source: "telegram", Caption: "kept"}, []byte("X"), 5)


### PR DESCRIPTION
## What

The M823 file manager only listed inbound images. Now the run outputs the agent offloads to the blob store are indexed too, so the Files view lists them.

- **`artifact.Index.IndexRef(ref, meta, createdMs)`** — records a metadata Entry for an ALREADY-stored blob (no re-Put), filling Size from the store.
- **`wireArtifactIndexer(ctx, k)`** (cmd/agezt) — a bus subscriber watching `tool.result` events that carry a `raw_ref` (the agent offloaded a large output) and `IndexRef`s them as `kind=tool-output, source=run, name=<tool>-output.txt` with the run correlation + `output_bytes`. Best-effort, on the daemon ctx, **decoupled** — the agent loop is untouched.

## Tests
`IndexRef`: pre-stored ref → entry (Size from store), listed under tool-output, absent ref rejected. **Live** (real deepseek): an agent run that printed 9000 chars via `code_exec` (> the 8 KiB offload threshold) → `/api/artifacts?kind=tool-output` shows `code_exec-output.txt` (9091 bytes). `go test` artifact + cmd/agezt green; vet + staticcheck + linux clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)