### PR TITLE
Feat: computer-use out of the box — built-in skill bundle (M853)

### DIFF
--- a/.project/PHASE-M853-COMPUTER-USE-SKILL-REPORT.md
+++ b/.project/PHASE-M853-COMPUTER-USE-SKILL-REPORT.md
@@ -1,0 +1,55 @@
+# PHASE M853 — Computer-use, out of the box (built-in skill bundle)
+
+**Status:** shipped
+**Milestone:** M853
+**Theme:** Full machine control — install/update/remove software and automate the
+desktop GUI (screenshot, click, type, hotkeys) — working out of the box. Owner
+ask: computer-use / full-privilege machine control (#44), the second half of the
+chosen browser+computer-use area.
+
+## Approach
+
+Same proven path as M852 (browser-use): a **built-in skill bundle** the daemon
+seeds active at startup, driven through the always-on `code_exec`/`shell` tools
+— zero Go deps, on-ethos. The M852 `plugins/builtinskills` seeder already handles
+multiple bundles, so this is a drop-in.
+
+## What shipped
+
+- **The `computer-use` bundle**, added to the startup seeder:
+  - `SKILL.md` — the two halves: software management via `shell` (winget/choco/
+    brew/apt/npm/pip, full permission) and GUI automation via the desktop driver;
+    the see-then-act loop.
+  - `scripts/setup.sh` — `pip install pyautogui pillow` (with Linux notes for
+    scrot / python3-tk).
+  - `scripts/desktop.py` — a stateless driver: an ordered action list
+    (screenshot/move/click/double_click/type/press/scroll/wait/locate) plus a
+    final screenshot, emitting JSON. Needs a desktop session; on a headless host
+    it returns a clear error instead of crashing.
+  - `reference/patterns.md` — per-OS package-manager recipes, the see-then-act
+    loop, locate-by-template, and safety notes for destructive UI actions.
+- `plugins/builtinskills/builtinskills.go` — `computeruse` added to the
+  `go:embed` set and `builtinBundles`.
+
+## Verification
+
+- **Gate:** `go build`, `go vet`, `staticcheck`, linux cross-build clean;
+  `builtinskills` tests green; `python -m py_compile desktop.py` passes. No new Go
+  dep (go.mod unchanged); no new env. `.gitattributes` already forces LF on
+  `plugins/builtinskills/**`.
+- **Unit:** `SeedAll` installs both `browser-use` and `computer-use` active;
+  `TestSeedAll_InstallsComputerUse` asserts the desktop driver + setup + reference
+  are materialized on disk; re-seed idempotent.
+- **Boot smoke (isolated home):** daemon logs `built-in skills : seeded
+  (browser-use, computer-use)`; `agt skill list` shows both `[active]`.
+- The live pyautogui install + a real GUI action can't run in the build sandbox
+  (no display / no network); the driver is syntax-validated and uses standard
+  pyautogui APIs, with an explicit headless error path. Seeding/activation/
+  materialization fully verified.
+
+## Notes
+- Computer-use was already *possible* (shell + code_exec install/run anything
+  under default-allow, and the M848 briefing says so); this packages the GUI
+  half as a ready, documented, active skill so the agent does it reliably.
+- The seeder is now the home for any built-in bundle; future additions (e.g. a
+  docker-services bundle for #51) drop into `builtinBundles`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
   `delegate` tool now coaches the leader pattern and prefers reusing an existing named agent. (M843)
 
 ### Added
+- **Computer-use, out of the box (M853).** Full machine control to match browser-use: a built-in
+  `computer-use` skill bundle, seeded active at startup, covers both halves — install/update/remove
+  software via the shell (winget/choco/brew/apt/npm/pip), and desktop GUI automation via
+  `scripts/desktop.py` (a stateless pyautogui driver: screenshot, click, double-click, type, hotkeys,
+  scroll, locate-by-image), run through code_exec in a see-then-act loop. A desktop session is required;
+  on a headless host the driver returns a clear error. No new Go dependency — it rides the same
+  `plugins/builtinskills` seeder as browser-use. (M853)
 - **Browser-use, out of the box (M852).** Full agentic browser automation — navigate, click, type,
   submit forms, screenshot, and extract from JavaScript-rendered pages — now works without setup. The
   daemon seeds a built-in `browser-use` skill bundle (agentskills.io shape) into the Forge at startup,

--- a/plugins/builtinskills/builtinskills.go
+++ b/plugins/builtinskills/builtinskills.go
@@ -24,7 +24,7 @@ import (
 	"github.com/agezt/agezt/kernel/skill"
 )
 
-//go:embed browseruse
+//go:embed browseruse computeruse
 var bundles embed.FS
 
 // Forge is the slice of *skill.Forge the seeder needs — an interface so it is
@@ -44,7 +44,7 @@ type Seeded struct {
 }
 
 // builtinBundles lists the embedded bundle directories to seed.
-var builtinBundles = []string{"browseruse"}
+var builtinBundles = []string{"browseruse", "computeruse"}
 
 // SeedAll installs every embedded bundle into the Forge and promotes each to
 // active. It is best-effort per bundle: an error on one is returned but does not

--- a/plugins/builtinskills/builtinskills_test.go
+++ b/plugins/builtinskills/builtinskills_test.go
@@ -77,6 +77,30 @@ func TestSeedAll_InstallsActiveBrowserUse(t *testing.T) {
 	}
 }
 
+func TestSeedAll_InstallsComputerUse(t *testing.T) {
+	f := newForge(t)
+	if _, err := SeedAll(f, ""); err != nil {
+		t.Fatalf("SeedAll: %v", err)
+	}
+	// The computer-use bundle's desktop driver must be materialized.
+	driver, err := f.Bundles().Read("computer-use", "scripts/desktop.py")
+	if err != nil || len(driver) == 0 {
+		t.Fatalf("computer-use desktop.py unreadable/empty: %v", err)
+	}
+	files, _ := f.Bundles().List("computer-use")
+	want := map[string]bool{"scripts/desktop.py": false, "scripts/setup.sh": false, "reference/patterns.md": false}
+	for _, rel := range files {
+		if _, ok := want[rel]; ok {
+			want[rel] = true
+		}
+	}
+	for rel, found := range want {
+		if !found {
+			t.Errorf("computer-use bundle missing %q (got %v)", rel, files)
+		}
+	}
+}
+
 func TestSeedAll_Idempotent(t *testing.T) {
 	f := newForge(t)
 	if _, err := SeedAll(f, ""); err != nil {

--- a/plugins/builtinskills/computeruse/SKILL.md
+++ b/plugins/builtinskills/computeruse/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: computer-use
+description: Control the machine — install/update/remove software, and automate the desktop GUI (screenshot, click, type, hotkeys) when a task needs the real computer, not just a browser
+triggers: [computer, desktop, gui, install, uninstall, screenshot, click, keyboard, app, software, automate]
+tools: [shell, code_exec, artifacts]
+---
+
+# Computer use — full machine control
+
+When a task needs the actual computer — install an app, run a CLI, or click
+through a desktop GUI — use this. Two halves:
+
+1. **Software management** via the `shell` tool. You have full machine
+   permission: install, update, and remove software with the host's package
+   manager (winget/choco on Windows, brew on macOS, apt on Linux) or language
+   managers (npm/pip/cargo). If a command is missing, install it, then use it.
+
+2. **GUI automation** via `scripts/desktop.py`, run through `code_exec`
+   (language: python). It screenshots the screen, clicks at coordinates, types,
+   sends hotkeys, scrolls, and can locate a control by a template image. A
+   desktop session is required (it drives the real screen/keyboard); on a
+   headless host it returns a clear error.
+
+## One-time setup
+
+Run `scripts/setup.sh` once (via code_exec or shell): it installs `pyautogui` +
+`pillow`. Use `skill op=files computer-use` to find the bundle directory.
+
+## Driving the desktop
+
+`scripts/desktop.py` takes a JSON spec — an ordered list of actions, plus a final
+screenshot by default. Run it with `code_exec`:
+
+```
+python scripts/desktop.py '{"actions":[{"type":"screenshot"}],"screenshot":true}'
+```
+
+See `reference/patterns.md` for the full action set (move/click/double_click/
+type/press/scroll/wait/locate), package-manager recipes per OS, and the
+see-then-act loop.
+
+## Loop
+
+1. Screenshot; read the PNG back to see the screen.
+2. Decide the next action from what you see (find the control's coordinates, or
+   `locate` it by a template image).
+3. Click / type / press; screenshot again. Repeat until done.
+
+Register screenshots with the `artifacts` tool to view them in the Files view.
+Be deliberate with destructive actions — read the screen before confirming.

--- a/plugins/builtinskills/computeruse/reference/patterns.md
+++ b/plugins/builtinskills/computeruse/reference/patterns.md
@@ -1,0 +1,59 @@
+# computer-use patterns
+
+Two halves: **install/manage software** (the shell tool, full permission) and
+**GUI control** (`scripts/desktop.py` via code_exec, needs a desktop session).
+
+## Installing / updating / removing software
+
+Use the `shell` tool. Pick the host's package manager:
+
+- Windows: `winget install <id>` / `winget upgrade --all` / `winget uninstall <id>`
+  (or `choco install <pkg>` if Chocolatey is present).
+- macOS: `brew install <pkg>` / `brew upgrade` / `brew uninstall <pkg>`.
+- Debian/Ubuntu: `sudo apt-get update && sudo apt-get install -y <pkg>`.
+- Language tools: `npm i -g <pkg>`, `pip install <pkg>`, `cargo install <pkg>`.
+
+You have full machine permission — if a command needs a dependency, install it,
+then continue.
+
+## GUI control (desktop.py)
+
+Run via code_exec (language: python), passing a JSON spec. Each call runs an
+ordered list of actions and (by default) returns a final screenshot path:
+
+```json
+{ "actions": [
+    { "type": "screenshot" },
+    { "type": "click", "x": 640, "y": 360 },
+    { "type": "type", "text": "hello world" },
+    { "type": "press", "keys": ["ctrl", "s"] }
+  ],
+  "screenshot": true }
+```
+
+### See, then act
+
+Always start with a screenshot, read it back to find the coordinates of the
+control you want, then click/type. The driver returns `screen` (the resolution)
+and `screenshot` (an absolute PNG path) — register it with the `artifacts` tool
+to view it in the Files view, or read it directly to look.
+
+### Find a control by image
+
+If you have a template PNG of a button, locate it instead of guessing
+coordinates:
+
+```json
+{ "actions": [ { "type": "locate", "image": "/path/to/button.png" } ] }
+```
+
+Returns its `box` ({left, top, width, height}); click its centre.
+
+### Notes & safety
+
+- A GUI session is required; on a headless server the driver returns a clear
+  error — there install nothing and report back.
+- Be deliberate with destructive UI actions; prefer keyboard shortcuts and
+  confirm dialogs by reading the screenshot first.
+- Never type secrets in plain sight if a message will be shown; pull them from
+  the vault/config.

--- a/plugins/builtinskills/computeruse/scripts/desktop.py
+++ b/plugins/builtinskills/computeruse/scripts/desktop.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""computer-use driver — control the real desktop (screenshot, click, type, hotkeys).
+
+Usage:  python desktop.py '<json-spec>'   (or pipe the JSON on stdin)
+Spec:   { "actions": [ {type, ...}, ... ], "screenshot": true }
+Output: one JSON object on stdout: { ok, screen, screenshot?, results } or { ok:false, error }.
+
+Action types:
+  {"type":"screenshot"}                         -> capture the screen now (also auto-captured at end unless screenshot:false)
+  {"type":"move","x":100,"y":200}
+  {"type":"click","x":100,"y":200,"button":"left"}   (button: left|right|middle)
+  {"type":"double_click","x":100,"y":200}
+  {"type":"type","text":"hello"}                -> type text at the current focus
+  {"type":"press","keys":["ctrl","s"]}          -> a hotkey chord (pyautogui.hotkey)
+  {"type":"scroll","amount":-300}               -> scroll (negative = down)
+  {"type":"wait","ms":500}
+  {"type":"locate","image":"/path/to/template.png"}  -> find an image on screen, returns its box
+
+Needs a real display (GUI session). On a headless host it returns a clear error.
+Install once: pip install pyautogui pillow  (see scripts/setup.sh).
+"""
+import json
+import os
+import sys
+import tempfile
+import time
+
+
+def read_spec():
+    if len(sys.argv) > 1 and sys.argv[1].strip():
+        return json.loads(sys.argv[1])
+    data = sys.stdin.read()
+    if data.strip():
+        return json.loads(data)
+    raise ValueError("no spec: pass a JSON spec as argv[1] or on stdin")
+
+
+def run(spec):
+    try:
+        import pyautogui
+    except Exception as e:  # noqa: BLE001
+        raise RuntimeError(
+            "pyautogui is not installed or no display is available "
+            "(run scripts/setup.sh; a GUI session is required): " + str(e)
+        )
+    pyautogui.FAILSAFE = False
+
+    width, height = pyautogui.size()
+    out = {"ok": True, "screen": {"width": width, "height": height}, "results": []}
+
+    for a in spec.get("actions", []):
+        t = a.get("type")
+        if t == "screenshot":
+            out["results"].append({"type": "screenshot", "path": _shot(pyautogui)})
+        elif t == "move":
+            pyautogui.moveTo(a["x"], a["y"], duration=0.1)
+            out["results"].append({"type": "move", "ok": True})
+        elif t == "click":
+            pyautogui.click(a["x"], a["y"], button=a.get("button", "left"))
+            out["results"].append({"type": "click", "ok": True})
+        elif t == "double_click":
+            pyautogui.doubleClick(a["x"], a["y"])
+            out["results"].append({"type": "double_click", "ok": True})
+        elif t == "type":
+            pyautogui.typewrite(str(a.get("text", "")), interval=0.01)
+            out["results"].append({"type": "type", "ok": True})
+        elif t == "press":
+            keys = a.get("keys") or []
+            if len(keys) == 1:
+                pyautogui.press(keys[0])
+            else:
+                pyautogui.hotkey(*keys)
+            out["results"].append({"type": "press", "ok": True})
+        elif t == "scroll":
+            pyautogui.scroll(int(a.get("amount", 0)))
+            out["results"].append({"type": "scroll", "ok": True})
+        elif t == "wait":
+            time.sleep(max(0, int(a.get("ms", 500))) / 1000.0)
+            out["results"].append({"type": "wait", "ok": True})
+        elif t == "locate":
+            box = pyautogui.locateOnScreen(a["image"], confidence=a.get("confidence", 0.9))
+            out["results"].append(
+                {"type": "locate", "found": bool(box),
+                 "box": ({"left": box.left, "top": box.top, "width": box.width, "height": box.height} if box else None)}
+            )
+        else:
+            raise ValueError("unknown action type: " + str(t))
+
+    if spec.get("screenshot", True):
+        out["screenshot"] = _shot(pyautogui)
+    return out
+
+
+def _shot(pyautogui):
+    path = os.path.join(tempfile.mkdtemp(prefix="computeruse-"), "screen.png")
+    pyautogui.screenshot(path)
+    return path
+
+
+def main():
+    try:
+        print(json.dumps(run(read_spec())))
+    except Exception as e:  # noqa: BLE001
+        print(json.dumps({"ok": False, "error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/builtinskills/computeruse/scripts/setup.sh
+++ b/plugins/builtinskills/computeruse/scripts/setup.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# computer-use setup: install the desktop-automation deps. Run via code_exec or shell.
+# A GUI session is required at run time (pyautogui controls the real screen/keyboard).
+set -e
+
+echo "installing pyautogui + pillow (python) ..."
+# Prefer pip; fall back to pip3. On Linux, pyautogui also needs python3-tk and
+# scrot for screenshots — install them with the shell tool if a run reports them
+# missing (you have full machine permission).
+python -m pip install --quiet pyautogui pillow 2>/dev/null \
+  || pip install --quiet pyautogui pillow 2>/dev/null \
+  || pip3 install pyautogui pillow
+
+echo "computer-use ready: drive it with scripts/desktop.py"
+echo "(Linux note: if screenshots fail, install 'scrot' and 'python3-tk' via the shell tool.)"


### PR DESCRIPTION
## What

Full machine control to match browser-use (#44) — the second half of the chosen browser+computer-use area. Same proven path as M852: a built-in skill bundle the daemon seeds **active** at startup, driven through the always-on `code_exec`/`shell` tools. Zero Go deps.

## The `computer-use` bundle

- `SKILL.md` — two halves: **software management** via `shell` (winget/choco/brew/apt/npm/pip, full permission) and **GUI automation** via the desktop driver; the see-then-act loop.
- `scripts/setup.sh` — `pip install pyautogui pillow` (+ Linux scrot/tk notes).
- `scripts/desktop.py` — stateless driver: ordered actions (screenshot/move/click/double_click/type/press/scroll/wait/locate) + a final screenshot → JSON. Needs a desktop session; on a headless host returns a clear error.
- `reference/patterns.md` — per-OS package managers, see-then-act, locate-by-template, safety.

`computeruse` added to the `go:embed` set + `builtinBundles` — the M852 seeder handles the rest.

## Verification

- `go build`, `go vet`, `staticcheck`, linux cross-build clean; `builtinskills` tests green; `python -m py_compile desktop.py` passes. No new Go dep (go.mod unchanged); `.gitattributes` forces LF on the embedded scripts.
- Unit: `SeedAll` installs browser-use + computer-use active; `TestSeedAll_InstallsComputerUse` asserts the driver/setup/reference are on disk; re-seed idempotent.
- Boot smoke: daemon logs `built-in skills : seeded (browser-use, computer-use)`; `agt skill list` shows both `[active]`.
- Live pyautogui install + a real GUI action can't run in the build sandbox (no display); driver is syntax-checked with an explicit headless error path; seeding/activation/materialization fully verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)