### PR TITLE
Fix: web_search — switch to DuckDuckGo lite endpoint (M830)

### DIFF
--- a/.project/PHASE-M830-WEBSEARCH-LITE-REPORT.md
+++ b/.project/PHASE-M830-WEBSEARCH-LITE-REPORT.md
@@ -1,0 +1,32 @@
+# Phase M830 — fix web_search (DuckDuckGo endpoint moved/blocked)
+
+**Date:** 2026-06-11 · **Status:** DONE · **Trigger:** owner: "google search
+duck duck go vs ne lazımsa çalışmıyor" — web_search returned nothing.
+
+## Root cause
+
+The tool scraped `https://html.duckduckgo.com/html/`. That endpoint now answers
+bot GETs with **HTTP 202 + an anti-bot challenge page** (no results) — confirmed
+live (14 KB page, zero `result__a` anchors). So every search came back empty.
+
+## Fix (`plugins/tools/websearch/websearch.go`)
+
+- Switch the engine to the **lite** endpoint `https://lite.duckduckgo.com/lite/`,
+  which still serves a plain, parseable results page for a GET (verified live:
+  HTTP 200, 10 results).
+- Update the result regexes to the lite markup: the anchor carries `href` BEFORE a
+  (single- or double-quoted) `class='result-link'`, and the snippet is a
+  `<td class='result-snippet'>`. `cleanURL` (uddg redirect unwrap) + fail-soft
+  behaviour are unchanged.
+
+## Verification
+
+- Unit: the parser test fixture updated to the lite markup; tool tests green.
+- **Live** (real deepseek agent run): `web_search "playwright end to end testing"`
+  → real results — playwright.dev, developer.microsoft.com, medium.com — with
+  titles. Previously: zero results.
+
+## Gate
+
+websearch tests green; vet + staticcheck + linux clean; gofmt clean. Engine host
+still fixed (no operator-controlled target); SSRF guard unchanged.

--- a/plugins/tools/websearch/websearch.go
+++ b/plugins/tools/websearch/websearch.go
@@ -48,9 +48,12 @@ const (
 	MaxLimit     = 15
 )
 
-// engineURL is the no-JS DuckDuckGo HTML endpoint. Fixed by design — the
-// operator never controls the target host, only the query.
-const engineURL = "https://html.duckduckgo.com/html/"
+// engineURL is the no-JS DuckDuckGo LITE endpoint. Fixed by design — the
+// operator never controls the target host, only the query. (M830: the older
+// html.duckduckgo.com/html/ endpoint now answers bot GETs with an HTTP 202
+// anti-bot challenge and no results; the lite endpoint still serves a plain,
+// parseable results page.)
+const engineURL = "https://lite.duckduckgo.com/lite/"
 
 // Tool is the web_search implementation of agent.Tool.
 type Tool struct {
@@ -183,17 +186,18 @@ func (t *Tool) Invoke(ctx context.Context, raw json.RawMessage) (agent.Result, e
 	return softResult(q, results, ""), nil
 }
 
-// resultLink matches DuckDuckGo HTML result anchors; snippet matches the
-// adjacent snippet block. The endpoint's markup is stable (it's the
-// deliberately-simple no-JS variant).
+// reLink matches the DuckDuckGo LITE result anchors; reSnippet matches the
+// adjacent snippet cell. The lite markup is a plain table: the anchor carries
+// href BEFORE a (single- or double-quoted) class='result-link', and the snippet
+// is a <td class='result-snippet'>. Deliberately tolerant of quote style.
 var (
-	reLink    = regexp.MustCompile(`(?s)<a[^>]*class="result__a"[^>]*href="([^"]+)"[^>]*>(.*?)</a>`)
-	reSnippet = regexp.MustCompile(`(?s)<a[^>]*class="result__snippet"[^>]*>(.*?)</a>`)
+	reLink    = regexp.MustCompile(`(?s)<a[^>]*href="([^"]+)"[^>]*class=['"]result-link['"][^>]*>(.*?)</a>`)
+	reSnippet = regexp.MustCompile(`(?s)<td[^>]*class=['"]result-snippet['"][^>]*>(.*?)</td>`)
 	reTag     = regexp.MustCompile(`<[^>]+>`)
 	reSpace   = regexp.MustCompile(`\s+`)
 )
 
-// parseResults extracts up to limit hits from a DuckDuckGo HTML result page.
+// parseResults extracts up to limit hits from a DuckDuckGo lite result page.
 func parseResults(body string, limit int) []Result {
 	links := reLink.FindAllStringSubmatch(body, -1)
 	snips := reSnippet.FindAllStringSubmatch(body, -1)

--- a/plugins/tools/websearch/websearch_test.go
+++ b/plugins/tools/websearch/websearch_test.go
@@ -13,15 +13,20 @@ import (
 
 // sampleHTML mimics the DuckDuckGo no-JS result markup the tool parses,
 // including the //duckduckgo.com/l/?uddg= redirect wrapper.
+// sampleHTML mirrors the DuckDuckGo LITE results markup (M830): a plain table
+// where the anchor carries href before a single-quoted class='result-link', and
+// the snippet is a <td class='result-snippet'>.
 const sampleHTML = `<!DOCTYPE html><html><body>
-<div class="result">
-  <a rel="nofollow" class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fgithub.com%2Fagiresearch%2FAIOS">AIOS: <b>AI</b> Agent OS</a>
-  <a class="result__snippet" href="x">AIOS is an <b>AI</b> agent operating &amp; system.</a>
-</div>
-<div class="result">
-  <a rel="nofollow" class="result__a" href="https://example.com/agentic">Agentic OS direct link</a>
-  <a class="result__snippet" href="y">A   plain    snippet with   spaces.</a>
-</div>
+<table>
+  <tr><td>
+    <a rel="nofollow" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fgithub.com%2Fagiresearch%2FAIOS&amp;rut=abc" class='result-link'>AIOS: <b>AI</b> Agent OS</a>
+  </td></tr>
+  <tr><td class='result-snippet'>AIOS is an <b>AI</b> agent operating &amp; system.</td></tr>
+  <tr><td>
+    <a rel="nofollow" href="https://example.com/agentic" class='result-link'>Agentic OS direct link</a>
+  </td></tr>
+  <tr><td class='result-snippet'>A   plain    snippet with   spaces.</td></tr>
+</table>
 </body></html>`
 
 func newStub(t *testing.T, body string, status int) *Tool {


### PR DESCRIPTION
## Root cause
web_search returned nothing: `html.duckduckgo.com/html/` now answers bot GETs with **HTTP 202 + an anti-bot challenge page** (zero results) — confirmed live.

## Fix
Switch to the **lite** endpoint `lite.duckduckgo.com/lite/` (still serves a plain parseable page for a GET — verified live, HTTP 200, 10 results) and update the regexes to its markup (`href` before single-quoted `class='result-link'`; snippet is `<td class='result-snippet'>`). `cleanURL`/uddg-unwrap + fail-soft + fixed-host + SSRF guard all unchanged.

## Verification
Live agent run `web_search "playwright end to end testing"` → real results (playwright.dev, developer.microsoft.com, medium.com). Test fixture updated to lite markup; tests + vet + staticcheck + linux green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)