### PR TITLE
Feat: seed built-in Data Lake collections at boot (M835)

### DIFF
--- a/.project/PHASE-M835-DATA-LAKE-BUILTINS-REPORT.md
+++ b/.project/PHASE-M835-DATA-LAKE-BUILTINS-REPORT.md
@@ -1,0 +1,38 @@
+# Phase M835 — Data Lake built-in collections (seeded at boot)
+
+**Date:** 2026-06-11 · **Status:** DONE · **Trigger:** owner: "built-in olarak
+expense tracker, calendar, tasks, notes, habits, bookmarks, contacts gibi
+veritabanları olsun, bunları personal data lake olarak isimlendir." Milestone 2
+of the Data Lake arc (after M834's engine + `db` tool).
+
+## What shipped (`kernel/datalake/builtins.go`)
+
+- `BuiltinSchemas()` — the seven out-of-the-box collections the owner named, each
+  with a title, lucide icon, a `view` hint for the bespoke Web UI app view to
+  come, and a field schema (typed hints text/number/money/date/bool/url/tags/note):
+  **expenses** (view=expense), **calendar**, **tasks**, **notes**, **habits**,
+  **bookmarks**, **contacts**. All marked `Builtin` + `System` (always present,
+  undroppable — records inside stay fully agent/user managed).
+- `(*Lake).SeedBuiltins(actor)` — `EnsureCollection`s each; idempotent (existing
+  ones and their data untouched); returns the names newly created.
+- `kernel/runtime` seeds them at boot right after the lake opens — best-effort so
+  a seed hiccup never blocks startup, retried next boot.
+
+## Verification
+
+- **Unit:** first seed creates all 7; second seed creates none (idempotent); each
+  built-in is present with `Builtin`+`System`+`View` set and refuses `Drop`
+  (ErrSystem); a record can still be inserted into a built-in.
+- Runtime tests still green (kernel Open seeds without disturbing other suites).
+
+## Gate
+
+datalake + runtime tests green; vet + staticcheck + linux cross-build clean.
+go.mod unchanged. (Local Windows `gofmt -l` flags CRLF working-copy files — a
+false positive; committed blobs are LF and the linux CI gate is authoritative.)
+
+## Next
+
+M836+: control-plane list/CRUD routes + a Web UI **Data** view — generic table
+viewer first, then the bespoke per-built-in app views (expense tracker like a
+real app, calendar, bookmarks, …) keyed off each schema's `View`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **Built-in Data Lake collections (M835).** The Personal Data Lake now ships seven ready-to-use
+  collections out of the box — **expenses, calendar, tasks, notes, habits, bookmarks, contacts** —
+  each with a typed field schema and a `view` hint for a bespoke UI. Seeded idempotently at boot;
+  always present and undroppable, but you (and agents) fill and query them freely. (M835)
 - **Personal Data Lake — agents get real databases (M834).** A new `db` tool lets agents build and
   use structured **collections** (tables): `create_collection`, `insert`, `query` (search / exact-match
   / sort / limit), `get`, `update`, `delete`, `drop_collection`, `list_collections`. Collections are

--- a/kernel/datalake/builtins.go
+++ b/kernel/datalake/builtins.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+
+package datalake
+
+// builtins.go defines the Personal Data Lake's out-of-the-box collections (M835)
+// — the everyday "apps" the owner asked for (expenses, calendar, tasks, notes,
+// habits, bookmarks, contacts). They are seeded at boot via SeedBuiltins and
+// marked System so they're always present (the Web UI renders each with its own
+// bespoke view named by Schema.View). Records inside are fully agent/user
+// managed; only the collection definitions are fixed.
+
+// BuiltinSchemas returns the definitions of the built-in collections. Pure data
+// (no I/O) so it's trivially testable and reusable. Field Types are UI/agent
+// hints: text | number | money | date | bool | url | tags | note.
+func BuiltinSchemas() []Schema {
+	return []Schema{
+		{
+			Name: "expenses", Title: "Expenses", Icon: "wallet", View: "expense",
+			Desc:    "Track spending — amount, category, date.",
+			Builtin: true, System: true,
+			Fields: []Field{
+				{Name: "date", Type: "date", Label: "Date"},
+				{Name: "item", Type: "text", Label: "Item"},
+				{Name: "amount", Type: "money", Label: "Amount"},
+				{Name: "category", Type: "text", Label: "Category"},
+				{Name: "note", Type: "note", Label: "Note"},
+			},
+		},
+		{
+			Name: "calendar", Title: "Calendar", Icon: "calendar", View: "calendar",
+			Desc:    "Events and appointments.",
+			Builtin: true, System: true,
+			Fields: []Field{
+				{Name: "title", Type: "text", Label: "Title"},
+				{Name: "date", Type: "date", Label: "Date"},
+				{Name: "time", Type: "text", Label: "Time"},
+				{Name: "location", Type: "text", Label: "Location"},
+				{Name: "note", Type: "note", Label: "Note"},
+			},
+		},
+		{
+			Name: "tasks", Title: "Tasks", Icon: "list-todo", View: "tasks",
+			Desc:    "To-dos with status, due date, priority.",
+			Builtin: true, System: true,
+			Fields: []Field{
+				{Name: "title", Type: "text", Label: "Title"},
+				{Name: "done", Type: "bool", Label: "Done"},
+				{Name: "due", Type: "date", Label: "Due"},
+				{Name: "priority", Type: "text", Label: "Priority"},
+				{Name: "note", Type: "note", Label: "Note"},
+			},
+		},
+		{
+			Name: "notes", Title: "Notes", Icon: "sticky-note", View: "notes",
+			Desc:    "Free-form notes.",
+			Builtin: true, System: true,
+			Fields: []Field{
+				{Name: "title", Type: "text", Label: "Title"},
+				{Name: "body", Type: "note", Label: "Body"},
+				{Name: "tags", Type: "tags", Label: "Tags"},
+			},
+		},
+		{
+			Name: "habits", Title: "Habits", Icon: "repeat", View: "habits",
+			Desc:    "Habit tracking with streaks.",
+			Builtin: true, System: true,
+			Fields: []Field{
+				{Name: "name", Type: "text", Label: "Habit"},
+				{Name: "streak", Type: "number", Label: "Streak"},
+				{Name: "last", Type: "date", Label: "Last done"},
+				{Name: "cadence", Type: "text", Label: "Cadence"},
+			},
+		},
+		{
+			Name: "bookmarks", Title: "Bookmarks", Icon: "bookmark", View: "bookmarks",
+			Desc:    "Saved links.",
+			Builtin: true, System: true,
+			Fields: []Field{
+				{Name: "title", Type: "text", Label: "Title"},
+				{Name: "url", Type: "url", Label: "URL"},
+				{Name: "tags", Type: "tags", Label: "Tags"},
+				{Name: "note", Type: "note", Label: "Note"},
+			},
+		},
+		{
+			Name: "contacts", Title: "Contacts", Icon: "contact", View: "contacts",
+			Desc:    "People and their details.",
+			Builtin: true, System: true,
+			Fields: []Field{
+				{Name: "name", Type: "text", Label: "Name"},
+				{Name: "email", Type: "text", Label: "Email"},
+				{Name: "phone", Type: "text", Label: "Phone"},
+				{Name: "company", Type: "text", Label: "Company"},
+				{Name: "note", Type: "note", Label: "Note"},
+			},
+		},
+	}
+}
+
+// SeedBuiltins ensures every built-in collection exists, leaving any that are
+// already present (and their data) untouched. Returns the names that were newly
+// created this call. Idempotent — safe to run on every boot.
+func (l *Lake) SeedBuiltins(actor string) ([]string, error) {
+	var created []string
+	for _, sc := range BuiltinSchemas() {
+		_, isNew, err := l.EnsureCollection(sc, actor)
+		if err != nil {
+			return created, err
+		}
+		if isNew {
+			created = append(created, sc.Name)
+		}
+	}
+	return created, nil
+}

--- a/kernel/datalake/datalake_test.go
+++ b/kernel/datalake/datalake_test.go
@@ -145,6 +145,40 @@ func TestEnsureIdempotentAndPersistence(t *testing.T) {
 	}
 }
 
+func TestSeedBuiltins(t *testing.T) {
+	l := newLake(t)
+	created, err := l.SeedBuiltins("system")
+	if err != nil {
+		t.Fatalf("SeedBuiltins: %v", err)
+	}
+	want := len(BuiltinSchemas())
+	if want == 0 {
+		t.Fatal("no built-in schemas defined")
+	}
+	if len(created) != want {
+		t.Fatalf("first seed created %d, want %d", len(created), want)
+	}
+	// Idempotent: a second seed creates nothing new.
+	created2, _ := l.SeedBuiltins("system")
+	if len(created2) != 0 {
+		t.Errorf("second seed created %v, want none", created2)
+	}
+	// Built-ins are present, marked, and protected from drop.
+	for _, sc := range BuiltinSchemas() {
+		got, ok := l.Schema(sc.Name)
+		if !ok || !got.Builtin || !got.System || got.View == "" {
+			t.Fatalf("built-in %q not seeded correctly: %+v", sc.Name, got)
+		}
+		if err := l.DropCollection(sc.Name); err != ErrSystem {
+			t.Errorf("drop built-in %q = %v, want ErrSystem", sc.Name, err)
+		}
+	}
+	// A user can still add records to a built-in.
+	if _, err := l.Insert("contacts", map[string]any{"name": "Ada"}, "agent"); err != nil {
+		t.Errorf("insert into built-in: %v", err)
+	}
+}
+
 func TestQueryNotFound(t *testing.T) {
 	l := newLake(t)
 	if _, err := l.Query("nope", Query{}); err != ErrNotFound {

--- a/kernel/runtime/runtime.go
+++ b/kernel/runtime/runtime.go
@@ -504,6 +504,11 @@ func Open(cfg Config) (*Kernel, error) {
 		skstore.Close()
 		return nil, fmt.Errorf("runtime: data lake: %w", err)
 	}
+	// Seed the built-in Personal Data Lake collections (M835) — expenses, calendar,
+	// tasks, notes, habits, bookmarks, contacts. Idempotent (EnsureCollection skips
+	// existing ones) and best-effort: a seed hiccup must not block boot, and the
+	// next start retries.
+	_, _ = lake.SeedBuiltins("system")
 
 	ststore, err := standing.Open(filepath.Join(cfg.BaseDir, "standing"))
 	if err != nil {


### PR DESCRIPTION
## What

Milestone 2 of the Data Lake arc. The Personal Data Lake now ships the seven built-in collections the owner named, ready to use out of the box: **expenses, calendar, tasks, notes, habits, bookmarks, contacts**.

## How

- `kernel/datalake/builtins.go` — `BuiltinSchemas()` defines each collection (title, lucide icon, `view` hint for the bespoke UI, typed field schema). `SeedBuiltins(actor)` `EnsureCollection`s them idempotently and returns the newly-created names.
- `kernel/runtime` seeds them at boot right after the lake opens — best-effort, so a hiccup never blocks startup and the next boot retries.
- All marked `Builtin`+`System`: always present and undroppable; records inside stay fully agent/user managed.

## Verification

- **Unit:** first seed creates all 7, second seed creates none (idempotent); each built-in is present with `Builtin`+`System`+`View` set and refuses drop (`ErrSystem`); records can still be inserted.
- Runtime tests green (kernel Open seeds cleanly).
- **Gate:** datalake + runtime tests green; vet + staticcheck + linux clean; go.mod unchanged.

## Next

M836+: control-plane CRUD routes + a Web UI **Data** view — generic table viewer, then bespoke per-built-in app views (expense tracker like a real app, calendar, bookmarks, …) keyed off each schema's `View`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)