### PR TITLE
Feat: self-healing watchdog — `agezt watchdog` respawns the daemon (M840)

### DIFF
--- a/.project/PHASE-M840-WATCHDOG-REPORT.md
+++ b/.project/PHASE-M840-WATCHDOG-REPORT.md
@@ -1,0 +1,47 @@
+# Phase M840 — self-healing watchdog (`agezt watchdog`)
+
+**Date:** 2026-06-11 · **Status:** DONE · **Trigger:** owner: "bizim daemon
+durduğunda tekrar onu ayağa kaldıracak 2. bir daemon/servis lazım … agent.exe
+down olursa geri kaldıracak bir servis lazım, agezt kendi yapmalı."
+
+## What shipped
+
+A new **`agezt watchdog`** subcommand — the "keep it alive" service. It is the
+**same binary** supervising itself (so "agezt kendi yapmalı"): it spawns `agezt
+daemon`, waits for it, and respawns it whenever it exits, so a crash brings the
+daemon back on its own. Run it instead of `agezt daemon`, or install it as a
+Windows service / scheduled task.
+
+- **Backoff** — exponential from 1 s, capped at 30 s; the count resets after the
+  daemon has run cleanly for ≥60 s (so an occasional restart doesn't slow the
+  next one).
+- **Crash-loop guard** — if the daemon restarts more than 6 times within 2
+  minutes, the watchdog gives up with a clear error instead of spinning forever.
+- **Clean shutdown** — SIGINT/SIGTERM stop the watchdog AND kill the supervised
+  daemon (it does not respawn after an intentional stop).
+- The supervise loop is factored behind a `proc` interface with injectable
+  clock/sleep, so the restart policy is unit-testable without real processes.
+
+`cmd/agezt/watchdog.go` (new) + a `watchdog` case in the command dispatch + a help
+line.
+
+## Verification
+
+- **Unit** (`cmd/agezt`): `nextDelay` backoff schedule (base→2×→4×→cap);
+  supervise loop restarts then stops cleanly on cancel; crash-loop guard gives up
+  after exceeding `maxCrashes`; a running child is killed on cancel.
+- **Live** (isolated home): `agezt watchdog` spawned the daemon (pid 116664);
+  killing that pid produced `daemon exited after 17s (exit status 1); restarting
+  in 1s` → `daemon started (pid 86352)` and the daemon came back ready —
+  self-healing confirmed end-to-end.
+
+## Gate
+
+cmd/agezt tests green; vet + staticcheck + linux cross-build clean; gofmt swept.
+go.mod unchanged. No new env var.
+
+## Note / next
+
+This is the manual-but-same-binary supervisor. A follow-up could add a one-shot
+installer (`agezt watchdog --install` → Windows Task Scheduler / systemd unit) so
+it survives reboots automatically; for now the operator runs `agezt watchdog`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **Self-healing watchdog — `agezt watchdog` (M840).** A new subcommand supervises the daemon using
+  the same binary: it spawns `agezt daemon` and **respawns it whenever it exits**, so a crash brings
+  the daemon back on its own. Exponential backoff (1 s→30 s, reset after a clean 60 s run), a crash-loop
+  guard (gives up after 6 restarts in 2 min), and clean shutdown (SIGINT/SIGTERM stops both). Run it
+  instead of `agezt daemon`, or install it as a service/scheduled task. (M840)
 - **Council of Elders Web UI (M839).** A new **Council** view lets you put a question to the panel
   from the console: it shows the seated models, takes your question (+ deliberation rounds), convenes
   the council, and renders the consensus (with any dissent) above the full per-round transcript.

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -134,6 +134,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 		return 0
 	case "daemon":
 		return runDaemon(stdout, stderr)
+	case "watchdog":
+		return runWatchdog(stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "%s: unknown command %q\n", brand.Binary, args[0])
 		printHelp(stderr)
@@ -147,6 +149,7 @@ func printHelp(w io.Writer) {
 	fmt.Fprintf(w, "Commands:\n")
 	fmt.Fprintf(w, "  (none)    run the daemon (default)\n")
 	fmt.Fprintf(w, "  daemon    run the daemon, explicit\n")
+	fmt.Fprintf(w, "  watchdog  supervise the daemon, restarting it if it exits (self-healing)\n")
 	fmt.Fprintf(w, "  version   show version and exit\n")
 	fmt.Fprintf(w, "  help      show this help\n")
 	fmt.Fprintf(w, "\n")

--- a/cmd/agezt/watchdog.go
+++ b/cmd/agezt/watchdog.go
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: MIT
+
+package main
+
+// Self-healing watchdog (M840): `agezt watchdog` is the "keep it alive" service
+// the owner asked for — a second, tiny supervisor process (the SAME binary, so
+// agezt supervises itself) that spawns `agezt daemon`, waits for it, and respawns
+// it whenever it exits, with exponential backoff and a crash-loop guard. Run it
+// instead of `agezt daemon` (or install it as a service / scheduled task) and the
+// daemon comes back on its own after a crash.
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/agezt/agezt/internal/brand"
+)
+
+// watchdogPolicy tunes the restart behaviour.
+type watchdogPolicy struct {
+	baseDelay   time.Duration // backoff for the first quick failure
+	maxDelay    time.Duration // backoff ceiling
+	resetUptime time.Duration // a daemon that ran at least this long resets the backoff
+	crashWindow time.Duration // window over which crashes are counted
+	maxCrashes  int           // more than this many restarts within crashWindow → give up
+}
+
+func defaultWatchdogPolicy() watchdogPolicy {
+	return watchdogPolicy{
+		baseDelay:   1 * time.Second,
+		maxDelay:    30 * time.Second,
+		resetUptime: 60 * time.Second,
+		crashWindow: 2 * time.Minute,
+		maxCrashes:  6,
+	}
+}
+
+// nextDelay returns the backoff before the next start given the count of
+// CONSECUTIVE quick failures (1-based): base, 2×base, 4×base, … capped at maxDelay.
+func (p watchdogPolicy) nextDelay(consecutive int) time.Duration {
+	if consecutive <= 1 {
+		return p.baseDelay
+	}
+	d := p.baseDelay
+	for i := 1; i < consecutive; i++ {
+		d *= 2
+		if d >= p.maxDelay {
+			return p.maxDelay
+		}
+	}
+	return d
+}
+
+// proc is the slice of a child process the supervisor needs — an interface so the
+// loop is testable without spawning real processes.
+type proc interface {
+	pid() int
+	wait() error
+	kill() error
+}
+
+// execProc wraps a real *exec.Cmd.
+type execProc struct{ cmd *exec.Cmd }
+
+func (e *execProc) pid() int    { return e.cmd.Process.Pid }
+func (e *execProc) wait() error { return e.cmd.Wait() }
+func (e *execProc) kill() error { return e.cmd.Process.Kill() }
+
+// pruneOlderThan drops timestamps before cutoff (keeping order).
+func pruneOlderThan(ts []time.Time, cutoff time.Time) []time.Time {
+	out := ts[:0]
+	for _, t := range ts {
+		if t.After(cutoff) {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// superviseLoop is the testable heart of the watchdog: spawn → wait → backoff →
+// respawn, until ctx is cancelled (clean shutdown, returns nil) or a crash loop is
+// detected (returns an error). spawn starts one daemon; now/sleep are injectable
+// for tests; logf reports lifecycle. On ctx cancel mid-run it kills the child.
+func superviseLoop(
+	ctx context.Context,
+	spawn func() (proc, error),
+	p watchdogPolicy,
+	now func() time.Time,
+	sleep func(context.Context, time.Duration) error,
+	logf func(string, ...any),
+) error {
+	var recent []time.Time
+	consecutive := 0
+	for {
+		if ctx.Err() != nil {
+			return nil
+		}
+		start := now()
+		recent = append(recent, start)
+		recent = pruneOlderThan(recent, start.Add(-p.crashWindow))
+		if len(recent) > p.maxCrashes {
+			return fmt.Errorf("watchdog: daemon restarted %d times within %s — looks like a crash loop, giving up", len(recent), p.crashWindow)
+		}
+
+		child, err := spawn()
+		if err != nil {
+			consecutive++
+			delay := p.nextDelay(consecutive)
+			logf("failed to start daemon: %v; retrying in %s", err, delay)
+			if sleep(ctx, delay) != nil {
+				return nil
+			}
+			continue
+		}
+		logf("daemon started (pid %d)", child.pid())
+
+		// Wait for the child, but abandon the wait if we're asked to shut down.
+		done := make(chan error, 1)
+		go func() { done <- child.wait() }()
+		select {
+		case <-ctx.Done():
+			_ = child.kill()
+			<-done // reap
+			logf("watchdog stopping; daemon killed")
+			return nil
+		case waitErr := <-done:
+			uptime := now().Sub(start)
+			if uptime >= p.resetUptime {
+				consecutive = 0 // it ran fine for a while; forget the backoff
+			}
+			consecutive++
+			delay := p.nextDelay(consecutive)
+			logf("daemon exited after %s (%v); restarting in %s", uptime.Round(time.Second), waitErr, delay)
+			if sleep(ctx, delay) != nil {
+				return nil
+			}
+		}
+	}
+}
+
+// ctxSleep sleeps for d or until ctx is cancelled (returning ctx.Err()).
+func ctxSleep(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return ctx.Err()
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+// runWatchdog supervises `agezt daemon` using the same executable, restarting it
+// on exit. SIGINT/SIGTERM stop the watchdog and the daemon cleanly.
+func runWatchdog(stdout, stderr io.Writer) int {
+	exe, err := os.Executable()
+	if err != nil {
+		fmt.Fprintf(stderr, "%s watchdog: cannot find own executable: %v\n", brand.Binary, err)
+		return 1
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	logf := func(format string, a ...any) {
+		fmt.Fprintf(stdout, "%s watchdog: %s\n", brand.Binary, fmt.Sprintf(format, a...))
+	}
+	logf("supervising %q daemon — it will be restarted if it exits (Ctrl-C to stop)", exe)
+
+	spawn := func() (proc, error) {
+		cmd := exec.Command(exe, "daemon")
+		cmd.Stdout = stdout
+		cmd.Stderr = stderr
+		cmd.Stdin = nil
+		cmd.Env = os.Environ()
+		if err := cmd.Start(); err != nil {
+			return nil, err
+		}
+		return &execProc{cmd: cmd}, nil
+	}
+
+	if err := superviseLoop(ctx, spawn, defaultWatchdogPolicy(), time.Now, ctxSleep, logf); err != nil {
+		fmt.Fprintf(stderr, "%s watchdog: %v\n", brand.Binary, err)
+		return 1
+	}
+	return 0
+}

--- a/cmd/agezt/watchdog_test.go
+++ b/cmd/agezt/watchdog_test.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestWatchdogNextDelay(t *testing.T) {
+	p := watchdogPolicy{baseDelay: time.Second, maxDelay: 8 * time.Second}
+	cases := []struct {
+		consecutive int
+		want        time.Duration
+	}{
+		{0, time.Second}, {1, time.Second}, {2, 2 * time.Second},
+		{3, 4 * time.Second}, {4, 8 * time.Second}, {5, 8 * time.Second}, // capped
+		{10, 8 * time.Second},
+	}
+	for _, c := range cases {
+		if got := p.nextDelay(c.consecutive); got != c.want {
+			t.Errorf("nextDelay(%d) = %s, want %s", c.consecutive, got, c.want)
+		}
+	}
+}
+
+// fakeProc exits immediately when wait() is called.
+type fakeProc struct {
+	mu     sync.Mutex
+	killed bool
+}
+
+func (f *fakeProc) pid() int    { return 4242 }
+func (f *fakeProc) wait() error { return nil }
+func (f *fakeProc) kill() error {
+	f.mu.Lock()
+	f.killed = true
+	f.mu.Unlock()
+	return nil
+}
+
+func TestSuperviseLoop_RestartsThenStops(t *testing.T) {
+	p := defaultWatchdogPolicy()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var spawns int
+	spawn := func() (proc, error) {
+		spawns++
+		if spawns >= 3 {
+			cancel() // after the 3rd start, ask the watchdog to stop
+		}
+		return &fakeProc{}, nil
+	}
+	// Fixed clock (uptime 0 → backoff grows, but we stop well before the crash cap).
+	now := func() time.Time { return time.Unix(0, 0) }
+	sleep := func(ctx context.Context, _ time.Duration) error { return ctx.Err() }
+
+	err := superviseLoop(ctx, spawn, p, now, sleep, func(string, ...any) {})
+	if err != nil {
+		t.Fatalf("clean shutdown should return nil, got %v", err)
+	}
+	if spawns != 3 {
+		t.Errorf("spawns = %d, want 3 (restarted twice then stopped)", spawns)
+	}
+}
+
+func TestSuperviseLoop_CrashLoopGivesUp(t *testing.T) {
+	p := watchdogPolicy{baseDelay: time.Millisecond, maxDelay: time.Millisecond, crashWindow: time.Hour, maxCrashes: 2}
+	var spawns int
+	spawn := func() (proc, error) {
+		spawns++
+		return &fakeProc{}, nil
+	}
+	now := func() time.Time { return time.Unix(0, 0) } // all crashes in the same instant → within window
+	sleep := func(context.Context, time.Duration) error { return nil }
+
+	err := superviseLoop(context.Background(), spawn, p, now, sleep, func(string, ...any) {})
+	if err == nil {
+		t.Fatal("a crash loop should return an error")
+	}
+	// maxCrashes=2 → two starts happen, then the 3rd attempt trips the guard
+	// (refused before spawning), so the daemon was started exactly twice.
+	if spawns != 2 {
+		t.Errorf("spawns = %d, want 2 (gave up when the 3rd restart exceeded maxCrashes)", spawns)
+	}
+}
+
+func TestSuperviseLoop_KillsChildOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	fp := &fakeProc{}
+	blocked := make(chan struct{})
+	spawn := func() (proc, error) { return &blockingProc{fakeProc: fp, release: blocked}, nil }
+	now := time.Now
+	sleep := ctxSleep
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel() // ask to stop while the child is "running"
+	}()
+	err := superviseLoop(ctx, spawn, defaultWatchdogPolicy(), now, sleep, func(string, ...any) {})
+	if err != nil {
+		t.Fatalf("cancel should be a clean stop, got %v", err)
+	}
+	fp.mu.Lock()
+	killed := fp.killed
+	fp.mu.Unlock()
+	if !killed {
+		t.Error("the running child should have been killed on cancel")
+	}
+}
+
+// blockingProc.wait blocks until kill() (mimics a long-running daemon).
+type blockingProc struct {
+	*fakeProc
+	release chan struct{}
+	once    sync.Once
+}
+
+func (b *blockingProc) wait() error {
+	<-b.release
+	return errors.New("killed")
+}
+func (b *blockingProc) kill() error {
+	b.once.Do(func() { close(b.release) })
+	return b.fakeProc.kill()
+}


### PR DESCRIPTION
## What

Owner: "agent.exe down olursa geri kaldıracak bir servis lazım, agezt kendi yapmalı." A new **`agezt watchdog`** subcommand — the same binary supervising itself — spawns `agezt daemon`, waits, and **respawns it whenever it exits**, so a crash brings the daemon back automatically. Run it instead of `agezt daemon`, or install it as a service/scheduled task.

## How (`cmd/agezt/watchdog.go`)

- **Backoff:** exponential 1 s→30 s; resets after the daemon runs cleanly ≥60 s.
- **Crash-loop guard:** >6 restarts within 2 min → give up with a clear error instead of spinning.
- **Clean shutdown:** SIGINT/SIGTERM stop the watchdog AND kill the supervised daemon (no respawn after an intentional stop).
- The supervise loop sits behind a `proc` interface with injectable clock/sleep → restart policy is unit-testable without real processes.

## Verification

- **Unit:** `nextDelay` schedule; restart-then-clean-stop; crash-loop give-up after `maxCrashes`; child killed on cancel.
- **Live** (isolated home): `agezt watchdog` spawned the daemon (pid 116664); killing it logged `daemon exited after 17s (exit status 1); restarting in 1s` → `daemon started (pid 86352)`, ready again — self-healing confirmed.
- **Gate:** cmd/agezt tests green; vet + staticcheck + linux clean; gofmt swept; go.mod unchanged.

## Next (optional)

`agezt watchdog --install` → Windows Task Scheduler / systemd unit so it survives reboots; for now the operator launches `agezt watchdog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)