### PR TITLE
Fix: board tool infers a missing op (workflow board node) (M844)

### DIFF
--- a/.project/PHASE-M844-BOARD-INFER-OP-REPORT.md
+++ b/.project/PHASE-M844-BOARD-INFER-OP-REPORT.md
@@ -1,0 +1,40 @@
+# Phase M844 — board tool infers a missing `op` (workflow node fix)
+
+**Date:** 2026-06-11 · **Status:** DONE · **Trigger:** owner: "workflow içinden
+tool board failed: board: op required (post|read|topics|send|inbox|reply|replies)
+ile board'a mesaj yazamadı node."
+
+## Root cause
+
+A workflow **tool node** passes its `config.args` object verbatim as the tool's
+input. The board tool **required** an explicit `op` and hard-errored ("op
+required …") when it was absent. A board node configured with just
+`{topic, text}` (the natural "post a message" shape) therefore failed.
+
+## Fix (`plugins/tools/boardtool/tool.go`)
+
+The board tool now **infers a missing `op`** from the supplied fields, before the
+op switch:
+
+- `text` + `to` → **send** (a direct message)
+- `text` + `id` → **reply**
+- `text` (alone or with a topic) → **post**
+- nothing → **read** (the harmless default)
+
+Explicit ops are untouched. The input schema no longer lists `op` as `required`
+and documents the inference. So a workflow board node with `{topic, text}` now
+posts, and an agent that forgets `op` does the obvious thing instead of erroring.
+
+## Verification
+
+- **Unit** (`TestInferOp`): op-less `{topic, text}` → post; `{to, text}` → send;
+  empty `{}` → read (no error). `TestBadInputs` updated (an empty op is no longer
+  an error — it reads). Board + workflow package tests green.
+- The workflow runner's verbatim `args → tool.Invoke` path is unchanged; the fix
+  is entirely in how the board tool interprets its input, so it applies to the
+  reported workflow node, the agent, and the CLI alike.
+
+## Gate
+
+boardtool + workflow tests green; vet + staticcheck + linux clean; gofmt swept.
+go.mod unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,10 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
   the network-GET capability — no new grant or env var. (M831)
 
 ### Fixed
+- **Board tool no longer fails when `op` is omitted (M844).** A workflow board node (or an agent)
+  passing `{topic, text}` without an explicit `op` previously errored with "op required". The board
+  tool now infers the op from the fields — text+to → send, text+id → reply, text → post, else read —
+  so posting from a workflow node just works. Explicit ops are unchanged.
 - **Delegation never runs a sub-agent on an unkeyed model (M838).** `delegate` (and roster-profile
   model/fallback chains) could pick a model from a provider with no API key, which then failed to
   route mid-delegation. The effective chain is now filtered to models a credentialed provider actually

--- a/plugins/tools/boardtool/board_test.go
+++ b/plugins/tools/boardtool/board_test.go
@@ -125,6 +125,33 @@ func TestDefinitionValid(t *testing.T) {
 	}
 }
 
+// TestInferOp (M844): a board call without an explicit op infers one from the
+// fields — so a workflow board node passing {topic, text} posts instead of
+// failing with "op required".
+func TestInferOp(t *testing.T) {
+	tool := newTool(t)
+	// {topic, text} with no op → post.
+	out, isErr := invoke(t, tool, map[string]any{"topic": "findings", "text": "from a workflow node"})
+	if isErr {
+		t.Fatalf("op-less post should succeed: %v", out)
+	}
+	if _, ok := out["posted"]; !ok {
+		t.Errorf("expected a post, got %v", out)
+	}
+	// {to, text} with no op → send.
+	out, isErr = invoke(t, tool, map[string]any{"to": "researcher", "text": "ping"})
+	if isErr {
+		t.Fatalf("op-less send should succeed: %v", out)
+	}
+	if _, ok := out["sent"]; !ok {
+		t.Errorf("expected a send, got %v", out)
+	}
+	// No fields at all → read (the harmless default), not an error.
+	if _, isErr := invoke(t, tool, map[string]any{}); isErr {
+		t.Error("op-less empty call should default to read, not error")
+	}
+}
+
 func TestPostThenRead_SharedAcrossCalls(t *testing.T) {
 	tool := newTool(t)
 	if _, isErr := invoke(t, tool, map[string]any{"op": "post", "topic": "findings", "from": "researcher", "text": "Go site is go.dev"}); isErr {
@@ -193,7 +220,7 @@ func TestBadInputs(t *testing.T) {
 		{"op": "post", "text": "no topic"},
 		{"op": "post", "topic": "t"}, // no text
 		{"op": "bogus"},
-		{"op": ""},
+		// {"op":""} is no longer an error — it infers a harmless read (M844).
 	} {
 		if _, isErr := invoke(t, tool, c); !isErr {
 			t.Errorf("expected error for %v", c)

--- a/plugins/tools/boardtool/tool.go
+++ b/plugins/tools/boardtool/tool.go
@@ -26,9 +26,8 @@ func (t *Tool) Definition() agent.ToolDef {
 			"reads the answers to a message you sent. The board is shared and persistent.",
 		InputSchema: json.RawMessage(`{
   "type": "object",
-  "required": ["op"],
   "properties": {
-    "op":    {"type":"string", "enum":["post","read","topics","send","inbox","reply","replies"]},
+    "op":    {"type":"string", "enum":["post","read","topics","send","inbox","reply","replies"], "description":"What to do. Optional — if omitted it is inferred: text+to → send, text+id → reply, text (alone/with topic) → post, otherwise read."},
     "topic": {"type":"string", "description":"The topic to post under, or to filter reads by (a short label). For op=send: optional, defaults to \"dm\"."},
     "text":  {"type":"string", "description":"For op=post/send/reply: the message body."},
     "from":  {"type":"string", "description":"Who is posting/sending/replying — use YOUR agent slug so replies can find you."},
@@ -72,6 +71,23 @@ func (t *Tool) Invoke(ctx context.Context, raw json.RawMessage) (agent.Result, e
 	st, nowFn, notify := t.current()
 	if st == nil {
 		return errResult("the board is not available on this daemon"), nil
+	}
+
+	// Infer a missing op from the supplied fields (M844): a workflow board node (or
+	// an agent) that passes {topic, text} without an explicit op should post, not
+	// fail. Keeps the common write ergonomic while leaving explicit ops untouched.
+	in.Op = strings.ToLower(strings.TrimSpace(in.Op))
+	if in.Op == "" {
+		switch {
+		case strings.TrimSpace(in.Text) != "" && strings.TrimSpace(in.To) != "":
+			in.Op = "send"
+		case strings.TrimSpace(in.Text) != "" && strings.TrimSpace(in.ID) != "":
+			in.Op = "reply"
+		case strings.TrimSpace(in.Text) != "":
+			in.Op = "post"
+		default:
+			in.Op = "read"
+		}
 	}
 
 	switch in.Op {


### PR DESCRIPTION
## Bug

Owner: a workflow board node failed with `board: op required (post|read|topics|send|inbox|reply|replies)` — it couldn't post a message.

## Root cause

A workflow **tool node** passes its `config.args` verbatim as the tool input. The board tool **required** an explicit `op` and hard-errored when absent, so a board node configured with just `{topic, text}` (the natural post shape) failed.

## Fix (`plugins/tools/boardtool/tool.go`)

Infer a missing `op` from the fields before the op switch:

- `text` + `to` → **send**
- `text` + `id` → **reply**
- `text` (alone/with topic) → **post**
- nothing → **read**

Explicit ops untouched; the schema no longer marks `op` required and documents the inference. So an op-less board node posts — fixing the workflow case and any agent that omits `op`.

## Verification

- **Unit** (`TestInferOp`): `{topic,text}`→post, `{to,text}`→send, `{}`→read (no error). `TestBadInputs` updated (empty op now reads, not errors). Board + workflow tests green.
- **Gate:** vet + staticcheck + linux clean; gofmt swept; go.mod unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)