### PR TITLE
Fix: delegate never runs a sub-agent on an unkeyed model (M838)

### DIFF
--- a/.project/PHASE-M838-DELEGATE-KEYED-MODEL-REPORT.md
+++ b/.project/PHASE-M838-DELEGATE-KEYED-MODEL-REPORT.md
@@ -1,0 +1,44 @@
+# Phase M838 — delegate never runs on an unkeyed model
+
+**Date:** 2026-06-11 · **Status:** DONE · **Trigger:** owner: "delegate ederken
+key girilmemiş provider ve modeller seçiliyor, bunu engelleyelim" — when
+delegating, models from providers with no API key were being selected (and then
+failing to route mid-delegation).
+
+## Root cause
+
+`runSubAgent` (kernel/runtime/subagent.go) set the child's model from the
+explicit `delegate {model}` arg or the roster profile's `model`/`fallbacks`, with
+no check that a **credentialed** provider actually serves it. An unkeyed model
+therefore reached the Governor and failed to route.
+
+## Fix
+
+- New `Config.ModelAvailable func(modelID string) bool` — the daemon injects it
+  (cmd/agezt), reporting whether some **registered + credentialed** provider
+  serves the id (bare or `provider/model`). Built exactly like `VisionModel` /
+  `CouncilMembers`, so the kernel stays free of credential logic.
+- `runSubAgent` now resolves the effective model chain (chosen model + profile
+  fallbacks) and passes it through `keyedModelChain(...)`: it **drops unkeyed
+  models**, and if nothing keyed survives, falls back to the daemon's active
+  (keyed) model so the delegation still runs. Done **before** the
+  `subagent.spawned` event is journaled and the child runs, so the recorded and
+  executed model is the one actually used. No-op when `ModelAvailable` is unset
+  (tests / single-provider setups) — existing behaviour preserved.
+
+## Verification
+
+- **Unit** (`keyedModelChain`): drops an unkeyed primary → keyed default; keeps a
+  keyed primary and filters unkeyed fallbacks; single keyed → nil chain; nothing
+  keyed + no default → originals unchanged. Existing delegation/roster tests still
+  green (filter is a no-op without the predicate).
+- **Live** (isolated home, real keyed providers): `delegate {model:
+  "totally-fake-unkeyed-model-9000"}` → the sub-agent **ran and returned PONG**,
+  and `subagent.spawned` now records `model: deepseek-v4-pro` (the keyed
+  fallback) instead of the bogus id. Before the fix the unkeyed id would reach the
+  governor.
+
+## Gate
+
+runtime tests green; vet + staticcheck + linux cross-build clean; gofmt swept.
+go.mod unchanged. No new env var.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,13 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
   complements `http` (which returns a page's *text* into context) by capturing the *bytes*. Reuses
   the network-GET capability — no new grant or env var. (M831)
 
+### Fixed
+- **Delegation never runs a sub-agent on an unkeyed model (M838).** `delegate` (and roster-profile
+  model/fallback chains) could pick a model from a provider with no API key, which then failed to
+  route mid-delegation. The effective chain is now filtered to models a credentialed provider actually
+  serves; if none survive, it falls back to the daemon's active (keyed) model — so a delegation always
+  runs on something that works, and the journaled `subagent.spawned` records the real model.
+
 ### Changed
 - **Chat can Continue a run that hit the iteration limit (instead of only Retry).** When a run
   exhausts its tool-round cap, chat now offers **Continue** — it resumes from where the agent

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -756,6 +756,43 @@ func runDaemon(stdout, stderr io.Writer) int {
 		})
 	}
 
+	// Keyed-model predicate (M838 bugfix): true when some registered+credentialed
+	// provider actually serves the model id. Delegation uses it to drop unkeyed
+	// models from a sub-agent's chain so a delegate never lands on a provider with
+	// no API key. Built like VisionModel — the daemon owns the keyed set.
+	cfg.ModelAvailable = func(modelID string) bool {
+		modelID = strings.TrimSpace(modelID)
+		if modelID == "" {
+			return false
+		}
+		if k == nil {
+			return true // set not built yet → don't block a non-empty id
+		}
+		cat := k.Catalog()
+		if cat == nil {
+			return true
+		}
+		lookup, _ := buildAWSCredChain(credStore.Lookup)
+		// Accept a bare ("model") or provider-qualified ("provider/model") id.
+		want := modelID
+		if i := strings.IndexByte(modelID, '/'); i >= 0 {
+			want = modelID[i+1:]
+		}
+		for _, p := range cat.ProviderList() {
+			e := cat.Providers[p.ID]
+			if e == nil || !compat.IsSupportedFamily(e.Family()) || !e.HasCredentials(lookup) {
+				continue
+			}
+			if _, ok := e.Models[modelID]; ok {
+				return true
+			}
+			if _, ok := e.Models[want]; ok {
+				return true
+			}
+		}
+		return false
+	}
+
 	// Council of Elders default membership (M837): one seat per KEYED provider's
 	// best model, so the panel speaks across providers. AGEZT_COUNCIL_MEMBERS (a
 	// comma-separated model list) overrides. Built like VisionModel — the daemon

--- a/kernel/runtime/runtime.go
+++ b/kernel/runtime/runtime.go
@@ -341,6 +341,13 @@ type Config struct {
 	// model can't see them. Nil disables the vision sidecar.
 	VisionModel func() (modelID string, ok bool)
 
+	// ModelAvailable, when set, reports whether a model id can actually be served
+	// by a registered+credentialed provider. The daemon (cmd/agezt) injects it
+	// (it owns the keyed set). Delegation uses it to drop unkeyed models from a
+	// sub-agent's model chain (M838 bugfix) so a delegate never runs on a provider
+	// with no API key. Nil → no filtering (the historical behaviour; tests).
+	ModelAvailable func(modelID string) bool
+
 	// CouncilMembers, when set, returns the default Council of Elders membership
 	// (M837) — one seat per keyed provider's best model, so the council speaks
 	// across providers. Injected by the daemon (cmd/agezt), which owns the

--- a/kernel/runtime/subagent.go
+++ b/kernel/runtime/subagent.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/agezt/agezt/kernel/agent"
@@ -148,6 +149,25 @@ func (k *Kernel) runSubAgent(ctx context.Context, task, model, taskType, agentRe
 	}
 	if k.IsHalted() {
 		return "", ErrHalted
+	}
+
+	// Build the effective model chain (M787): the chosen model first, then the
+	// profile's ordered fallbacks. Restrict to KEYED models (M838 bugfix) — an
+	// unkeyed explicit model or fallback would fail to route mid-delegation, so
+	// drop it; if nothing keyed remains, fall back to the daemon default. Done
+	// HERE (before the spawn is journaled and the child runs) so the recorded and
+	// executed model is the one actually used. No-op when ModelAvailable is unset.
+	var modelChain []string
+	if prof != nil && len(prof.Fallbacks) > 0 {
+		modelChain = []string{subModel}
+		for _, m := range prof.Fallbacks {
+			if m = strings.TrimSpace(m); m != "" && m != subModel {
+				modelChain = append(modelChain, m)
+			}
+		}
+	}
+	if avail := k.cfg.ModelAvailable; avail != nil {
+		subModel, modelChain = keyedModelChain(subModel, modelChain, avail, k.cfg.Model)
 	}
 
 	depth := depthFromCtx(ctx)
@@ -302,20 +322,13 @@ func (k *Kernel) runSubAgent(ctx context.Context, task, model, taskType, agentRe
 	// first (an explicit delegate model still wins the front slot), walked
 	// in order by the Governor; duplicates of the primary are skipped.
 	var maxRunCost, agentDailyMc int64
-	var modelChain []string
 	var agentSlug string
 	if prof != nil {
 		maxRunCost = prof.MaxCostMc
 		agentSlug, agentDailyMc = prof.Slug, prof.MaxDailyMc // M793: identity ledger
-		if len(prof.Fallbacks) > 0 {
-			modelChain = []string{subModel}
-			for _, m := range prof.Fallbacks {
-				if m = strings.TrimSpace(m); m != "" && m != subModel {
-					modelChain = append(modelChain, m)
-				}
-			}
-		}
 	}
+	// modelChain + subModel were resolved (and keyed-filtered) above, before the
+	// spawn was journaled.
 
 	answer, err := agent.Run(childCtx, agent.LoopConfig{
 		Provider:             k.cfg.Provider,
@@ -419,4 +432,41 @@ func budgetCostMicrocents(payload json.RawMessage) int64 {
 		return 0
 	}
 	return int64(p.Cost)
+}
+
+// keyedModelChain restricts a delegation's effective model chain to models a
+// KEYED provider can serve (M838 bugfix). It folds subModel + the profile chain
+// into one de-duped ordered list, keeps only those for which avail() is true,
+// and — if nothing keyed survives — falls back to def (the daemon's active,
+// keyed model). Returns the chosen primary model and the chain (nil when a single
+// model, matching the pre-filter convention). A nil/empty result leaves the
+// caller's values unchanged.
+func keyedModelChain(subModel string, modelChain []string, avail func(string) bool, def string) (string, []string) {
+	chain := []string{}
+	if subModel != "" {
+		chain = append(chain, subModel)
+	}
+	for _, m := range modelChain {
+		if m != "" && !slices.Contains(chain, m) {
+			chain = append(chain, m)
+		}
+	}
+	kept := make([]string, 0, len(chain))
+	for _, m := range chain {
+		if avail(m) {
+			kept = append(kept, m)
+		}
+	}
+	if len(kept) == 0 {
+		if d := strings.TrimSpace(def); d != "" {
+			kept = append(kept, d)
+		}
+	}
+	if len(kept) == 0 {
+		return subModel, modelChain // nothing to do; keep originals
+	}
+	if len(kept) == 1 {
+		return kept[0], nil
+	}
+	return kept[0], kept
 }

--- a/kernel/runtime/subagent_keyed_internal_test.go
+++ b/kernel/runtime/subagent_keyed_internal_test.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+
+package runtime
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestKeyedModelChain(t *testing.T) {
+	keyed := func(want ...string) func(string) bool {
+		return func(m string) bool { return slices.Contains(want, m) }
+	}
+
+	cases := []struct {
+		name      string
+		subModel  string
+		chain     []string
+		avail     func(string) bool
+		def       string
+		wantModel string
+		wantChain []string
+	}{
+		{
+			name:     "drops unkeyed primary, falls back to keyed default",
+			subModel: "unkeyed-x", chain: nil, avail: keyed("good"), def: "good",
+			wantModel: "good", wantChain: nil,
+		},
+		{
+			name:     "keeps keyed primary + filters fallbacks",
+			subModel: "good", chain: []string{"good", "bad", "good2"}, avail: keyed("good", "good2"), def: "good",
+			wantModel: "good", wantChain: []string{"good", "good2"},
+		},
+		{
+			name:     "single keyed model → nil chain",
+			subModel: "good", chain: nil, avail: keyed("good"), def: "deflt",
+			wantModel: "good", wantChain: nil,
+		},
+		{
+			name:     "unkeyed fallback is dropped, leaving the keyed primary",
+			subModel: "good", chain: []string{"good", "bad"}, avail: keyed("good"), def: "deflt",
+			wantModel: "good", wantChain: nil,
+		},
+		{
+			name:     "nothing keyed and no default → originals unchanged",
+			subModel: "bad", chain: []string{"bad2"}, avail: keyed("none"), def: "",
+			wantModel: "bad", wantChain: []string{"bad2"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotModel, gotChain := keyedModelChain(c.subModel, c.chain, c.avail, c.def)
+			if gotModel != c.wantModel {
+				t.Errorf("model = %q, want %q", gotModel, c.wantModel)
+			}
+			if !slices.Equal(gotChain, c.wantChain) {
+				t.Errorf("chain = %v, want %v", gotChain, c.wantChain)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Bug

Owner: "delegate ederken key girilmemiş provider ve modeller seçiliyor, bunu engelleyelim." When delegating, a model from a provider with **no API key** could be selected (via the explicit `delegate {model}` arg or a roster profile's `model`/`fallbacks`) and then **fail to route** mid-delegation.

## Fix

- New `Config.ModelAvailable func(modelID string) bool` — daemon-injected (cmd/agezt), true when a **registered + credentialed** provider serves the id (bare or `provider/model`). Built like `VisionModel`/`CouncilMembers`, keeping credential logic out of the kernel.
- `runSubAgent` resolves the effective chain (chosen model + profile fallbacks) and passes it through `keyedModelChain(...)`: **drops unkeyed models**; if none survive, falls back to the daemon's active (keyed) model so the delegation still runs. Applied **before** `subagent.spawned` is journaled and the child runs, so the recorded + executed model is the real one. No-op when the predicate is unset (existing behaviour preserved).

## Verification

- **Unit** (`keyedModelChain`): unkeyed primary → keyed default; keyed primary + filtered fallbacks; single keyed → nil chain; nothing keyed + no default → unchanged. Existing delegation/roster tests still green.
- **Live**: `delegate {model: "totally-fake-unkeyed-model-9000"}` → sub-agent **ran and returned PONG**, and `subagent.spawned` records `model: deepseek-v4-pro` (the keyed fallback) instead of the bogus id.
- **Gate:** runtime tests green; vet + staticcheck + linux clean; gofmt swept; go.mod unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)