### PR TITLE
Feat: deeper delegation by default — leader/worker trees (M843)

### DIFF
--- a/.project/PHASE-M843-DEEP-DELEGATION-REPORT.md
+++ b/.project/PHASE-M843-DEEP-DELEGATION-REPORT.md
@@ -1,0 +1,45 @@
+# Phase M843 — deeper delegation by default (leader/worker trees)
+
+**Date:** 2026-06-11 · **Status:** DONE · **Trigger:** owner: "agentlar alt
+agentlar spawn edebilir, taskları birden çok parçaya bölerek kendileri leader
+konumda durarak daha fazla agent çalıştırabilir."
+
+## What shipped
+
+Delegation nesting defaulted to **depth 1** — a lead could spawn workers, but
+those workers could not delegate further, so no real leader/worker tree. Now:
+
+- **`cmd/agezt`**: default `AGEZT_SUBAGENT_DEPTH` raised **1 → 3** — a lead can
+  decompose a task, delegate the parts, and those sub-agents can delegate again.
+- **Safety rail**: the code's own design (M629) notes depth>1 needs a tree-total
+  cap (depth×fan-out alone can't bound a tree). So when the operator hasn't set
+  `AGEZT_SUBAGENT_MAX_TOTAL` and depth>1, it now defaults to **48** total
+  sub-agents per tree — far beyond any real task, but a hard stop against a
+  fork-bomb. `depth==1` stays unbounded (unchanged). Both overridable by env.
+- **`delegate` tool description**: now coaches the leader pattern — break a big
+  task into parts, delegate each, and note that sub-agents can delegate further;
+  prefer reusing an existing named roster `agent` over inventing an ad-hoc one
+  (the owner's "reuse over create" guidance).
+
+## Verification
+
+- Build + existing delegation/subagent tests green (kernel default stays 1, so
+  kernel tests are unaffected; only the daemon's product default changed).
+- **Live** (isolated home, real agent): banner showed `delegation: depth≤3,
+  fan-out unbounded, total ≤48`. A forced two-level delegation — lead → mid-lead
+  → worker computing 17+25 — returned **42**, with `subagent.spawned` events at
+  `depth:1` AND `depth:2`. Under the old depth=1 default the second delegation
+  would have failed with "max sub-agent depth 1 reached".
+
+## Gate
+
+cmd/agezt + runtime tests green; vet/staticcheck unaffected; gofmt swept. go.mod
+unchanged. Default-allow posture: deeper delegation on by default, bounded only by
+the generous tree-total safety budget (the kind of budget rail the owner's law
+keeps).
+
+## Note
+
+Reuse-over-create as an enforced roster dedup check (scan for a similar agent
+before CREATING one) remains future work (task #40 / #53 reaper); this milestone
+delivers the depth/leader half plus the description nudge.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 
 ## [Unreleased]
 
+### Changed
+- **Agents can delegate in depth — leader/worker trees by default (M843).** Delegation nesting now
+  defaults to depth 3 (was 1): a lead agent can split a task, delegate the parts, and those sub-agents
+  can delegate further. A generous tree-total rail (48 sub-agents, when unset and depth>1) keeps deep
+  recursion from running away; `AGEZT_SUBAGENT_DEPTH` / `AGEZT_SUBAGENT_MAX_TOTAL` override. The
+  `delegate` tool now coaches the leader pattern and prefers reusing an existing named agent. (M843)
+
 ### Added
 - **Files view previews more than images (M842).** The file preview now renders inline: PDFs (embedded),
   markdown (rendered), JSON (pretty-printed), and code / text / CSV / logs (monospace) — fetched from

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -413,7 +413,12 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// agent spawn bounded sub-agents. On by default; AGEZT_SUBAGENT=off disables
 	// it, AGEZT_SUBAGENT_DEPTH sets how deep delegation may nest (default 1).
 	subAgentOn := !strings.EqualFold(os.Getenv(brand.EnvPrefix+"SUBAGENT"), "off")
-	subAgentDepth := 1
+	// Default depth 3 (M843): a lead agent can decompose a task, delegate the parts
+	// to sub-agents, and THOSE sub-agents can delegate further — a real leader/worker
+	// tree, not just one flat layer. The owner wants agents to "split tasks and run
+	// more agents", and the default-allow posture favours capability; the tree-total
+	// rail below keeps deep delegation bounded. AGEZT_SUBAGENT_DEPTH overrides.
+	subAgentDepth := 3
 	if v := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "SUBAGENT_DEPTH")); v != "" {
 		if d, err := strconv.Atoi(v); err == nil && d > 0 {
 			subAgentDepth = d
@@ -452,6 +457,15 @@ func runDaemon(stdout, stderr io.Writer) int {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			subAgentTotal = n
 		}
+	}
+	// With deep delegation on by default (depth>1), give the tree a generous but
+	// finite size rail when the operator hasn't set one (M843) — depth×fan-out
+	// alone can't bound a tree, so an unbounded total + deep recursion risks a
+	// fork-bomb. 48 total sub-agents is far more than any real leader/worker task
+	// needs while still preventing runaway. depth==1 stays unbounded (unchanged);
+	// AGEZT_SUBAGENT_MAX_TOTAL overrides.
+	if subAgentTotal == 0 && subAgentDepth > 1 {
+		subAgentTotal = 48
 	}
 
 	// Artifact offload threshold (SPEC-04 §3.6): tool outputs larger than this are

--- a/kernel/runtime/subagent.go
+++ b/kernel/runtime/subagent.go
@@ -50,10 +50,12 @@ func (t *subAgentTool) Definition() agent.ToolDef {
 	return agent.ToolDef{
 		Name: "delegate",
 		Description: "Delegate a focused subtask to a fresh sub-agent that works " +
-			"autonomously (its own tool-loop) and returns a concise result. Use this " +
-			"to parallelise independent subtasks or isolate a self-contained piece of " +
-			"work. Issue multiple delegate calls in one turn to fan out concurrently. " +
-			"Optionally pick the sub-agent's model (otherwise the daemon default) and/or " +
+			"autonomously (its own tool-loop) and returns a concise result. LEAD the work: " +
+			"break a big task into parts and delegate each — your sub-agents can delegate " +
+			"FURTHER, so you can build a leader/worker tree, not just one flat layer. Issue " +
+			"multiple delegate calls in one turn to fan out concurrently. Prefer reusing an " +
+			"existing named `agent` (roster slug) whose role fits over inventing an ad-hoc " +
+			"one. Optionally pick the sub-agent's model (otherwise the daemon default) and/or " +
 			"its routing task type (defaults to \"delegate\"); a configured routing chain " +
 			"for that task type provides the fallback models.",
 		InputSchema: json.RawMessage(`{


### PR DESCRIPTION
## What

Owner: "agentlar alt agentlar spawn edebilir, taskları parçalara bölerek kendileri leader konumda daha fazla agent çalıştırabilir." Delegation nesting defaulted to **depth 1**, so a lead could spawn workers but those workers couldn't delegate further. Now agents can build real **leader/worker trees**.

## How

- `cmd/agezt`: default `AGEZT_SUBAGENT_DEPTH` **1 → 3**.
- **Safety rail:** the code's design (M629) notes depth>1 needs a tree-total cap (depth×fan-out alone can't bound a tree). So when unset and depth>1, `SubAgentMaxTotal` defaults to **48** — generous but fork-bomb-safe. `depth==1` stays unbounded. Both env-overridable.
- `delegate` tool description now coaches the leader pattern (decompose → delegate parts → sub-agents delegate further) and prefers reusing an existing named roster `agent`.

## Verification

- Build + existing delegation/subagent tests green (kernel default stays 1 → kernel tests unaffected).
- **Live**: banner `delegation: depth≤3, fan-out unbounded, total ≤48`; a forced 2-level delegation (lead → mid-lead → worker computing 17+25) returned **42**, with `subagent.spawned` at `depth:1` AND `depth:2` — refused under the old depth=1 default.
- **Gate:** cmd/agezt + runtime tests green; gofmt swept; go.mod unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)