### PR TITLE
Feat: `fetch` tool — download a URL into a browsable artifact (M831)

### DIFF
--- a/.project/PHASE-M831-FETCH-TOOL-REPORT.md
+++ b/.project/PHASE-M831-FETCH-TOOL-REPORT.md
@@ -1,0 +1,59 @@
+# Phase M831 — `fetch` tool: download a URL → browsable artifact
+
+**Date:** 2026-06-11 · **Status:** DONE · **Trigger:** owner: "sistemde sıfır
+hata olması için ne gerekiyorsa yap, daha fazla tool ekle bize gerekebilen şu
+anki toollar yetersiz gibi" — add more built-in tools; the current set is thin.
+
+## Gap
+
+The agent could read a page's **text** (`http`/`browser.read`) but had no way to
+**keep a file from the web**. Binary content — an image, PDF, archive, dataset —
+was unreachable: `http` returns text into context (and is capped), and nothing
+landed it in the artifact store / Files view (M822–M823) where the operator can
+preview and download it. So "save this picture", "grab that PDF" had no path.
+
+## What shipped (`plugins/tools/fetch/`)
+
+A new in-process `fetch` tool:
+
+- **`fetch {url, name?}`** → GETs the URL through a **netguard-protected** client
+  (same SSRF guard as `http`/`web_search`; loopback/private only when
+  `AGEZT_ALLOW_ALL`/the private-net flags are set), reads up to **50 MiB**,
+  detects the mime (Content-Type, else sniffed), and **`PutEntry`s the bytes into
+  the artifact index** with `Source:"fetch"` and `Kind` = `image` (image/*) or
+  `download`. Returns `{id, ref, name, mime, size, saved}` so the model can
+  reference the saved file by id.
+- Decoupled from the kernel via an `Indexer` interface; the daemon injects the
+  real `*artifact.Index` with `SetIndex(k.ArtifactIndex())` after Open (mirrors
+  the M827 indexer wiring). Without an index it fails soft ("artifact store
+  unavailable").
+- Fail-soft on every operator-reachable error (bad URL, HTTP ≥400, empty body,
+  over-limit) — returns an error *result*, never a hard tool failure that aborts
+  the run.
+
+## Wiring
+
+- `cmd/agezt/main.go` `buildTools`: register `fetch` (`fetch(url→artifact)` in the
+  startup tools line), relax egress under allow-all, inject the index post-Open.
+- `kernel/edict/toolmap.go`: `case "fetch": return CapHTTPGet` — a download is a
+  network GET, so it reuses the existing capability (no new grant, no new env).
+
+## Verification
+
+- **Unit** (`fetch_test.go`): stub server + fake index — asserts the image is
+  stored with the right mime/kind/name/source/bytes/time and the result reports
+  the id; rejects non-http/empty URLs and missing index; HTTP 404 is a soft error.
+- **Live** (isolated `AGEZT_HOME`, real MiniMax agent): `agt run "fetch
+  https://go.dev/images/go-logo-blue.svg and save it"` → agent invoked `fetch`,
+  got `art-01KTT…`, and the index sidecar shows
+  `{kind:image, source:fetch, mime:image/svg+xml, name:go-logo-blue.svg,
+  size:1472}` — i.e. it lands in the Files gallery automatically (no frontend
+  change: M823 already renders `image`/`download` artifacts).
+
+## Gate
+
+fetch + edict + artifact + catalog + runtime + webui + controlplane tests green;
+vet + staticcheck + linux cross-build clean; gofmt swept. go.mod unchanged
+(net/http + existing netguard/artifact only). No new env var → no `configEnvVars`
+change. SSRF guard intact; default-allow posture preserved (fetch is on by
+default, restriction only via the existing egress/policy opt-outs).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 
 ## [Unreleased]
 
+### Added
+- **New `fetch` tool — download a URL and keep the file.** Agents can now save binary content from
+  the web (an image, PDF, archive, dataset) straight into the artifact store: `fetch {url, name?}`
+  downloads through the SSRF-guarded client (≤50 MiB), detects the mime, and files it in the Files
+  view (`Source: fetch`, grouped as `image`/`download`), returning `{id, mime, size, name}`. It
+  complements `http` (which returns a page's *text* into context) by capturing the *bytes*. Reuses
+  the network-GET capability — no new grant or env var. (M831)
+
 ### Changed
 - **Chat can Continue a run that hit the iteration limit (instead of only Retry).** When a run
   exhausts its tool-round cap, chat now offers **Continue** — it resumes from where the agent

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -96,6 +96,7 @@ import (
 	"github.com/agezt/agezt/plugins/tools/codeexec"
 	"github.com/agezt/agezt/plugins/tools/coding"
 	configtool "github.com/agezt/agezt/plugins/tools/config"
+	"github.com/agezt/agezt/plugins/tools/fetch"
 	filetool "github.com/agezt/agezt/plugins/tools/file"
 	"github.com/agezt/agezt/plugins/tools/forgetool"
 	hatool "github.com/agezt/agezt/plugins/tools/homeassistant"
@@ -731,6 +732,11 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// fields (provider/model) rebuild the provider in place via Reload().
 	if ct, ok := tools["config"].(*configtool.Tool); ok {
 		ct.SetKernel(k)
+	}
+	// Inject the artifact index into the fetch tool (M831) now that the kernel
+	// owns it, so downloaded files are saved as browsable artifacts.
+	if fe, ok := tools["fetch"].(*fetch.Tool); ok {
+		fe.SetIndex(k.ArtifactIndex())
 	}
 
 	// Wire the bus into the Governor and the Warden so their events
@@ -4475,6 +4481,18 @@ func buildTools(baseDir string, stderr io.Writer, ward warden.Engine) (map[strin
 	}
 	out["web_search"] = ws
 	registered = append(registered, "web_search(duckduckgo)")
+
+	// fetch — download a URL's bytes and save them as a browsable artifact (M831),
+	// so the agent can keep an image/PDF/file it finds (it shows up in Files). Same
+	// SSRF-guarded egress as the other network tools; the artifact index is injected
+	// after the kernel opens. Always registered.
+	fe := fetch.New()
+	if allowAll {
+		fe.AllowLoopback = true
+		fe.AllowPrivate = true
+	}
+	out["fetch"] = fe
+	registered = append(registered, "fetch(url→artifact)")
 
 	// coding — external coding-agent bridge (P6-CODE). Registered only when
 	// AGEZT_CODING_CMD is set (the command that runs Claude Code / Codex / Aider

--- a/kernel/edict/toolmap.go
+++ b/kernel/edict/toolmap.go
@@ -53,6 +53,9 @@ func CapabilityForToolCall(toolName string, input json.RawMessage) Capability {
 		return CapBrowserRead
 	case "web_search":
 		return CapWebSearch
+	case "fetch":
+		// A download is a network GET that saves the bytes — same capability as http.get.
+		return CapHTTPGet
 	case "schedule":
 		return CapSchedule
 	case "runs":

--- a/kernel/edict/toolmap_test.go
+++ b/kernel/edict/toolmap_test.go
@@ -26,6 +26,8 @@ func TestCapabilityForToolCall(t *testing.T) {
 		{"http", `{"method":"GET","url":"https://x"}`, CapHTTPGet},
 		{"http", `{"method":"POST","url":"https://x"}`, CapHTTPPost},
 		{"http", `{"method":"  post  ","url":"https://x"}`, CapHTTPPost},
+		// A download (fetch) is a network GET that saves the bytes (M831).
+		{"fetch", `{"url":"https://x/cat.png"}`, CapHTTPGet},
 		{"remote_run", `{"task":"x"}`, CapRemoteRun},
 		{"notify", `{"text":"hi"}`, CapNotify},
 		{"homeassistant", `{"operation":"get_states","entity_id":"light.x"}`, CapHomeAssistantRead},

--- a/plugins/tools/fetch/fetch.go
+++ b/plugins/tools/fetch/fetch.go
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: MIT
+
+// Package fetch is the in-process `fetch` tool: it downloads a URL's bytes and
+// SAVES them as a browsable artifact (M831), returning the artifact id + mime +
+// size. It complements the `http` tool — which returns a page's text into the
+// model's context — by capturing BINARY content (images, PDFs, archives, …) into
+// the artifact store / file manager, where the operator can preview and download
+// it. The capability is a plain network GET (edict CapHTTPGet).
+//
+// Like the http/web_search tools it goes through a netguard-protected client
+// that refuses internal/metadata addresses (SSRF guard), relaxed only by the
+// explicit AllowLoopback/AllowPrivate flags.
+package fetch
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	stdhttp "net/http"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/artifact"
+	"github.com/agezt/agezt/kernel/netguard"
+)
+
+// DefaultTimeout caps a single download.
+const DefaultTimeout = 60 * time.Second
+
+// MaxBytes caps a single download so one fetch can't exhaust disk/memory.
+const MaxBytes = 50 << 20 // 50 MiB
+
+// Indexer is the slice of the artifact index the tool needs — satisfied by
+// *artifact.Index. An interface keeps the tool decoupled and testable.
+type Indexer interface {
+	PutEntry(meta artifact.Entry, data []byte, createdMs int64) (artifact.Entry, error)
+}
+
+// Tool is the `fetch` implementation of agent.Tool.
+type Tool struct {
+	// HTTP overrides the default client; when nil a netguard-protected client is
+	// built (default-deny to internal/metadata addresses).
+	HTTP *stdhttp.Client
+	// AllowLoopback / AllowPrivate relax the egress guard for the default client.
+	AllowLoopback bool
+	AllowPrivate  bool
+	// UserAgent is sent on every request.
+	UserAgent string
+	// OnBlock is called when the egress guard refuses a dial (journaled by the daemon).
+	OnBlock func(ip, reason string)
+	// Now returns the wall-clock millis stamped on the stored entry; injectable for tests.
+	Now func() int64
+
+	index Indexer
+}
+
+// DefaultUserAgent identifies the fetcher.
+const DefaultUserAgent = "agezt-fetch/1.0"
+
+// New returns a Tool with safe defaults.
+func New() *Tool {
+	return &Tool{UserAgent: DefaultUserAgent, Now: func() int64 { return time.Now().UnixMilli() }}
+}
+
+// SetIndex injects the artifact index (done by the daemon after the kernel opens,
+// since the index lives on the kernel). Without it, the tool reports unavailable.
+func (t *Tool) SetIndex(idx Indexer) { t.index = idx }
+
+func (t *Tool) client() *stdhttp.Client {
+	if t.HTTP != nil {
+		return t.HTTP
+	}
+	var opts []netguard.Option
+	if t.AllowLoopback {
+		opts = append(opts, netguard.AllowLoopback())
+	}
+	if t.AllowPrivate {
+		opts = append(opts, netguard.AllowPrivate())
+	}
+	if t.OnBlock != nil {
+		opts = append(opts, netguard.OnBlock(t.OnBlock))
+	}
+	return netguard.New(opts...).HTTPClient(DefaultTimeout)
+}
+
+// Definition implements agent.Tool.
+func (t *Tool) Definition() agent.ToolDef {
+	return agent.ToolDef{
+		Name: "fetch",
+		Description: "Download a URL and SAVE its bytes as an artifact (file) — use this to keep " +
+			"an image, PDF, or other file from the web (it appears in the Files view and can be " +
+			"downloaded). Returns the artifact {id, mime, size, name}. For reading a page's TEXT " +
+			"into your context, use the http tool instead.",
+		InputSchema: json.RawMessage(`{
+  "type": "object",
+  "required": ["url"],
+  "properties": {
+    "url":  {"type":"string", "description":"Absolute http/https URL to download."},
+    "name": {"type":"string", "description":"Optional file name for the saved artifact."}
+  }
+}`),
+	}
+}
+
+type fetchInput struct {
+	URL  string `json:"url"`
+	Name string `json:"name,omitempty"`
+}
+
+// Invoke implements agent.Tool.
+func (t *Tool) Invoke(ctx context.Context, raw json.RawMessage) (agent.Result, error) {
+	var in fetchInput
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return agent.Result{}, fmt.Errorf("fetch: parse input: %w", err)
+	}
+	u := strings.TrimSpace(in.URL)
+	if u == "" {
+		return errResult("url required"), nil
+	}
+	if !strings.HasPrefix(u, "http://") && !strings.HasPrefix(u, "https://") {
+		return errResult("url must be an absolute http/https URL"), nil
+	}
+	if t.index == nil {
+		return errResult("artifact store unavailable"), nil
+	}
+
+	req, err := stdhttp.NewRequestWithContext(ctx, stdhttp.MethodGet, u, nil)
+	if err != nil {
+		return errResult("build request: " + err.Error()), nil
+	}
+	ua := t.UserAgent
+	if ua == "" {
+		ua = DefaultUserAgent
+	}
+	req.Header.Set("User-Agent", ua)
+
+	resp, err := t.client().Do(req)
+	if err != nil {
+		return errResult("download failed: " + err.Error()), nil
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return errResult(fmt.Sprintf("server returned HTTP %d", resp.StatusCode)), nil
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, MaxBytes+1))
+	if err != nil {
+		return errResult("read body: " + err.Error()), nil
+	}
+	if len(data) > MaxBytes {
+		return errResult(fmt.Sprintf("download exceeds the %d MiB limit", MaxBytes>>20)), nil
+	}
+	if len(data) == 0 {
+		return errResult("downloaded 0 bytes"), nil
+	}
+
+	mime := cleanMime(resp.Header.Get("Content-Type"))
+	if mime == "" {
+		mime = stdhttp.DetectContentType(data)
+	}
+	name := strings.TrimSpace(in.Name)
+	if name == "" {
+		name = nameFromURL(u)
+	}
+
+	e, err := t.index.PutEntry(artifact.Entry{
+		Kind:   kindForMime(mime),
+		Source: "fetch",
+		Name:   name,
+		Mime:   mime,
+	}, data, t.Now())
+	if err != nil {
+		return errResult("save: " + err.Error()), nil
+	}
+
+	out, _ := json.MarshalIndent(map[string]any{
+		"id":    e.ID,
+		"ref":   e.Ref,
+		"name":  e.Name,
+		"mime":  e.Mime,
+		"size":  e.Size,
+		"saved": true,
+		"note":  "saved to the Files view; reference it by id",
+	}, "", "  ")
+	return agent.Result{Output: string(out)}, nil
+}
+
+// cleanMime strips any "; charset=…" parameter from a Content-Type.
+func cleanMime(ct string) string {
+	ct = strings.TrimSpace(ct)
+	if i := strings.IndexByte(ct, ';'); i >= 0 {
+		ct = ct[:i]
+	}
+	return strings.ToLower(strings.TrimSpace(ct))
+}
+
+// kindForMime buckets a mime into the artifact-index Kind the file manager groups by.
+func kindForMime(mime string) string {
+	if strings.HasPrefix(mime, "image/") {
+		return "image"
+	}
+	return "download"
+}
+
+// nameFromURL derives a file name from the URL's last path segment, or a default.
+func nameFromURL(raw string) string {
+	if pu, err := url.Parse(raw); err == nil {
+		if base := path.Base(pu.Path); base != "" && base != "/" && base != "." {
+			return base
+		}
+		if pu.Host != "" {
+			return pu.Host
+		}
+	}
+	return "download"
+}
+
+func errResult(msg string) agent.Result {
+	return agent.Result{Output: "fetch: " + msg, IsError: true}
+}

--- a/plugins/tools/fetch/fetch_test.go
+++ b/plugins/tools/fetch/fetch_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+
+package fetch
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/agezt/agezt/kernel/artifact"
+)
+
+// fakeIndex captures PutEntry calls.
+type fakeIndex struct {
+	got  artifact.Entry
+	data []byte
+}
+
+func (f *fakeIndex) PutEntry(meta artifact.Entry, data []byte, createdMs int64) (artifact.Entry, error) {
+	meta.ID = "art-test"
+	meta.Ref = "deadbeef"
+	meta.Size = int64(len(data))
+	meta.CreatedMs = createdMs
+	f.got = meta
+	f.data = data
+	return meta, nil
+}
+
+func TestFetch_SavesImageAsArtifact(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png; charset=binary")
+		_, _ = w.Write([]byte("PNGBYTES"))
+	}))
+	defer srv.Close()
+
+	idx := &fakeIndex{}
+	tool := New()
+	tool.HTTP = srv.Client()
+	tool.SetIndex(idx)
+	tool.Now = func() int64 { return 7 }
+
+	res, err := tool.Invoke(context.Background(), json.RawMessage(`{"url":"`+srv.URL+`/cat.png"}`))
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error result: %s", res.Output)
+	}
+	// Stored with the sniffed/declared mime, image kind, name from the URL path.
+	if idx.got.Mime != "image/png" || idx.got.Kind != "image" || idx.got.Name != "cat.png" || idx.got.Source != "fetch" {
+		t.Fatalf("stored entry = %+v", idx.got)
+	}
+	if string(idx.data) != "PNGBYTES" || idx.got.CreatedMs != 7 {
+		t.Fatalf("data/time = %q,%d", idx.data, idx.got.CreatedMs)
+	}
+	// The result reports the saved artifact id.
+	if !strings.Contains(res.Output, "art-test") || !strings.Contains(res.Output, `"saved": true`) {
+		t.Fatalf("result missing id/saved: %s", res.Output)
+	}
+}
+
+func TestFetch_Rejections(t *testing.T) {
+	tool := New()
+	tool.SetIndex(&fakeIndex{})
+
+	// Non-http URL.
+	if r, _ := tool.Invoke(context.Background(), json.RawMessage(`{"url":"ftp://x/y"}`)); !r.IsError {
+		t.Error("ftp URL should be rejected")
+	}
+	// Empty URL.
+	if r, _ := tool.Invoke(context.Background(), json.RawMessage(`{"url":""}`)); !r.IsError {
+		t.Error("empty URL should be rejected")
+	}
+	// No index configured.
+	noIdx := New()
+	if r, _ := noIdx.Invoke(context.Background(), json.RawMessage(`{"url":"https://x/y"}`)); !r.IsError || !strings.Contains(r.Output, "unavailable") {
+		t.Errorf("missing index should report unavailable: %s", r.Output)
+	}
+}
+
+func TestFetch_ServerErrorIsSoftError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	tool := New()
+	tool.HTTP = srv.Client()
+	tool.SetIndex(&fakeIndex{})
+	r, err := tool.Invoke(context.Background(), json.RawMessage(`{"url":"`+srv.URL+`/missing"}`))
+	if err != nil {
+		t.Fatalf("Invoke returned a hard error: %v", err)
+	}
+	if !r.IsError || !strings.Contains(r.Output, "404") {
+		t.Errorf("HTTP 404 should be a soft error result: %s", r.Output)
+	}
+}


### PR DESCRIPTION
## What

Adds a new in-process **`fetch`** tool so the agent can *keep a file from the web*, not just read a page's text.

`fetch {url, name?}` → GETs the URL through the **SSRF-guarded** client (same guard as `http`/`web_search`; ≤50 MiB), detects the mime, and **saves the bytes into the artifact index** (`Source: fetch`, `Kind` = `image` / `download`). It returns `{id, ref, name, mime, size, saved}` so the model can reference the saved file. The file then shows up in the **Files view** (gallery for images, list otherwise) where the operator can preview and download it.

It complements `http` — which returns a page's **text** into context — by capturing **binary** content (images, PDFs, archives, datasets).

## How

- `plugins/tools/fetch/` — the tool, decoupled from the kernel via an `Indexer` interface; the daemon injects the real `*artifact.Index` with `SetIndex(...)` after Open (mirrors the M827 indexer wiring). Fails soft without an index.
- `cmd/agezt/main.go` — register in `buildTools` (`fetch(url→artifact)`), relax egress under allow-all, inject the index post-Open.
- `kernel/edict/toolmap.go` — `case "fetch": return CapHTTPGet`. A download is a network GET → reuses the existing capability. **No new grant, no new env var.**

## Verification

- **Unit:** stub server + fake index — image stored with correct mime/kind/name/source/bytes/time, result reports the id; non-http/empty URL + missing index rejected; HTTP 404 is a soft error.
- **Live** (isolated `AGEZT_HOME`, real agent): `fetch https://go.dev/images/go-logo-blue.svg` → agent invoked `fetch`, index sidecar shows `{kind:image, source:fetch, mime:image/svg+xml, size:1472}` → lands in the Files gallery (no frontend change; M823 already renders these).
- **Gate:** fetch + edict + artifact + catalog + runtime + webui + controlplane tests green; vet + staticcheck + linux cross-build clean; gofmt swept; go.mod unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)