### PR TITLE
Feat: Personal Data Lake — agents get real databases via the `db` tool (M834)

### DIFF
--- a/.project/PHASE-M834-DATA-LAKE-REPORT.md
+++ b/.project/PHASE-M834-DATA-LAKE-REPORT.md
@@ -1,0 +1,79 @@
+# Phase M834 — Personal Data Lake (engine + `db` tool)
+
+**Date:** 2026-06-11 · **Status:** DONE · **Trigger:** owner: "custom veritabanı
+yaratabilme … veri ekleme çıkarma arama … custom databases ajanların kullanımına
+açık olmalı … birden çok agent tarafından kullanılabilir … chat ortamından
+erişebilirim … database viewer … built-in expense/calendar/tasks/notes/habits/
+bookmarks/contacts … personal data lake."
+
+This is **milestone 1** of the Data Lake arc: the storage engine + the agent
+tool. Built-in collections (expense/calendar/…) and the bespoke Web UI app views
+follow in M835+.
+
+## Decision: file-based, no DB dependency
+
+The owner was unsure (sqlite vs postgres). AGEZT is a single static binary with a
+frozen go.mod and a file-based architecture (journal, board, memory, artifacts
+are all on-disk). Pulling in SQLite (CGO) or Postgres (a server) would break that.
+So the Data Lake is a **pure-Go, dependency-free, on-disk structured store** —
+the same shape as the existing stores — surfaced as a DB-like API.
+
+## What shipped
+
+**`kernel/datalake`** — a `Lake` of named **collections** (tables), each a set of
+JSON **records** with an optional **schema**:
+
+- Layout: `<base>/datalake/<collection>/_schema.json` + `…/rec/<id>.json` (one
+  file per record), in-memory index loaded at Open, single mutex. Collections are
+  shared across every agent on the daemon.
+- API: `CreateCollection`/`EnsureCollection`(idempotent seed)/`DropCollection`
+  (system collections protected); `Insert`/`Get`/`Update`(field-merge, nil
+  deletes a key)/`Delete`; `Query{Search, Equals, SortBy, Desc, Limit, Offset}`
+  (case-insensitive search across string fields, exact-match filter, numeric-or-
+  string sort); `ListCollections`/`Schema`/`Count`.
+- **Provenance** (serves the owner's "hangi agent ekledi" ask): every record and
+  collection records `created_by` / `updated_by` (the run correlation, which maps
+  to an agent in the journal) and `created_ms` / `updated_ms`.
+- Schema carries a `view` hint (`table` | `expense` | `calendar` | `tasks` |
+  `notes` | `habits` | `bookmarks` | `contacts`) + `icon`, so M835+ can render
+  bespoke app-like front-ends.
+
+**`plugins/tools/db`** — the `db` tool: ops `list_collections`,
+`create_collection`, `drop_collection`, `insert`, `get`, `update`, `delete`,
+`query`. Decoupled via a `Store` interface; the daemon injects `k.DataLake()`
+after Open. Maps to the **memory** capability (structured durable knowledge) — no
+new grant, no new env var.
+
+## Wiring
+
+- `kernel/runtime`: `datalake.Open` at boot, `k.DataLake()` accessor, struct field.
+- `cmd/agezt`: register `db(data-lake)` in the tools line, inject the store.
+- `kernel/edict/toolmap.go`: `case "db": return CapMemory`.
+
+## Verification
+
+- **Unit** (`kernel/datalake`): create/dup-reject/invalid-name; insert+provenance;
+  query search/equals/sort/limit; update merge + nil-delete + provenance bump;
+  delete; system-collection drop protection; EnsureCollection idempotency;
+  persistence across reopen.
+- **Unit** (`plugins/tools/db`): full create→insert→query→update→get→delete
+  lifecycle over a real temp-dir lake; rejections (bad op, missing
+  collection/id, unknown collection, no store); drop-missing soft error.
+- **Live** (isolated home, real deepseek): one prompt had the agent create an
+  `expenses` collection (`view=expense`), insert two records, and query sorted by
+  amount desc — correct result; on disk, the schema + 2 record files carry
+  `created_by` = the run correlation. `db(data-lake)` shows in the tools banner.
+
+## Gate
+
+datalake + db + edict + runtime + cmd/agezt tests green; vet + staticcheck +
+linux cross-build clean; gofmt swept. go.mod unchanged (stdlib + ulid only).
+
+## Next (Data Lake arc)
+
+- M835: seed the built-in collections (expense/calendar/tasks/notes/habits/
+  bookmarks/contacts) at boot via `EnsureCollection`, with field schemas + view
+  hints.
+- M836+: control-plane list/CRUD routes + a Web UI **Data** view — generic table
+  viewer, then bespoke app views per built-in (expense tracker that looks like a
+  real app, calendar, bookmarks, …).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **Personal Data Lake — agents get real databases (M834).** A new `db` tool lets agents build and
+  use structured **collections** (tables): `create_collection`, `insert`, `query` (search / exact-match
+  / sort / limit), `get`, `update`, `delete`, `drop_collection`, `list_collections`. Collections are
+  shared across all agents and the human (so one agent files data another — or you, from chat — later
+  reads), every record records which agent created/updated it, and a `view` hint (expense / calendar /
+  tasks / notes / …) lets the Web UI render bespoke app views. File-based and dependency-free (no
+  SQLite/Postgres) to keep the single static binary; rides the memory capability — no new grant. (M834)
 - **Runs continue themselves past the iteration cap (M833).** A run that exhausts its tool-round
   budget without finishing no longer just stops with `max_iters` — the loop automatically injects a
   "keep going" turn and grants another batch of rounds, up to `AGEZT_MAX_AUTO_CONTINUE` times (default

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -97,6 +97,7 @@ import (
 	"github.com/agezt/agezt/plugins/tools/codeexec"
 	"github.com/agezt/agezt/plugins/tools/coding"
 	configtool "github.com/agezt/agezt/plugins/tools/config"
+	dbtool "github.com/agezt/agezt/plugins/tools/db"
 	"github.com/agezt/agezt/plugins/tools/fetch"
 	filetool "github.com/agezt/agezt/plugins/tools/file"
 	"github.com/agezt/agezt/plugins/tools/forgetool"
@@ -776,6 +777,10 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// list/read/delete the files it has saved.
 	if af, ok := tools["artifacts"].(*artifactstool.Tool); ok {
 		af.SetIndex(k.ArtifactIndex())
+	}
+	// Inject the data lake into the db tool (M834).
+	if dbt, ok := tools["db"].(*dbtool.Tool); ok {
+		dbt.SetStore(k.DataLake())
 	}
 
 	// Wire the bus into the Governor and the Warden so their events
@@ -4541,6 +4546,13 @@ func buildTools(baseDir string, stderr io.Writer, ward warden.Engine) (map[strin
 	af := artifactstool.New()
 	out["artifacts"] = af
 	registered = append(registered, "artifacts(list/read/delete)")
+
+	// db — the Personal Data Lake (M834): agent-built, multi-agent-shared structured
+	// collections (expenses, tasks, notes, contacts, …) the human can also browse in
+	// the Data view. The lake is injected after the kernel opens. Always registered.
+	dbt := dbtool.New()
+	out["db"] = dbt
+	registered = append(registered, "db(data-lake)")
 
 	// coding — external coding-agent bridge (P6-CODE). Registered only when
 	// AGEZT_CODING_CMD is set (the command that runs Claude Code / Codex / Aider

--- a/kernel/datalake/datalake.go
+++ b/kernel/datalake/datalake.go
@@ -1,0 +1,512 @@
+// SPDX-License-Identifier: MIT
+
+// Package datalake is AGEZT's file-based structured store — the "Personal Data
+// Lake" (M834). It gives agents (and the operator, via the Web UI) real
+// databases without a database: a Lake holds named COLLECTIONS (tables), each a
+// set of JSON RECORDS with an optional SCHEMA describing its fields and how the
+// UI should render it (a generic table, or a bespoke app view like an expense
+// tracker or calendar).
+//
+// It is deliberately dependency-free and on-disk, matching AGEZT's single-static-
+// binary / no-DB architecture: every collection is a directory, every record a
+// JSON file, with an in-memory index loaded at Open and guarded by one mutex.
+// Collections are shared across all agents on the daemon, so one agent can file
+// data another (or the human in chat) later reads.
+//
+// Layout:
+//
+//	<base>/datalake/<collection>/_schema.json   — the collection's schema
+//	<base>/datalake/<collection>/rec/<id>.json  — one record per file
+package datalake
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/agezt/agezt/kernel/ulid"
+)
+
+// ErrNotFound is returned when a collection or record id does not exist.
+var ErrNotFound = errors.New("datalake: not found")
+
+// ErrExists is returned by CreateCollection when the name is already taken.
+var ErrExists = errors.New("datalake: collection already exists")
+
+// ErrSystem is returned when an operation is refused on a system collection
+// (a built-in that must not be dropped).
+var ErrSystem = errors.New("datalake: system collection cannot be dropped")
+
+// Field describes one column of a collection — its key, a coarse type the UI
+// uses to render and the agent uses as a hint, and a human label.
+type Field struct {
+	Name  string `json:"name"`
+	Type  string `json:"type,omitempty"` // text | number | money | date | bool | url | tags | note
+	Label string `json:"label,omitempty"`
+}
+
+// Schema is a collection's definition. Fields are advisory — records may carry
+// extra keys (the store is schemaless at heart) — but they drive validation
+// hints and the Web UI rendering. View names a bespoke front-end (e.g.
+// "expense", "calendar", "tasks") or "" / "table" for the generic grid.
+type Schema struct {
+	Name      string  `json:"name"`
+	Title     string  `json:"title,omitempty"`
+	Icon      string  `json:"icon,omitempty"` // lucide icon name for the Web UI
+	View      string  `json:"view,omitempty"` // table (default) | expense | calendar | tasks | notes | habits | bookmarks | contacts
+	Desc      string  `json:"desc,omitempty"`
+	Fields    []Field `json:"fields,omitempty"`
+	Builtin   bool    `json:"builtin,omitempty"` // seeded by the daemon, not user-created
+	System    bool    `json:"system,omitempty"`  // must not be dropped
+	CreatedMs int64   `json:"created_ms"`
+	CreatedBy string  `json:"created_by,omitempty"`
+}
+
+// Record is one row: a stable id, the free-form field map, and provenance — who
+// (which run/agent) created and last updated it, and when. The provenance fields
+// answer the operator's "which agent put this here?".
+type Record struct {
+	ID        string         `json:"id"`
+	Fields    map[string]any `json:"fields"`
+	CreatedMs int64          `json:"created_ms"`
+	UpdatedMs int64          `json:"updated_ms"`
+	CreatedBy string         `json:"created_by,omitempty"`
+	UpdatedBy string         `json:"updated_by,omitempty"`
+}
+
+// Query narrows List. All constraints are ANDed; empty fields impose nothing.
+type Query struct {
+	Search string         // case-insensitive substring across all string field values
+	Equals map[string]any // exact field matches (compared by JSON-normalised value)
+	SortBy string         // field name to sort by; "" → created time
+	Desc   bool           // descending sort (default ascending; created-time default is newest-first)
+	Limit  int            // 0 → no limit
+	Offset int
+}
+
+// CollectionInfo is the listed summary of a collection (no records).
+type CollectionInfo struct {
+	Schema
+	Count int `json:"count"`
+}
+
+type collection struct {
+	schema  Schema
+	records map[string]Record
+}
+
+// Lake is the on-disk structured store. Safe for concurrent use.
+type Lake struct {
+	dir   string
+	mu    sync.Mutex
+	colls map[string]*collection
+	now   func() int64
+}
+
+// Open loads (creating if needed) the data lake rooted at <baseDir>/datalake.
+func Open(baseDir string, now func() int64) (*Lake, error) {
+	dir := filepath.Join(baseDir, "datalake")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("datalake: open %s: %w", dir, err)
+	}
+	l := &Lake{dir: dir, colls: map[string]*collection{}, now: now}
+	des, _ := os.ReadDir(dir)
+	for _, de := range des {
+		if !de.IsDir() {
+			continue
+		}
+		c, err := l.loadCollection(de.Name())
+		if err != nil {
+			continue // skip an unreadable collection rather than fail the whole lake
+		}
+		l.colls[c.schema.Name] = c
+	}
+	return l, nil
+}
+
+func (l *Lake) loadCollection(name string) (*collection, error) {
+	cdir := filepath.Join(l.dir, name)
+	b, err := os.ReadFile(filepath.Join(cdir, "_schema.json"))
+	if err != nil {
+		return nil, err
+	}
+	var sc Schema
+	if err := json.Unmarshal(b, &sc); err != nil || sc.Name == "" {
+		return nil, fmt.Errorf("datalake: bad schema for %s", name)
+	}
+	c := &collection{schema: sc, records: map[string]Record{}}
+	rdes, _ := os.ReadDir(filepath.Join(cdir, "rec"))
+	for _, rde := range rdes {
+		if rde.IsDir() || !strings.HasSuffix(rde.Name(), ".json") {
+			continue
+		}
+		rb, err := os.ReadFile(filepath.Join(cdir, "rec", rde.Name()))
+		if err != nil {
+			continue
+		}
+		var r Record
+		if json.Unmarshal(rb, &r) == nil && r.ID != "" {
+			c.records[r.ID] = r
+		}
+	}
+	return c, nil
+}
+
+// validName allows safe single path segments only.
+func validName(name string) bool {
+	name = strings.TrimSpace(name)
+	if name == "" || len(name) > 64 || name == "_schema" {
+		return false
+	}
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// CreateCollection records a new collection. It errors if the name is taken
+// (ErrExists) or invalid. CreatedMs/CreatedBy are stamped here.
+func (l *Lake) CreateCollection(sc Schema, actor string) (Schema, error) {
+	sc.Name = strings.TrimSpace(sc.Name)
+	if !validName(sc.Name) {
+		return Schema{}, fmt.Errorf("datalake: invalid collection name %q (use letters, digits, - or _)", sc.Name)
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if _, ok := l.colls[sc.Name]; ok {
+		return Schema{}, ErrExists
+	}
+	sc.CreatedMs = l.now()
+	if sc.CreatedBy == "" {
+		sc.CreatedBy = actor
+	}
+	if err := l.writeSchema(sc); err != nil {
+		return Schema{}, err
+	}
+	l.colls[sc.Name] = &collection{schema: sc, records: map[string]Record{}}
+	return sc, nil
+}
+
+// EnsureCollection creates the collection only if it does not exist yet, leaving
+// an existing one (and its data) untouched. Used to seed the built-ins at boot.
+func (l *Lake) EnsureCollection(sc Schema, actor string) (Schema, bool, error) {
+	l.mu.Lock()
+	if c, ok := l.colls[sc.Name]; ok {
+		out := c.schema
+		l.mu.Unlock()
+		return out, false, nil
+	}
+	l.mu.Unlock()
+	out, err := l.CreateCollection(sc, actor)
+	if errors.Is(err, ErrExists) {
+		// Raced with another caller; fetch the winner.
+		if s, ok := l.Schema(sc.Name); ok {
+			return s, false, nil
+		}
+	}
+	return out, err == nil, err
+}
+
+func (l *Lake) writeSchema(sc Schema) error {
+	cdir := filepath.Join(l.dir, sc.Name)
+	if err := os.MkdirAll(filepath.Join(cdir, "rec"), 0o700); err != nil {
+		return fmt.Errorf("datalake: mkdir %s: %w", cdir, err)
+	}
+	return writeJSON(filepath.Join(cdir, "_schema.json"), sc)
+}
+
+// DropCollection deletes a collection and all its records. System collections
+// are protected (ErrSystem).
+func (l *Lake) DropCollection(name string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	c, ok := l.colls[name]
+	if !ok {
+		return ErrNotFound
+	}
+	if c.schema.System {
+		return ErrSystem
+	}
+	delete(l.colls, name)
+	return os.RemoveAll(filepath.Join(l.dir, name))
+}
+
+// ListCollections returns every collection's schema + record count, sorted by
+// title/name.
+func (l *Lake) ListCollections() []CollectionInfo {
+	l.mu.Lock()
+	out := make([]CollectionInfo, 0, len(l.colls))
+	for _, c := range l.colls {
+		out = append(out, CollectionInfo{Schema: c.schema, Count: len(c.records)})
+	}
+	l.mu.Unlock()
+	sort.Slice(out, func(a, b int) bool {
+		ta, tb := titleOf(out[a].Schema), titleOf(out[b].Schema)
+		if ta != tb {
+			return ta < tb
+		}
+		return out[a].Name < out[b].Name
+	})
+	return out
+}
+
+func titleOf(s Schema) string {
+	if s.Title != "" {
+		return strings.ToLower(s.Title)
+	}
+	return strings.ToLower(s.Name)
+}
+
+// Schema returns a collection's schema.
+func (l *Lake) Schema(name string) (Schema, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	c, ok := l.colls[name]
+	if !ok {
+		return Schema{}, false
+	}
+	return c.schema, true
+}
+
+// Insert adds a record. Fields are stored verbatim; id/timestamps/provenance are
+// stamped here.
+func (l *Lake) Insert(coll string, fields map[string]any, actor string) (Record, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	c, ok := l.colls[coll]
+	if !ok {
+		return Record{}, ErrNotFound
+	}
+	if fields == nil {
+		fields = map[string]any{}
+	}
+	now := l.now()
+	r := Record{
+		ID:        "rec-" + ulid.New(),
+		Fields:    fields,
+		CreatedMs: now,
+		UpdatedMs: now,
+		CreatedBy: actor,
+		UpdatedBy: actor,
+	}
+	if err := l.writeRecord(coll, r); err != nil {
+		return Record{}, err
+	}
+	c.records[r.ID] = r
+	return r, nil
+}
+
+// Get returns one record.
+func (l *Lake) Get(coll, id string) (Record, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	c, ok := l.colls[coll]
+	if !ok {
+		return Record{}, ErrNotFound
+	}
+	r, ok := c.records[id]
+	if !ok {
+		return Record{}, ErrNotFound
+	}
+	return r, nil
+}
+
+// Update merges patch into an existing record's fields (a nil value deletes a
+// key) and bumps UpdatedMs/UpdatedBy.
+func (l *Lake) Update(coll, id string, patch map[string]any, actor string) (Record, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	c, ok := l.colls[coll]
+	if !ok {
+		return Record{}, ErrNotFound
+	}
+	r, ok := c.records[id]
+	if !ok {
+		return Record{}, ErrNotFound
+	}
+	merged := make(map[string]any, len(r.Fields)+len(patch))
+	maps.Copy(merged, r.Fields)
+	for k, v := range patch {
+		if v == nil {
+			delete(merged, k)
+			continue
+		}
+		merged[k] = v
+	}
+	r.Fields = merged
+	r.UpdatedMs = l.now()
+	r.UpdatedBy = actor
+	if err := l.writeRecord(coll, r); err != nil {
+		return Record{}, err
+	}
+	c.records[id] = r
+	return r, nil
+}
+
+// Delete removes one record.
+func (l *Lake) Delete(coll, id string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	c, ok := l.colls[coll]
+	if !ok {
+		return ErrNotFound
+	}
+	if _, ok := c.records[id]; !ok {
+		return ErrNotFound
+	}
+	delete(c.records, id)
+	return os.Remove(filepath.Join(l.dir, coll, "rec", id+".json"))
+}
+
+// Query returns the matching records (a copy), filtered/sorted/paged.
+func (l *Lake) Query(coll string, q Query) ([]Record, error) {
+	l.mu.Lock()
+	c, ok := l.colls[coll]
+	if !ok {
+		l.mu.Unlock()
+		return nil, ErrNotFound
+	}
+	all := make([]Record, 0, len(c.records))
+	for _, r := range c.records {
+		all = append(all, r)
+	}
+	l.mu.Unlock()
+
+	search := strings.ToLower(strings.TrimSpace(q.Search))
+	out := make([]Record, 0, len(all))
+	for _, r := range all {
+		if !matchEquals(r, q.Equals) {
+			continue
+		}
+		if search != "" && !matchSearch(r, search) {
+			continue
+		}
+		out = append(out, r)
+	}
+
+	sort.Slice(out, func(a, b int) bool {
+		less := lessRecords(out[a], out[b], q.SortBy)
+		if q.Desc {
+			return !less
+		}
+		return less
+	})
+
+	if q.Offset > 0 {
+		if q.Offset >= len(out) {
+			return []Record{}, nil
+		}
+		out = out[q.Offset:]
+	}
+	if q.Limit > 0 && len(out) > q.Limit {
+		out = out[:q.Limit]
+	}
+	return out, nil
+}
+
+// Count returns how many records a collection holds.
+func (l *Lake) Count(coll string) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	c, ok := l.colls[coll]
+	if !ok {
+		return 0, ErrNotFound
+	}
+	return len(c.records), nil
+}
+
+func matchEquals(r Record, eq map[string]any) bool {
+	for k, want := range eq {
+		got, ok := r.Fields[k]
+		if !ok || !jsonEqual(got, want) {
+			return false
+		}
+	}
+	return true
+}
+
+func matchSearch(r Record, lowerNeedle string) bool {
+	for _, v := range r.Fields {
+		if s, ok := v.(string); ok && strings.Contains(strings.ToLower(s), lowerNeedle) {
+			return true
+		}
+	}
+	return false
+}
+
+// lessRecords orders by the named field when set (numbers numerically, else
+// string-wise), falling back to created time (newest first by default — callers
+// flip with Desc).
+func lessRecords(a, b Record, sortBy string) bool {
+	if sortBy == "" {
+		// Default: newest first under ascending order is unintuitive, so the
+		// created-time default sorts NEWEST first (most-recent on top) — the
+		// common "show me my latest entries" case. Desc flips it.
+		return a.CreatedMs > b.CreatedMs
+	}
+	av, aok := a.Fields[sortBy]
+	bv, bok := b.Fields[sortBy]
+	if !aok || !bok {
+		// Missing keys sort last (after present ones).
+		if aok != bok {
+			return aok
+		}
+		return a.CreatedMs > b.CreatedMs
+	}
+	an, aNum := toFloat(av)
+	bn, bNum := toFloat(bv)
+	if aNum && bNum {
+		return an < bn
+	}
+	return fmt.Sprintf("%v", av) < fmt.Sprintf("%v", bv)
+}
+
+func toFloat(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	default:
+		return 0, false
+	}
+}
+
+func jsonEqual(a, b any) bool {
+	ab, _ := json.Marshal(a)
+	bb, _ := json.Marshal(b)
+	return string(ab) == string(bb)
+}
+
+func (l *Lake) writeRecord(coll string, r Record) error {
+	return writeJSON(filepath.Join(l.dir, coll, "rec", r.ID+".json"), r)
+}
+
+// writeJSON writes v as indented JSON atomically (temp + rename).
+func writeJSON(path string, v any) error {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o600); err != nil {
+		return fmt.Errorf("datalake: write %s: %w", path, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("datalake: write %s: %w", path, err)
+	}
+	return nil
+}

--- a/kernel/datalake/datalake_test.go
+++ b/kernel/datalake/datalake_test.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: MIT
+
+package datalake
+
+import (
+	"testing"
+)
+
+func newLake(t *testing.T) *Lake {
+	t.Helper()
+	var clock int64 = 1000
+	l, err := Open(t.TempDir(), func() int64 { clock++; return clock })
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	return l
+}
+
+func TestCreateInsertGetQuery(t *testing.T) {
+	l := newLake(t)
+	if _, err := l.CreateCollection(Schema{Name: "expenses", Title: "Expenses", View: "expense"}, "agent-1"); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	// Duplicate name is rejected.
+	if _, err := l.CreateCollection(Schema{Name: "expenses"}, "agent-1"); err != ErrExists {
+		t.Fatalf("duplicate create err = %v, want ErrExists", err)
+	}
+	// Invalid name rejected.
+	if _, err := l.CreateCollection(Schema{Name: "bad/name"}, "a"); err == nil {
+		t.Error("invalid collection name should be rejected")
+	}
+
+	a, err := l.Insert("expenses", map[string]any{"item": "coffee", "amount": float64(5)}, "agent-1")
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	if a.CreatedBy != "agent-1" || a.ID == "" {
+		t.Fatalf("insert provenance/id wrong: %+v", a)
+	}
+	_, _ = l.Insert("expenses", map[string]any{"item": "lunch sandwich", "amount": float64(12)}, "agent-2")
+	_, _ = l.Insert("expenses", map[string]any{"item": "bus ticket", "amount": float64(3)}, "agent-1")
+
+	// Query all.
+	all, _ := l.Query("expenses", Query{})
+	if len(all) != 3 {
+		t.Fatalf("query all = %d, want 3", len(all))
+	}
+	// Search.
+	hit, _ := l.Query("expenses", Query{Search: "SANDWICH"})
+	if len(hit) != 1 || hit[0].Fields["item"] != "lunch sandwich" {
+		t.Fatalf("search = %+v", hit)
+	}
+	// Equals.
+	eq, _ := l.Query("expenses", Query{Equals: map[string]any{"amount": float64(3)}})
+	if len(eq) != 1 || eq[0].Fields["item"] != "bus ticket" {
+		t.Fatalf("equals = %+v", eq)
+	}
+	// Sort by amount ascending.
+	asc, _ := l.Query("expenses", Query{SortBy: "amount"})
+	if asc[0].Fields["amount"] != float64(3) || asc[2].Fields["amount"] != float64(12) {
+		t.Fatalf("sort asc wrong: %v %v", asc[0].Fields["amount"], asc[2].Fields["amount"])
+	}
+	// Limit.
+	lim, _ := l.Query("expenses", Query{Limit: 2})
+	if len(lim) != 2 {
+		t.Fatalf("limit = %d, want 2", len(lim))
+	}
+
+	// Get.
+	got, err := l.Get("expenses", a.ID)
+	if err != nil || got.Fields["item"] != "coffee" {
+		t.Fatalf("Get: %v %+v", err, got)
+	}
+}
+
+func TestUpdateMergeAndDelete(t *testing.T) {
+	l := newLake(t)
+	_, _ = l.CreateCollection(Schema{Name: "tasks"}, "a")
+	r, _ := l.Insert("tasks", map[string]any{"title": "ship M834", "done": false}, "a")
+
+	// Update merges and can delete a key (nil value).
+	up, err := l.Update("tasks", r.ID, map[string]any{"done": true, "title": nil, "note": "merged"}, "agent-x")
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if up.Fields["done"] != true || up.Fields["note"] != "merged" {
+		t.Fatalf("merge wrong: %+v", up.Fields)
+	}
+	if _, ok := up.Fields["title"]; ok {
+		t.Errorf("nil value should delete the key, still present: %+v", up.Fields)
+	}
+	if up.UpdatedBy != "agent-x" || up.CreatedBy != "a" {
+		t.Errorf("provenance after update: created_by=%s updated_by=%s", up.CreatedBy, up.UpdatedBy)
+	}
+
+	if err := l.Delete("tasks", r.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := l.Get("tasks", r.ID); err != ErrNotFound {
+		t.Errorf("get after delete = %v, want ErrNotFound", err)
+	}
+}
+
+func TestSystemCollectionProtected(t *testing.T) {
+	l := newLake(t)
+	_, _ = l.CreateCollection(Schema{Name: "contacts", System: true, Builtin: true}, "daemon")
+	if err := l.DropCollection("contacts"); err != ErrSystem {
+		t.Fatalf("drop system = %v, want ErrSystem", err)
+	}
+	_, _ = l.CreateCollection(Schema{Name: "scratch"}, "a")
+	if err := l.DropCollection("scratch"); err != nil {
+		t.Fatalf("drop normal: %v", err)
+	}
+}
+
+func TestEnsureIdempotentAndPersistence(t *testing.T) {
+	dir := t.TempDir()
+	var clock int64 = 1
+	now := func() int64 { clock++; return clock }
+	l, _ := Open(dir, now)
+
+	sc, created, err := l.EnsureCollection(Schema{Name: "notes", Title: "Notes"}, "daemon")
+	if err != nil || !created || sc.Name != "notes" {
+		t.Fatalf("ensure first: created=%v err=%v", created, err)
+	}
+	// Second ensure is a no-op (and must not wipe data).
+	_, _ = l.Insert("notes", map[string]any{"text": "remember"}, "a")
+	_, created2, _ := l.EnsureCollection(Schema{Name: "notes", Title: "Renamed?"}, "daemon")
+	if created2 {
+		t.Error("second ensure should not re-create")
+	}
+
+	// Reopen from disk: schema + records survive.
+	l2, err := Open(dir, now)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	cols := l2.ListCollections()
+	if len(cols) != 1 || cols[0].Name != "notes" || cols[0].Count != 1 {
+		t.Fatalf("after reopen: %+v", cols)
+	}
+	recs, _ := l2.Query("notes", Query{})
+	if len(recs) != 1 || recs[0].Fields["text"] != "remember" {
+		t.Fatalf("records lost on reopen: %+v", recs)
+	}
+}
+
+func TestQueryNotFound(t *testing.T) {
+	l := newLake(t)
+	if _, err := l.Query("nope", Query{}); err != ErrNotFound {
+		t.Errorf("query missing collection = %v, want ErrNotFound", err)
+	}
+	if _, err := l.Insert("nope", nil, "a"); err != ErrNotFound {
+		t.Errorf("insert missing collection = %v, want ErrNotFound", err)
+	}
+}

--- a/kernel/edict/toolmap.go
+++ b/kernel/edict/toolmap.go
@@ -123,6 +123,11 @@ func CapabilityForToolCall(toolName string, input json.RawMessage) Capability {
 		return CapCodeExec
 	case "memory":
 		return CapMemory
+	case "db":
+		// The Personal Data Lake (M834) is structured durable knowledge the agent
+		// keeps for itself — same axis as memory, so it inherits that allow-by-
+		// default grant rather than introducing a new capability.
+		return CapMemory
 	case "world":
 		return CapWorld
 	case "delegate":

--- a/kernel/edict/toolmap_test.go
+++ b/kernel/edict/toolmap_test.go
@@ -33,6 +33,9 @@ func TestCapabilityForToolCall(t *testing.T) {
 		{"artifacts", `{"op":"read","id":"art-x"}`, CapFileRead},
 		{"artifacts", `{"op":"  DELETE  ","id":"art-x"}`, CapFileDelete},
 		{"artifacts", `{}`, CapFileRead}, // garbled call lands on read (low-risk default)
+		// The Personal Data Lake tool (M834) rides the memory capability.
+		{"db", `{"op":"query","collection":"expenses"}`, CapMemory},
+		{"db", `{"op":"insert","collection":"notes","record":{}}`, CapMemory},
 		{"remote_run", `{"task":"x"}`, CapRemoteRun},
 		{"notify", `{"text":"hi"}`, CapNotify},
 		{"homeassistant", `{"operation":"get_states","entity_id":"light.x"}`, CapHomeAssistantRead},

--- a/kernel/runtime/runtime.go
+++ b/kernel/runtime/runtime.go
@@ -29,6 +29,7 @@ import (
 	"github.com/agezt/agezt/kernel/bus"
 	"github.com/agezt/agezt/kernel/cadence"
 	"github.com/agezt/agezt/kernel/catalog"
+	"github.com/agezt/agezt/kernel/datalake"
 	"github.com/agezt/agezt/kernel/edict"
 	"github.com/agezt/agezt/kernel/event"
 	"github.com/agezt/agezt/kernel/governor"
@@ -366,6 +367,7 @@ type Kernel struct {
 	workflows *workflow.Store
 	artifacts *artifact.Store
 	artIndex  *artifact.Index // metadata sidecar over artifacts (M822): browsable/deletable entries
+	lake      *datalake.Lake  // Personal Data Lake (M834): agent-built structured collections
 	reflect   *reflect.Engine
 	schedules *cadence.Store        // persistent scheduled-intents store (autonomy)
 	tools     map[string]agent.Tool // cfg.Tools + the memory/world tools (when enabled)
@@ -490,6 +492,19 @@ func Open(cfg Config) (*Kernel, error) {
 		return nil, fmt.Errorf("runtime: artifact index: %w", err)
 	}
 
+	// Personal Data Lake (M834): file-based structured collections agents build
+	// and share. Pure on-disk (no handle to close), so its error path just unwinds
+	// the prior stores like the others.
+	lake, err := datalake.Open(cfg.BaseDir, func() int64 { return time.Now().UnixMilli() })
+	if err != nil {
+		j.Close()
+		st.Close()
+		mstore.Close()
+		wstore.Close()
+		skstore.Close()
+		return nil, fmt.Errorf("runtime: data lake: %w", err)
+	}
+
 	ststore, err := standing.Open(filepath.Join(cfg.BaseDir, "standing"))
 	if err != nil {
 		j.Close()
@@ -606,6 +621,7 @@ func Open(cfg Config) (*Kernel, error) {
 		workflows:    wfstore,
 		artifacts:    artStore,
 		artIndex:     artIndex,
+		lake:         lake,
 		reflect:      reflectEng,
 		schedules:    schedStore,
 		tools:        effTools,
@@ -721,6 +737,10 @@ func (k *Kernel) Artifacts() *artifact.Store { return k.artifacts }
 // browsable/deletable per-arrival entries (inbound images, tool outputs) the
 // file manager and inbound-image persistence use.
 func (k *Kernel) ArtifactIndex() *artifact.Index { return k.artIndex }
+
+// DataLake returns the Personal Data Lake (M834) — the file-based structured
+// collections agents build and share, surfaced by the `db` tool and the Web UI.
+func (k *Kernel) DataLake() *datalake.Lake { return k.lake }
 
 // Standing returns the Chronos standing-order store (SPEC-16 §4), backing
 // `agt standing`. Always non-nil after Open.

--- a/plugins/tools/db/db.go
+++ b/plugins/tools/db/db.go
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: MIT
+
+// Package db is the in-process `db` tool: it gives the agent a real database to
+// work with — the Personal Data Lake (M834). One agent can create a collection
+// (table), insert/query/update/delete records, and another agent (or the human
+// in chat) reads the same data later. It is the agent-facing front of
+// kernel/datalake; the Web UI renders the same collections.
+//
+// Capability-wise a db op reads or writes structured local state, mapped onto
+// the memory capability (the existing "agent's own durable knowledge" axis) so
+// it inherits the same allow-by-default posture without a new grant.
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/datalake"
+)
+
+// Store is the slice of *datalake.Lake the tool needs — an interface so the tool
+// is decoupled and unit-testable with a fake.
+type Store interface {
+	ListCollections() []datalake.CollectionInfo
+	CreateCollection(sc datalake.Schema, actor string) (datalake.Schema, error)
+	DropCollection(name string) error
+	Schema(name string) (datalake.Schema, bool)
+	Insert(coll string, fields map[string]any, actor string) (datalake.Record, error)
+	Get(coll, id string) (datalake.Record, error)
+	Update(coll, id string, patch map[string]any, actor string) (datalake.Record, error)
+	Delete(coll, id string) error
+	Query(coll string, q datalake.Query) ([]datalake.Record, error)
+}
+
+// Tool is the `db` implementation of agent.Tool.
+type Tool struct {
+	lake Store
+}
+
+// New returns an empty Tool; call SetStore before use.
+func New() *Tool { return &Tool{} }
+
+// SetStore injects the data lake (done by the daemon after the kernel opens).
+func (t *Tool) SetStore(s Store) { t.lake = s }
+
+// Definition implements agent.Tool.
+func (t *Tool) Definition() agent.ToolDef {
+	return agent.ToolDef{
+		Name: "db",
+		Description: "Your Personal Data Lake — real databases you can build and use. Collections are " +
+			"shared with other agents and the human (they can read your data from chat / the Files-style " +
+			"Data view). Ops: list_collections; create_collection {name, title?, icon?, view?, fields?}; " +
+			"drop_collection {name}; insert {collection, record}; get {collection, id}; " +
+			"update {collection, id, record}; delete {collection, id}; " +
+			"query {collection, search?, equals?, sort?, desc?, limit?}. Use it to remember structured " +
+			"things (expenses, tasks, contacts, notes, bookmarks, …) deterministically instead of free text.",
+		InputSchema: json.RawMessage(`{
+  "type": "object",
+  "required": ["op"],
+  "properties": {
+    "op":         {"type":"string", "enum":["list_collections","create_collection","drop_collection","insert","get","update","delete","query"]},
+    "collection": {"type":"string", "description":"Target collection name."},
+    "name":       {"type":"string", "description":"create_collection/drop_collection: collection name."},
+    "title":      {"type":"string", "description":"create_collection: human title."},
+    "icon":       {"type":"string", "description":"create_collection: lucide icon name for the UI."},
+    "view":       {"type":"string", "description":"create_collection: UI view (table|expense|calendar|tasks|notes|habits|bookmarks|contacts)."},
+    "fields":     {"type":"array", "items":{"type":"object"}, "description":"create_collection: field defs {name,type,label}."},
+    "id":         {"type":"string", "description":"get/update/delete: record id."},
+    "record":     {"type":"object", "description":"insert/update: the field map."},
+    "search":     {"type":"string", "description":"query: case-insensitive text match across fields."},
+    "equals":     {"type":"object", "description":"query: exact field matches."},
+    "sort":       {"type":"string", "description":"query: field to sort by."},
+    "desc":       {"type":"boolean", "description":"query: sort descending."},
+    "limit":      {"type":"integer", "description":"query: max records (default 50)."}
+  }
+}`),
+	}
+}
+
+type input struct {
+	Op         string           `json:"op"`
+	Collection string           `json:"collection,omitempty"`
+	Name       string           `json:"name,omitempty"`
+	Title      string           `json:"title,omitempty"`
+	Icon       string           `json:"icon,omitempty"`
+	View       string           `json:"view,omitempty"`
+	Fields     []datalake.Field `json:"fields,omitempty"`
+	ID         string           `json:"id,omitempty"`
+	Record     map[string]any   `json:"record,omitempty"`
+	Search     string           `json:"search,omitempty"`
+	Equals     map[string]any   `json:"equals,omitempty"`
+	Sort       string           `json:"sort,omitempty"`
+	Desc       bool             `json:"desc,omitempty"`
+	Limit      int              `json:"limit,omitempty"`
+}
+
+const defaultQueryLimit = 50
+
+// Invoke implements agent.Tool.
+func (t *Tool) Invoke(ctx context.Context, raw json.RawMessage) (agent.Result, error) {
+	var in input
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return agent.Result{}, fmt.Errorf("db: parse input: %w", err)
+	}
+	if t.lake == nil {
+		return errResult("data lake unavailable"), nil
+	}
+	// Provenance: attribute the mutation to the run that caused it (which maps to
+	// an agent via the journal). Falls back to a generic tag in a direct unit test.
+	actor := agent.CorrelationFromContext(ctx)
+	if actor == "" {
+		actor = "agent"
+	}
+
+	switch strings.ToLower(strings.TrimSpace(in.Op)) {
+	case "list_collections":
+		return jsonResult(map[string]any{"collections": t.lake.ListCollections()})
+	case "create_collection":
+		return t.create(in, actor)
+	case "drop_collection":
+		return t.drop(in)
+	case "insert":
+		return t.insert(in, actor)
+	case "get":
+		return t.get(in)
+	case "update":
+		return t.update(in, actor)
+	case "delete":
+		return t.del(in)
+	case "query":
+		return t.query(in)
+	default:
+		return errResult("op must be one of list_collections, create_collection, drop_collection, insert, get, update, delete, query"), nil
+	}
+}
+
+func (t *Tool) create(in input, actor string) (agent.Result, error) {
+	name := firstNonEmpty(in.Name, in.Collection)
+	sc, err := t.lake.CreateCollection(datalake.Schema{
+		Name: name, Title: in.Title, Icon: in.Icon, View: in.View, Fields: in.Fields,
+	}, actor)
+	if err != nil {
+		if errors.Is(err, datalake.ErrExists) {
+			return errResult(fmt.Sprintf("collection %q already exists", name)), nil
+		}
+		return errResult(err.Error()), nil
+	}
+	return jsonResult(map[string]any{"created": true, "collection": sc})
+}
+
+func (t *Tool) drop(in input) (agent.Result, error) {
+	name := firstNonEmpty(in.Name, in.Collection)
+	if err := t.lake.DropCollection(name); err != nil {
+		return errResult(dropErr(name, err)), nil
+	}
+	return jsonResult(map[string]any{"dropped": name})
+}
+
+func dropErr(name string, err error) string {
+	switch {
+	case errors.Is(err, datalake.ErrNotFound):
+		return fmt.Sprintf("no such collection %q", name)
+	case errors.Is(err, datalake.ErrSystem):
+		return fmt.Sprintf("%q is a built-in collection and cannot be dropped", name)
+	default:
+		return err.Error()
+	}
+}
+
+func (t *Tool) insert(in input, actor string) (agent.Result, error) {
+	if in.Collection == "" {
+		return errResult("collection required for insert"), nil
+	}
+	r, err := t.lake.Insert(in.Collection, in.Record, actor)
+	if err != nil {
+		return errResult(notFoundOr(in.Collection, err)), nil
+	}
+	return jsonResult(map[string]any{"inserted": true, "record": r})
+}
+
+func (t *Tool) get(in input) (agent.Result, error) {
+	if in.Collection == "" || in.ID == "" {
+		return errResult("collection and id required for get"), nil
+	}
+	r, err := t.lake.Get(in.Collection, in.ID)
+	if err != nil {
+		return errResult(notFoundOr(in.Collection+"/"+in.ID, err)), nil
+	}
+	return jsonResult(map[string]any{"record": r})
+}
+
+func (t *Tool) update(in input, actor string) (agent.Result, error) {
+	if in.Collection == "" || in.ID == "" {
+		return errResult("collection and id required for update"), nil
+	}
+	r, err := t.lake.Update(in.Collection, in.ID, in.Record, actor)
+	if err != nil {
+		return errResult(notFoundOr(in.Collection+"/"+in.ID, err)), nil
+	}
+	return jsonResult(map[string]any{"updated": true, "record": r})
+}
+
+func (t *Tool) del(in input) (agent.Result, error) {
+	if in.Collection == "" || in.ID == "" {
+		return errResult("collection and id required for delete"), nil
+	}
+	if err := t.lake.Delete(in.Collection, in.ID); err != nil {
+		return errResult(notFoundOr(in.Collection+"/"+in.ID, err)), nil
+	}
+	return jsonResult(map[string]any{"deleted": in.ID})
+}
+
+func (t *Tool) query(in input) (agent.Result, error) {
+	if in.Collection == "" {
+		return errResult("collection required for query"), nil
+	}
+	limit := in.Limit
+	if limit <= 0 {
+		limit = defaultQueryLimit
+	}
+	recs, err := t.lake.Query(in.Collection, datalake.Query{
+		Search: in.Search, Equals: in.Equals, SortBy: in.Sort, Desc: in.Desc, Limit: limit,
+	})
+	if err != nil {
+		return errResult(notFoundOr(in.Collection, err)), nil
+	}
+	return jsonResult(map[string]any{"count": len(recs), "records": recs})
+}
+
+func notFoundOr(what string, err error) string {
+	if errors.Is(err, datalake.ErrNotFound) {
+		return fmt.Sprintf("no such collection or record: %s", what)
+	}
+	return err.Error()
+}
+
+func firstNonEmpty(a, b string) string {
+	if strings.TrimSpace(a) != "" {
+		return a
+	}
+	return b
+}
+
+func jsonResult(v any) (agent.Result, error) {
+	out, _ := json.MarshalIndent(v, "", "  ")
+	return agent.Result{Output: string(out)}, nil
+}
+
+func errResult(msg string) agent.Result {
+	return agent.Result{Output: "db: " + msg, IsError: true}
+}

--- a/plugins/tools/db/db_test.go
+++ b/plugins/tools/db/db_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT
+
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/agezt/agezt/kernel/datalake"
+)
+
+// realStore wires the tool to an actual in-memory-backed Lake (temp dir), which
+// is the simplest faithful fake — the engine is already unit-tested separately.
+func newTool(t *testing.T) *Tool {
+	t.Helper()
+	var clock int64 = 100
+	l, err := datalake.Open(t.TempDir(), func() int64 { clock++; return clock })
+	if err != nil {
+		t.Fatalf("open lake: %v", err)
+	}
+	tool := New()
+	tool.SetStore(l)
+	return tool
+}
+
+func call(t *testing.T, tool *Tool, in string) (string, bool) {
+	t.Helper()
+	r, err := tool.Invoke(context.Background(), json.RawMessage(in))
+	if err != nil {
+		t.Fatalf("Invoke(%s): %v", in, err)
+	}
+	return r.Output, r.IsError
+}
+
+func TestDB_FullLifecycle(t *testing.T) {
+	tool := newTool(t)
+
+	// create
+	if out, isErr := call(t, tool, `{"op":"create_collection","name":"expenses","title":"Expenses","view":"expense"}`); isErr {
+		t.Fatalf("create: %s", out)
+	}
+	// list shows it
+	out, _ := call(t, tool, `{"op":"list_collections"}`)
+	if !strings.Contains(out, "expenses") {
+		t.Fatalf("list missing collection: %s", out)
+	}
+	// insert
+	out, isErr := call(t, tool, `{"op":"insert","collection":"expenses","record":{"item":"coffee","amount":5}}`)
+	if isErr {
+		t.Fatalf("insert: %s", out)
+	}
+	var ins struct {
+		Record datalake.Record `json:"record"`
+	}
+	_ = json.Unmarshal([]byte(out), &ins)
+	if ins.Record.ID == "" {
+		t.Fatalf("insert returned no id: %s", out)
+	}
+	id := ins.Record.ID
+
+	// query (search)
+	out, _ = call(t, tool, `{"op":"query","collection":"expenses","search":"coffee"}`)
+	if !strings.Contains(out, "coffee") || !strings.Contains(out, `"count": 1`) {
+		t.Fatalf("query: %s", out)
+	}
+	// update
+	out, isErr = call(t, tool, `{"op":"update","collection":"expenses","id":"`+id+`","record":{"amount":7}}`)
+	if isErr || !strings.Contains(out, `"updated": true`) {
+		t.Fatalf("update: %s", out)
+	}
+	// get reflects the update
+	out, _ = call(t, tool, `{"op":"get","collection":"expenses","id":"`+id+`"}`)
+	if !strings.Contains(out, `"amount": 7`) {
+		t.Fatalf("get after update: %s", out)
+	}
+	// delete
+	if out, isErr := call(t, tool, `{"op":"delete","collection":"expenses","id":"`+id+`"}`); isErr {
+		t.Fatalf("delete: %s", out)
+	}
+	out, _ = call(t, tool, `{"op":"query","collection":"expenses"}`)
+	if !strings.Contains(out, `"count": 0`) {
+		t.Fatalf("query after delete should be empty: %s", out)
+	}
+}
+
+func TestDB_Rejections(t *testing.T) {
+	tool := newTool(t)
+	cases := []string{
+		`{"op":"frobnicate"}`,
+		`{"op":"insert"}`,                                    // missing collection
+		`{"op":"get","collection":"x"}`,                      // missing id
+		`{"op":"insert","collection":"missing","record":{}}`, // unknown collection
+		`{"op":"query","collection":"missing"}`,
+	}
+	for _, c := range cases {
+		if _, isErr := call(t, tool, c); !isErr {
+			t.Errorf("expected error result for %s", c)
+		}
+	}
+
+	// no store configured
+	noStore := New()
+	r, _ := noStore.Invoke(context.Background(), json.RawMessage(`{"op":"list_collections"}`))
+	if !r.IsError || !strings.Contains(r.Output, "unavailable") {
+		t.Errorf("missing store should report unavailable: %s", r.Output)
+	}
+}
+
+func TestDB_DropSystemRefused(t *testing.T) {
+	tool := newTool(t)
+	// A normal collection can be dropped.
+	_, _ = call(t, tool, `{"op":"create_collection","name":"scratch"}`)
+	if _, isErr := call(t, tool, `{"op":"drop_collection","name":"scratch"}`); isErr {
+		t.Error("dropping a normal collection should succeed")
+	}
+	// Dropping a missing collection is a soft error.
+	if _, isErr := call(t, tool, `{"op":"drop_collection","name":"ghost"}`); !isErr {
+		t.Error("dropping a missing collection should be a soft error")
+	}
+}


### PR DESCRIPTION
## What

Milestone 1 of the **Personal Data Lake** arc. Agents now get **real databases** — structured **collections** (tables) they build, fill, and query, shared with other agents and the human (who can read them from chat / the upcoming Data view).

## Decision: file-based, no DB dependency

The owner was unsure (sqlite vs postgres). AGEZT is a single static binary with a frozen go.mod and a file-based architecture. So the Data Lake is a **pure-Go, dependency-free, on-disk structured store** (same shape as the journal/board/memory/artifact stores), surfaced as a DB-like API.

## How

- **`kernel/datalake`** — a `Lake` of named collections, each a set of JSON records (one file per record) with an optional schema. `Create/Ensure/DropCollection` (system collections protected), `Insert/Get/Update`(field-merge, nil-deletes-key)`/Delete`, `Query{Search, Equals, SortBy, Desc, Limit}`, `ListCollections/Schema/Count`. Every record + collection records `created_by`/`updated_by` **provenance** (the run → agent) and timestamps. Schema carries a `view` hint (expense/calendar/tasks/…) + icon for bespoke Web UI app views to come.
- **`plugins/tools/db`** — the `db` tool: `list_collections`, `create_collection`, `drop_collection`, `insert`, `get`, `update`, `delete`, `query`. Decoupled via a `Store` interface; the daemon injects `k.DataLake()` after Open.
- **`kernel/edict/toolmap.go`** — `db` rides the **memory** capability (structured durable knowledge). No new grant, no new env var.

## Verification

- **Unit:** engine (create/dup/invalid-name, insert+provenance, query search/equals/sort/limit, update merge + nil-delete, delete, system-drop protection, Ensure idempotency, persistence across reopen) + tool (full lifecycle, rejections, drop-missing).
- **Live** (isolated home, real deepseek): agent created an `expenses` collection (`view=expense`), inserted two records, queried sorted-desc → correct; on disk the schema + 2 records carry `created_by` = the run correlation. `db(data-lake)` shows in the tools banner.
- **Gate:** datalake + db + edict + runtime + cmd/agezt tests green; vet + staticcheck + linux clean; gofmt swept; go.mod unchanged.

## Next in the arc

M835: seed built-in collections (expense/calendar/tasks/notes/habits/bookmarks/contacts). M836+: control-plane CRUD routes + a Web UI **Data** view (generic table, then bespoke app views per built-in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)