### PR TITLE
Feat: skill bundles — reference files + scripts, agentskills.io shape (M847)

### DIFF
--- a/.project/PHASE-M847-SKILL-BUNDLES-REPORT.md
+++ b/.project/PHASE-M847-SKILL-BUNDLES-REPORT.md
@@ -1,0 +1,87 @@
+# PHASE M847 — Skill Bundles (agentskills.io shape: reference files + scripts)
+
+**Status:** shipped
+**Milestone:** M847
+**Theme:** Make a skill more than an inline body — an **agentskills.io-style
+bundle**: a `SKILL.md` plus **reference files** and **scripts** on disk, disclosed
+progressively and runnable. Owner ask: *"skill mimarimiz agentskills.io stili
+olmalı, skiller reference dosyalara ve hatta scripts e sahip olabilir… şu CLI'ı
+kur şu app'i kur kullan vs dediğinde yapabilmeliyiz her şeyi"* — and the
+follow-up: *"ajanların kendi kapasitelerini bilmesi lazım… python scriptler
+javascript çalıştırmak, CLI tool kurmak, npm paketi kurmak… sınırları yok."*
+
+A bundle's `scripts/setup.sh` (npm install, pip install, build a CLI…) is exactly
+the "install this and use it" surface — run with the agent's existing
+shell/code_exec tools (already max-capability, default-allow), now anchored to a
+real on-disk directory the skill ships.
+
+## What shipped
+
+- **A skill can carry a bundle of files.** New `BundleStore`
+  (`kernel/skill/bundle.go`) materializes a skill's resources under
+  `<home>/skills/bundles/<slug>/…`, keyed by the skill's slug (stable across body
+  edits). Write replaces the whole bundle atomically (temp-dir swap), List/Read
+  serve it back, Dir is the working directory for scripts. Path-confined: any
+  `..`/absolute path is rejected, so a bundle can never read or write outside its
+  own directory. Caps: 1 MiB/file, 8 MiB/bundle.
+- **`Skill.Resources []string`** — the manifest of bundled paths, on the record
+  and in every wire view. `CreateSpec.Resources map[string][]byte` carries the
+  files in; `Forge.SetBundles` wires the store (nil → body-only, unchanged).
+- **Import a directory.** `agt skill import <dir>` reads `SKILL.md` (frontmatter
+  → name/description/body) and sends every other file as a resource; the daemon
+  materializes the bundle and registers the skill as a fresh **draft**.
+- **Inspect a bundle.** `agt skill files <id>` lists the resources + the dir;
+  `agt skill cat <id> <path>` prints one. Control plane: `CmdSkillFiles`,
+  `CmdSkillReadFile`. Web UI (read-only): `/api/skill/files`, `/api/skill/file`.
+- **The agent reaches its own bundles.** The `skill` tool gains `op=files`
+  (list + dir) and `op=read` (one resource). When a bundled skill is retrieved
+  into a run, the injected context now lists its resources and tells the agent to
+  read references with `op=read` and run scripts with shell/code_exec from the
+  reported dir — so "run `scripts/setup.sh` to install the CLI, then use it"
+  actually executes.
+
+## Surface
+
+- `kernel/skill/bundle.go` (new) + `bundle_test.go` (new).
+- `kernel/skill/skill.go` — `Skill.Resources`.
+- `kernel/skill/forge.go` — `bundles` field, `SetBundles`/`Bundles`,
+  `CreateSpec.Resources`, `writeBundle`, Create writes/attaches the bundle.
+- `kernel/runtime/runtime.go` — wire `OpenBundles` into the Forge; `injectSkills`
+  lists bundled resources with usage guidance.
+- `kernel/controlplane/{protocol,server,skill}.go` — `CmdSkillFiles` /
+  `CmdSkillReadFile` + dispatch; `handleSkillImport` accepts `resources`;
+  `argResources` decoder; `skillView` includes resources.
+- `kernel/webui/webui.go` — read-only `/api/skill/files`, `/api/skill/file`.
+- `plugins/tools/skilltool/{skilltool,tool}.go` + test — `Bundles()` on the forge
+  interface; `op=files` / `op=read`.
+- `cmd/agt/skill.go`, `skill_import.go`, `skill_md.go`, `skill_files.go` (new) —
+  directory import + `agt skill files` / `agt skill cat`.
+
+## Verification
+
+- **Gate:** `go build ./...`, `go vet`, `staticcheck`, linux cross-build all
+  clean. Targeted tests green: `kernel/skill`, `plugins/tools/skilltool`,
+  `kernel/controlplane`, `kernel/webui`, `kernel/runtime`. No frontend changed
+  (the webui change is Go-only), so vitest is unaffected. No new `AGEZT_*` env;
+  go.mod unchanged.
+- **Unit:** bundle Write/List/Read/Dir, replace-drops-stale, escape rejection,
+  size cap, absent-bundle, slugify; tool `op=files`/`op=read` over a real bundle +
+  the no-bundle-store path.
+- **Live (isolated AGEZT_HOME):** authored a sample bundle (`SKILL.md` +
+  `reference/usage.md` + `scripts/setup.sh` that `npm install -g cowsay`):
+  1. `agt skill import /tmp/sample-skill` → installed draft, 2 resources.
+  2. `agt skill files <id>` → listed both files + the bundle dir.
+  3. `agt skill cat <id> scripts/setup.sh` → printed the script.
+  4. Bundle materialized under `skills/bundles/cowsay-greeter/`.
+  5. `agt skill cat <id> ../../creds.json` → **refused** (escape blocked).
+  6. Web UI `/api/skill/files` and `/api/skill/file` returned the same; the
+     escaping HTTP read was refused too.
+
+## Notes
+- Default-allow preserved: bundles ship with their scripts; running them uses the
+  existing shell/code_exec (net-on, allow-by-default). The path-confinement and
+  size caps are the only guards, and they bound the bundle store itself, not the
+  agent's capability.
+- Follow-ups: a Skills-view UI panel to browse/read a bundle (routes already
+  exist), and a capability self-awareness briefing so agents know up front they
+  may install/run anything to finish a task (next milestone).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
   `delegate` tool now coaches the leader pattern and prefers reusing an existing named agent. (M843)
 
 ### Added
+- **Skills can ship a bundle of files — agentskills.io shape (M847).** A skill is no longer just an
+  inline body: it can carry reference files and scripts on disk. `agt skill import <dir>` ingests an
+  agentskills.io-style directory (`SKILL.md` + `reference/…` + `scripts/…`); the resources are
+  materialized under `skills/bundles/<slug>/`, path-confined and size-capped. Inspect them with
+  `agt skill files <id>` / `agt skill cat <id> <path>` (or `/api/skill/files` · `/api/skill/file`), and
+  the agent reaches its own with the `skill` tool's new `op=files` / `op=read`. A retrieved bundled
+  skill now tells the agent how to use its resources — read a reference, then run a script (e.g.
+  `scripts/setup.sh` to install a CLI / npm package) with shell or code_exec. This is the "install this
+  and use it, no limits" surface: the bundle anchors the files, the always-on exec tools run them. (M847)
 - **Dead-agent graveyard — retire and revive (M846).** Agents you no longer need can be retired to a
   graveyard instead of deleted: a retired agent is paused, delegation to it is refused ("agent is
   retired — revive it first"), and it is greyed out under a "graveyard" marker in the Roster — but its

--- a/cmd/agt/skill.go
+++ b/cmd/agt/skill.go
@@ -39,6 +39,10 @@ func cmdSkill(args []string, stdout, stderr io.Writer) int {
 		return cmdSkillExport(args[1:], stdout, stderr)
 	case "import":
 		return cmdSkillImport(args[1:], stdout, stderr)
+	case "files":
+		return cmdSkillFiles(args[1:], stdout, stderr)
+	case "cat":
+		return cmdSkillCat(args[1:], stdout, stderr)
 	case "registry":
 		return cmdSkillRegistry(args[1:], stdout, stderr)
 	case "-h", "--help", "help":
@@ -52,7 +56,9 @@ func cmdSkill(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stdout, "  diff <id> [<id2>]             diff a skill's body vs its parent (or vs id2)\n")
 		fmt.Fprintf(stdout, "  export <id> [--out <file>]    write a portable, verifiable skill bundle\n")
 		fmt.Fprintf(stdout, "  export --all [--dir <dir>]    export every skill into a directory registry\n")
-		fmt.Fprintf(stdout, "  import <bundle> [--json]      verify a bundle and install it as a draft\n")
+		fmt.Fprintf(stdout, "  import <bundle|dir> [--json]  install a bundle/SKILL.md/skill directory as a draft\n")
+		fmt.Fprintf(stdout, "  files <id> [--json]           list a skill's bundle resources + their directory\n")
+		fmt.Fprintf(stdout, "  cat <id> <path>               print one bundle resource (reference file or script)\n")
 		fmt.Fprintf(stdout, "  registry <dir> [--install <name>]   list/install verifiable bundles in a directory\n")
 		return 0
 	default:

--- a/cmd/agt/skill_files.go
+++ b/cmd/agt/skill_files.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/agezt/agezt/internal/brand"
+	"github.com/agezt/agezt/kernel/controlplane"
+)
+
+// cmdSkillFiles implements `agt skill files <id>` (M847): list the on-disk
+// bundle resources (reference files + scripts) that travel with a skill, plus
+// the directory they live in — the working directory a bundled script runs from.
+func cmdSkillFiles(args []string, stdout, stderr io.Writer) int {
+	id, asJSON := "", false
+	for _, a := range args {
+		switch a {
+		case "--json":
+			asJSON = true
+		case "-h", "--help":
+			fmt.Fprintf(stdout, "usage: %s skill files <id> [--json]\n", brand.CLI)
+			return 0
+		default:
+			if id == "" {
+				id = a
+			}
+		}
+	}
+	if id == "" {
+		fmt.Fprintf(stderr, "usage: %s skill files <id> [--json]\n", brand.CLI)
+		return 2
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := c.Call(ctx, controlplane.CmdSkillFiles, map[string]any{"id": id})
+	if err != nil {
+		fmt.Fprintf(stderr, "%s skill files: %v\n", brand.CLI, err)
+		return 1
+	}
+	if asJSON {
+		return encodeJSON(stdout, res)
+	}
+	name, _ := res["name"].(string)
+	dir, _ := res["dir"].(string)
+	files, _ := res["files"].([]any)
+	if len(files) == 0 {
+		fmt.Fprintf(stdout, "skill %q has no bundle resources\n", name)
+		return 0
+	}
+	fmt.Fprintf(stdout, "skill %q bundle (%d file(s)):\n", name, len(files))
+	for _, f := range files {
+		fmt.Fprintf(stdout, "  %s\n", str(f))
+	}
+	if dir != "" {
+		fmt.Fprintf(stdout, "dir: %s\n", dir)
+		fmt.Fprintf(stdout, "read one: %s skill cat %s <path>\n", brand.CLI, shortHash(str(res["id"])))
+	}
+	return 0
+}
+
+// cmdSkillCat implements `agt skill cat <id> <path>` (M847): print one bundle
+// resource — a reference file or a script. The path is one of those listed by
+// `agt skill files`; the daemon rejects any path that escapes the bundle.
+func cmdSkillCat(args []string, stdout, stderr io.Writer) int {
+	var id, path string
+	for _, a := range args {
+		switch {
+		case a == "-h" || a == "--help":
+			fmt.Fprintf(stdout, "usage: %s skill cat <id> <path>\n", brand.CLI)
+			return 0
+		case id == "":
+			id = a
+		case path == "":
+			path = a
+		}
+	}
+	if id == "" || path == "" {
+		fmt.Fprintf(stderr, "usage: %s skill cat <id> <path>\n", brand.CLI)
+		return 2
+	}
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := c.Call(ctx, controlplane.CmdSkillReadFile, map[string]any{"id": id, "path": path})
+	if err != nil {
+		fmt.Fprintf(stderr, "%s skill cat: %v\n", brand.CLI, err)
+		return 1
+	}
+	content, _ := res["content"].(string)
+	fmt.Fprint(stdout, content)
+	if content != "" && content[len(content)-1] != '\n' {
+		fmt.Fprintln(stdout)
+	}
+	return 0
+}

--- a/cmd/agt/skill_import.go
+++ b/cmd/agt/skill_import.go
@@ -51,6 +51,12 @@ func cmdSkillImport(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 
+	// A directory is an agentskills.io skill bundle: SKILL.md + reference files +
+	// scripts (M847). Import the whole tree, not just the body.
+	if info, statErr := os.Stat(bundlePath); statErr == nil && info.IsDir() {
+		return importSkillDir(bundlePath, asJSON, stdout, stderr)
+	}
+
 	data, err := os.ReadFile(bundlePath)
 	if err != nil {
 		fmt.Fprintf(stderr, "%s skill import: read %s: %v\n", brand.CLI, bundlePath, err)

--- a/cmd/agt/skill_md.go
+++ b/cmd/agt/skill_md.go
@@ -6,6 +6,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -20,6 +23,108 @@ import (
 func isSkillMarkdown(path string) bool {
 	lower := strings.ToLower(path)
 	return strings.HasSuffix(lower, ".md") || strings.HasSuffix(lower, ".markdown")
+}
+
+// importSkillDir ingests a full agentskills.io skill BUNDLE (M847): a directory
+// holding a SKILL.md plus reference files and scripts. SKILL.md becomes the
+// skill's name/description/body; every other file is sent as a bundle resource
+// (relative path → content) and materialized on the daemon, so the agent can
+// later list them (skill files), read a reference (skill cat), and run a bundled
+// script. The skill arrives as a fresh DRAFT, content-addressed and journaled.
+func importSkillDir(dir string, asJSON bool, stdout, stderr io.Writer) int {
+	mdPath := filepath.Join(dir, "SKILL.md")
+	mdData, err := os.ReadFile(mdPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s skill import: a skill directory must contain SKILL.md (%v)\n", brand.CLI, err)
+		return 1
+	}
+	md, err := skill.ParseSkillMD(mdData)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s skill import: %v\n", brand.CLI, err)
+		return 1
+	}
+
+	// Collect every file except SKILL.md as a resource, preserving the relative
+	// layout (reference/..., scripts/...). Enforce the same caps the bundle store
+	// applies, but fail early here with a clear message.
+	resources := map[string]any{}
+	total := 0
+	walkErr := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, rerr := filepath.Rel(dir, path)
+		if rerr != nil {
+			return rerr
+		}
+		if filepath.ToSlash(rel) == "SKILL.md" {
+			return nil // the body, not a resource
+		}
+		data, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return rerr
+		}
+		if len(data) > skill.MaxBundleFile {
+			return fmt.Errorf("resource %q is %d bytes (max %d)", rel, len(data), skill.MaxBundleFile)
+		}
+		total += len(data)
+		if total > skill.MaxBundleTotal {
+			return fmt.Errorf("bundle exceeds %d bytes total", skill.MaxBundleTotal)
+		}
+		resources[filepath.ToSlash(rel)] = string(data)
+		return nil
+	})
+	if walkErr != nil {
+		fmt.Fprintf(stderr, "%s skill import: %v\n", brand.CLI, walkErr)
+		return 1
+	}
+
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	callArgs := map[string]any{
+		"name":        md.Name,
+		"description": md.Description,
+		"body":        md.Body,
+	}
+	if len(md.Triggers) > 0 {
+		callArgs["triggers"] = md.Triggers
+	}
+	if len(md.ToolsRequired) > 0 {
+		callArgs["tools_required"] = md.ToolsRequired
+	}
+	if len(resources) > 0 {
+		callArgs["resources"] = resources
+	}
+	res, err := c.Call(ctx, controlplane.CmdSkillImport, callArgs)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s skill import: %v\n", brand.CLI, err)
+		return 1
+	}
+	if asJSON {
+		_ = encodeJSON(stdout, res)
+		return 0
+	}
+	gotID, _ := res["id"].(string)
+	created, _ := res["created"].(bool)
+	status, _ := res["status"].(string)
+	verb := "already present (refreshed)"
+	if created {
+		verb = "installed as a new " + status
+	}
+	fmt.Fprintf(stdout, "skill bundle %q %s\n", md.Name, verb)
+	fmt.Fprintf(stdout, "  id: %s  status: %s  resources: %d\n", shortHash(gotID), status, len(resources))
+	if created {
+		fmt.Fprintf(stdout, "  inspect its files: %s skill files %s\n", brand.CLI, shortHash(gotID))
+		fmt.Fprintf(stdout, "  promote it into the retrieval pool: %s skill promote %s\n", brand.CLI, gotID)
+	}
+	return 0
 }
 
 // importSkillMarkdownBytes ingests an agentskills.io/ClawHub SKILL.md (SPEC-13

--- a/kernel/controlplane/protocol.go
+++ b/kernel/controlplane/protocol.go
@@ -904,8 +904,18 @@ const (
 	// CmdSkillImport installs a skill from a portable bundle as a fresh DRAFT
 	// (via the Forge, so it is content-addressed, deduped, and journaled like
 	// any other authored skill). Args: name, body (required); description,
-	// triggers, tools_required (optional). Returns: { id, name, status, created }
+	// triggers, tools_required, resources (optional; resources is an object of
+	// {relative-path: text-content} — the agentskills.io bundle of reference
+	// files + scripts, M847). Returns: { id, name, status, created, resources }
 	CmdSkillImport = "skill_import"
+
+	// CmdSkillFiles lists a skill's on-disk bundle resources (M847).
+	// Args: id (required). Returns: { id, name, files: [...], dir, count }
+	CmdSkillFiles = "skill_files"
+
+	// CmdSkillReadFile returns one bundle resource's text content (M847).
+	// Args: id, path (required). Returns: { id, name, path, content, bytes }
+	CmdSkillReadFile = "skill_read_file"
 
 	// Chronos standing orders (SPEC-16 §4) — persistent-goal CRUD behind
 	// `agt standing`. Add: args.order (object). SetEnabled: args{id, enabled}.

--- a/kernel/controlplane/server.go
+++ b/kernel/controlplane/server.go
@@ -698,6 +698,10 @@ func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
 		s.handleSkillRevert(conn, req)
 	case CmdSkillImport:
 		s.handleSkillImport(conn, req)
+	case CmdSkillFiles:
+		s.handleSkillFiles(conn, req)
+	case CmdSkillReadFile:
+		s.handleSkillReadFile(conn, req)
 	case CmdStandingList:
 		s.handleStandingList(conn, req)
 	case CmdStandingAdd:

--- a/kernel/controlplane/skill.go
+++ b/kernel/controlplane/skill.go
@@ -9,6 +9,7 @@ package controlplane
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 
 	"github.com/agezt/agezt/kernel/event"
@@ -167,12 +168,18 @@ func (s *Server) handleSkillImport(conn net.Conn, req Request) {
 		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: toerr.Error()})
 		return
 	}
+	resources, rerr := argResources(req.Args, "resources")
+	if rerr != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: rerr.Error()})
+		return
+	}
 	sk, created, err := s.k.Forge().Create("", skill.CreateSpec{
 		Name:          name,
 		Description:   stringArg(req.Args, "description"),
 		Triggers:      triggers,
 		Body:          body,
 		ToolsRequired: tools,
+		Resources:     resources,
 	})
 	if err != nil {
 		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
@@ -181,8 +188,101 @@ func (s *Server) handleSkillImport(conn net.Conn, req Request) {
 	s.writeResp(conn, Response{
 		ID: req.ID, Type: RespResult,
 		Result: map[string]any{
-			"id": sk.ID, "name": sk.Name, "status": string(sk.Status), "created": created,
+			"id": sk.ID, "name": sk.Name, "status": string(sk.Status),
+			"created": created, "resources": sk.Resources,
 		},
+	})
+}
+
+// argResources decodes the optional resources bundle from a control-plane call:
+// a JSON object mapping each relative path to that file's text content. Absent
+// or empty → nil (a body-only skill). A non-object value is rejected.
+func argResources(args map[string]any, key string) (map[string][]byte, error) {
+	raw, ok := args[key]
+	if !ok || raw == nil {
+		return nil, nil
+	}
+	obj, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("args.%s must be an object of {path: content}", key)
+	}
+	if len(obj) == 0 {
+		return nil, nil
+	}
+	out := make(map[string][]byte, len(obj))
+	for path, v := range obj {
+		content, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("args.%s[%q] must be a string", key, path)
+		}
+		out[path] = []byte(content)
+	}
+	return out, nil
+}
+
+// handleSkillFiles lists a skill's bundle resources (relative paths) plus the
+// absolute bundle directory the agent runs scripts from. Read-only.
+func (s *Server) handleSkillFiles(conn net.Conn, req Request) {
+	id, _ := req.Args["id"].(string)
+	if id == "" {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.id required"})
+		return
+	}
+	sk, found, err := s.k.Forge().Get(id)
+	if err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
+		return
+	}
+	if !found {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "no skill with id " + id})
+		return
+	}
+	bundles := s.k.Forge().Bundles()
+	files := sk.Resources
+	dir := ""
+	if bundles != nil {
+		if live, lerr := bundles.List(sk.Name); lerr == nil && live != nil {
+			files = live // the on-disk truth, in case the manifest drifted
+		}
+		dir = bundles.Dir(sk.Name)
+	}
+	s.writeResp(conn, Response{
+		ID: req.ID, Type: RespResult,
+		Result: map[string]any{"id": sk.ID, "name": sk.Name, "files": files, "dir": dir, "count": len(files)},
+	})
+}
+
+// handleSkillReadFile returns the text content of one bundle resource. Read-only;
+// the bundle store rejects any path that escapes the skill's directory.
+func (s *Server) handleSkillReadFile(conn net.Conn, req Request) {
+	id, _ := req.Args["id"].(string)
+	path, _ := req.Args["path"].(string)
+	if id == "" || path == "" {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "args.id and args.path required"})
+		return
+	}
+	sk, found, err := s.k.Forge().Get(id)
+	if err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
+		return
+	}
+	if !found {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "no skill with id " + id})
+		return
+	}
+	bundles := s.k.Forge().Bundles()
+	if bundles == nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "skill bundles are not available on this daemon"})
+		return
+	}
+	data, err := bundles.Read(sk.Name, path)
+	if err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
+		return
+	}
+	s.writeResp(conn, Response{
+		ID: req.ID, Type: RespResult,
+		Result: map[string]any{"id": sk.ID, "name": sk.Name, "path": path, "content": string(data), "bytes": len(data)},
 	})
 }
 
@@ -216,6 +316,9 @@ func skillView(sk skill.Skill) map[string]any {
 	}
 	if len(sk.ToolsRequired) > 0 {
 		v["tools_required"] = sk.ToolsRequired
+	}
+	if len(sk.Resources) > 0 {
+		v["resources"] = sk.Resources
 	}
 	if len(sk.Lineage) > 0 {
 		v["lineage"] = sk.Lineage

--- a/kernel/runtime/runtime.go
+++ b/kernel/runtime/runtime.go
@@ -471,6 +471,12 @@ func Open(cfg Config) (*Kernel, error) {
 		return nil, fmt.Errorf("runtime: skills: %w", err)
 	}
 	forge := skill.NewForge(skstore, kbus)
+	// Wire the on-disk bundle store so skills can ship reference files + scripts
+	// (agentskills.io shape, M847). Best-effort: a bundle-store failure leaves
+	// skills body-only rather than failing daemon start.
+	if bundles, berr := skill.OpenBundles(filepath.Join(cfg.BaseDir, "skills")); berr == nil {
+		forge.SetBundles(bundles)
+	}
 
 	schedStore, err := cadence.OpenStore(filepath.Join(cfg.BaseDir, "cadence"))
 	if err != nil {
@@ -2077,6 +2083,17 @@ func injectSkills(system string, hits []skill.Scored) string {
 	for _, h := range hits {
 		s := h.Skill
 		fmt.Fprintf(&b, "## %s — %s\n%s\n", s.Name, s.Description, s.Body)
+		// A bundled skill (agentskills.io shape, M847) ships reference files and
+		// scripts. List them and tell the agent how to reach them: read a reference
+		// with `skill op=read`, run a script with shell/code_exec from the dir that
+		// `skill op=files` reports. This is what lets a skill say "run scripts/setup.sh
+		// to install the CLI" and have the agent actually do it.
+		if len(s.Resources) > 0 {
+			fmt.Fprintf(&b, "Bundled resources (use the `skill` tool: op=files for the directory, op=read \"<path>\" to read one; run scripts with shell/code_exec):\n")
+			for _, r := range s.Resources {
+				fmt.Fprintf(&b, "  - %s\n", r)
+			}
+		}
 	}
 	if system != "" {
 		b.WriteString("\n")

--- a/kernel/skill/bundle.go
+++ b/kernel/skill/bundle.go
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: MIT
+
+package skill
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// BundleStore holds the on-disk resources that travel with a skill — the
+// agentskills.io / ClawHub bundle shape (SPEC-13). A skill is no longer only an
+// inline body: it can ship REFERENCE files (extra docs the body points at) and
+// SCRIPTS (helpers the agent runs — `scripts/setup.sh` to install a CLI, a
+// Python tool, etc.). The SKILL.md body stays small and is injected into
+// context; the heavier resources live here and are disclosed progressively —
+// the agent lists them (op=files), reads one when relevant (op=read), and runs
+// scripts with its existing shell/code_exec tools against the bundle Dir.
+//
+// Layout: <skillsDir>/bundles/<slug>/<relative-path...>. Bundles are keyed by
+// the skill's slug (normalized name), not its content-id, because resources are
+// stable across body edits (a new version of "pdf-fill" keeps the same scripts).
+//
+// A BundleStore is safe for concurrent use: each operation is a self-contained
+// filesystem call and writes go through a temp-dir swap (see Write).
+type BundleStore struct {
+	root string // <skillsDir>/bundles
+}
+
+// OpenBundles opens (or creates) the bundle store rooted at <dir>/bundles.
+func OpenBundles(dir string) (*BundleStore, error) {
+	root := filepath.Join(dir, "bundles")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return nil, fmt.Errorf("skill: mkdir bundles %s: %w", root, err)
+	}
+	return &BundleStore{root: root}, nil
+}
+
+// MaxBundleFile caps a single resource file; MaxBundleTotal caps a whole bundle.
+// Bundles are text procedures and helper scripts, not data blobs — generous
+// limits that still stop an accidental gigabyte from landing in the skill store.
+const (
+	MaxBundleFile  = 1 << 20       // 1 MiB per file
+	MaxBundleTotal = 8 * (1 << 20) // 8 MiB per bundle
+)
+
+// slugify normalizes a skill name into a filesystem-safe directory segment:
+// lowercased, trimmed, with any run of non-[a-z0-9_] folded to a single '-'.
+// Matches the name-folding ContentID uses so a bundle and its skill agree.
+func slugify(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	var b strings.Builder
+	dash := false
+	for _, r := range name {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_':
+			b.WriteRune(r)
+			dash = false
+		default:
+			if !dash && b.Len() > 0 {
+				b.WriteByte('-')
+				dash = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+// cleanRel validates a bundle-relative path and returns it in slash-free OS form.
+// It rejects absolute paths and any path that escapes the bundle root (`..`), so
+// an imported bundle can never write outside its own directory.
+func cleanRel(rel string) (string, error) {
+	rel = strings.TrimSpace(strings.ReplaceAll(rel, "\\", "/"))
+	if rel == "" {
+		return "", errors.New("skill: empty bundle path")
+	}
+	if strings.HasPrefix(rel, "/") {
+		return "", fmt.Errorf("skill: bundle path %q must be relative", rel)
+	}
+	cleaned := filepath.Clean(filepath.FromSlash(rel))
+	if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) || filepath.IsAbs(cleaned) {
+		return "", fmt.Errorf("skill: bundle path %q escapes the bundle", rel)
+	}
+	return cleaned, nil
+}
+
+// Write materializes a bundle for the named skill, REPLACING any prior bundle so
+// a re-import that drops a file leaves no stale resource behind. The write is
+// staged in a sibling temp directory and swapped into place, so a partial or
+// failed write never corrupts an existing bundle. Returns the relative paths
+// actually written, sorted, in slash form (the stable wire shape).
+func (b *BundleStore) Write(name string, files map[string][]byte) ([]string, error) {
+	slug := slugify(name)
+	if slug == "" {
+		return nil, fmt.Errorf("skill: cannot derive a bundle slug from name %q", name)
+	}
+	if len(files) == 0 {
+		return nil, nil
+	}
+	// Validate everything before touching disk.
+	total := 0
+	staged := make(map[string][]byte, len(files))
+	for rel, data := range files {
+		cleaned, err := cleanRel(rel)
+		if err != nil {
+			return nil, err
+		}
+		if len(data) > MaxBundleFile {
+			return nil, fmt.Errorf("skill: bundle file %q is %d bytes (max %d)", rel, len(data), MaxBundleFile)
+		}
+		total += len(data)
+		if total > MaxBundleTotal {
+			return nil, fmt.Errorf("skill: bundle %q exceeds %d bytes total", name, MaxBundleTotal)
+		}
+		staged[cleaned] = data
+	}
+
+	dst := filepath.Join(b.root, slug)
+	tmp := dst + ".tmp"
+	if err := os.RemoveAll(tmp); err != nil {
+		return nil, fmt.Errorf("skill: clear bundle temp: %w", err)
+	}
+	rels := make([]string, 0, len(staged))
+	for cleaned, data := range staged {
+		full := filepath.Join(tmp, cleaned)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			os.RemoveAll(tmp)
+			return nil, fmt.Errorf("skill: mkdir bundle dir: %w", err)
+		}
+		if err := os.WriteFile(full, data, 0o644); err != nil {
+			os.RemoveAll(tmp)
+			return nil, fmt.Errorf("skill: write bundle file %q: %w", cleaned, err)
+		}
+		rels = append(rels, filepath.ToSlash(cleaned))
+	}
+	// Swap: remove the old bundle, then rename the staged one over it.
+	if err := os.RemoveAll(dst); err != nil {
+		os.RemoveAll(tmp)
+		return nil, fmt.Errorf("skill: replace bundle: %w", err)
+	}
+	if err := os.Rename(tmp, dst); err != nil {
+		os.RemoveAll(tmp)
+		return nil, fmt.Errorf("skill: commit bundle: %w", err)
+	}
+	sort.Strings(rels)
+	return rels, nil
+}
+
+// List returns the bundle's resource paths (sorted, slash form), or nil if the
+// skill has no bundle.
+func (b *BundleStore) List(name string) ([]string, error) {
+	slug := slugify(name)
+	if slug == "" {
+		return nil, nil
+	}
+	dir := filepath.Join(b.root, slug)
+	var rels []string
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil // no bundle for this skill — not an error
+			}
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, rerr := filepath.Rel(dir, path)
+		if rerr != nil {
+			return rerr
+		}
+		rels = append(rels, filepath.ToSlash(rel))
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("skill: list bundle %q: %w", name, err)
+	}
+	sort.Strings(rels)
+	return rels, nil
+}
+
+// Read returns the contents of one bundle resource. The relative path is
+// validated against escape, so a caller (or a tool the agent drives) can never
+// read outside the bundle.
+func (b *BundleStore) Read(name, rel string) ([]byte, error) {
+	slug := slugify(name)
+	if slug == "" {
+		return nil, fmt.Errorf("skill: cannot derive a bundle slug from name %q", name)
+	}
+	cleaned, err := cleanRel(rel)
+	if err != nil {
+		return nil, err
+	}
+	full := filepath.Join(b.root, slug, cleaned)
+	data, err := os.ReadFile(full)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("skill: bundle resource %q not found in %q", rel, name)
+		}
+		return nil, fmt.Errorf("skill: read bundle resource: %w", err)
+	}
+	return data, nil
+}
+
+// Dir returns the absolute bundle directory for the named skill — the working
+// directory the agent runs the bundle's scripts from. The directory may not yet
+// exist (a skill with no resources); callers that need it present should List
+// first.
+func (b *BundleStore) Dir(name string) string {
+	slug := slugify(name)
+	if slug == "" {
+		return ""
+	}
+	return filepath.Join(b.root, slug)
+}
+
+// Remove deletes a skill's bundle directory (used when a skill is hard-removed).
+// Absent bundle is not an error.
+func (b *BundleStore) Remove(name string) error {
+	slug := slugify(name)
+	if slug == "" {
+		return nil
+	}
+	if err := os.RemoveAll(filepath.Join(b.root, slug)); err != nil {
+		return fmt.Errorf("skill: remove bundle %q: %w", name, err)
+	}
+	return nil
+}

--- a/kernel/skill/bundle_test.go
+++ b/kernel/skill/bundle_test.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+
+package skill
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBundleStore_WriteListRead(t *testing.T) {
+	bs, err := OpenBundles(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenBundles: %v", err)
+	}
+	files := map[string][]byte{
+		"reference/api.md": []byte("# API\nuse the thing"),
+		"scripts/setup.sh": []byte("#!/bin/sh\nnpm i -g cowsay"),
+		"SKILL.md":         []byte("---\nname: pdf-fill\n---\nbody"),
+	}
+	rels, err := bs.Write("PDF Fill", files)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	// Manifest is sorted, slash form.
+	want := []string{"SKILL.md", "reference/api.md", "scripts/setup.sh"}
+	if strings.Join(rels, ",") != strings.Join(want, ",") {
+		t.Fatalf("manifest = %v, want %v", rels, want)
+	}
+	// List agrees with Write.
+	listed, err := bs.List("PDF Fill")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if strings.Join(listed, ",") != strings.Join(want, ",") {
+		t.Fatalf("List = %v, want %v", listed, want)
+	}
+	// Read returns the exact bytes.
+	got, err := bs.Read("PDF Fill", "scripts/setup.sh")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if string(got) != "#!/bin/sh\nnpm i -g cowsay" {
+		t.Fatalf("Read content = %q", got)
+	}
+	// Dir points under bundles/<slug>; the slug folds name casing/spaces.
+	if base := filepath.Base(bs.Dir("PDF Fill")); base != "pdf-fill" {
+		t.Fatalf("Dir slug = %q, want pdf-fill", base)
+	}
+}
+
+func TestBundleStore_ReplaceDropsStale(t *testing.T) {
+	bs, _ := OpenBundles(t.TempDir())
+	if _, err := bs.Write("s", map[string][]byte{"a.txt": []byte("1"), "b.txt": []byte("2")}); err != nil {
+		t.Fatal(err)
+	}
+	// Re-import with only a.txt — b.txt must be gone (bundle is replaced, not merged).
+	if _, err := bs.Write("s", map[string][]byte{"a.txt": []byte("1b")}); err != nil {
+		t.Fatal(err)
+	}
+	listed, _ := bs.List("s")
+	if len(listed) != 1 || listed[0] != "a.txt" {
+		t.Fatalf("after replace, files = %v, want [a.txt]", listed)
+	}
+	if _, err := bs.Read("s", "b.txt"); err == nil {
+		t.Fatalf("stale b.txt still readable after replace")
+	}
+}
+
+func TestBundleStore_RejectsEscape(t *testing.T) {
+	bs, _ := OpenBundles(t.TempDir())
+	for _, bad := range []string{"../evil.sh", "/etc/passwd", "a/../../b", "..\\win"} {
+		if _, err := bs.Write("s", map[string][]byte{bad: []byte("x")}); err == nil {
+			t.Fatalf("Write accepted escaping path %q", bad)
+		}
+		if _, err := bs.Read("s", bad); err == nil {
+			t.Fatalf("Read accepted escaping path %q", bad)
+		}
+	}
+}
+
+func TestBundleStore_FileSizeCap(t *testing.T) {
+	bs, _ := OpenBundles(t.TempDir())
+	big := make([]byte, MaxBundleFile+1)
+	if _, err := bs.Write("s", map[string][]byte{"big.bin": big}); err == nil {
+		t.Fatalf("Write accepted an oversized file")
+	}
+	// And nothing was committed.
+	if dir := bs.Dir("s"); dirExists(dir) {
+		t.Fatalf("oversized write left a bundle dir behind")
+	}
+}
+
+func TestBundleStore_AbsentBundle(t *testing.T) {
+	bs, _ := OpenBundles(t.TempDir())
+	files, err := bs.List("never-written")
+	if err != nil {
+		t.Fatalf("List of absent bundle errored: %v", err)
+	}
+	if files != nil {
+		t.Fatalf("List of absent bundle = %v, want nil", files)
+	}
+}
+
+func TestSlugify(t *testing.T) {
+	cases := map[string]string{
+		"PDF Fill":        "pdf-fill",
+		"  diagnose-ci  ": "diagnose-ci",
+		"a/b\\c":          "a-b-c",
+		"Hello   World":   "hello-world",
+		"keep_under":      "keep_under",
+		"!!!":             "",
+	}
+	for in, want := range cases {
+		if got := slugify(in); got != want {
+			t.Errorf("slugify(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func dirExists(p string) bool {
+	info, err := os.Stat(p)
+	return err == nil && info.IsDir()
+}

--- a/kernel/skill/forge.go
+++ b/kernel/skill/forge.go
@@ -24,6 +24,11 @@ import (
 type Forge struct {
 	store Store
 	bus   *bus.Bus
+	// bundles holds the on-disk resources (reference files + scripts) that travel
+	// with a skill (agentskills.io shape, SPEC-13). Optional: nil in store-only
+	// tests and on daemons without a bundle store; when nil, Create simply ignores
+	// any Resources and a skill stays body-only. Injected via SetBundles.
+	bundles *BundleStore
 	// now is the clock, injectable for deterministic tests.
 	now func() time.Time
 	// mu serialises the read-modify-write lifecycle mutators so two concurrent runs
@@ -92,6 +97,16 @@ func (f *Forge) SetAutoQuarantine(minFailures int, rate float64) {
 // The daemon calls this from config; off by default.
 func (f *Forge) SetAutoShadow(on bool) { f.autoShadow = on }
 
+// SetBundles wires the on-disk bundle store so Create can materialize a skill's
+// reference files and scripts (agentskills.io shape). The daemon injects it at
+// startup; nil leaves skills body-only. Bundles returns the wired store (nil if
+// unset) for callers that need to read resources directly.
+func (f *Forge) SetBundles(b *BundleStore) { f.bundles = b }
+
+// Bundles returns the wired bundle store (nil if none). The control plane uses
+// it to serve a skill's resource list and file reads.
+func (f *Forge) Bundles() *BundleStore { return f.bundles }
+
 // SetAutoPromote tunes (or, with minWins <= 0, disables) shadow→active
 // auto-promotion. The daemon calls this from config; tests use it to assert the
 // disabled path.
@@ -113,6 +128,12 @@ type CreateSpec struct {
 	Triggers      []string
 	Body          string
 	ToolsRequired []string
+	// Resources is an optional bundle of on-disk files (relative path → content)
+	// that travel with the skill — reference docs and scripts (agentskills.io
+	// shape). When non-empty and a bundle store is wired (SetBundles), Create
+	// materializes them and records their manifest on the skill. Ignored when no
+	// bundle store is set.
+	Resources map[string][]byte
 }
 
 // Create authors a new draft skill and journals it. Content-addressing by
@@ -135,10 +156,22 @@ func (f *Forge) Create(corr string, spec CreateSpec) (Skill, bool, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
+	// Materialize any bundle first: resources are keyed by name, so they attach
+	// to both a fresh skill and a refreshed-existing one. A bundle-write failure
+	// fails the create (a half-installed skill that points at missing files is
+	// worse than no skill).
+	resources, err := f.writeBundle(name, spec.Resources)
+	if err != nil {
+		return Skill{}, false, err
+	}
+
 	if existing, found, err := f.store.Get(id); err != nil {
 		return Skill{}, false, err
 	} else if found {
 		existing.LastSeenMS = nowMS
+		if resources != nil {
+			existing.Resources = resources
+		}
 		if err := f.store.Put(existing); err != nil {
 			return Skill{}, false, err
 		}
@@ -152,6 +185,7 @@ func (f *Forge) Create(corr string, spec CreateSpec) (Skill, bool, error) {
 		Triggers:      normalizeList(spec.Triggers),
 		Body:          spec.Body,
 		ToolsRequired: normalizeList(spec.ToolsRequired),
+		Resources:     resources,
 		Version:       DefaultVersion,
 		Lineage:       f.lineageFor(name),
 		Status:        StatusDraft,
@@ -189,6 +223,17 @@ func (f *Forge) maybeAutoShadow(corr string, sk Skill) {
 		return
 	}
 	_, _ = f.promoteWithReason(corr, sk.ID, "auto-shadow: shadow-test passed")
+}
+
+// writeBundle materializes a skill's resource bundle when both resources and a
+// bundle store are present. It returns the manifest (sorted relative paths) to
+// record on the skill, or nil when there is nothing to attach (no resources, or
+// no bundle store wired). Caller holds f.mu.
+func (f *Forge) writeBundle(name string, resources map[string][]byte) ([]string, error) {
+	if len(resources) == 0 || f.bundles == nil {
+		return nil, nil
+	}
+	return f.bundles.Write(name, resources)
 }
 
 // lineageFor returns the ids of non-archived skills sharing name — the

--- a/kernel/skill/skill.go
+++ b/kernel/skill/skill.go
@@ -139,6 +139,12 @@ type Skill struct {
 	Body string `json:"body"`
 	// ToolsRequired lists tools the skill expects to be available.
 	ToolsRequired []string `json:"tools_required,omitempty"`
+	// Resources lists the relative paths of the skill's on-disk bundle —
+	// reference files and scripts that travel with it (agentskills.io shape,
+	// SPEC-13). Empty for a plain body-only skill. The files live under the
+	// BundleStore (kernel/skill/bundle.go); this is the manifest the retrieval
+	// layer, the CLI, and the agent's skill tool use to discover them.
+	Resources []string `json:"resources,omitempty"`
 	// Version is semver; a new body is a new version (§4.3).
 	Version string `json:"version"`
 	// Lineage is the ids this skill evolved from (parent-first).

--- a/kernel/webui/webui.go
+++ b/kernel/webui/webui.go
@@ -175,7 +175,11 @@ var readArgsRoutes = map[string]writeRoute{
 	"/api/data/records": {controlplane.CmdDataRecords, []string{"collection", "search", "sort", "desc", "limit", "offset"}},
 	// Agent graveyard impact (M846): what standing orders fire this agent. Read-only.
 	"/api/agents/impact": {controlplane.CmdAgentImpact, []string{"ref"}},
-	"/api/policy_log":    {controlplane.CmdEdictLog, []string{"limit", "denied"}},
+	// Skill bundle resources (M847): list a skill's reference files + scripts, and
+	// read one resource's content. Both read-only; the daemon path-confines reads.
+	"/api/skill/files": {controlplane.CmdSkillFiles, []string{"id"}},
+	"/api/skill/file":  {controlplane.CmdSkillReadFile, []string{"id", "path"}},
+	"/api/policy_log":  {controlplane.CmdEdictLog, []string{"limit", "denied"}},
 	// Resolved HITL approval history (M773): a timeline of past approval requests
 	// joined with their granted/denied/timeout outcome. Read-only.
 	"/api/approvals_log": {controlplane.CmdApprovalsLog, []string{"limit", "denied"}},

--- a/plugins/tools/skilltool/skilltool.go
+++ b/plugins/tools/skilltool/skilltool.go
@@ -31,6 +31,10 @@ type forge interface {
 	Quarantine(corr, id, reason string) error
 	Get(id string) (skill.Skill, bool, error)
 	List() ([]skill.Skill, error)
+	// Bundles returns the on-disk resource store (reference files + scripts) so
+	// the agent can list and read a skill's bundle (op=files / op=read, M847).
+	// nil when no bundle store is wired.
+	Bundles() *skill.BundleStore
 }
 
 // Tool implements agent.Tool. Created unbound via New(); Bind wires the Forge.

--- a/plugins/tools/skilltool/skilltool_test.go
+++ b/plugins/tools/skilltool/skilltool_test.go
@@ -21,6 +21,7 @@ type fakeForge struct {
 	promoted string
 	retired  string
 	retErr   error
+	bundles  *skill.BundleStore
 }
 
 func newFake() *fakeForge { return &fakeForge{byID: map[string]skill.Skill{}} }
@@ -68,6 +69,8 @@ func (f *fakeForge) List() ([]skill.Skill, error) {
 	}
 	return out, nil
 }
+
+func (f *fakeForge) Bundles() *skill.BundleStore { return f.bundles }
 
 func newTool(f forge) *Tool {
 	t := New()
@@ -127,8 +130,8 @@ func TestLearn_CorrelationFromContextIsPassedThrough(t *testing.T) {
 func TestLearn_NeedsNameAndBody(t *testing.T) {
 	f := newFake()
 	for _, c := range []map[string]any{
-		{"op": "learn", "body": "b"},  // no name
-		{"op": "learn", "name": "n"},  // no body
+		{"op": "learn", "body": "b"}, // no name
+		{"op": "learn", "name": "n"}, // no body
 	} {
 		if _, isErr := invoke(t, newTool(f), c); !isErr {
 			t.Errorf("expected error for %v", c)
@@ -220,6 +223,66 @@ func TestBadOps(t *testing.T) {
 		if _, isErr := invoke(t, newTool(f), c); !isErr {
 			t.Errorf("expected error for %v", c)
 		}
+	}
+}
+
+func TestFilesAndRead_Bundle(t *testing.T) {
+	f := newFake()
+	bs, err := skill.OpenBundles(t.TempDir())
+	if err != nil {
+		t.Fatalf("OpenBundles: %v", err)
+	}
+	f.bundles = bs
+	tool := newTool(f)
+
+	// Author a skill, then attach a bundle out-of-band (the daemon would do this
+	// during import; here we drive the store directly and register the skill).
+	invoke(t, tool, map[string]any{"op": "learn", "name": "pdf-fill", "body": "fill a pdf"})
+	if _, err := bs.Write("pdf-fill", map[string][]byte{
+		"reference/fields.md": []byte("the fields"),
+		"scripts/run.py":      []byte("print('hi')"),
+	}); err != nil {
+		t.Fatalf("bundle Write: %v", err)
+	}
+	id := skill.ContentID("pdf-fill", "fill a pdf")
+
+	// op=files lists the bundle + reports the dir.
+	fl, isErr := invoke(t, tool, map[string]any{"op": "files", "id": id})
+	if isErr {
+		t.Fatalf("files errored: %v", fl)
+	}
+	if fl["count"].(float64) != 2 {
+		t.Fatalf("files count = %v, want 2", fl["count"])
+	}
+	if fl["dir"] == "" {
+		t.Error("files did not report a bundle dir")
+	}
+
+	// op=read returns one resource's content.
+	rd, isErr := invoke(t, tool, map[string]any{"op": "read", "id": id, "path": "scripts/run.py"})
+	if isErr {
+		t.Fatalf("read errored: %v", rd)
+	}
+	if rd["content"] != "print('hi')" {
+		t.Errorf("read content = %v, want print('hi')", rd["content"])
+	}
+
+	// op=read needs a path; an escaping path is refused by the store.
+	if _, isErr := invoke(t, tool, map[string]any{"op": "read", "id": id}); !isErr {
+		t.Error("op=read without a path should error")
+	}
+	if _, isErr := invoke(t, tool, map[string]any{"op": "read", "id": id, "path": "../escape"}); !isErr {
+		t.Error("op=read with an escaping path should error")
+	}
+}
+
+func TestFiles_NoBundleStore(t *testing.T) {
+	f := newFake() // bundles nil
+	tool := newTool(f)
+	invoke(t, tool, map[string]any{"op": "learn", "name": "x", "body": "y"})
+	id := skill.ContentID("x", "y")
+	if _, isErr := invoke(t, tool, map[string]any{"op": "files", "id": id}); !isErr {
+		t.Error("op=files without a bundle store should error gracefully")
 	}
 }
 

--- a/plugins/tools/skilltool/tool.go
+++ b/plugins/tools/skilltool/tool.go
@@ -21,19 +21,25 @@ func (t *Tool) Definition() agent.ToolDef {
 			"op=list shows your skills with their status and usage; op=show returns one skill's " +
 			"full body; op=promote advances a skill toward your active retrieval pool " +
 			"(draft→shadow→active); op=retire pulls a skill that's gone wrong (quarantine). " +
+			"A skill can also carry a BUNDLE of files (agentskills.io shape): reference docs and " +
+			"scripts. op=files lists a skill's bundled resources and the directory they live in; " +
+			"op=read returns one resource's contents — read a reference doc when you need the " +
+			"detail, then run a bundled script (e.g. scripts/setup.sh to install a CLI) with your " +
+			"shell or code_exec tool from the reported dir. " +
 			"Use this to get better over time: when you work out how to do something, capture it " +
 			"as a skill so future runs can reuse it. Every change is journaled and reversible.",
 		InputSchema: json.RawMessage(`{
   "type": "object",
   "required": ["op"],
   "properties": {
-    "op":          {"type":"string", "enum":["learn","list","show","promote","retire"]},
+    "op":          {"type":"string", "enum":["learn","list","show","promote","retire","files","read"]},
     "name":        {"type":"string", "description":"For op=learn: a short kebab-case name, e.g. \"diagnose-failing-ci\"."},
     "description": {"type":"string", "description":"For op=learn: one line on when this skill applies (the retrieval-matching key)."},
     "body":        {"type":"string", "description":"For op=learn: the procedure itself — the steps/instructions to follow."},
     "triggers":    {"type":"array", "items":{"type":"string"}, "description":"For op=learn (optional): tags/conditions hinting when the skill is relevant."},
     "tools":       {"type":"array", "items":{"type":"string"}, "description":"For op=learn (optional): tools this skill expects to be available."},
-    "id":          {"type":"string", "description":"For op=show/promote/retire: the skill id (a prefix is accepted)."},
+    "id":          {"type":"string", "description":"For op=show/promote/retire/files/read: the skill id (a prefix is accepted)."},
+    "path":        {"type":"string", "description":"For op=read: the bundle-relative path of the resource to read (from op=files), e.g. \"reference/api.md\" or \"scripts/setup.sh\"."},
     "reason":      {"type":"string", "description":"For op=retire (optional): why you're pulling the skill."}
   }
 }`),
@@ -48,6 +54,7 @@ type input struct {
 	Triggers    []string `json:"triggers"`
 	Tools       []string `json:"tools"`
 	ID          string   `json:"id"`
+	Path        string   `json:"path"`
 	Reason      string   `json:"reason"`
 }
 
@@ -137,10 +144,49 @@ func (t *Tool) Invoke(ctx context.Context, raw json.RawMessage) (agent.Result, e
 		}
 		return okJSON(map[string]any{"id": shortID(sk.ID), "name": sk.Name, "status": string(skill.StatusQuarantined), "message": "retired (quarantined)"}), nil
 
+	case "files":
+		sk, err := t.resolve(f, in.ID)
+		if err != nil {
+			return errResult(err.Error()), nil
+		}
+		bundles := f.Bundles()
+		if bundles == nil {
+			return errResult("skill bundles are not available on this daemon"), nil
+		}
+		files, err := bundles.List(sk.Name)
+		if err != nil {
+			return errResult(err.Error()), nil
+		}
+		return okJSON(map[string]any{
+			"id": shortID(sk.ID), "name": sk.Name, "dir": bundles.Dir(sk.Name),
+			"files": files, "count": len(files),
+		}), nil
+
+	case "read":
+		sk, err := t.resolve(f, in.ID)
+		if err != nil {
+			return errResult(err.Error()), nil
+		}
+		if strings.TrimSpace(in.Path) == "" {
+			return errResult(`op=read needs a "path" (a bundle-relative file from op=files)`), nil
+		}
+		bundles := f.Bundles()
+		if bundles == nil {
+			return errResult("skill bundles are not available on this daemon"), nil
+		}
+		data, err := bundles.Read(sk.Name, in.Path)
+		if err != nil {
+			return errResult(err.Error()), nil
+		}
+		return okJSON(map[string]any{
+			"id": shortID(sk.ID), "name": sk.Name, "path": in.Path,
+			"content": string(data), "bytes": len(data),
+		}), nil
+
 	case "":
-		return errResult("op required (learn|list|show|promote|retire)"), nil
+		return errResult("op required (learn|list|show|promote|retire|files|read)"), nil
 	default:
-		return errResult("unknown op " + in.Op + " (learn|list|show|promote|retire)"), nil
+		return errResult("unknown op " + in.Op + " (learn|list|show|promote|retire|files|read)"), nil
 	}
 }
 


### PR DESCRIPTION
## What

Makes a skill an **agentskills.io-style bundle**: a `SKILL.md` plus **reference files** and **scripts** on disk — disclosed progressively and runnable. Owner ask: *"skill mimarimiz agentskills.io stili olmalı… şu CLI'ı kur şu app'i kur kullan"* + *"ajanların kendi kapasitelerini bilmesi lazım… python/js çalıştırmak, CLI/npm kurmak… sınırları yok."*

A bundle's `scripts/setup.sh` (npm/pip install, build a CLI…) is the "install this and use it" surface — run with the agent's existing shell/code_exec (already max-capability, default-allow), now anchored to a real on-disk directory the skill ships.

## Highlights

- **`BundleStore`** (`kernel/skill/bundle.go`): materializes resources under `skills/bundles/<slug>/`, atomic replace (temp-dir swap), List/Read/Dir, path-confined (`..`/absolute rejected), caps 1 MiB/file · 8 MiB/bundle.
- **`Skill.Resources`** manifest; `Forge.SetBundles` + `CreateSpec.Resources` (nil → body-only, unchanged).
- **`agt skill import <dir>`** ingests SKILL.md + the rest as resources → fresh draft.
- **Inspect:** `agt skill files <id>` / `agt skill cat <id> <path>`; control plane `CmdSkillFiles` / `CmdSkillReadFile`; read-only `/api/skill/files` · `/api/skill/file`.
- **Agent reach:** `skill` tool `op=files` / `op=read`; a retrieved bundled skill is injected with guidance to read references and run scripts via shell/code_exec.

## Verification

- `go build`, `go vet`, `staticcheck`, linux cross-build clean; targeted tests green (`kernel/skill`, `skilltool`, `controlplane`, `webui`, `runtime`). No frontend change (webui is Go-only) → vitest unaffected. No new env; go.mod unchanged.
- Unit: bundle Write/List/Read/Dir, replace-drops-stale, escape rejection, size cap, slugify; tool op=files/op=read + no-store path.
- Live (isolated home): authored a `cowsay-greeter` bundle (SKILL.md + reference/usage.md + scripts/setup.sh) → import (2 resources) → `skill files` → `skill cat` → on-disk bundle present → escaping read (`../../creds.json`) refused on both CLI and HTTP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)