### PR TITLE
Feat: agents know their own (unlimited) capabilities (M848)

### DIFF
--- a/.project/PHASE-M848-CAPABILITY-BRIEFING-REPORT.md
+++ b/.project/PHASE-M848-CAPABILITY-BRIEFING-REPORT.md
@@ -1,0 +1,52 @@
+# PHASE M848 — Capability Self-Awareness Briefing
+
+**Status:** shipped
+**Milestone:** M848
+**Theme:** Tell every agent, plainly, how much it is allowed to do — so it acts
+boldly instead of timidly assuming limits. Owner ask: *"ajanların kendi
+kapasitelerini bilmesi lazım… istedikleri kadar uygulama geliştirebilir, python
+scriptler javascript çalıştırmak, CLI tool kurmak çalıştırmak, npm paketi kurmak
+kullanmak gibi her şeyi yapabilirler… altını üstüne getirebilir, sınırları yok."*
+
+M847 gave agents the *mechanics* (bundles ship scripts; shell + code_exec run
+them). M848 gives them the *self-awareness*: a capability briefing in the run's
+environment preamble so the model knows it may build apps, run Python/JS, install
+and run CLIs and npm/pip packages — whatever it takes — with no artificial limit.
+
+## What shipped
+
+- **`capabilityBriefing(tools)`** in `kernel/runtime/runtime.go`, appended to the
+  per-run environment preamble (`injectEnvironment`, right after the tool list).
+  A "## What you can do — act without artificial limits" section that:
+  - states plainly the agent is a full agent on a real machine, default-allow, and
+    should marshal whatever it takes to finish the task;
+  - lists the concrete powers **tuned to the tools actually present** this run:
+    code_exec → write/run Python · Node/JS · Deno; shell → install & run CLIs,
+    npm/pip/cargo/go packages, build systems, background services ("if a command
+    is missing, install it, then use it"); file → build as many files/apps as
+    needed; tool_forge → forge a durable tool; skill → capture it as a reusable
+    bundled skill;
+  - stays honest about the only real rails — explicit denials, spend budgets, and
+    the network/secret guards (SSRF off, secrets redacted) — and tells the agent
+    to default to action otherwise.
+  - returns "" when the run has none of shell/code_exec/file (nothing to promise).
+
+## Surface
+
+- `kernel/runtime/runtime.go` — `capabilityBriefing`; `injectEnvironment` calls it.
+- `kernel/runtime/environment_internal_test.go` — `TestCapabilityBriefing_TunedToTools`
+  (full set → all lines + emphatic framing; no code_exec/tool_forge → those lines
+  absent; no build/run tools → empty).
+
+## Verification
+
+- **Gate:** `go build ./...`, `go vet`, `staticcheck`, linux cross-build clean;
+  `kernel/runtime` tests green. No new env; go.mod unchanged; no frontend change.
+- **Unit:** the briefing is present and tool-tuned; absent powers are never
+  promised; empty when nothing can build/run.
+
+## Notes
+- This is the system-prompt expression of the owner's standing **default-allow**
+  law: the briefing is the agent-facing statement of "every capability on unless
+  opted out". It is descriptive of the real posture, not a new grant — the actual
+  capability ladder (Edict) is unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
   `delegate` tool now coaches the leader pattern and prefers reusing an existing named agent. (M843)
 
 ### Added
+- **Agents know their own (unlimited) capabilities (M848).** Every run's environment preamble now
+  carries a "What you can do — act without artificial limits" briefing, tuned to the tools actually
+  present: write and run Python / Node / Deno (code_exec), install and run CLIs and npm/pip/cargo
+  packages and background services (shell — "if a command is missing, install it, then use it"), build
+  whole apps in the workspace, forge durable tools, and capture what works as a reusable bundled skill.
+  It stays honest about the only real rails (explicit denials, budgets, SSRF/secret guards) and tells the
+  agent to default to action otherwise — the system-prompt expression of the default-allow posture, so
+  agents act boldly instead of assuming limits. (M848)
 - **Skills can ship a bundle of files — agentskills.io shape (M847).** A skill is no longer just an
   inline body: it can carry reference files and scripts on disk. `agt skill import <dir>` ingests an
   agentskills.io-style directory (`SKILL.md` + `reference/…` + `scripts/…`); the resources are

--- a/kernel/runtime/environment_internal_test.go
+++ b/kernel/runtime/environment_internal_test.go
@@ -69,6 +69,45 @@ func TestInjectEnvironment_CoreFields(t *testing.T) {
 	}
 }
 
+func TestCapabilityBriefing_TunedToTools(t *testing.T) {
+	// A full tool set yields the emphatic, no-limits briefing with the relevant lines.
+	full := map[string]agent.Tool{
+		"shell":      envFakeTool{name: "shell", desc: "Run a command."},
+		"code_exec":  envFakeTool{name: "code_exec", desc: "Run code."},
+		"file":       envFakeTool{name: "file", desc: "Files."},
+		"tool_forge": envFakeTool{name: "tool_forge", desc: "Forge tools."},
+		"skill":      envFakeTool{name: "skill", desc: "Skills."},
+	}
+	out := capabilityBriefing(full)
+	for _, want := range []string{
+		"act without artificial limits",
+		"Python, Node/JavaScript, Deno", // code_exec line
+		"npm / pip",                     // shell install line
+		"forge your own durable tool",   // tool_forge line
+		"reusable skill",                // skill line
+		"Default to action",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("full briefing missing %q\n---\n%s", want, out)
+		}
+	}
+
+	// Tuned: no code_exec → no code line; no tool_forge → no forge line.
+	noCode := map[string]agent.Tool{"shell": full["shell"], "file": full["file"]}
+	out2 := capabilityBriefing(noCode)
+	if strings.Contains(out2, "Python, Node/JavaScript") {
+		t.Errorf("briefing promised code execution without code_exec:\n%s", out2)
+	}
+	if strings.Contains(out2, "forge your own durable tool") {
+		t.Errorf("briefing promised tool_forge when absent:\n%s", out2)
+	}
+
+	// No build/run tools at all → empty briefing (nothing to promise).
+	if got := capabilityBriefing(map[string]agent.Tool{"notify": full["skill"]}); got != "" {
+		t.Errorf("expected empty briefing with no build/run tools, got:\n%s", got)
+	}
+}
+
 func TestShellGuidance_ByInterpreter(t *testing.T) {
 	cases := map[string]string{
 		"cmd":            "Windows",

--- a/kernel/runtime/runtime.go
+++ b/kernel/runtime/runtime.go
@@ -2145,12 +2145,55 @@ func injectEnvironment(system, workspaceRoot string, tools map[string]agent.Tool
 			fmt.Fprintf(&b, "  - %s — %s\n", name, firstSentence(tools[name].Definition().Description))
 		}
 	}
+	if brief := capabilityBriefing(tools); brief != "" {
+		b.WriteString(brief)
+	}
 	b.WriteString("Some capabilities require operator approval and may be denied; if a call is denied, adapt your approach rather than repeating it.\n")
 
 	if system != "" {
 		b.WriteString("\n")
 		b.WriteString(system)
 	}
+	return b.String()
+}
+
+// capabilityBriefing tells the agent, plainly, how much it is allowed to do —
+// so it knows its own reach instead of timidly assuming limits (M848). AGEZT is
+// default-allow (owner law): every capability is on unless explicitly opted out,
+// so an agent should marshal whatever it takes to finish the task — write and run
+// code, install and run CLIs and packages, build whole apps and services. The
+// briefing is tuned to the tools ACTUALLY present this run (no point promising
+// code execution if code_exec was opted out), and stays honest about the few real
+// rails: explicit operator denials, budgets, and the SSRF/secret guards. Returns
+// "" when none of the relevant tools are available.
+func capabilityBriefing(tools map[string]agent.Tool) string {
+	_, hasShell := tools["shell"]
+	_, hasCode := tools["code_exec"]
+	_, hasFile := tools["file"]
+	_, hasForge := tools["tool_forge"]
+	_, hasSkill := tools["skill"]
+	if !hasShell && !hasCode && !hasFile {
+		return "" // nothing to brief — this run can't build or run anything
+	}
+	var b strings.Builder
+	b.WriteString("## What you can do — act without artificial limits\n")
+	b.WriteString("You are a full agent on a real machine, not a sandboxed chat. To accomplish the task you may do whatever it takes — there are no artificial capability limits. Be bold: build it, install it, run it.\n")
+	if hasCode {
+		b.WriteString("- Write and run real code — Python, Node/JavaScript, Deno — via code_exec. Build scripts, prototypes, data pipelines, whole programs.\n")
+	}
+	if hasShell {
+		b.WriteString("- Install and run anything the host supports via the shell: CLI tools, npm / pip / cargo / go packages, build systems, even long-running background services. If a command is missing, install it, then use it.\n")
+	}
+	if hasFile {
+		b.WriteString("- Create and edit as many files, projects, and applications as the task needs in your working directory.\n")
+	}
+	if hasForge {
+		b.WriteString("- When a one-off script isn't enough, forge your own durable tool (tool_forge) so the capability persists.\n")
+	}
+	if hasSkill {
+		b.WriteString("- Capture what works as a reusable skill — including bundled reference files and scripts — so future runs reuse it (skill op=learn / op=files / op=read).\n")
+	}
+	b.WriteString("Default to action: prefer doing the work over asking whether you're allowed. The only real limits are explicit — a denied approval, a spend budget, and the network/secret guards (no SSRF, secrets stay redacted). Everything else is yours to use.\n")
 	return b.String()
 }
 


### PR DESCRIPTION
## What

Tells every agent, plainly, how much it is allowed to do — so it acts boldly instead of timidly assuming limits. Owner ask: *"ajanların kendi kapasitelerini bilmesi lazım… python/js çalıştırmak, CLI/npm kurmak kullanmak… her şeyi yapabilirler, sınırları yok."*

M847 gave agents the *mechanics* (bundles ship scripts; shell + code_exec run them). M848 gives the *self-awareness*.

## How

`capabilityBriefing(tools)` appended to each run's environment preamble (`injectEnvironment`): a "What you can do — act without artificial limits" section **tuned to the tools actually present** —
- code_exec → write/run Python · Node/JS · Deno
- shell → install & run CLIs, npm/pip/cargo/go packages, build systems, background services ("if a command is missing, install it, then use it")
- file → build as many files/apps as needed
- tool_forge → forge a durable tool; skill → capture a reusable bundled skill

Stays honest about the only real rails (explicit denials, spend budgets, SSRF/secret guards) and tells the agent to default to action. Returns "" when the run has no build/run tools. This is the system-prompt expression of the standing default-allow posture — descriptive, not a new grant; the Edict ladder is unchanged.

## Verification

- `go build`, `go vet`, `staticcheck`, linux cross-build clean; `kernel/runtime` tests green. No new env; go.mod unchanged; no frontend change.
- Unit `TestCapabilityBriefing_TunedToTools`: full set → all lines + emphatic framing; no code_exec/tool_forge → those lines absent; no build/run tools → empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)