### PR TITLE
Feat: browser-use out of the box — built-in skill bundle (M852)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,6 @@
 # the committed dist (CRLF) differs from a Linux rebuild (LF) and the gate fails.
 frontend/** text=auto eol=lf
 kernel/webui/dist/** text eol=lf
+# Built-in skill bundles are go:embed-ded into the binary (M852). Force LF so a
+# Windows checkout doesn't embed CRLF — the shell setup script must run on Linux.
+plugins/builtinskills/** text eol=lf

--- a/.project/PHASE-M852-BROWSER-USE-SKILL-REPORT.md
+++ b/.project/PHASE-M852-BROWSER-USE-SKILL-REPORT.md
@@ -1,0 +1,76 @@
+# PHASE M852 — Browser-use, out of the box (built-in skill bundle)
+
+**Status:** shipped
+**Milestone:** M852
+**Theme:** Full agentic browser automation — navigate, click, type, submit
+forms, screenshot, extract from JavaScript-rendered pages — working **out of the
+box**. Owner ask: full browser-use / computer-use (#43/#44), headless-first,
+Playwright-style "see when needed".
+
+## Architecture decision
+
+A native Go interactive browser tool would mean bundling Chromium (chromedp/rod)
+or a Playwright-go dep — a multi-MB engine that violates AGEZT's **single static
+binary, one external dep (BLAKE3)** ethos (DEPENDENCIES.md lists browser engines
+as explicit anti-deps for core). And M847/M848 already made agents able to
+**install and run anything** (npm, Playwright) via the always-on `code_exec`
+sandbox (net-on) + shell.
+
+So browser-use ships as a **built-in skill bundle** the daemon seeds at startup —
+zero Go deps, on-ethos, and immediately usable. The agent gets a ready, active
+`browser-use` skill whose Playwright driver it runs through `code_exec`.
+
+## What shipped
+
+- **`plugins/builtinskills`** — bundles baked into the binary via `go:embed` and
+  seeded into the Forge on boot. `SeedAll` reads each embedded bundle's SKILL.md +
+  resources, `Create`s the skill (content-addressed → idempotent) and promotes it
+  to **active** so it's in the retrieval pool. Best-effort: a seed failure never
+  blocks startup. Daemon prints `built-in skills : seeded (browser-use)`.
+- **The `browser-use` bundle** (agentskills.io shape, M847):
+  - `SKILL.md` — how to set up and drive the browser; the see/act loop.
+  - `scripts/setup.sh` — `npm install playwright` + `npx playwright install
+    chromium` (idempotent; the agent runs it once via code_exec/shell; full
+    machine permission to install OS deps if needed).
+  - `scripts/browse.mjs` — a stateless Playwright driver: opens a fresh headless
+    Chromium, runs an ordered action list (goto/click/fill/press/wait),
+    optionally screenshots, extracts (text/html/selector), and emits JSON. The
+    agent passes a JSON spec and iterates: screenshot → look → act.
+  - `reference/actions.md` — login flows, SPA waits, search, table/list
+    extraction, failure recovery.
+
+## Surface
+
+- `plugins/builtinskills/builtinskills.go` (embed + `SeedAll`/`seedOne`) +
+  `builtinskills_test.go`.
+- `plugins/builtinskills/browseruse/{SKILL.md, scripts/setup.sh,
+  scripts/browse.mjs, reference/actions.md}`.
+- `cmd/agezt/main.go` — `builtinskills.SeedAll(k.Forge(), "")` after the skill
+  tool binds; startup line.
+- `.gitattributes` — `plugins/builtinskills/** text eol=lf` (the embedded shell
+  script must run on Linux).
+
+## Verification
+
+- **Gate:** `go build`, `go vet`, `staticcheck`, linux cross-build clean;
+  `builtinskills` tests green; `node --check browse.mjs` passes. No new Go dep
+  (go.mod unchanged); no new env.
+- **Unit:** `SeedAll` installs `browser-use` **active** with its 3 bundle files
+  materialized on disk and a non-empty driver; re-seed is idempotent (dedupes on
+  content address, stays active).
+- **Boot smoke (isolated home):** daemon logs `built-in skills : seeded
+  (browser-use)`; `agt skill list` shows `[active] browser-use`; `agt skill files`
+  lists `scripts/browse.mjs`, `scripts/setup.sh`, `reference/actions.md` + the
+  bundle dir; files present on disk.
+- **The live Playwright install + a real navigation** can't run in the build
+  sandbox (no network → npm/Chromium download blocked). The driver is
+  syntax-validated and uses standard Playwright APIs; the seeding/activation/
+  materialization path is fully verified.
+
+## Notes
+- Computer-use (#44) is largely already present: the shell + code_exec tools
+  install and run anything under the default-allow posture, and the M848 briefing
+  tells agents so. This bundle is the browser slice; future built-in bundles
+  (e.g. a desktop-control bundle with pyautogui/scrot) drop into the same seeder.
+- Each agent installs Playwright once into its sandbox; the driver is stateless
+  so there's no hidden session to manage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
   `delegate` tool now coaches the leader pattern and prefers reusing an existing named agent. (M843)
 
 ### Added
+- **Browser-use, out of the box (M852).** Full agentic browser automation — navigate, click, type,
+  submit forms, screenshot, and extract from JavaScript-rendered pages — now works without setup. The
+  daemon seeds a built-in `browser-use` skill bundle (agentskills.io shape) into the Forge at startup,
+  active and ready: a `SKILL.md`, a one-time `scripts/setup.sh` (installs Playwright + Chromium), and a
+  stateless `scripts/browse.mjs` Playwright driver the agent runs via code_exec (it screenshots, looks,
+  and acts in a loop). No new Go dependency — it rides the always-on code_exec sandbox and the M848
+  "you can install/run anything" posture, keeping the single-binary, one-dep ethos. New
+  `plugins/builtinskills` go:embed-seeds the bundle (idempotent, content-addressed). (M852)
 - **Memory provenance — who added & updated each fact (M851).** Every memory record now records WHO
   wrote it: the acting agent's slug, or `operator` for a console/CLI write, or `distill` for an
   auto-distilled summary. `added_by` is first-writer-wins (the original author survives a peer's

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -76,6 +76,7 @@ import (
 	"github.com/agezt/agezt/kernel/webhook"
 	"github.com/agezt/agezt/kernel/webui"
 	"github.com/agezt/agezt/kernel/workflow"
+	"github.com/agezt/agezt/plugins/builtinskills"
 	"github.com/agezt/agezt/plugins/channels/discord"
 	"github.com/agezt/agezt/plugins/channels/email"
 	"github.com/agezt/agezt/plugins/channels/homeassistant"
@@ -1521,6 +1522,19 @@ func runDaemon(stdout, stderr io.Writer) int {
 	if fg := k.Forge(); fg != nil {
 		skillToolInst.Bind(fg)
 		fmt.Fprintf(stdout, "  skill tool       : enabled (the agent can author and manage its own skills)\n")
+		// Seed the built-in skill bundles baked into the binary (M852), so
+		// capabilities like full browser automation work out of the box — the
+		// agent gets a ready, active skill with its scripts on disk. Idempotent
+		// (content-addressed); best-effort — a seed failure never blocks startup.
+		if seeded, serr := builtinskills.SeedAll(fg, ""); serr != nil {
+			fmt.Fprintf(stderr, "  built-in skills  : partial (%v)\n", serr)
+		} else if len(seeded) > 0 {
+			names := make([]string, 0, len(seeded))
+			for _, s := range seeded {
+				names = append(names, s.Name)
+			}
+			fmt.Fprintf(stdout, "  built-in skills  : seeded (%s)\n", strings.Join(names, ", "))
+		}
 	}
 
 	// Bind the introspection tool to the live kernel (M682), so the agent can read

--- a/plugins/builtinskills/browseruse/SKILL.md
+++ b/plugins/builtinskills/browseruse/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: browser-use
+description: Drive a real headless browser — navigate, click, type, submit forms, screenshot, and extract from JavaScript-rendered pages (when browser.read's plain fetch isn't enough)
+triggers: [browser, web, navigate, click, screenshot, scrape, form, login, spa, javascript]
+tools: [code_exec, shell, artifacts]
+---
+
+# Browser use — full headless automation
+
+When a page needs JavaScript, a click, a form submission, or a screenshot, the
+plain `browser.read` fetch isn't enough. This skill drives a **real headless
+Chromium** via Playwright, which you run through the `code_exec` tool. It is
+headless-first: you act, take a screenshot, look at it, and act again.
+
+## One-time setup (install Playwright)
+
+Run the setup script once via `code_exec` (or the `shell` tool). It installs
+Playwright and its Chromium browser into the sandbox:
+
+```
+node scripts/setup.sh        # or: bash scripts/setup.sh
+```
+
+(Use `skill op=files browser-use` to see the bundle directory, then run
+`scripts/setup.sh` from there. First run downloads Chromium — it can take a
+minute. If `npx playwright install` reports a missing OS dependency, install it
+with the `shell` tool, then re-run — you have full machine permission.)
+
+## Driving the browser
+
+`scripts/browse.mjs` is a stateless driver: each call opens a page, runs your
+ordered list of **actions**, optionally screenshots, and returns extracted text +
+the screenshot path as JSON. Pass the spec as a single JSON argument.
+
+Run it through `code_exec` (language: node), e.g.:
+
+```
+node scripts/browse.mjs '{"url":"https://example.com","actions":[{"type":"click","selector":"text=More information"}],"screenshot":true,"extract":"text"}'
+```
+
+### Spec fields
+
+- `url` (required) — the page to open.
+- `actions` (optional) — ordered steps, each `{type, ...}`:
+  - `{"type":"click","selector":"<css-or-text>"}`
+  - `{"type":"fill","selector":"<css>","value":"<text>"}` — type into an input.
+  - `{"type":"press","selector":"<css>","key":"Enter"}`
+  - `{"type":"wait","ms":1000}` or `{"type":"wait","selector":"<css>"}`
+  - `{"type":"goto","url":"<url>"}` — navigate again (e.g. after a click).
+- `screenshot` (optional, default true) — save a PNG to the artifacts dir.
+- `extract` (optional) — `"text"` (visible text, default), `"html"` (full HTML),
+  or a CSS selector (the matched elements' text).
+- `timeout_ms` (optional, default 30000).
+
+Selectors accept Playwright syntax: CSS (`#id`, `.class`, `input[name=q]`) or
+text (`text=Sign in`).
+
+### Output (JSON on stdout)
+
+```
+{ "ok": true, "url": "<final-url>", "title": "...", "text": "<extracted>",
+  "screenshot": "<absolute path to the PNG>" }
+```
+
+The screenshot is written under the sandbox; copy or register it with the
+`artifacts` tool if you want it to appear in the Files view. To **see** the page
+state before deciding your next action, read the screenshot back (it's a real
+PNG you can attach).
+
+## Loop
+
+1. `goto` the URL, screenshot, read the screenshot + text.
+2. Decide the next action (click/fill/press) from what you see.
+3. Call again with the next actions. Repeat until done.
+
+See `reference/actions.md` for richer patterns (login flows, waiting for SPA
+content, extracting tables, downloading files).

--- a/plugins/builtinskills/browseruse/reference/actions.md
+++ b/plugins/builtinskills/browseruse/reference/actions.md
@@ -1,0 +1,64 @@
+# browser-use patterns
+
+All examples run `scripts/browse.mjs` via `code_exec` (language: node) with a
+single JSON spec argument. The driver is stateless — pass the full action list
+each call.
+
+## Read a JavaScript-rendered page (SPA)
+
+When `browser.read` returns an almost-empty shell, render it for real:
+
+```json
+{ "url": "https://example-spa.com/dashboard",
+  "actions": [{ "type": "wait", "selector": "main [data-loaded]" }],
+  "extract": "text" }
+```
+
+## Search and read results
+
+```json
+{ "url": "https://duckduckgo.com/",
+  "actions": [
+    { "type": "fill", "selector": "input[name=q]", "value": "agezt agentic os" },
+    { "type": "press", "selector": "input[name=q]", "key": "Enter" },
+    { "type": "wait", "selector": "[data-testid=result]" }
+  ],
+  "extract": "[data-testid=result]" }
+```
+
+## Log in, then act
+
+```json
+{ "url": "https://app.example.com/login",
+  "actions": [
+    { "type": "fill", "selector": "#email", "value": "me@example.com" },
+    { "type": "fill", "selector": "#password", "value": "..." },
+    { "type": "click", "selector": "text=Sign in" },
+    { "type": "wait", "selector": "text=Welcome" },
+    { "type": "goto", "url": "https://app.example.com/reports" }
+  ],
+  "screenshot": true, "extract": "text" }
+```
+
+Pull secrets from the config/vault rather than hard-coding them; never echo a
+password in a message.
+
+## See before you act
+
+Always screenshot, then read the PNG back to decide the next step. The driver
+returns `screenshot` (an absolute path). Register it with the `artifacts` tool to
+make it appear in the Files view, or read it directly to look at the page.
+
+## Extracting structure
+
+- A table: `"extract": "table tr"` returns each row's text.
+- A list of links/titles: `"extract": "a.result-title"`.
+- The whole DOM for parsing: `"extract": "html"`, then parse with code.
+
+## When a step fails
+
+The driver returns `{ "ok": false, "error": "..." }` (e.g. a selector timed
+out). Re-screenshot to see the actual page, adjust the selector (try a `text=`
+selector), add a `wait`, and retry. You have full machine permission — if
+Chromium reports a missing OS library, install it with the `shell` tool and
+re-run `scripts/setup.sh`.

--- a/plugins/builtinskills/browseruse/scripts/browse.mjs
+++ b/plugins/builtinskills/browseruse/scripts/browse.mjs
@@ -1,0 +1,91 @@
+// browser-use driver — a stateless Playwright runner the agent calls via code_exec.
+//
+// Usage:  node browse.mjs '<json-spec>'   (or pipe the JSON on stdin)
+// Spec:   { url, actions?: [...], screenshot?: bool, extract?: "text"|"html"|"<css>", timeout_ms?: number }
+// Output: one JSON object on stdout: { ok, url, title, text, screenshot } or { ok:false, error }.
+//
+// Each invocation opens a fresh headless Chromium, runs the ordered actions,
+// optionally screenshots, extracts, and exits — so the agent drives an explicit
+// see/act loop without any hidden session state.
+
+import { chromium } from "playwright";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+function readSpec() {
+  const arg = process.argv[2];
+  if (arg && arg.trim() !== "") return JSON.parse(arg);
+  // Fall back to stdin (fd 0).
+  const data = readFileSync(0, "utf8");
+  if (data.trim()) return JSON.parse(data);
+  throw new Error("no spec: pass a JSON spec as argv[2] or on stdin");
+}
+
+async function run(spec) {
+  if (!spec || !spec.url) throw new Error("spec.url is required");
+  const timeout = Number(spec.timeout_ms) > 0 ? Number(spec.timeout_ms) : 30000;
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const page = await browser.newPage();
+    page.setDefaultTimeout(timeout);
+    await page.goto(spec.url, { waitUntil: "domcontentloaded", timeout });
+
+    for (const a of spec.actions || []) {
+      switch (a.type) {
+        case "goto":
+          await page.goto(a.url, { waitUntil: "domcontentloaded", timeout });
+          break;
+        case "click":
+          await page.click(a.selector, { timeout });
+          break;
+        case "fill":
+          await page.fill(a.selector, String(a.value ?? ""), { timeout });
+          break;
+        case "press":
+          await page.press(a.selector, a.key || "Enter", { timeout });
+          break;
+        case "wait":
+          if (a.selector) await page.waitForSelector(a.selector, { timeout });
+          else await page.waitForTimeout(Number(a.ms) > 0 ? Number(a.ms) : 1000);
+          break;
+        default:
+          throw new Error("unknown action type: " + a.type);
+      }
+    }
+
+    const out = { ok: true, url: page.url(), title: await page.title() };
+
+    const extract = spec.extract ?? "text";
+    if (extract === "html") {
+      out.text = await page.content();
+    } else if (extract === "text") {
+      out.text = (await page.innerText("body")).slice(0, 200000);
+    } else {
+      // Treat as a selector: join the matched elements' visible text.
+      const texts = await page.locator(extract).allInnerTexts();
+      out.text = texts.join("\n").slice(0, 200000);
+    }
+
+    if (spec.screenshot !== false) {
+      const dir = mkdtempSync(join(tmpdir(), "browseruse-"));
+      const shot = join(dir, "page.png");
+      await page.screenshot({ path: shot, fullPage: false });
+      out.screenshot = shot;
+    }
+
+    return out;
+  } finally {
+    await browser.close();
+  }
+}
+
+(async () => {
+  try {
+    const out = await run(readSpec());
+    process.stdout.write(JSON.stringify(out));
+  } catch (err) {
+    process.stdout.write(JSON.stringify({ ok: false, error: String(err && err.message ? err.message : err) }));
+    process.exitCode = 1;
+  }
+})();

--- a/plugins/builtinskills/browseruse/scripts/setup.sh
+++ b/plugins/builtinskills/browseruse/scripts/setup.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# browser-use setup: install Playwright + the Chromium browser into the sandbox.
+# Idempotent — re-running is cheap once installed. Run via code_exec or shell.
+set -e
+
+echo "installing playwright (node) ..."
+# Local install keeps it in the sandbox project; -g also works if you prefer.
+npm install playwright@latest >/dev/null 2>&1 || npm install playwright@latest
+
+echo "downloading the chromium browser ..."
+# --with-deps pulls OS libraries on Linux; harmless elsewhere. If it fails for a
+# missing OS package, install that package with the shell tool and re-run.
+npx playwright install chromium --with-deps 2>/dev/null || npx playwright install chromium
+
+echo "browser-use ready: drive it with scripts/browse.mjs"

--- a/plugins/builtinskills/builtinskills.go
+++ b/plugins/builtinskills/builtinskills.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: MIT
+
+// Package builtinskills ships skill bundles baked into the binary and seeds them
+// into the daemon's Forge at startup, so capabilities like full browser
+// automation work out of the box — no operator install, no agent having to
+// author the skill first (M852). Each bundle is the agentskills.io shape (M847):
+// a SKILL.md plus reference files and scripts, embedded here and materialized
+// into the skill store on boot.
+//
+// Seeding is idempotent: skills are content-addressed by (name, body), so a
+// re-seed of an unchanged bundle dedupes onto the existing record and just
+// refreshes its on-disk files; a changed bundle (new binary) becomes a new
+// version. The seeded skill is promoted to active so it is immediately in the
+// retrieval pool.
+package builtinskills
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"path"
+	"strings"
+
+	"github.com/agezt/agezt/kernel/skill"
+)
+
+//go:embed browseruse
+var bundles embed.FS
+
+// Forge is the slice of *skill.Forge the seeder needs — an interface so it is
+// testable with a fake and so this package doesn't pull the kernel runtime.
+type Forge interface {
+	Create(corr string, spec skill.CreateSpec) (skill.Skill, bool, error)
+	Promote(corr, id string) (skill.Status, error)
+	Get(id string) (skill.Skill, bool, error)
+}
+
+// Seeded names one bundle that was installed, with its final lifecycle status.
+type Seeded struct {
+	Name    string
+	ID      string
+	Status  skill.Status
+	Created bool
+}
+
+// builtinBundles lists the embedded bundle directories to seed.
+var builtinBundles = []string{"browseruse"}
+
+// SeedAll installs every embedded bundle into the Forge and promotes each to
+// active. It is best-effort per bundle: an error on one is returned but does not
+// stop the others. corr is the journaling correlation (use "" for boot).
+func SeedAll(f Forge, corr string) ([]Seeded, error) {
+	var out []Seeded
+	var firstErr error
+	for _, dir := range builtinBundles {
+		s, err := seedOne(f, corr, dir)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("seed %s: %w", dir, err)
+			}
+			continue
+		}
+		out = append(out, s)
+	}
+	return out, firstErr
+}
+
+// seedOne reads one embedded bundle dir (its SKILL.md + the rest as resources),
+// creates the skill, and promotes it to active.
+func seedOne(f Forge, corr, dir string) (Seeded, error) {
+	mdRaw, err := bundles.ReadFile(path.Join(dir, "SKILL.md"))
+	if err != nil {
+		return Seeded{}, fmt.Errorf("read SKILL.md: %w", err)
+	}
+	md, err := skill.ParseSkillMD(mdRaw)
+	if err != nil {
+		return Seeded{}, err
+	}
+
+	resources := map[string][]byte{}
+	walkErr := fs.WalkDir(bundles, dir, func(p string, d fs.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel := strings.TrimPrefix(p, dir+"/")
+		if rel == "SKILL.md" {
+			return nil // the body, not a resource
+		}
+		data, rerr := bundles.ReadFile(p)
+		if rerr != nil {
+			return rerr
+		}
+		resources[rel] = data
+		return nil
+	})
+	if walkErr != nil {
+		return Seeded{}, walkErr
+	}
+
+	sk, created, err := f.Create(corr, skill.CreateSpec{
+		Name:          md.Name,
+		Description:   md.Description,
+		Triggers:      md.Triggers,
+		Body:          md.Body,
+		ToolsRequired: md.ToolsRequired,
+		Resources:     resources,
+	})
+	if err != nil {
+		return Seeded{}, err
+	}
+
+	// Promote to active so it is immediately in the retrieval pool. Idempotent:
+	// stop once active (or once a promote makes no progress); ignore the terminal
+	// "already active" error.
+	status := sk.Status
+	for i := 0; i < 3 && status != skill.StatusActive; i++ {
+		next, perr := f.Promote(corr, sk.ID)
+		if perr != nil {
+			break
+		}
+		if next == status {
+			break
+		}
+		status = next
+	}
+	return Seeded{Name: md.Name, ID: sk.ID, Status: status, Created: created}, nil
+}

--- a/plugins/builtinskills/builtinskills_test.go
+++ b/plugins/builtinskills/builtinskills_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+
+package builtinskills
+
+import (
+	"testing"
+
+	"github.com/agezt/agezt/kernel/skill"
+)
+
+// newForge builds a real Forge over a temp store + bundle store — the same wiring
+// the daemon uses, so the seed test exercises Create + bundle materialization +
+// promotion end to end.
+func newForge(t *testing.T) *skill.Forge {
+	t.Helper()
+	dir := t.TempDir()
+	store, err := skill.Open(dir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	f := skill.NewForge(store, nil)
+	bundles, err := skill.OpenBundles(dir)
+	if err != nil {
+		t.Fatalf("open bundles: %v", err)
+	}
+	f.SetBundles(bundles)
+	return f
+}
+
+func TestSeedAll_InstallsActiveBrowserUse(t *testing.T) {
+	f := newForge(t)
+	seeded, err := SeedAll(f, "")
+	if err != nil {
+		t.Fatalf("SeedAll: %v", err)
+	}
+	if len(seeded) != len(builtinBundles) {
+		t.Fatalf("seeded %d bundles, want %d", len(seeded), len(builtinBundles))
+	}
+
+	var bu *Seeded
+	for i := range seeded {
+		if seeded[i].Name == "browser-use" {
+			bu = &seeded[i]
+		}
+	}
+	if bu == nil {
+		t.Fatalf("browser-use not seeded: %+v", seeded)
+	}
+	if !bu.Created {
+		t.Errorf("first seed should create the skill")
+	}
+	if bu.Status != skill.StatusActive {
+		t.Errorf("browser-use status = %q, want active (in the retrieval pool)", bu.Status)
+	}
+
+	// The bundle's scripts/reference must be materialized on disk.
+	files, err := f.Bundles().List("browser-use")
+	if err != nil {
+		t.Fatalf("list bundle: %v", err)
+	}
+	wantFiles := map[string]bool{"scripts/browse.mjs": false, "scripts/setup.sh": false, "reference/actions.md": false}
+	for _, rel := range files {
+		if _, ok := wantFiles[rel]; ok {
+			wantFiles[rel] = true
+		}
+	}
+	for rel, found := range wantFiles {
+		if !found {
+			t.Errorf("bundle missing %q (got %v)", rel, files)
+		}
+	}
+
+	// The driver script is real, non-empty.
+	driver, err := f.Bundles().Read("browser-use", "scripts/browse.mjs")
+	if err != nil || len(driver) == 0 {
+		t.Errorf("browse.mjs unreadable/empty: %v", err)
+	}
+}
+
+func TestSeedAll_Idempotent(t *testing.T) {
+	f := newForge(t)
+	if _, err := SeedAll(f, ""); err != nil {
+		t.Fatalf("first SeedAll: %v", err)
+	}
+	seeded, err := SeedAll(f, "")
+	if err != nil {
+		t.Fatalf("second SeedAll: %v", err)
+	}
+	for _, s := range seeded {
+		if s.Created {
+			t.Errorf("re-seed created %q again (should dedupe on content address)", s.Name)
+		}
+		if s.Status != skill.StatusActive {
+			t.Errorf("re-seed left %q at %q, want active", s.Name, s.Status)
+		}
+	}
+}


### PR DESCRIPTION
## What

Full agentic browser automation — navigate, click, type, submit forms, screenshot, extract from JS-rendered pages — working **out of the box**. Owner ask: full browser-use / computer-use (#43/#44), headless-first, Playwright-style.

## Architecture

A native Go interactive browser would mean bundling Chromium (chromedp/rod) or playwright-go — a multi-MB engine against AGEZT's single-binary, one-dep (BLAKE3) ethos (browser engines are explicit anti-deps for core). M847/M848 already let agents **install and run anything** via the always-on `code_exec` sandbox + shell. So browser-use ships as a **built-in skill bundle the daemon seeds at startup** — zero Go deps, on-ethos, immediately usable.

## Highlights

- **`plugins/builtinskills`** — `go:embed` bundles; `SeedAll` reads each bundle's SKILL.md + resources, `Create`s the skill (content-addressed → idempotent) and promotes it **active**. Best-effort; never blocks startup. Daemon: `built-in skills : seeded (browser-use)`.
- **`browser-use` bundle**: `SKILL.md` (see/act loop), `scripts/setup.sh` (install Playwright + Chromium), `scripts/browse.mjs` (stateless driver: ordered actions → screenshot + extract → JSON), `reference/actions.md` (login/SPA/extract patterns). The agent runs the driver via code_exec and iterates.

## Verification

- `go build`, `go vet`, `staticcheck`, linux cross-build clean; `builtinskills` tests green; `node --check browse.mjs` passes. No new Go dep (go.mod unchanged); no new env. `.gitattributes` forces LF on the embedded bundle (the `.sh` runs on Linux).
- Unit: `SeedAll` installs `browser-use` active with 3 bundle files on disk + non-empty driver; re-seed idempotent.
- Boot smoke (isolated home): `agt skill list` → `[active] browser-use`; `agt skill files` lists the bundle + dir; files on disk.
- Live Playwright install + a real navigation can't run in the build sandbox (no network); driver is syntax-checked, standard Playwright APIs; seeding/activation/materialization fully verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)