### PR TITLE
Feat: overseer tool — a brain agent that supervises and intervenes (M850)

### DIFF
--- a/.project/PHASE-M850-OVERSEER-TOOL-REPORT.md
+++ b/.project/PHASE-M850-OVERSEER-TOOL-REPORT.md
@@ -1,0 +1,72 @@
+# PHASE M850 — Overseer Tool (the brain agent's intervene controls)
+
+**Status:** shipped
+**Milestone:** M850
+**Theme:** Give a privileged "brain" agent the controls to supervise and
+**intervene** on the rest of the system. Owner ask: *"bir tane agentlar üstü
+brain agent lazım… denetleyen durduran modifiye eden"* (task #46) — an agent
+above all agents that oversees, stops, and modifies.
+
+This is the **teeth**: the same controls an operator has (`agt halt`,
+`agt agent retire`, cancel a run) are now reachable by an agent through one
+`overseer` tool, so supervision can be autonomous. It pairs with the M849
+mailbox — the overseer triages the open help requests agents raise.
+
+## What shipped
+
+The `overseer` tool (`plugins/tools/overseertool`), bound to the live kernel
+after open (mirroring the introspect tool). Ops:
+
+- **Read / situational awareness:** `status` (halted?, active-run count, agent
+  count, open-help count), `agents` (every agent with state enabled/paused/
+  retired + model), `runs` (the correlation ids in flight right now), `help`
+  (the open help requests to triage), `impact` (what standing orders fire an
+  agent).
+- **Intervene:** `cancel` (stop one run by correlation id), `halt` / `resume`
+  (stop ALL runs and block new ones / clear it), `pause` / `unpause` (an agent),
+  `retire` (to the graveyard, surfacing impact first) / `revive`.
+
+Every action goes through the kernel's own methods, so each is journaled and
+reversible exactly like its operator-driven equivalent (kernel.halt→resume,
+roster.updated retired→revived).
+
+- New kernel method `Kernel.ActiveRunIDs() []string` — the live correlation ids
+  of in-flight runs (the cancel registry keys), sorted; distinct from the
+  journal-derived run history. This is what `op=runs` lists and `op=cancel` acts
+  on.
+- New Edict capability `CapOversee` ("oversee"), allow-by-default per the
+  default-allow law but with its **own** opt-out knob so an owner can disable
+  autonomous oversight without touching delegation. `toolmap`: `overseer →
+  CapOversee`.
+- Daemon wiring: constructed in buildTools, `Bind(NewKernelSource(k, baseDir))`
+  after open; the adapter reads the kernel + opens the board fresh per `op=help`.
+
+## Surface
+
+- `plugins/tools/overseertool/{overseer,tool,kernelsource}.go` + `overseer_test.go`.
+- `kernel/runtime/runtime.go` — `ActiveRunIDs`.
+- `kernel/edict/edict.go` — `CapOversee` + in `AllCapabilities`; `toolmap.go` map.
+- `cmd/agezt/main.go` — construct + bind + startup line.
+
+## Verification
+
+- **Gate:** `go build`, `go vet`, `staticcheck`, linux cross-build clean;
+  `overseertool` (8 tests) + `edict` green. No new env; go.mod unchanged.
+- **Unit:** status counts; runs+cancel (and cancel-needs-run); halt/resume;
+  agent pause/unpause/retire(+impact)/revive (each needs a target); kernel-error
+  surfaced; help triage; unknown/missing op; unbound-safe.
+- **Boot smoke (isolated home):** daemon starts clean and advertises
+  `overseer tool : enabled`.
+- **Live LLM end-to-end:** not possible in this sandbox — the run fell back to
+  the offline-mock provider (no network for the real provider; mock ignores the
+  instruction). The integration risk is low: the adapter is a thin pass-through
+  to kernel methods that are themselves already live-verified (M846 retire/revive,
+  M849 OpenHelp), and every op is unit-tested against a fake Source.
+
+## Notes
+- Default-allow preserved: `CapOversee` ships at LevelAllow; the powerful actions
+  (halt, retire) are journaled + reversible, and the operator can opt out via
+  Edict if desired.
+- Follow-ups: a dedicated "brain" agent persona/standing-order that runs the
+  overseer on a cadence, and a Web UI overseer panel. The data it needs is
+  already exposed (runs, roster, `/api/board/help`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
   `delegate` tool now coaches the leader pattern and prefers reusing an existing named agent. (M843)
 
 ### Added
+- **Overseer tool — a brain agent that supervises and intervenes (M850).** A new `overseer` tool gives a
+  privileged agent the operator's own controls over the whole fleet: see the daemon `status`, list
+  `agents` and their state, list the `runs` in flight, and triage open `help` requests — then intervene:
+  `cancel` one run, `halt`/`resume` the whole daemon, `pause`/`unpause`, `retire`/`revive` an agent
+  (with impact). Every action routes through the kernel's journaled, reversible methods, so autonomous
+  oversight is as auditable as an operator's. Gated by a new allow-by-default `oversee` capability with
+  its own opt-out knob; backed by a new `Kernel.ActiveRunIDs()` for the live in-flight run set. (M850)
 - **Agent mailbox — broadcast + help requests (M849).** The shared board is now a full mailbox: on top
   of directed agent-to-agent DMs, an agent can `op=broadcast` an announcement to every agent's inbox, or
   `op=help` to ask for assistance — broadcast to all (or directed with `to=<slug>`), it stays open until

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -107,6 +107,7 @@ import (
 	"github.com/agezt/agezt/plugins/tools/introspecttool"
 	"github.com/agezt/agezt/plugins/tools/mcptool"
 	"github.com/agezt/agezt/plugins/tools/notify"
+	"github.com/agezt/agezt/plugins/tools/overseertool"
 	"github.com/agezt/agezt/plugins/tools/peer"
 	"github.com/agezt/agezt/plugins/tools/runstool"
 	scheduletool "github.com/agezt/agezt/plugins/tools/schedule"
@@ -355,6 +356,12 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// guessing. Registered now, Bound to the live kernel after it opens.
 	introspectToolInst := introspecttool.New()
 	tools["introspect"] = introspectToolInst
+
+	// Overseer tool (`overseer`, M850): the brain/overseer agent supervises and
+	// intervenes on the fleet — list/cancel runs, halt/resume the daemon, pause/
+	// retire/revive agents, triage open help. Registered now, Bound after open.
+	overseerToolInst := overseertool.New()
+	tools["overseer"] = overseerToolInst
 
 	// Tool-forge tool (`tool_forge`, M794): the agent builds its OWN tools —
 	// drafts a script, tests it in the code_exec sandbox, and once the operator
@@ -1520,6 +1527,12 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// the daemon's own health/schedules/standing-orders in one call.
 	introspectToolInst.Bind(introspecttool.NewKernelSource(k))
 	fmt.Fprintf(stdout, "  introspect tool  : enabled (the agent can read the daemon's own live state)\n")
+
+	// Bind the overseer tool to the live kernel (M850), so a brain/overseer agent
+	// can supervise and intervene on the fleet — cancel runs, halt/resume, pause/
+	// retire/revive agents, triage open help. baseDir locates the board it reads.
+	overseerToolInst.Bind(overseertool.NewKernelSource(k, baseDir))
+	fmt.Fprintf(stdout, "  overseer tool    : enabled (a brain agent can supervise & intervene on the fleet)\n")
 
 	// Bind the code-execution tool to the live bus (M683) so each run journals a
 	// code.executed event. The tool itself was constructed in buildTools (it needed

--- a/kernel/edict/edict.go
+++ b/kernel/edict/edict.go
@@ -133,6 +133,15 @@ const (
 	// network — low risk, Allow by default (M682), so a "summarise AGEZT's health"
 	// task can actually see everything instead of guessing.
 	CapIntrospect Capability = "introspect"
+	// CapOversee gates the `overseer` tool: a privileged "brain" agent supervising
+	// and INTERVENING on the rest of the system — cancel a runaway run, halt or
+	// resume the whole daemon, pause / retire / revive other agents, triage the
+	// open help requests (M850). High blast radius (it can stop everything), but
+	// every action goes through the kernel's own journaled, reversible methods —
+	// the same controls an operator has. Allow by default per the default-allow
+	// posture, with its OWN knob so an owner can opt OUT of autonomous oversight
+	// without disabling delegation.
+	CapOversee Capability = "oversee"
 	// CapCodeExec gates the `code_exec` tool: the agent WRITING and RUNNING
 	// arbitrary code (Python / Node / Deno) to compute, scrape, and build things
 	// (M683). A high-blast-radius capability — code can read/write the sandbox
@@ -639,7 +648,7 @@ func AllCapabilities() []Capability {
 		CapACPAgent, CapRemoteRun, CapNotify,
 		CapHomeAssistantRead, CapHomeAssistantCall,
 		CapBrowserRead, CapMemory, CapWorld, CapWebSearch, CapSchedule, CapRunsRead, CapStanding, CapBoard, CapSkill,
-		CapIntrospect, CapCodeExec, CapToolForge, CapMCPInstall, CapMCP, CapConfigRead, CapConfigWrite,
+		CapIntrospect, CapOversee, CapCodeExec, CapToolForge, CapMCPInstall, CapMCP, CapConfigRead, CapConfigWrite,
 		CapWorkflow,
 	}
 	slices.Sort(caps)

--- a/kernel/edict/toolmap.go
+++ b/kernel/edict/toolmap.go
@@ -119,6 +119,8 @@ func CapabilityForToolCall(toolName string, input json.RawMessage) Capability {
 		return CapWorkflow
 	case "introspect":
 		return CapIntrospect
+	case "overseer":
+		return CapOversee
 	case "code_exec":
 		return CapCodeExec
 	case "memory":

--- a/kernel/runtime/runtime.go
+++ b/kernel/runtime/runtime.go
@@ -961,6 +961,22 @@ func (k *Kernel) ActiveRuns() int {
 	return len(k.runs)
 }
 
+// ActiveRunIDs returns the correlation ids of the runs in flight right now —
+// the live keys of the cancel registry, sorted for determinism. This is the
+// "what is running" the overseer (M850) cancels by id, distinct from the
+// journal-derived run history (CmdRunsList): these are exactly the runs a
+// CancelRun can still stop. Safe under concurrent run starts/completes.
+func (k *Kernel) ActiveRunIDs() []string {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	ids := make([]string, 0, len(k.runs))
+	for corr := range k.runs {
+		ids = append(ids, corr)
+	}
+	slices.Sort(ids)
+	return ids
+}
+
 // StartTime returns the wall-clock time Open() returned. Used by
 // `agt status` to compute uptime; not adjusted by Reload or any
 // in-process state change, so it reflects "since this process

--- a/plugins/tools/overseertool/kernelsource.go
+++ b/plugins/tools/overseertool/kernelsource.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+
+package overseertool
+
+import (
+	"path/filepath"
+
+	"github.com/agezt/agezt/kernel/board"
+	"github.com/agezt/agezt/kernel/roster"
+	kernelruntime "github.com/agezt/agezt/kernel/runtime"
+)
+
+// kernelSource adapts the live *runtime.Kernel to the overseer's Source. Reads
+// and interventions go straight to the kernel's own methods, so each is
+// journaled and reversible exactly like its operator-driven equivalent. The
+// board is opened fresh per OpenHelp read (mirroring the control plane's board
+// view) so the overseer always sees the latest committed help requests without
+// sharing the board tool's in-process instance.
+type kernelSource struct {
+	k        *kernelruntime.Kernel
+	boardDir string
+}
+
+// NewKernelSource builds the kernel-backed Source. baseDir is the daemon's base
+// directory; the board lives at <baseDir>/board.
+func NewKernelSource(k *kernelruntime.Kernel, baseDir string) Source {
+	return &kernelSource{k: k, boardDir: filepath.Join(baseDir, "board")}
+}
+
+func (s *kernelSource) IsHalted() bool         { return s.k.IsHalted() }
+func (s *kernelSource) ActiveRunIDs() []string { return s.k.ActiveRunIDs() }
+func (s *kernelSource) Agents() []roster.Profile {
+	return s.k.Roster().List()
+}
+func (s *kernelSource) AgentImpact(slug string) []string { return s.k.AgentImpact(slug) }
+func (s *kernelSource) CancelRun(corr string) bool       { return s.k.CancelRun(corr) }
+func (s *kernelSource) Halt(reason string)               { s.k.HaltWith(reason) }
+func (s *kernelSource) ResumeAll(reason string)          { s.k.ResumeWith(reason) }
+
+func (s *kernelSource) SetAgentEnabled(ref string, enabled bool) (roster.Profile, error) {
+	return s.k.SetProfileEnabled(ref, enabled)
+}
+func (s *kernelSource) SetAgentRetired(ref string, retired bool) (roster.Profile, error) {
+	return s.k.SetProfileRetired(ref, retired)
+}
+
+// OpenHelp opens the board fresh and returns its open help requests. A failure
+// to open (no board yet) yields an empty list rather than an error — the
+// overseer should still report on everything else.
+func (s *kernelSource) OpenHelp(limit int) []board.Message {
+	st, err := board.Open(s.boardDir)
+	if err != nil {
+		return nil
+	}
+	return st.OpenHelp(limit)
+}

--- a/plugins/tools/overseertool/overseer.go
+++ b/plugins/tools/overseertool/overseer.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+
+// Package overseertool is the agent-facing supervisory control: it lets a
+// privileged "brain" agent oversee and INTERVENE on the rest of the system —
+// see who is running, cancel a runaway run, halt or resume the whole daemon,
+// pause / retire / revive agents, and triage the open help requests on the board
+// (M850). It is the teeth behind "an agent above all agents" (the owner's brain
+// overseer): the same controls `agt halt` / `agt agent retire` give an operator,
+// now reachable by an agent so supervision can be autonomous.
+//
+// Every action it takes goes through the kernel's own methods, so each is
+// journaled and reversible exactly like the operator-driven equivalent (kernel.
+// halt → resume, roster.updated retired → revived). The tool holds nothing
+// authoritative; it reads and steers the live kernel through a narrow Source
+// interface, mirroring the introspect tool's bind-after-open pattern.
+package overseertool
+
+import (
+	"sync"
+
+	"github.com/agezt/agezt/kernel/board"
+	"github.com/agezt/agezt/kernel/roster"
+)
+
+// Source is the narrow slice of the live kernel the overseer steers — an
+// interface so the tool is testable without a real daemon (a fake Source + an
+// in-memory board is enough). Satisfied by the kernel adapter (kernelsource.go).
+type Source interface {
+	// Read.
+	IsHalted() bool
+	ActiveRunIDs() []string
+	Agents() []roster.Profile
+	OpenHelp(limit int) []board.Message
+	AgentImpact(slug string) []string
+	// Intervene. Each mirrors an operator control and journals through the kernel.
+	CancelRun(corr string) bool
+	Halt(reason string)
+	ResumeAll(reason string)
+	SetAgentEnabled(ref string, enabled bool) (roster.Profile, error)
+	SetAgentRetired(ref string, retired bool) (roster.Profile, error)
+}
+
+// Tool implements agent.Tool. Created unbound via New(); Bind wires the live
+// kernel Source after the daemon opens.
+type Tool struct {
+	mu  sync.RWMutex
+	src Source
+}
+
+// New returns an unbound overseer tool (no Source until Bind).
+func New() *Tool { return &Tool{} }
+
+// Bind wires the live kernel Source. Called once after the kernel opens.
+func (t *Tool) Bind(s Source) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if s != nil {
+		t.src = s
+	}
+}
+
+func (t *Tool) current() Source {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.src
+}

--- a/plugins/tools/overseertool/overseer_test.go
+++ b/plugins/tools/overseertool/overseer_test.go
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: MIT
+
+package overseertool
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/board"
+	"github.com/agezt/agezt/kernel/roster"
+)
+
+// fakeSource is an in-memory Source recording interventions so the tool's
+// op → kernel-method mapping is asserted without a live daemon.
+type fakeSource struct {
+	halted    bool
+	runs      []string
+	agents    []roster.Profile
+	help      []board.Message
+	impact    []string
+	cancelled string
+	cancelOK  bool
+	haltCalls int
+	resumes   int
+	enabled   map[string]bool
+	retired   map[string]bool
+	setErr    error
+}
+
+func (f *fakeSource) IsHalted() bool              { return f.halted }
+func (f *fakeSource) ActiveRunIDs() []string      { return f.runs }
+func (f *fakeSource) Agents() []roster.Profile    { return f.agents }
+func (f *fakeSource) AgentImpact(string) []string { return f.impact }
+func (f *fakeSource) OpenHelp(limit int) []board.Message {
+	if limit > 0 && len(f.help) > limit {
+		return f.help[:limit]
+	}
+	return f.help
+}
+func (f *fakeSource) CancelRun(corr string) bool { f.cancelled = corr; return f.cancelOK }
+func (f *fakeSource) Halt(string)                { f.haltCalls++; f.halted = true }
+func (f *fakeSource) ResumeAll(string)           { f.resumes++; f.halted = false }
+func (f *fakeSource) SetAgentEnabled(ref string, enabled bool) (roster.Profile, error) {
+	if f.setErr != nil {
+		return roster.Profile{}, f.setErr
+	}
+	if f.enabled == nil {
+		f.enabled = map[string]bool{}
+	}
+	f.enabled[ref] = enabled
+	return roster.Profile{Slug: ref, Enabled: enabled}, nil
+}
+func (f *fakeSource) SetAgentRetired(ref string, retired bool) (roster.Profile, error) {
+	if f.setErr != nil {
+		return roster.Profile{}, f.setErr
+	}
+	if f.retired == nil {
+		f.retired = map[string]bool{}
+	}
+	f.retired[ref] = retired
+	return roster.Profile{Slug: ref, Retired: retired, Enabled: !retired}, nil
+}
+
+func newTool(s Source) *Tool {
+	t := New()
+	t.Bind(s)
+	return t
+}
+
+func invoke(t *testing.T, tool *Tool, in map[string]any) (map[string]any, bool) {
+	t.Helper()
+	raw, _ := json.Marshal(in)
+	res, err := tool.Invoke(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("Invoke error: %v", err)
+	}
+	var out map[string]any
+	_ = json.Unmarshal([]byte(res.Output), &out)
+	return out, res.IsError
+}
+
+func TestDefinitionValid(t *testing.T) {
+	d := New().Definition()
+	if d.Name != "overseer" || !json.Valid(d.InputSchema) {
+		t.Fatalf("bad definition: %+v", d)
+	}
+}
+
+func TestStatus(t *testing.T) {
+	f := &fakeSource{
+		halted: true,
+		runs:   []string{"c1", "c2"},
+		agents: []roster.Profile{{Slug: "a"}, {Slug: "b"}},
+		help:   []board.Message{{ID: "h1", Help: true}},
+	}
+	out, isErr := invoke(t, newTool(f), map[string]any{"op": "status"})
+	if isErr {
+		t.Fatalf("status errored: %v", out)
+	}
+	if out["halted"] != true || out["active_runs"].(float64) != 2 || out["agents"].(float64) != 2 || out["open_help"].(float64) != 1 {
+		t.Fatalf("status wrong: %+v", out)
+	}
+}
+
+func TestRunsAndCancel(t *testing.T) {
+	f := &fakeSource{runs: []string{"c1", "c2"}, cancelOK: true}
+	tool := newTool(f)
+
+	runs, _ := invoke(t, tool, map[string]any{"op": "runs"})
+	if runs["count"].(float64) != 2 {
+		t.Fatalf("runs count = %v, want 2", runs["count"])
+	}
+	out, isErr := invoke(t, tool, map[string]any{"op": "cancel", "run": "c1"})
+	if isErr {
+		t.Fatalf("cancel errored: %v", out)
+	}
+	if f.cancelled != "c1" || out["cancelled"] != true {
+		t.Fatalf("cancel wrong: cancelled=%q out=%+v", f.cancelled, out)
+	}
+	// Cancel needs a run id.
+	if _, isErr := invoke(t, tool, map[string]any{"op": "cancel"}); !isErr {
+		t.Error("op=cancel without run should error")
+	}
+}
+
+func TestHaltResume(t *testing.T) {
+	f := &fakeSource{}
+	tool := newTool(f)
+	invoke(t, tool, map[string]any{"op": "halt", "reason": "fire drill"})
+	if f.haltCalls != 1 || !f.halted {
+		t.Fatalf("halt not applied: %+v", f)
+	}
+	invoke(t, tool, map[string]any{"op": "resume"})
+	if f.resumes != 1 || f.halted {
+		t.Fatalf("resume not applied: %+v", f)
+	}
+}
+
+func TestAgentInterventions(t *testing.T) {
+	f := &fakeSource{impact: []string{"nightly (01ABC)"}}
+	tool := newTool(f)
+
+	// pause / unpause.
+	invoke(t, tool, map[string]any{"op": "pause", "agent": "worker"})
+	if f.enabled["worker"] != false {
+		t.Errorf("pause did not disable worker: %+v", f.enabled)
+	}
+	invoke(t, tool, map[string]any{"op": "unpause", "agent": "worker"})
+	if f.enabled["worker"] != true {
+		t.Errorf("unpause did not enable worker: %+v", f.enabled)
+	}
+
+	// retire surfaces impact; revive clears it.
+	out, _ := invoke(t, tool, map[string]any{"op": "retire", "agent": "worker"})
+	if f.retired["worker"] != true {
+		t.Errorf("retire did not retire worker: %+v", f.retired)
+	}
+	if imp, _ := out["impact"].([]any); len(imp) != 1 {
+		t.Errorf("retire did not surface impact: %+v", out)
+	}
+	invoke(t, tool, map[string]any{"op": "revive", "agent": "worker"})
+	if f.retired["worker"] != false {
+		t.Errorf("revive did not revive worker: %+v", f.retired)
+	}
+
+	// each agent op needs a target.
+	for _, op := range []string{"pause", "unpause", "retire", "revive", "impact"} {
+		if _, isErr := invoke(t, tool, map[string]any{"op": op}); !isErr {
+			t.Errorf("op=%s without agent should error", op)
+		}
+	}
+}
+
+func TestInterventionSurfacesError(t *testing.T) {
+	f := &fakeSource{setErr: errors.New("no such agent")}
+	if _, isErr := invoke(t, newTool(f), map[string]any{"op": "pause", "agent": "ghost"}); !isErr {
+		t.Error("a kernel error should surface as a tool error")
+	}
+}
+
+func TestHelpTriage(t *testing.T) {
+	f := &fakeSource{help: []board.Message{
+		{ID: "h1", From: "worker", Text: "build red", Help: true},
+	}}
+	out, _ := invoke(t, newTool(f), map[string]any{"op": "help"})
+	if out["count"].(float64) != 1 {
+		t.Fatalf("help count = %v, want 1", out["count"])
+	}
+}
+
+func TestBadAndUnbound(t *testing.T) {
+	if _, isErr := invoke(t, newTool(&fakeSource{}), map[string]any{"op": "bogus"}); !isErr {
+		t.Error("unknown op should error")
+	}
+	if _, isErr := invoke(t, newTool(&fakeSource{}), map[string]any{}); !isErr {
+		t.Error("missing op should error")
+	}
+	res, err := New().Invoke(context.Background(), json.RawMessage(`{"op":"status"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Error("an unbound overseer should return an error result")
+	}
+}
+
+var _ = agent.Tool(New())

--- a/plugins/tools/overseertool/tool.go
+++ b/plugins/tools/overseertool/tool.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: MIT
+
+package overseertool
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/board"
+	"github.com/agezt/agezt/kernel/roster"
+)
+
+const defaultHelpLimit = 20
+
+// Definition implements agent.Tool.
+func (t *Tool) Definition() agent.ToolDef {
+	return agent.ToolDef{
+		Name: "overseer",
+		Description: "Supervise and intervene on the whole system — the brain/overseer's controls. " +
+			"op=status shows the daemon's health (halted?, active runs, agent count, open help); " +
+			"op=agents lists every agent with its state (enabled/paused/retired) and model; " +
+			"op=runs lists the runs in flight right now (correlation ids you can cancel); " +
+			"op=help lists the open help requests waiting for an answer (triage). " +
+			"Intervene: op=cancel stops one run by its correlation id; op=halt stops ALL runs and blocks " +
+			"new ones until op=resume; op=pause/op=unpause pause or resume a named agent; op=retire moves " +
+			"an agent to the graveyard (op=impact first to see what depends on it) and op=revive brings it " +
+			"back. Every action is journaled and reversible. Use this to keep the fleet healthy: stop a " +
+			"runaway, pause a misbehaving agent, answer or route a help request.",
+		InputSchema: json.RawMessage(`{
+  "type": "object",
+  "required": ["op"],
+  "properties": {
+    "op":     {"type":"string", "enum":["status","agents","runs","help","cancel","halt","resume","pause","unpause","retire","revive","impact"]},
+    "agent":  {"type":"string", "description":"For op=pause/unpause/retire/revive/impact: the target agent's slug (or id)."},
+    "run":    {"type":"string", "description":"For op=cancel: the correlation id of the run to stop (from op=runs)."},
+    "reason": {"type":"string", "description":"For op=halt/resume/cancel (optional): why — recorded in the journal."},
+    "limit":  {"type":"integer", "description":"For op=help: max requests to list (default 20)."}
+  }
+}`),
+	}
+}
+
+type input struct {
+	Op     string `json:"op"`
+	Agent  string `json:"agent"`
+	Run    string `json:"run"`
+	Reason string `json:"reason"`
+	Limit  int    `json:"limit"`
+}
+
+// Invoke implements agent.Tool.
+func (t *Tool) Invoke(_ context.Context, raw json.RawMessage) (agent.Result, error) {
+	var in input
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return agent.Result{}, fmt.Errorf("overseer: parse input: %w", err)
+	}
+	s := t.current()
+	if s == nil {
+		return errResult("the overseer is not available on this daemon"), nil
+	}
+	op := strings.ToLower(strings.TrimSpace(in.Op))
+
+	switch op {
+	case "status":
+		return okJSON(map[string]any{
+			"halted":      s.IsHalted(),
+			"active_runs": len(s.ActiveRunIDs()),
+			"agents":      len(s.Agents()),
+			"open_help":   len(s.OpenHelp(0)),
+		}), nil
+
+	case "agents":
+		ags := s.Agents()
+		views := make([]map[string]any, 0, len(ags))
+		for _, p := range ags {
+			views = append(views, agentView(p))
+		}
+		return okJSON(map[string]any{"count": len(views), "agents": views}), nil
+
+	case "runs":
+		ids := s.ActiveRunIDs()
+		return okJSON(map[string]any{"count": len(ids), "active_runs": ids,
+			"hint": "stop one with op=cancel run=<id>"}), nil
+
+	case "help":
+		limit := in.Limit
+		if limit <= 0 {
+			limit = defaultHelpLimit
+		}
+		open := s.OpenHelp(limit)
+		views := make([]map[string]any, 0, len(open))
+		for _, m := range open {
+			views = append(views, helpView(m))
+		}
+		return okJSON(map[string]any{"count": len(views), "open_help": views,
+			"hint": "answer one with the board tool: op=reply id=<id>"}), nil
+
+	case "cancel":
+		if strings.TrimSpace(in.Run) == "" {
+			return errResult(`op=cancel needs "run" (the correlation id from op=runs)`), nil
+		}
+		ok := s.CancelRun(strings.TrimSpace(in.Run))
+		return okJSON(map[string]any{"run": in.Run, "cancelled": ok,
+			"note": cancelNote(ok)}), nil
+
+	case "halt":
+		s.Halt(strings.TrimSpace(in.Reason))
+		return okJSON(map[string]any{"halted": true,
+			"note": "all in-flight runs cancelled; new runs are refused until op=resume"}), nil
+
+	case "resume":
+		s.ResumeAll(strings.TrimSpace(in.Reason))
+		return okJSON(map[string]any{"halted": false, "note": "the daemon accepts runs again"}), nil
+
+	case "pause", "unpause":
+		if strings.TrimSpace(in.Agent) == "" {
+			return errResult("op=" + op + ` needs "agent" (the target slug)`), nil
+		}
+		enabled := op == "unpause"
+		p, err := s.SetAgentEnabled(strings.TrimSpace(in.Agent), enabled)
+		if err != nil {
+			return errResult(err.Error()), nil
+		}
+		return okJSON(map[string]any{"agent": p.Slug, "enabled": p.Enabled,
+			"action": map[bool]string{true: "resumed", false: "paused"}[enabled]}), nil
+
+	case "retire":
+		if strings.TrimSpace(in.Agent) == "" {
+			return errResult(`op=retire needs "agent" (the target slug)`), nil
+		}
+		impact := s.AgentImpact(strings.TrimSpace(in.Agent))
+		p, err := s.SetAgentRetired(strings.TrimSpace(in.Agent), true)
+		if err != nil {
+			return errResult(err.Error()), nil
+		}
+		out := map[string]any{"agent": p.Slug, "retired": true, "action": "retired"}
+		if len(impact) > 0 {
+			out["impact"] = impact
+		}
+		return okJSON(out), nil
+
+	case "revive":
+		if strings.TrimSpace(in.Agent) == "" {
+			return errResult(`op=revive needs "agent" (the target slug)`), nil
+		}
+		p, err := s.SetAgentRetired(strings.TrimSpace(in.Agent), false)
+		if err != nil {
+			return errResult(err.Error()), nil
+		}
+		return okJSON(map[string]any{"agent": p.Slug, "retired": false, "action": "revived"}), nil
+
+	case "impact":
+		if strings.TrimSpace(in.Agent) == "" {
+			return errResult(`op=impact needs "agent" (the target slug)`), nil
+		}
+		impact := s.AgentImpact(strings.TrimSpace(in.Agent))
+		return okJSON(map[string]any{"agent": in.Agent, "standing_orders": impact, "count": len(impact)}), nil
+
+	case "":
+		return errResult("op required (status|agents|runs|help|cancel|halt|resume|pause|unpause|retire|revive|impact)"), nil
+	default:
+		return errResult("unknown op " + op), nil
+	}
+}
+
+func cancelNote(ok bool) string {
+	if ok {
+		return "the run was in flight and has been cancelled"
+	}
+	return "no in-flight run matched that id (already finished or unknown)"
+}
+
+func agentView(p roster.Profile) map[string]any {
+	state := "enabled"
+	switch {
+	case p.Retired:
+		state = "retired"
+	case !p.Enabled:
+		state = "paused"
+	}
+	v := map[string]any{"slug": p.Slug, "state": state, "enabled": p.Enabled, "retired": p.Retired}
+	if p.Name != "" {
+		v["name"] = p.Name
+	}
+	if p.Model != "" {
+		v["model"] = p.Model
+	}
+	return v
+}
+
+func helpView(m board.Message) map[string]any {
+	v := map[string]any{"id": m.ID, "text": m.Text}
+	if m.From != "" {
+		v["from"] = m.From
+	}
+	if m.To != "" {
+		v["to"] = m.To
+	}
+	if m.TSMS > 0 {
+		v["at"] = time.UnixMilli(m.TSMS).Format(time.RFC3339)
+	}
+	return v
+}
+
+func okJSON(v any) agent.Result {
+	enc, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return errResult("marshal: " + err.Error())
+	}
+	return agent.Result{Output: string(enc)}
+}
+
+func errResult(msg string) agent.Result {
+	return agent.Result{Output: "overseer: " + msg, IsError: true}
+}


### PR DESCRIPTION
## What

Gives a privileged "brain" agent the operator's own controls over the fleet — the teeth behind *"agentlar üstü brain agent… denetleyen durduran modifiye eden"* (#46). Pairs with the M849 mailbox: the overseer triages the help requests agents raise.

## The `overseer` tool

- **Read:** `status` (halted?, active runs, agents, open help), `agents` (each agent + state), `runs` (in-flight correlation ids), `help` (open requests), `impact` (what fires an agent).
- **Intervene:** `cancel` one run, `halt`/`resume` the whole daemon, `pause`/`unpause`, `retire`/`revive` an agent (with impact).

Every action routes through the kernel's journaled, reversible methods — autonomous oversight as auditable as an operator's.

## Wiring

- New `Kernel.ActiveRunIDs()` — live in-flight run correlations (cancel-registry keys), what `op=runs`/`op=cancel` use.
- New Edict `CapOversee` ("oversee") — allow-by-default per the default-allow law, with its **own** opt-out knob (disable autonomous oversight without touching delegation); `toolmap`: `overseer → CapOversee`.
- Bound to the live kernel after open (mirrors introspect); adapter opens the board fresh for `op=help`.

## Verification

- `go build`, `go vet`, `staticcheck`, linux cross-build clean; `overseertool` (8 tests) + `edict` green. No new env; go.mod unchanged.
- Unit: every op against a fake Source (status counts, runs+cancel, halt/resume, pause/retire+impact/revive, error surfaced, help triage, bad/missing op, unbound-safe).
- Boot smoke (isolated home): daemon advertises `overseer tool : enabled`.
- Live LLM end-to-end not possible in the build sandbox (no network → offline-mock, which ignores the instruction). Risk is low: the adapter is a thin pass-through to kernel methods already live-verified (M846 retire/revive, M849 OpenHelp), every op unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)