### PR TITLE
Feat: built-in data-analysis skill bundle (M861)

### DIFF
--- a/.project/PHASE-M861-DATA-ANALYSIS-SKILL-REPORT.md
+++ b/.project/PHASE-M861-DATA-ANALYSIS-SKILL-REPORT.md
@@ -1,0 +1,47 @@
+# PHASE M861 — Built-in data-analysis skill bundle
+
+**Status:** shipped
+**Milestone:** M861 (numbered to stay clear of concurrent in-progress
+M858/M859 work in the tree).
+**Theme:** A third out-of-the-box skill bundle (after browser-use M852 and
+computer-use M853): real number-crunching over data files with pandas. Extends
+#34 ("more capabilities") and pairs naturally with the Data Lake.
+
+## What shipped
+
+A built-in `data-analysis` bundle, seeded active at startup by the existing
+`plugins/builtinskills` seeder (no daemon wiring change — `builtinBundles` +
+`go:embed` only):
+
+- `SKILL.md` — when and how to load CSV/Excel/JSON/Parquet into pandas, run the
+  helper, and go further by writing pandas directly.
+- `scripts/setup.sh` — `pip install pandas matplotlib openpyxl pyarrow`.
+- `scripts/analyze.py` — a stateless helper: loads a file (format inferred from
+  extension), prints a JSON summary (shape, dtypes, `describe()`, head), and
+  optionally a group-by aggregate and a saved chart PNG. The agent runs it via
+  `code_exec`.
+- `reference/recipes.md` — cleaning, joins, pivots, time series, charts→artifacts,
+  and analyzing a Data Lake collection.
+
+## Why this milestone is conflict-free
+
+A new bundle touches **only** `plugins/builtinskills/` — never `cmd/agezt/main.go`
+or `kernel/runtime`/`agent`/`governor` (the files a concurrent session is
+actively editing for M858/M859). The seeder auto-loads it. It also tests in
+isolation: `go test ./plugins/builtinskills/` compiles just this package +
+`kernel/skill`, so verification never compiles the in-flux Go kernel.
+
+## Verification
+
+- **Isolated gate:** `go vet`, `staticcheck`, and a linux build of
+  `./plugins/builtinskills/` clean; `python -m py_compile analyze.py` passes; the
+  package test suite green — `SeedAll` installs **browser-use + computer-use +
+  data-analysis**, and `TestSeedAll_InstallsDataAnalysis` asserts the bundle's
+  `analyze.py` / `setup.sh` / `recipes.md` are materialized. No new Go dep; no new
+  env. `.gitattributes` already forces LF on `plugins/builtinskills/**`.
+- Full `go build ./...` and a daemon smoke were deliberately skipped — they'd
+  compile the concurrent in-progress Go edits.
+
+## Notes
+- Three seeded bundles now ship out of the box. Future ones (pdf-tools, git-ops,
+  …) drop into `builtinBundles` the same way.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
   `delegate` tool now coaches the leader pattern and prefers reusing an existing named agent. (M843)
 
 ### Added
+- **Built-in data-analysis skill bundle (M861).** A third out-of-the-box skill (after browser-use and
+  computer-use), seeded active at startup: crunch real data with pandas. `scripts/analyze.py` loads a
+  CSV/Excel/JSON/Parquet file and returns a JSON summary (shape, dtypes, describe, head) plus optional
+  group-by aggregates and a saved chart; `setup.sh` installs pandas/matplotlib; `reference/recipes.md`
+  covers joins/pivots/time-series. The agent runs it via code_exec — pairs naturally with the Data Lake.
+  No new Go dependency (rides the `plugins/builtinskills` seeder). (M861)
 - **Data Lake app-like views for every built-in collection (M860).** After expense + tasks (M856), the
   remaining built-ins now render as apps instead of a raw table: `calendar` (an agenda grouped into
   upcoming/past), `habits` (streak cards), `notes` (a card grid with tags), `bookmarks` (openable link

--- a/plugins/builtinskills/builtinskills.go
+++ b/plugins/builtinskills/builtinskills.go
@@ -24,7 +24,7 @@ import (
 	"github.com/agezt/agezt/kernel/skill"
 )
 
-//go:embed browseruse computeruse
+//go:embed browseruse computeruse dataanalysis
 var bundles embed.FS
 
 // Forge is the slice of *skill.Forge the seeder needs — an interface so it is
@@ -44,7 +44,7 @@ type Seeded struct {
 }
 
 // builtinBundles lists the embedded bundle directories to seed.
-var builtinBundles = []string{"browseruse", "computeruse"}
+var builtinBundles = []string{"browseruse", "computeruse", "dataanalysis"}
 
 // SeedAll installs every embedded bundle into the Forge and promotes each to
 // active. It is best-effort per bundle: an error on one is returned but does not

--- a/plugins/builtinskills/builtinskills_test.go
+++ b/plugins/builtinskills/builtinskills_test.go
@@ -101,6 +101,29 @@ func TestSeedAll_InstallsComputerUse(t *testing.T) {
 	}
 }
 
+func TestSeedAll_InstallsDataAnalysis(t *testing.T) {
+	f := newForge(t)
+	if _, err := SeedAll(f, ""); err != nil {
+		t.Fatalf("SeedAll: %v", err)
+	}
+	driver, err := f.Bundles().Read("data-analysis", "scripts/analyze.py")
+	if err != nil || len(driver) == 0 {
+		t.Fatalf("data-analysis analyze.py unreadable/empty: %v", err)
+	}
+	files, _ := f.Bundles().List("data-analysis")
+	want := map[string]bool{"scripts/analyze.py": false, "scripts/setup.sh": false, "reference/recipes.md": false}
+	for _, rel := range files {
+		if _, ok := want[rel]; ok {
+			want[rel] = true
+		}
+	}
+	for rel, found := range want {
+		if !found {
+			t.Errorf("data-analysis bundle missing %q (got %v)", rel, files)
+		}
+	}
+}
+
 func TestSeedAll_Idempotent(t *testing.T) {
 	f := newForge(t)
 	if _, err := SeedAll(f, ""); err != nil {

--- a/plugins/builtinskills/dataanalysis/SKILL.md
+++ b/plugins/builtinskills/dataanalysis/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: data-analysis
+description: Analyze spreadsheets and data files — CSV, Excel, JSON, Parquet — with pandas, summarize and aggregate them, and make charts, when a task needs real number-crunching instead of eyeballing
+triggers: [data, csv, excel, spreadsheet, analyze, pandas, chart, plot, aggregate, statistics, json]
+tools: [code_exec, shell, artifacts]
+---
+
+# Data analysis — crunch real data with pandas
+
+When a task involves a data file (CSV, Excel, JSON, Parquet) or columns of
+numbers, don't eyeball it — load it into pandas and compute. This skill runs
+through the `code_exec` tool (language: python).
+
+## One-time setup
+
+Run `scripts/setup.sh` once (via code_exec or shell): it installs `pandas`,
+`matplotlib`, and `openpyxl` (for Excel). Use `skill op=files data-analysis` to
+find the bundle directory.
+
+## Quick analysis with the helper
+
+`scripts/analyze.py` loads a file and prints a structured summary as JSON —
+shape, columns/dtypes, numeric describe(), and the head. Optional group-by
+aggregation and a chart. Run it via code_exec:
+
+```
+python scripts/analyze.py '{"path":"data.csv"}'
+```
+
+### Spec fields
+
+- `path` (required) — the data file. Format is inferred from the extension
+  (`.csv`, `.tsv`, `.json`, `.xlsx`/`.xls`, `.parquet`).
+- `describe` (optional, default true) — include `df.describe()` for numeric cols.
+- `group_by` (optional) — `{"by":"<col>","agg":"sum","column":"<numeric col>"}`
+  → a grouped aggregate (agg ∈ sum/mean/count/min/max).
+- `chart` (optional) — `{"kind":"bar"|"line","x":"<col>","y":"<col>","out":"chart.png"}`
+  → save a PNG you can register with the `artifacts` tool to show in Files.
+- `head` (optional, default 10) — rows to preview.
+
+### Output (JSON on stdout)
+
+```
+{ "ok": true, "rows": 1234, "cols": ["a","b"], "dtypes": {...},
+  "describe": {...}, "head": [...], "group_by": {...}?, "chart": "<path>"? }
+```
+
+## Going further
+
+For anything the helper doesn't cover, write your own pandas in `code_exec` — the
+helper is a fast start, not a cage. See `reference/recipes.md` for joins, time
+series, pivot tables, and cleaning patterns. To analyze a Data Lake collection,
+export it (the `db` tool / `/api/data/records`) to JSON first, then point
+`analyze.py` at it.

--- a/plugins/builtinskills/dataanalysis/reference/recipes.md
+++ b/plugins/builtinskills/dataanalysis/reference/recipes.md
@@ -1,0 +1,54 @@
+# data-analysis recipes
+
+The helper (`scripts/analyze.py`) covers load → summarize → group-by → chart. For
+everything else, write pandas directly in `code_exec`. Common patterns:
+
+## Clean before you compute
+
+```python
+import pandas as pd
+df = pd.read_csv("data.csv")
+df.columns = df.columns.str.strip().str.lower()      # tidy headers
+df = df.drop_duplicates()
+df["amount"] = pd.to_numeric(df["amount"], errors="coerce")  # bad cells → NaN
+df = df.dropna(subset=["amount"])
+```
+
+## Aggregate / pivot
+
+```python
+df.groupby("category")["amount"].agg(["sum", "mean", "count"])
+df.pivot_table(index="month", columns="category", values="amount", aggfunc="sum")
+```
+
+## Join two files
+
+```python
+a = pd.read_csv("orders.csv"); b = pd.read_csv("customers.csv")
+merged = a.merge(b, on="customer_id", how="left")
+```
+
+## Time series
+
+```python
+df["date"] = pd.to_datetime(df["date"])
+monthly = df.set_index("date").resample("ME")["amount"].sum()
+```
+
+## Charts → artifacts
+
+Save a PNG and register it with the `artifacts` tool so it shows in the Files
+view:
+
+```python
+import matplotlib; matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+ax = monthly.plot(kind="line", figsize=(8, 4.5), title="Spend / month")
+ax.figure.tight_layout(); ax.figure.savefig("spend.png")
+```
+
+## Analyze a Data Lake collection
+
+Export the collection to JSON (the `db` tool, or `GET /api/data/records`), write
+it to a file, then `python scripts/analyze.py '{"path":"expenses.json"}'` — or
+load it straight into pandas with `pd.read_json`.

--- a/plugins/builtinskills/dataanalysis/scripts/analyze.py
+++ b/plugins/builtinskills/dataanalysis/scripts/analyze.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""data-analysis helper — load a data file and summarize it with pandas.
+
+Usage:  python analyze.py '<json-spec>'   (or pipe the JSON on stdin)
+Spec:   { "path": "data.csv", "describe": true, "head": 10,
+          "group_by": {"by":"col","agg":"sum","column":"num"},
+          "chart": {"kind":"bar","x":"col","y":"num","out":"chart.png"} }
+Output: one JSON object on stdout (shape, dtypes, describe, head, group_by?, chart?).
+
+A fast start, not a cage: for anything beyond this, write your own pandas in code_exec.
+Install once with scripts/setup.sh (pandas + matplotlib + openpyxl + pyarrow).
+"""
+import json
+import sys
+
+
+def read_spec():
+    if len(sys.argv) > 1 and sys.argv[1].strip():
+        return json.loads(sys.argv[1])
+    data = sys.stdin.read()
+    if data.strip():
+        return json.loads(data)
+    raise ValueError("no spec: pass a JSON spec as argv[1] or on stdin")
+
+
+def load(path):
+    import pandas as pd
+
+    low = path.lower()
+    if low.endswith((".xlsx", ".xls")):
+        return pd.read_excel(path)
+    if low.endswith(".json"):
+        return pd.read_json(path)
+    if low.endswith(".parquet"):
+        return pd.read_parquet(path)
+    if low.endswith(".tsv"):
+        return pd.read_csv(path, sep="\t")
+    return pd.read_csv(path)
+
+
+def run(spec):
+    if not spec.get("path"):
+        raise ValueError("spec.path is required")
+    df = load(spec["path"])
+
+    out = {
+        "ok": True,
+        "rows": int(df.shape[0]),
+        "cols": [str(c) for c in df.columns],
+        "dtypes": {str(c): str(t) for c, t in df.dtypes.items()},
+    }
+
+    if spec.get("describe", True):
+        try:
+            out["describe"] = json.loads(df.describe(include="all").to_json())
+        except Exception:  # noqa: BLE001
+            out["describe"] = json.loads(df.describe().to_json())
+
+    head_n = int(spec.get("head", 10))
+    out["head"] = json.loads(df.head(head_n).to_json(orient="records"))
+
+    gb = spec.get("group_by")
+    if gb and gb.get("by"):
+        agg = gb.get("agg", "sum")
+        col = gb.get("column")
+        grouped = df.groupby(gb["by"])
+        series = getattr(grouped[col] if col else grouped, agg)()
+        out["group_by"] = json.loads(series.to_json())
+
+    ch = spec.get("chart")
+    if ch and ch.get("x"):
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        kind = ch.get("kind", "bar")
+        x, y = ch["x"], ch.get("y")
+        fig, ax = plt.subplots(figsize=(8, 4.5))
+        plot_df = df.set_index(x)[y] if y else df.set_index(x)
+        plot_df.plot(kind=kind, ax=ax)
+        fig.tight_layout()
+        out_path = ch.get("out", "chart.png")
+        fig.savefig(out_path)
+        out["chart"] = out_path
+
+    return out
+
+
+def main():
+    try:
+        print(json.dumps(run(read_spec()), default=str))
+    except Exception as e:  # noqa: BLE001
+        print(json.dumps({"ok": False, "error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/builtinskills/dataanalysis/scripts/setup.sh
+++ b/plugins/builtinskills/dataanalysis/scripts/setup.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# data-analysis setup: install pandas + matplotlib (+ Excel/parquet support).
+# Idempotent. Run via code_exec or shell.
+set -e
+
+echo "installing pandas + matplotlib + openpyxl ..."
+python -m pip install --quiet pandas matplotlib openpyxl pyarrow 2>/dev/null \
+  || pip install --quiet pandas matplotlib openpyxl pyarrow 2>/dev/null \
+  || pip3 install pandas matplotlib openpyxl pyarrow
+
+echo "data-analysis ready: run scripts/analyze.py '<json-spec>'"


### PR DESCRIPTION
## What

A third out-of-the-box skill bundle (after browser-use M852, computer-use M853), seeded active at startup: real number-crunching with pandas. Extends #34 and pairs with the Data Lake.

- `SKILL.md` — load CSV/Excel/JSON/Parquet, run the helper, or write pandas directly.
- `scripts/analyze.py` — stateless helper: file → JSON summary (shape, dtypes, describe, head) + optional group-by aggregate + saved chart PNG. Run via code_exec.
- `scripts/setup.sh` — pip install pandas/matplotlib/openpyxl/pyarrow.
- `reference/recipes.md` — cleaning, joins, pivots, time series, charts→artifacts, analyzing a Data Lake collection.

## Conflict-free by construction

Touches **only** `plugins/builtinskills/` (`builtinBundles` + `go:embed`) — never `main.go`/`runtime`/`agent`/`governor` (the files a concurrent session is editing for M858/M859). The seeder auto-loads it; it tests in isolation.

## Verification

- Isolated: `go vet` / `staticcheck` / linux build of `./plugins/builtinskills/` clean; `py_compile analyze.py` passes; package tests green — `SeedAll` installs browser-use + computer-use + data-analysis, and `TestSeedAll_InstallsDataAnalysis` asserts the files are materialized. No new Go dep/env; scripts committed LF.
- Full `go build ./...` + daemon smoke deliberately skipped (would compile the concurrent in-flux Go kernel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)