### PR TITLE
Feat: `artifacts` tool — agent lists/reads/deletes its own saved files (M832)

### DIFF
--- a/.project/PHASE-M832-ARTIFACTS-TOOL-REPORT.md
+++ b/.project/PHASE-M832-ARTIFACTS-TOOL-REPORT.md
@@ -1,0 +1,61 @@
+# Phase M832 — `artifacts` tool: agent lists/reads/deletes its own saved files
+
+**Date:** 2026-06-11 · **Status:** DONE · **Trigger:** owner: "daha fazla tool
+ekle bize gerekebilen şu anki toollar yetersiz gibi" — continuing the more-tools
+arc; the natural companion to `fetch` (M831).
+
+## Gap
+
+`fetch` (M831), the tool-output offloader (M827), and inbound-image persistence
+(M822) all PUT files into the artifact store / Files view. But the agent had no
+way to read them back OUT: it got an `id` from `fetch` yet couldn't enumerate
+"what files do I have", pull a saved file's bytes into context, or delete one —
+the Files view was operator-only. So a file saved in one run was unusable in the
+next.
+
+## What shipped (`plugins/tools/artifacts/`)
+
+A new in-process `artifacts` tool — a read/list/delete view over the existing
+artifact index (no new store, no network):
+
+- **`op=list {kind?, source?, corr?, limit?}`** → metadata of the saved files
+  (`{id, name, mime, kind, source, size, caption?}`), newest-first, capped
+  (default 50, `truncated` flagged).
+- **`op=read {id}`** → a **text** file's contents inline (header + body, capped at
+  256 KiB with a truncation note). A **binary** file instead returns its metadata
+  + "download from the Files view" — raw bytes never flood the model context.
+  Text-vs-binary is decided by mime (text/*, json/xml/yaml/svg, +json/+xml) or,
+  for an unknown mime, a NUL-byte sniff.
+- **`op=delete {id}`** → removes the entry (and GCs the blob when unreferenced,
+  via the index's existing dedup-aware Delete).
+
+Decoupled from the kernel via an `Index` interface (List/Bytes/Delete); the daemon
+injects the real `*artifact.Index` post-Open with `SetIndex(...)`, mirroring the
+fetch (M831) and indexer (M827) wiring. Fails soft without it.
+
+## Wiring
+
+- `cmd/agezt/main.go` `buildTools`: register `artifacts`
+  (`artifacts(list/read/delete)` in the startup tools line), inject the index
+  post-Open. Always registered.
+- `kernel/edict/toolmap.go`: `case "artifacts"` → `op=delete` ⇒ `CapFileDelete`,
+  else (list/read, and any garbled op) ⇒ `CapFileRead`. Artifacts are files →
+  reuses the file capabilities (no new grant, no new env).
+
+## Verification
+
+- **Unit** (`artifacts_test.go`): list (+kind filter), text read returns content,
+  binary read reports metadata (no byte dump), delete propagates + missing-id is a
+  soft error, unknown op / read-without-id / missing-index all rejected.
+- **Live** (isolated `AGEZT_HOME`, real deepseek agent): one prompt drove all
+  three ops — `fetch https://go.dev/robots.txt` → `artifacts list` (showed the one
+  `text/plain`, source=fetch entry) → `artifacts read <id>` returned the exact
+  contents (`User-agent: *` / `Allow: /`). Closed the save→list→read loop.
+
+## Gate
+
+artifacts + fetch + edict tests green; vet + staticcheck + linux cross-build
+clean; gofmt swept. go.mod unchanged (stdlib + existing agent/artifact only). No
+new env var → no `configEnvVars` change. No network surface; default-allow posture
+preserved (on by default, restriction only via the existing file-capability
+opt-outs).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **New `artifacts` tool — the agent can list/read/delete its own saved files.** Files that `fetch`,
+  the tool-output offloader, or inbound-image persistence put into the artifact store were readable
+  only from the Files view; now the agent can `artifacts {op:list}` (metadata, filterable by
+  kind/source/corr), `{op:read, id}` (a text file's contents inline — binary reports metadata
+  instead), and `{op:delete, id}`. So a file saved in one run is usable in the next. Reuses the
+  file-read / file-delete capabilities — no new grant or env var. (M832)
 - **New `fetch` tool — download a URL and keep the file.** Agents can now save binary content from
   the web (an image, PDF, archive, dataset) straight into the artifact store: `fetch {url, name?}`
   downloads through the SSRF-guarded client (≤50 MiB), detects the mime, and files it in the Files

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -91,6 +91,7 @@ import (
 	"github.com/agezt/agezt/plugins/providers/compat"
 	"github.com/agezt/agezt/plugins/providers/mock"
 	"github.com/agezt/agezt/plugins/tools/acpagent"
+	artifactstool "github.com/agezt/agezt/plugins/tools/artifacts"
 	boardtool "github.com/agezt/agezt/plugins/tools/boardtool"
 	"github.com/agezt/agezt/plugins/tools/browser"
 	"github.com/agezt/agezt/plugins/tools/codeexec"
@@ -737,6 +738,11 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// owns it, so downloaded files are saved as browsable artifacts.
 	if fe, ok := tools["fetch"].(*fetch.Tool); ok {
 		fe.SetIndex(k.ArtifactIndex())
+	}
+	// Inject the artifact index into the artifacts tool (M832) so the agent can
+	// list/read/delete the files it has saved.
+	if af, ok := tools["artifacts"].(*artifactstool.Tool); ok {
+		af.SetIndex(k.ArtifactIndex())
 	}
 
 	// Wire the bus into the Governor and the Warden so their events
@@ -4493,6 +4499,14 @@ func buildTools(baseDir string, stderr io.Writer, ward warden.Engine) (map[strin
 	}
 	out["fetch"] = fe
 	registered = append(registered, "fetch(url→artifact)")
+
+	// artifacts — list/read/delete the files the agent has saved (fetch downloads,
+	// offloaded tool outputs, inbound images), so a file from one run is usable in a
+	// later one (M832). A read/list/delete view over the artifact index injected
+	// after the kernel opens. Always registered.
+	af := artifactstool.New()
+	out["artifacts"] = af
+	registered = append(registered, "artifacts(list/read/delete)")
 
 	// coding — external coding-agent bridge (P6-CODE). Registered only when
 	// AGEZT_CODING_CMD is set (the command that runs Claude Code / Codex / Aider

--- a/kernel/edict/toolmap.go
+++ b/kernel/edict/toolmap.go
@@ -56,6 +56,18 @@ func CapabilityForToolCall(toolName string, input json.RawMessage) Capability {
 	case "fetch":
 		// A download is a network GET that saves the bytes — same capability as http.get.
 		return CapHTTPGet
+	case "artifacts":
+		var p struct {
+			Op string `json:"op"`
+		}
+		_ = json.Unmarshal(input, &p)
+		if strings.EqualFold(strings.TrimSpace(p.Op), "delete") {
+			// Removing a saved file is the file-delete axis.
+			return CapFileDelete
+		}
+		// list/read (and anything unrecognised) reads stored files — the low-risk
+		// default, so a garbled call lands on read rather than gaining delete.
+		return CapFileRead
 	case "schedule":
 		return CapSchedule
 	case "runs":

--- a/kernel/edict/toolmap_test.go
+++ b/kernel/edict/toolmap_test.go
@@ -28,6 +28,11 @@ func TestCapabilityForToolCall(t *testing.T) {
 		{"http", `{"method":"  post  ","url":"https://x"}`, CapHTTPPost},
 		// A download (fetch) is a network GET that saves the bytes (M831).
 		{"fetch", `{"url":"https://x/cat.png"}`, CapHTTPGet},
+		// The artifacts tool (M832): list/read are file-read; delete is file-delete.
+		{"artifacts", `{"op":"list"}`, CapFileRead},
+		{"artifacts", `{"op":"read","id":"art-x"}`, CapFileRead},
+		{"artifacts", `{"op":"  DELETE  ","id":"art-x"}`, CapFileDelete},
+		{"artifacts", `{}`, CapFileRead}, // garbled call lands on read (low-risk default)
 		{"remote_run", `{"task":"x"}`, CapRemoteRun},
 		{"notify", `{"text":"hi"}`, CapNotify},
 		{"homeassistant", `{"operation":"get_states","entity_id":"light.x"}`, CapHomeAssistantRead},

--- a/plugins/tools/artifacts/artifacts.go
+++ b/plugins/tools/artifacts/artifacts.go
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: MIT
+
+// Package artifacts is the in-process `artifacts` tool: it lets the agent
+// enumerate, read back, and delete the files it has saved — the artifact store /
+// Files view (M822–M823) seen from the agent's side (M832). `fetch` and the
+// tool-output offloader PUT files in; this tool reads them back OUT, so a file
+// saved in one run is usable in a later one (the model gets an id from `fetch`
+// but, without this, had no way to list "what do I have" or pull a saved file's
+// bytes into context).
+//
+// It is a read/list/delete view over the existing artifact index — no new store,
+// no network. Listing and reading are the file-read axis; delete is file-delete.
+package artifacts
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/artifact"
+)
+
+// MaxReadBytes caps how much of a text artifact `read` returns inline, so pulling
+// a large file back can't blow the model's context. Bigger files are truncated
+// with a note (the whole file is still downloadable from the Files view).
+const MaxReadBytes = 256 << 10 // 256 KiB
+
+// DefaultListLimit caps a `list` with no explicit limit.
+const DefaultListLimit = 50
+
+// Index is the slice of the artifact index the tool needs — satisfied by
+// *artifact.Index. An interface keeps the tool decoupled and testable.
+type Index interface {
+	List(f artifact.Filter) []artifact.Entry
+	Bytes(id string) ([]byte, artifact.Entry, error)
+	Delete(id string) error
+}
+
+// Tool is the `artifacts` implementation of agent.Tool.
+type Tool struct {
+	index Index
+}
+
+// New returns an empty Tool; call SetIndex before use.
+func New() *Tool { return &Tool{} }
+
+// SetIndex injects the artifact index (done by the daemon after the kernel opens,
+// since the index lives on the kernel). Without it, the tool reports unavailable.
+func (t *Tool) SetIndex(idx Index) { t.index = idx }
+
+// Definition implements agent.Tool.
+func (t *Tool) Definition() agent.ToolDef {
+	return agent.ToolDef{
+		Name: "artifacts",
+		Description: "List, read, or delete the files saved in the artifact store / Files view — " +
+			"the images, downloads (from `fetch`), and offloaded tool outputs you've produced. " +
+			"op=list returns metadata {id, name, mime, kind, source, size} (filter by kind/source/corr); " +
+			"op=read returns a text file's content by id (binary files report their metadata instead — " +
+			"download them from the Files view); op=delete removes one by id.",
+		InputSchema: json.RawMessage(`{
+  "type": "object",
+  "required": ["op"],
+  "properties": {
+    "op":     {"type":"string", "enum":["list","read","delete"], "description":"What to do."},
+    "id":     {"type":"string", "description":"Artifact id (required for read/delete)."},
+    "kind":   {"type":"string", "description":"list filter: image | download | tool-output | …"},
+    "source": {"type":"string", "description":"list filter: fetch | telegram | run | …"},
+    "corr":   {"type":"string", "description":"list filter: correlation id of the run/message."},
+    "limit":  {"type":"integer", "description":"list: max entries to return (default 50)."}
+  }
+}`),
+	}
+}
+
+type input struct {
+	Op     string `json:"op"`
+	ID     string `json:"id,omitempty"`
+	Kind   string `json:"kind,omitempty"`
+	Source string `json:"source,omitempty"`
+	Corr   string `json:"corr,omitempty"`
+	Limit  int    `json:"limit,omitempty"`
+}
+
+// Invoke implements agent.Tool.
+func (t *Tool) Invoke(ctx context.Context, raw json.RawMessage) (agent.Result, error) {
+	var in input
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return agent.Result{}, fmt.Errorf("artifacts: parse input: %w", err)
+	}
+	if t.index == nil {
+		return errResult("artifact store unavailable"), nil
+	}
+	switch strings.ToLower(strings.TrimSpace(in.Op)) {
+	case "list":
+		return t.list(in), nil
+	case "read":
+		return t.read(in), nil
+	case "delete":
+		return t.del(in), nil
+	default:
+		return errResult("op must be one of list, read, delete"), nil
+	}
+}
+
+func (t *Tool) list(in input) agent.Result {
+	entries := t.index.List(artifact.Filter{Kind: in.Kind, Source: in.Source, Corr: in.Corr})
+	limit := in.Limit
+	if limit <= 0 {
+		limit = DefaultListLimit
+	}
+	truncated := false
+	if len(entries) > limit {
+		entries = entries[:limit]
+		truncated = true
+	}
+	rows := make([]map[string]any, 0, len(entries))
+	for _, e := range entries {
+		row := map[string]any{
+			"id": e.ID, "name": e.Name, "mime": e.Mime, "kind": e.Kind,
+			"source": e.Source, "size": e.Size,
+		}
+		if e.Caption != "" {
+			row["caption"] = e.Caption
+		}
+		rows = append(rows, row)
+	}
+	out, _ := json.MarshalIndent(map[string]any{
+		"count":     len(rows),
+		"truncated": truncated,
+		"artifacts": rows,
+	}, "", "  ")
+	return agent.Result{Output: string(out)}
+}
+
+func (t *Tool) read(in input) agent.Result {
+	id := strings.TrimSpace(in.ID)
+	if id == "" {
+		return errResult("id required for read")
+	}
+	data, e, err := t.index.Bytes(id)
+	if err != nil {
+		return errResult("read " + id + ": " + err.Error())
+	}
+	if !isTextMime(e.Mime, data) {
+		out, _ := json.MarshalIndent(map[string]any{
+			"id": e.ID, "name": e.Name, "mime": e.Mime, "size": e.Size,
+			"binary": true,
+			"note":   "binary file — not shown inline; download it from the Files view",
+		}, "", "  ")
+		return agent.Result{Output: string(out)}
+	}
+	text := string(data)
+	note := ""
+	if len(data) > MaxReadBytes {
+		text = string(data[:MaxReadBytes])
+		note = fmt.Sprintf("\n\n[truncated: showing first %d of %d bytes]", MaxReadBytes, len(data))
+	}
+	header := fmt.Sprintf("%s (%s, %d bytes)\n\n", e.Name, e.Mime, e.Size)
+	return agent.Result{Output: header + text + note}
+}
+
+func (t *Tool) del(in input) agent.Result {
+	id := strings.TrimSpace(in.ID)
+	if id == "" {
+		return errResult("id required for delete")
+	}
+	if err := t.index.Delete(id); err != nil {
+		return errResult("delete " + id + ": " + err.Error())
+	}
+	return agent.Result{Output: "deleted " + id}
+}
+
+// isTextMime reports whether an artifact is safe to return inline as text — either
+// its mime is text-like, or (when the mime is missing/opaque) the bytes contain no
+// NUL, the classic "looks binary" tell.
+func isTextMime(mime string, data []byte) bool {
+	m := strings.ToLower(strings.TrimSpace(mime))
+	switch {
+	case strings.HasPrefix(m, "text/"):
+		return true
+	case m == "application/json" || m == "application/xml" || m == "application/javascript" ||
+		m == "application/x-yaml" || m == "application/yaml" || m == "image/svg+xml" ||
+		strings.HasSuffix(m, "+json") || strings.HasSuffix(m, "+xml"):
+		return true
+	case m == "":
+		// Unknown mime: treat as text only if the bytes look like text (no NUL).
+		return !bytes.Contains(data, []byte{0})
+	default:
+		return false
+	}
+}
+
+func errResult(msg string) agent.Result {
+	return agent.Result{Output: "artifacts: " + msg, IsError: true}
+}

--- a/plugins/tools/artifacts/artifacts_test.go
+++ b/plugins/tools/artifacts/artifacts_test.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: MIT
+
+package artifacts
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/agezt/agezt/kernel/artifact"
+)
+
+// fakeIndex is an in-memory stand-in for *artifact.Index.
+type fakeIndex struct {
+	entries map[string]artifact.Entry
+	blobs   map[string][]byte // id -> bytes
+	deleted []string
+}
+
+func (f *fakeIndex) List(flt artifact.Filter) []artifact.Entry {
+	var out []artifact.Entry
+	for _, e := range f.entries {
+		if flt.Kind != "" && e.Kind != flt.Kind {
+			continue
+		}
+		if flt.Source != "" && e.Source != flt.Source {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+func (f *fakeIndex) Bytes(id string) ([]byte, artifact.Entry, error) {
+	e, ok := f.entries[id]
+	if !ok {
+		return nil, artifact.Entry{}, artifact.ErrNotFound
+	}
+	return f.blobs[id], e, nil
+}
+
+func (f *fakeIndex) Delete(id string) error {
+	if _, ok := f.entries[id]; !ok {
+		return artifact.ErrNotFound
+	}
+	delete(f.entries, id)
+	f.deleted = append(f.deleted, id)
+	return nil
+}
+
+func newTool() (*Tool, *fakeIndex) {
+	idx := &fakeIndex{
+		entries: map[string]artifact.Entry{
+			"art-img": {ID: "art-img", Name: "cat.png", Mime: "image/png", Kind: "image", Source: "fetch", Size: 8},
+			"art-txt": {ID: "art-txt", Name: "notes.md", Mime: "text/markdown", Kind: "download", Source: "fetch", Size: 5},
+		},
+		blobs: map[string][]byte{
+			"art-img": {0x89, 'P', 'N', 'G', 0, 1, 2, 3}, // contains NUL → binary
+			"art-txt": []byte("hello"),
+		},
+	}
+	t := New()
+	t.SetIndex(idx)
+	return t, idx
+}
+
+func invoke(t *testing.T, tool *Tool, in string) (string, bool) {
+	t.Helper()
+	r, err := tool.Invoke(context.Background(), json.RawMessage(in))
+	if err != nil {
+		t.Fatalf("Invoke(%s): %v", in, err)
+	}
+	return r.Output, r.IsError
+}
+
+func TestArtifacts_List(t *testing.T) {
+	tool, _ := newTool()
+	out, isErr := invoke(t, tool, `{"op":"list"}`)
+	if isErr {
+		t.Fatalf("list error: %s", out)
+	}
+	var got struct {
+		Count     int              `json:"count"`
+		Artifacts []map[string]any `json:"artifacts"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal list: %v (%s)", err, out)
+	}
+	if got.Count != 2 {
+		t.Fatalf("count = %d, want 2", got.Count)
+	}
+
+	// Filter by kind.
+	out, _ = invoke(t, tool, `{"op":"list","kind":"image"}`)
+	_ = json.Unmarshal([]byte(out), &got)
+	if got.Count != 1 || got.Artifacts[0]["id"] != "art-img" {
+		t.Fatalf("kind filter = %s", out)
+	}
+}
+
+func TestArtifacts_ReadText(t *testing.T) {
+	tool, _ := newTool()
+	out, isErr := invoke(t, tool, `{"op":"read","id":"art-txt"}`)
+	if isErr {
+		t.Fatalf("read error: %s", out)
+	}
+	if !strings.Contains(out, "hello") || !strings.Contains(out, "notes.md") {
+		t.Fatalf("text read missing content: %s", out)
+	}
+}
+
+func TestArtifacts_ReadBinaryReportsMetadata(t *testing.T) {
+	tool, _ := newTool()
+	out, isErr := invoke(t, tool, `{"op":"read","id":"art-img"}`)
+	if isErr {
+		t.Fatalf("read error: %s", out)
+	}
+	if !strings.Contains(out, `"binary": true`) || !strings.Contains(out, "Files view") {
+		t.Fatalf("binary read should report metadata + note: %s", out)
+	}
+	// The raw PNG bytes must NOT be dumped inline.
+	if strings.Contains(out, "PNG\x00") {
+		t.Fatalf("binary bytes leaked into output: %s", out)
+	}
+}
+
+func TestArtifacts_Delete(t *testing.T) {
+	tool, idx := newTool()
+	out, isErr := invoke(t, tool, `{"op":"delete","id":"art-txt"}`)
+	if isErr {
+		t.Fatalf("delete error: %s", out)
+	}
+	if len(idx.deleted) != 1 || idx.deleted[0] != "art-txt" {
+		t.Fatalf("delete not propagated: %v", idx.deleted)
+	}
+	// Deleting a missing id is a soft error.
+	if _, isErr := invoke(t, tool, `{"op":"delete","id":"nope"}`); !isErr {
+		t.Error("deleting unknown id should be a soft error")
+	}
+}
+
+func TestArtifacts_Rejections(t *testing.T) {
+	tool, _ := newTool()
+	if _, isErr := invoke(t, tool, `{"op":"frobnicate"}`); !isErr {
+		t.Error("unknown op should be rejected")
+	}
+	if _, isErr := invoke(t, tool, `{"op":"read"}`); !isErr {
+		t.Error("read without id should be rejected")
+	}
+	// No index configured.
+	noIdx := New()
+	r, _ := noIdx.Invoke(context.Background(), json.RawMessage(`{"op":"list"}`))
+	if !r.IsError || !strings.Contains(r.Output, "unavailable") {
+		t.Errorf("missing index should report unavailable: %s", r.Output)
+	}
+}


### PR DESCRIPTION
## What

Adds the **read side** of the artifact store for the agent. Files that `fetch` (M831), the tool-output offloader (M827), and inbound-image persistence (M822) put **in** were readable only from the operator's **Files view**. Now the agent can work with them:

- **`artifacts {op:list, kind?, source?, corr?, limit?}`** → metadata of saved files `{id, name, mime, kind, source, size, caption?}`, newest-first, capped (default 50).
- **`artifacts {op:read, id}`** → a **text** file's contents inline (capped at 256 KiB, truncation noted). A **binary** file returns its metadata + "download from the Files view" — raw bytes never flood context. Text-vs-binary by mime, or a NUL-sniff for unknown mime.
- **`artifacts {op:delete, id}`** → removes the entry (blob GC'd when unreferenced).

So a file saved in one run is usable in the next — closing the `fetch` → use loop.

## How

- `plugins/tools/artifacts/` — a read/list/delete view over the existing artifact index, decoupled via an `Index` interface; the daemon injects the real `*artifact.Index` post-Open with `SetIndex(...)` (mirrors the fetch/M827 wiring). Fails soft without it.
- `cmd/agezt/main.go` — register in `buildTools` (`artifacts(list/read/delete)`), inject the index.
- `kernel/edict/toolmap.go` — `op=delete` ⇒ `CapFileDelete`, else (list/read) ⇒ `CapFileRead`. Artifacts are files → reuses the file capabilities. **No new grant, no new env var.**

## Verification

- **Unit:** list (+kind filter), text read returns content, binary read reports metadata (no byte dump), delete propagates + missing-id soft error, unknown op / read-without-id / missing-index rejected.
- **Live** (isolated `AGEZT_HOME`, real agent): one prompt drove all three ops — `fetch https://go.dev/robots.txt` → `artifacts list` (the one `text/plain`, source=fetch entry) → `artifacts read <id>` returned the exact contents (`User-agent: *` / `Allow: /`).
- **Gate:** artifacts + fetch + edict tests green; vet + staticcheck + linux cross-build clean; gofmt swept; go.mod unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)