### PR TITLE
Feat: built-in docker-services skill bundle (M863)

### DIFF
--- a/.project/PHASE-M863-DOCKER-SERVICES-SKILL-REPORT.md
+++ b/.project/PHASE-M863-DOCKER-SERVICES-SKILL-REPORT.md
@@ -1,0 +1,57 @@
+# PHASE M863 — Built-in docker-services skill bundle
+
+**Status:** shipped
+**Milestone:** M863 (numbered to stay clear of concurrent in-progress
+M858/M859 work in the tree).
+**Theme:** Backlog #51 — *agents can run self-hosted services in the background
+via Docker* — delivered conflict-free as a fourth out-of-the-box skill bundle.
+
+## Approach
+
+Agents already have full machine capability (the `shell` and `code_exec` tools,
+default-allow posture) — they *can* already run `docker`. What was missing was
+the **lifecycle discipline**: a consistent way to start services so they survive
+reboots, stay discoverable, and don't become orphaned junk. That is exactly what
+a skill bundle provides — knowledge + a helper script — with no kernel plumbing.
+
+## What shipped
+
+A built-in `docker-services` bundle, seeded active at startup by the existing
+`plugins/builtinskills` seeder (no daemon wiring change — `builtinBundles` +
+`go:embed` only):
+
+- `SKILL.md` — when to stand up a real background service vs a throwaway script,
+  the **one rule** (label every service `agezt.service=1` so agezt's containers
+  are always findable/reapable without touching the user's own), the docker
+  availability check, the lifecycle, and how to connect/persist/clean up.
+- `scripts/svc.sh` — a POSIX lifecycle helper enforcing the label + `agezt-<name>`
+  naming: `up` (idempotent — reuses a running container, starts a stopped one,
+  else creates with `--restart unless-stopped`), `down`, `nuke` (down + remove
+  named volumes), `ls` (only agezt services), `logs`, `ip`.
+- `reference/services.md` — ready recipes (Postgres, Redis, MinIO, Ollama,
+  Meilisearch, n8n) with ports, named volumes, and connection strings, plus
+  health-poll and compose guidance.
+
+## Why this milestone is conflict-free
+
+A new bundle touches **only** `plugins/builtinskills/` — never `cmd/agezt/main.go`
+or `kernel/runtime`/`agent`/`governor` (the files a concurrent session is actively
+editing for M858/M859). The seeder auto-loads it. It tests in isolation:
+`go test ./plugins/builtinskills/` compiles just this package + `kernel/skill`, so
+verification never compiles the in-flux Go kernel.
+
+## Verification
+
+- **Isolated gate:** `go vet` clean; linux cross-build of `./plugins/builtinskills/`
+  clean; `gofmt -l` empty; `sh -n svc.sh` syntax-clean (shellcheck not installed in
+  this env). Package test suite green — `TestSeedAll_InstallsDockerServices` asserts
+  the bundle seeds **active** and materializes `scripts/svc.sh` + `reference/services.md`;
+  the existing `len(seeded) == len(builtinBundles)` assertions now cover four bundles.
+- No new Go dep; no new env. `.gitattributes` already forces LF on
+  `plugins/builtinskills/**`. Full `go build ./...` / daemon smoke deliberately
+  skipped — they'd compile the concurrent in-progress Go edits.
+
+## Notes
+- Four seeded bundles now ship out of the box (browser-use, computer-use,
+  data-analysis, docker-services). The `agezt.service=1` label is the contract a
+  future automated reaper (#53) can use to collect dead services.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
   `delegate` tool now coaches the leader pattern and prefers reusing an existing named agent. (M843)
 
 ### Added
+- **Built-in docker-services skill bundle (M863).** A fourth out-of-the-box skill (after browser-use,
+  computer-use, data-analysis) that lets agents stand up real self-hosted services in the background via
+  Docker — Postgres, Redis, MinIO, Ollama, n8n, … — and tear them down cleanly (#51). `scripts/svc.sh`
+  wraps the lifecycle (`up`/`down`/`nuke`/`ls`/`logs`/`ip`), labelling every container `agezt.service=1`
+  and naming it `agezt-<name>` so agezt's services stay discoverable and reapable without touching the
+  user's own containers; `up` is idempotent and adds `--restart unless-stopped`. `reference/services.md`
+  ships ready recipes with ports, named volumes, and connection strings. Agents run it via the existing
+  shell/code_exec tools — no new Go dependency (rides the `plugins/builtinskills` seeder). (M863)
 - **Overseer supervisory dashboard (M862).** A new read-only view (Agents → Overseer) that folds three
   existing read routes into one at-a-glance triage screen, refreshing every 5s: the **Active runs** panel
   (runs still `running`, with model/iters/start time and a sub-agent tag for delegated runs), an

--- a/plugins/builtinskills/builtinskills.go
+++ b/plugins/builtinskills/builtinskills.go
@@ -24,7 +24,7 @@ import (
 	"github.com/agezt/agezt/kernel/skill"
 )
 
-//go:embed browseruse computeruse dataanalysis
+//go:embed browseruse computeruse dataanalysis dockerservices
 var bundles embed.FS
 
 // Forge is the slice of *skill.Forge the seeder needs — an interface so it is
@@ -44,7 +44,7 @@ type Seeded struct {
 }
 
 // builtinBundles lists the embedded bundle directories to seed.
-var builtinBundles = []string{"browseruse", "computeruse", "dataanalysis"}
+var builtinBundles = []string{"browseruse", "computeruse", "dataanalysis", "dockerservices"}
 
 // SeedAll installs every embedded bundle into the Forge and promotes each to
 // active. It is best-effort per bundle: an error on one is returned but does not

--- a/plugins/builtinskills/builtinskills_test.go
+++ b/plugins/builtinskills/builtinskills_test.go
@@ -124,6 +124,42 @@ func TestSeedAll_InstallsDataAnalysis(t *testing.T) {
 	}
 }
 
+func TestSeedAll_InstallsDockerServices(t *testing.T) {
+	f := newForge(t)
+	seeded, err := SeedAll(f, "")
+	if err != nil {
+		t.Fatalf("SeedAll: %v", err)
+	}
+	var got *Seeded
+	for i := range seeded {
+		if seeded[i].Name == "docker-services" {
+			got = &seeded[i]
+		}
+	}
+	if got == nil {
+		t.Fatalf("docker-services not seeded: %+v", seeded)
+	}
+	if got.Status != skill.StatusActive {
+		t.Errorf("docker-services status = %q, want active", got.Status)
+	}
+	svc, err := f.Bundles().Read("docker-services", "scripts/svc.sh")
+	if err != nil || len(svc) == 0 {
+		t.Fatalf("docker-services svc.sh unreadable/empty: %v", err)
+	}
+	files, _ := f.Bundles().List("docker-services")
+	want := map[string]bool{"scripts/svc.sh": false, "reference/services.md": false}
+	for _, rel := range files {
+		if _, ok := want[rel]; ok {
+			want[rel] = true
+		}
+	}
+	for rel, found := range want {
+		if !found {
+			t.Errorf("docker-services bundle missing %q (got %v)", rel, files)
+		}
+	}
+}
+
 func TestSeedAll_Idempotent(t *testing.T) {
 	f := newForge(t)
 	if _, err := SeedAll(f, ""); err != nil {

--- a/plugins/builtinskills/dockerservices/SKILL.md
+++ b/plugins/builtinskills/dockerservices/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: docker-services
+description: Run self-hosted services (Postgres, Redis, MinIO, Ollama, n8n, …) in the background with Docker — start them detached and surviving reboots, list and inspect them, read their logs, and tear them down, when a task needs a real running service instead of a one-shot script
+triggers: [docker, service, postgres, redis, database, container, self-host, background, daemon, minio, ollama, compose]
+tools: [shell, code_exec]
+---
+
+# Docker services — stand up real background services
+
+When a task needs a *running* service — a database to hold state across runs, a
+cache, an object store, a local model server, a webhook receiver — don't fake it
+with a throwaway script. Run it as a Docker container, detached, so it keeps
+serving after this run ends and across daemon/host reboots. You have full machine
+capability (shell, code_exec); this skill is the lifecycle discipline that keeps
+those services discoverable and reapable instead of becoming orphaned junk.
+
+## The one rule: label everything
+
+Every service you start MUST carry the label `agezt.service=1` (the helper does
+this for you). That label is how you — and the operator, and any cleanup pass —
+find *only* the services agezt agents started, without touching the user's own
+containers. Never start an agezt service without it.
+
+## One-time check
+
+```sh
+docker version            # is the daemon up and reachable?
+```
+
+If Docker isn't installed, install it via the computer-use skill (the OS package
+manager), then re-check. On Linux the daemon may need `sudo systemctl start docker`.
+
+## Lifecycle with the helper
+
+`scripts/svc.sh` wraps the common operations and enforces the label + naming
+convention. Run it via shell or code_exec. Use `skill op=files docker-services`
+to find the bundle directory.
+
+```sh
+# Start (idempotent — reuses a healthy container of the same name):
+scripts/svc.sh up pg postgres:16 -e POSTGRES_PASSWORD=secret -p 5432:5432 \
+  -v agezt-pg:/var/lib/postgresql/data
+
+scripts/svc.sh ls               # only agezt services, with status + ports
+scripts/svc.sh logs pg 100      # last 100 log lines
+scripts/svc.sh ip pg            # the container's address + mapped ports
+scripts/svc.sh down pg          # stop + remove the container (named volume kept)
+scripts/svc.sh nuke pg          # down AND delete its named volumes (destroys data)
+```
+
+`up` adds `--restart unless-stopped` so the service comes back after a reboot,
+names the container `agezt-<name>`, and stamps the `agezt.service=1` label. It is
+safe to call again: if `agezt-<name>` is already running it is left alone; if it
+exists but is stopped it is started; otherwise it is created.
+
+## Doing it by hand
+
+The helper is a convenience, not a cage. Raw `docker run` is fine as long as you
+keep the contract:
+
+```sh
+docker run -d --name agezt-redis --label agezt.service=1 \
+  --restart unless-stopped -p 6379:6379 redis:7
+```
+
+For multi-container stacks, write a `docker-compose.yml` and
+`docker compose up -d`, but add `labels: ["agezt.service=1"]` to every service so
+the cleanup contract still holds.
+
+## Connecting from agent code
+
+Once a service is up, connect over the mapped host port like any client —
+e.g. `postgresql://postgres:secret@localhost:5432/postgres` from a pandas/psql
+run, or `redis://localhost:6379`. Persist connection details to a memory note or
+the Data Lake so later runs reuse the same service instead of starting a second.
+
+## Clean up after yourself
+
+A self-hosted service is durable on purpose, but don't leave dead ones running.
+When a task that owned a scratch service is done, `svc.sh down <name>` it. To see
+everything ag(ezt) ever started: `docker ps -a --filter label=agezt.service=1`.
+See `reference/services.md` for ready-to-run recipes (Postgres, Redis, MinIO,
+Ollama, n8n, Meilisearch) with ports, volumes, and connection strings.

--- a/plugins/builtinskills/dockerservices/reference/services.md
+++ b/plugins/builtinskills/dockerservices/reference/services.md
@@ -1,0 +1,67 @@
+# docker-services recipes
+
+Ready-to-run services. Each starts detached, labelled `agezt.service=1`, with a
+named volume so data survives `down`/restart (use `svc.sh nuke` to wipe). Adjust
+passwords/ports as the task needs. After `up`, connect over the mapped host port.
+
+## PostgreSQL
+
+```sh
+scripts/svc.sh up pg postgres:16 \
+  -e POSTGRES_PASSWORD=secret -p 5432:5432 -v agezt-pg:/var/lib/postgresql/data
+```
+Connect: `postgresql://postgres:secret@localhost:5432/postgres`
+
+## Redis
+
+```sh
+scripts/svc.sh up redis redis:7 -p 6379:6379 -v agezt-redis:/data \
+  redis-server --appendonly yes
+```
+Connect: `redis://localhost:6379`
+
+## MinIO (S3-compatible object store)
+
+```sh
+scripts/svc.sh up minio minio/minio \
+  -e MINIO_ROOT_USER=admin -e MINIO_ROOT_PASSWORD=secret123 \
+  -p 9000:9000 -p 9001:9001 -v agezt-minio:/data \
+  server /data --console-address ":9001"
+```
+S3 endpoint `http://localhost:9000`, console `http://localhost:9001`.
+
+## Ollama (local LLM server)
+
+```sh
+scripts/svc.sh up ollama ollama/ollama -p 11434:11434 -v agezt-ollama:/root/.ollama
+# then pull a model into the running container:
+docker exec agezt-ollama ollama pull llama3.2
+```
+API: `http://localhost:11434` (OpenAI-compatible at `/v1`).
+
+## Meilisearch (full-text search)
+
+```sh
+scripts/svc.sh up meili getmeili/meilisearch:v1.6 \
+  -e MEILI_MASTER_KEY=masterKey -p 7700:7700 -v agezt-meili:/meili_data
+```
+API: `http://localhost:7700`
+
+## n8n (workflow automation)
+
+```sh
+scripts/svc.sh up n8n n8nio/n8n -p 5678:5678 -v agezt-n8n:/home/node/.n8n
+```
+UI: `http://localhost:5678`
+
+## Tips
+
+- **Reuse, don't duplicate.** Before `up`, run `scripts/svc.sh ls` (or
+  `docker ps --filter label=agezt.service=1`) — `up` is idempotent on
+  `agezt-<name>`, so the same name = the same service.
+- **Health.** Some services take a few seconds. Poll readiness, e.g.
+  `until docker exec agezt-pg pg_isready -U postgres; do sleep 1; done`.
+- **Persist the connection.** Save the URL to a memory note or a Data Lake
+  `services` collection so later runs (and other agents) find it.
+- **Multi-container stacks** → write a `docker-compose.yml`, add
+  `labels: ["agezt.service=1"]` to every service, then `docker compose up -d`.

--- a/plugins/builtinskills/dockerservices/scripts/svc.sh
+++ b/plugins/builtinskills/dockerservices/scripts/svc.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+# docker-services lifecycle helper. Every container it starts is named
+# agezt-<name> and labelled agezt.service=1 so agezt's services are always
+# discoverable and reapable without touching the user's own containers.
+#
+# Usage:
+#   svc.sh up   <name> <image> [extra docker run args...]
+#   svc.sh down <name>            # stop + remove container (named volumes kept)
+#   svc.sh nuke <name>            # down AND remove its named volumes (destroys data)
+#   svc.sh ls                     # list only agezt services
+#   svc.sh logs <name> [lines]    # tail logs (default 50)
+#   svc.sh ip   <name>            # container IP + published ports
+set -e
+
+LABEL="agezt.service=1"
+PREFIX="agezt-"
+
+die() { echo "svc: $*" >&2; exit 1; }
+need_docker() { command -v docker >/dev/null 2>&1 || die "docker not found (install it first)"; }
+cname() { echo "${PREFIX}$1"; }
+
+cmd="${1:-}"
+[ -n "$cmd" ] || die "usage: up|down|nuke|ls|logs|ip <name> ..."
+need_docker
+
+case "$cmd" in
+  up)
+    name="${2:-}"; image="${3:-}"
+    [ -n "$name" ] && [ -n "$image" ] || die "up needs <name> <image>"
+    shift 3
+    c="$(cname "$name")"
+    # Idempotent: already running -> leave it; exists stopped -> start it.
+    state="$(docker inspect -f '{{.State.Running}}' "$c" 2>/dev/null || echo missing)"
+    if [ "$state" = "true" ]; then
+      echo "$c already running"; exit 0
+    fi
+    if [ "$state" = "false" ]; then
+      echo "starting existing $c"; docker start "$c" >/dev/null; exit 0
+    fi
+    echo "creating $c from $image"
+    # shellcheck disable=SC2068
+    docker run -d --name "$c" --label "$LABEL" --restart unless-stopped $@ "$image" >/dev/null
+    echo "$c up"
+    ;;
+  down)
+    name="${2:-}"; [ -n "$name" ] || die "down needs <name>"
+    c="$(cname "$name")"
+    docker rm -f "$c" >/dev/null 2>&1 && echo "$c removed" || echo "$c not present"
+    ;;
+  nuke)
+    name="${2:-}"; [ -n "$name" ] || die "nuke needs <name>"
+    c="$(cname "$name")"
+    vols="$(docker inspect -f '{{range .Mounts}}{{if eq .Type "volume"}}{{.Name}} {{end}}{{end}}' "$c" 2>/dev/null || true)"
+    docker rm -f "$c" >/dev/null 2>&1 && echo "$c removed" || echo "$c not present"
+    for v in $vols; do docker volume rm "$v" >/dev/null 2>&1 && echo "volume $v removed" || true; done
+    ;;
+  ls)
+    docker ps -a --filter "label=$LABEL" \
+      --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}\t{{.Image}}'
+    ;;
+  logs)
+    name="${2:-}"; [ -n "$name" ] || die "logs needs <name>"
+    lines="${3:-50}"
+    docker logs --tail "$lines" "$(cname "$name")"
+    ;;
+  ip)
+    name="${2:-}"; [ -n "$name" ] || die "ip needs <name>"
+    c="$(cname "$name")"
+    echo "addr: $(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}' "$c")"
+    echo "ports: $(docker port "$c" 2>/dev/null | tr '\n' ' ')"
+    ;;
+  *)
+    die "unknown command: $cmd (up|down|nuke|ls|logs|ip)"
+    ;;
+esac


### PR DESCRIPTION
## Summary
Backlog **#51 — agents can run self-hosted services in the background via Docker** — delivered as a fourth out-of-the-box skill bundle (after browser-use, computer-use, data-analysis).

Agents already have full machine capability (`shell`/`code_exec`, default-allow) — they can already run `docker`. What was missing is the **lifecycle discipline**: a consistent way to start services so they survive reboots, stay discoverable, and don't become orphaned junk.

- **`SKILL.md`** — when to stand up a real background service, the one rule (label every container `agezt.service=1`), the docker check, and how to connect/persist/clean up.
- **`scripts/svc.sh`** — POSIX lifecycle helper: `up` (idempotent; reuses running, starts stopped, else creates with `--restart unless-stopped`), `down`, `nuke` (down + volumes), `ls` (only agezt services), `logs`, `ip`. Names containers `agezt-<name>`, labels them `agezt.service=1`.
- **`reference/services.md`** — recipes for Postgres, Redis, MinIO, Ollama, Meilisearch, n8n with ports, named volumes, connection strings.

## Why it's conflict-free
Touches **only** `plugins/builtinskills/` (the seeder auto-loads it via `builtinBundles` + `go:embed`). No `cmd/agezt/main.go`, no `kernel/runtime`/`agent`/`governor` — the files a concurrent session is editing. No new Go dependency, no new env.

## Verification
- `go vet` + linux cross-build of `./plugins/builtinskills/` clean; `gofmt -l` empty; `sh -n svc.sh` clean.
- `TestSeedAll_InstallsDockerServices` asserts the bundle seeds **active** and materializes `svc.sh` + `services.md`; bundle-count assertions now cover four bundles. Package suite green in isolation.
- The `agezt.service=1` label is the contract a future reaper (#53) can use to collect dead services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)