### PR TITLE
Feat: built-in git-ops skill bundle (M864)

### DIFF
--- a/.project/PHASE-M864-GIT-OPS-SKILL-REPORT.md
+++ b/.project/PHASE-M864-GIT-OPS-SKILL-REPORT.md
@@ -1,0 +1,49 @@
+# PHASE M864 — Built-in git-ops skill bundle
+
+**Status:** shipped
+**Milestone:** M864 (numbered to stay clear of concurrent in-progress
+M858/M859 work in the tree).
+**Theme:** Backlog #34 (more out-of-the-box capability) with a direct line to #42
+(self-improvement): a fifth built-in skill bundle that gives agents a safe,
+disciplined git + GitHub workflow for changing code and shipping it as a PR.
+
+## What shipped
+
+A built-in `git-ops` bundle, seeded active at startup by the existing
+`plugins/builtinskills` seeder (no daemon wiring change — `builtinBundles` +
+`go:embed` only):
+
+- `SKILL.md` — the rules (never commit on `main`, one change per branch, clear
+  messages, never force-push shared branches, open a PR don't self-merge), the
+  `gh auth` preflight, and the conflict-resolution path.
+- `scripts/gitflow.sh` — a POSIX safe-workflow helper: `sync` (fetch + ff the
+  default branch), `branch`, `save` (add -A + commit; **refuses on the default
+  branch** so you can't push to main by reflex), `pr` (push + `gh pr create`
+  against the resolved default branch), `status`. Resolves origin's default
+  branch via `refs/remotes/origin/HEAD` with a main/master fallback.
+- `reference/recipes.md` — clone→PR end to end, auth check, undo/amend,
+  cherry-pick, rebase conflict resolution, throwaway worktrees, and the
+  self-improvement loop.
+
+## Why this milestone is conflict-free
+
+A new bundle touches **only** `plugins/builtinskills/` — never `cmd/agezt/main.go`
+or `kernel/runtime`/`agent`/`governor` (the files a concurrent session is editing
+for M858/M859). The seeder auto-loads it. It tests in isolation:
+`go test ./plugins/builtinskills/` compiles just this package + `kernel/skill`.
+
+## Verification
+
+- **Isolated gate:** `go vet` clean; linux cross-build of `./plugins/builtinskills/`
+  clean; `gofmt -l` empty; `sh -n gitflow.sh` syntax-clean. Package suite green —
+  `TestSeedAll_InstallsGitOps` asserts the bundle seeds **active** and materializes
+  `scripts/gitflow.sh` + `reference/recipes.md`; bundle-count assertions now cover
+  five bundles.
+- No new Go dep; no new env. `.gitattributes` already forces LF on
+  `plugins/builtinskills/**`. Full `go build ./...` / daemon smoke deliberately
+  skipped — they'd compile the concurrent in-progress Go edits.
+
+## Notes
+- Five seeded bundles now ship out of the box: browser-use, computer-use,
+  data-analysis, docker-services, git-ops. The helper's "refuse to commit on the
+  default branch" guard mirrors the operator's own discipline (branch-per-PR).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
   `delegate` tool now coaches the leader pattern and prefers reusing an existing named agent. (M843)
 
 ### Added
+- **Built-in git-ops skill bundle (M864).** A fifth out-of-the-box skill that gives agents a safe,
+  disciplined git + GitHub workflow for changing code and shipping it as a PR (#34, supports #42
+  self-improvement). `scripts/gitflow.sh` wraps `sync`/`branch`/`save`/`pr`/`status` and **refuses to
+  commit on the default branch** (branch-per-PR, like the operator's own discipline); `pr` pushes and
+  opens a PR via `gh`. `reference/recipes.md` covers clone→PR, auth checks, undo/amend, cherry-pick,
+  rebase conflict resolution, and throwaway worktrees. Rides the `plugins/builtinskills` seeder — no new
+  Go dependency. (M864)
 - **Built-in docker-services skill bundle (M863).** A fourth out-of-the-box skill (after browser-use,
   computer-use, data-analysis) that lets agents stand up real self-hosted services in the background via
   Docker — Postgres, Redis, MinIO, Ollama, n8n, … — and tear them down cleanly (#51). `scripts/svc.sh`

--- a/plugins/builtinskills/builtinskills.go
+++ b/plugins/builtinskills/builtinskills.go
@@ -24,7 +24,7 @@ import (
 	"github.com/agezt/agezt/kernel/skill"
 )
 
-//go:embed browseruse computeruse dataanalysis dockerservices
+//go:embed browseruse computeruse dataanalysis dockerservices gitops
 var bundles embed.FS
 
 // Forge is the slice of *skill.Forge the seeder needs — an interface so it is
@@ -44,7 +44,7 @@ type Seeded struct {
 }
 
 // builtinBundles lists the embedded bundle directories to seed.
-var builtinBundles = []string{"browseruse", "computeruse", "dataanalysis", "dockerservices"}
+var builtinBundles = []string{"browseruse", "computeruse", "dataanalysis", "dockerservices", "gitops"}
 
 // SeedAll installs every embedded bundle into the Forge and promotes each to
 // active. It is best-effort per bundle: an error on one is returned but does not

--- a/plugins/builtinskills/builtinskills_test.go
+++ b/plugins/builtinskills/builtinskills_test.go
@@ -160,6 +160,42 @@ func TestSeedAll_InstallsDockerServices(t *testing.T) {
 	}
 }
 
+func TestSeedAll_InstallsGitOps(t *testing.T) {
+	f := newForge(t)
+	seeded, err := SeedAll(f, "")
+	if err != nil {
+		t.Fatalf("SeedAll: %v", err)
+	}
+	var got *Seeded
+	for i := range seeded {
+		if seeded[i].Name == "git-ops" {
+			got = &seeded[i]
+		}
+	}
+	if got == nil {
+		t.Fatalf("git-ops not seeded: %+v", seeded)
+	}
+	if got.Status != skill.StatusActive {
+		t.Errorf("git-ops status = %q, want active", got.Status)
+	}
+	flow, err := f.Bundles().Read("git-ops", "scripts/gitflow.sh")
+	if err != nil || len(flow) == 0 {
+		t.Fatalf("git-ops gitflow.sh unreadable/empty: %v", err)
+	}
+	files, _ := f.Bundles().List("git-ops")
+	want := map[string]bool{"scripts/gitflow.sh": false, "reference/recipes.md": false}
+	for _, rel := range files {
+		if _, ok := want[rel]; ok {
+			want[rel] = true
+		}
+	}
+	for rel, found := range want {
+		if !found {
+			t.Errorf("git-ops bundle missing %q (got %v)", rel, files)
+		}
+	}
+}
+
 func TestSeedAll_Idempotent(t *testing.T) {
 	f := newForge(t)
 	if _, err := SeedAll(f, ""); err != nil {

--- a/plugins/builtinskills/gitops/SKILL.md
+++ b/plugins/builtinskills/gitops/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: git-ops
+description: Work with git and GitHub safely — clone a repo, branch, commit with clear messages, push, and open a pull request with the gh CLI, resolve conflicts, and keep main clean — when a task involves changing code in a repository or shipping your own improvements as a PR
+triggers: [git, github, gh, commit, branch, pull request, pr, clone, merge, rebase, repo, version control]
+tools: [shell, code_exec]
+---
+
+# git-ops — change code and ship it as a PR, safely
+
+When a task means editing code in a repository — fixing a bug, adding a feature,
+or improving your own tooling — do it the way a careful engineer does: on a
+branch, with clear commits, opened as a pull request for review. Never push
+straight to `main`. You have full shell capability; this skill is the workflow
+discipline that keeps the history clean and the change reviewable.
+
+## The rules
+
+1. **Never commit on `main`/`master`.** Branch first. The helper refuses to
+   commit on a default branch so you can't do it by reflex.
+2. **One logical change per branch**, named for what it does
+   (`fix/login-null-deref`, `feat/csv-export`).
+3. **Clear commit messages**: a concise imperative subject line, then a body
+   explaining *why* when it isn't obvious.
+4. **Never force-push a shared branch** (`main`, or a branch someone else is on).
+   Force-push only your own un-merged feature branch, and prefer
+   `--force-with-lease`.
+5. **Open a PR, don't self-merge** unless the task explicitly authorizes it.
+
+## Preflight
+
+```sh
+git status                         # clean tree? what branch?
+gh auth status                     # is the GitHub CLI authenticated?
+```
+If `gh` isn't installed, install it via the computer-use skill. If it isn't
+authenticated, the operator must run `gh auth login` (an interactive step you
+cannot do for them) — say so rather than guessing a token.
+
+## Workflow with the helper
+
+`scripts/gitflow.sh` wraps the safe path. Use `skill op=files git-ops` to find
+the bundle directory; run it via shell or code_exec from inside the repo.
+
+```sh
+scripts/gitflow.sh sync                     # fetch + fast-forward the default branch
+scripts/gitflow.sh branch fix/typo-readme   # create + switch to a feature branch
+# ... make your edits ...
+scripts/gitflow.sh save "Fix: typo in README intro"   # add -A + commit (refuses on main)
+scripts/gitflow.sh pr "Fix: README typo" "One-line fix to the intro paragraph."
+                                            # push + open a PR with gh, prints the URL
+```
+
+`save` stages all changes and commits; it aborts if you are on the default branch
+and tells you to branch first. `pr` pushes the current branch upstream and opens a
+pull request against the default branch.
+
+## Doing it by hand
+
+The helper is a fast path, not a cage — raw git/gh is fine:
+
+```sh
+git switch -c feat/thing
+git add -p && git commit -m "Feat: thing"
+git push -u origin feat/thing
+gh pr create --fill
+```
+
+## Conflicts
+
+```sh
+scripts/gitflow.sh sync          # update default branch first
+git switch your-branch
+git rebase main                  # replay your work on top; resolve, git add, git rebase --continue
+# or, if a rebase is risky: git merge main
+```
+Resolve each conflicted file, `git add` it, continue. If a rebase goes wrong,
+`git rebase --abort` returns you to safety — nothing is lost.
+
+See `reference/recipes.md` for cloning + PR end-to-end, cherry-picking, undoing a
+bad commit, and working in a throwaway worktree.

--- a/plugins/builtinskills/gitops/reference/recipes.md
+++ b/plugins/builtinskills/gitops/reference/recipes.md
@@ -1,0 +1,82 @@
+# git-ops recipes
+
+The helper (`scripts/gitflow.sh`) covers the safe path: sync → branch → save →
+pr. For everything else, raw git/gh is fine. Common patterns:
+
+## Clone a repo and open a PR end to end
+
+```sh
+gh repo clone owner/name && cd name        # or: git clone <url>
+scripts/gitflow.sh branch feat/my-change
+# ... edit files ...
+scripts/gitflow.sh save "Feat: my change"
+scripts/gitflow.sh pr "Feat: my change" "What and why."
+```
+
+## Check authentication before you push
+
+```sh
+gh auth status            # who am I, which scopes
+git remote -v             # where will a push go?
+```
+If `gh auth status` fails, the operator must run `gh auth login` themselves —
+it's interactive. Don't fabricate a token.
+
+## Undo a bad commit (not yet pushed)
+
+```sh
+git reset --soft HEAD~1     # keep the changes staged, drop the commit
+git reset --hard HEAD~1     # discard the commit AND its changes (careful)
+```
+
+## Amend the last commit
+
+```sh
+git add -A && git commit --amend -m "Better message"
+# if already pushed to YOUR feature branch only:
+git push --force-with-lease
+```
+
+## Cherry-pick a commit onto your branch
+
+```sh
+git switch your-branch
+git cherry-pick <sha>
+```
+
+## Resolve a merge/rebase conflict
+
+```sh
+scripts/gitflow.sh sync
+git switch your-branch
+git rebase main
+# for each conflict: edit the file, then:
+git add <file>
+git rebase --continue
+# bail out safely if it gets messy:
+git rebase --abort
+```
+
+## Work in a throwaway worktree (isolate risky edits)
+
+```sh
+git worktree add ../scratch -b experiment/thing
+cd ../scratch
+# ... experiment freely; the main checkout is untouched ...
+git worktree remove ../scratch        # when done
+```
+
+## Inspect before acting
+
+```sh
+git log --oneline -10
+git diff --stat main...HEAD           # what this branch changes vs main
+gh pr list --state open               # open PRs on the repo
+gh pr checks <number>                 # CI status for a PR
+```
+
+## Self-improvement loop
+
+When improving your own tooling/code: clone or `cd` into the repo, branch, make
+the change, run its tests, `save`, then `pr`. Keep the change small and
+reviewable — one concern per PR — so the operator can approve quickly.

--- a/plugins/builtinskills/gitops/scripts/gitflow.sh
+++ b/plugins/builtinskills/gitops/scripts/gitflow.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+# git-ops safe-workflow helper. Keeps main clean: branch, commit, push, PR.
+# Run from inside the target repository.
+#
+# Usage:
+#   gitflow.sh sync                       # fetch + fast-forward the default branch
+#   gitflow.sh branch <name>              # create + switch to a feature branch
+#   gitflow.sh save "<message>"           # add -A + commit (refuses on default branch)
+#   gitflow.sh pr "<title>" ["<body>"]    # push current branch + open a PR via gh
+#   gitflow.sh status                     # branch, upstream, short status
+set -e
+
+die() { echo "gitflow: $*" >&2; exit 1; }
+in_repo() { git rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "not a git repository"; }
+
+# default_branch resolves origin's HEAD (main/master); falls back to main.
+default_branch() {
+  b="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')"
+  [ -n "$b" ] && { echo "$b"; return; }
+  for c in main master; do
+    git show-ref --verify --quiet "refs/heads/$c" && { echo "$c"; return; }
+  done
+  echo main
+}
+current_branch() { git rev-parse --abbrev-ref HEAD; }
+
+cmd="${1:-}"
+[ -n "$cmd" ] || die "usage: sync|branch|save|pr|status ..."
+in_repo
+
+case "$cmd" in
+  sync)
+    def="$(default_branch)"
+    git fetch --prune origin
+    cur="$(current_branch)"
+    if [ "$cur" = "$def" ]; then
+      git merge --ff-only "origin/$def" && echo "fast-forwarded $def"
+    else
+      git fetch origin "$def:$def" 2>/dev/null && echo "updated $def (you are on $cur)" \
+        || echo "fetched; could not ff $def while on $cur (uncommitted overlap?)"
+    fi
+    ;;
+  branch)
+    name="${2:-}"; [ -n "$name" ] || die "branch needs <name>"
+    git switch -c "$name" 2>/dev/null || git checkout -b "$name"
+    echo "on branch $name"
+    ;;
+  save)
+    msg="${2:-}"; [ -n "$msg" ] || die "save needs a \"<message>\""
+    cur="$(current_branch)"; def="$(default_branch)"
+    [ "$cur" != "$def" ] || die "refusing to commit on default branch '$def' — run: gitflow.sh branch <name>"
+    git add -A
+    git diff --cached --quiet && die "nothing staged to commit"
+    git commit -m "$msg"
+    echo "committed on $cur"
+    ;;
+  pr)
+    title="${2:-}"; body="${3:-}"
+    [ -n "$title" ] || die "pr needs a \"<title>\""
+    cur="$(current_branch)"; def="$(default_branch)"
+    [ "$cur" != "$def" ] || die "you are on '$def' — branch + commit before opening a PR"
+    git push -u origin "$cur"
+    command -v gh >/dev/null 2>&1 || die "gh not installed; branch pushed — open the PR in the GitHub UI"
+    if [ -n "$body" ]; then
+      gh pr create --base "$def" --head "$cur" --title "$title" --body "$body"
+    else
+      gh pr create --base "$def" --head "$cur" --title "$title" --fill
+    fi
+    ;;
+  status)
+    echo "branch:   $(current_branch)  (default: $(default_branch))"
+    echo "upstream: $(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null || echo none)"
+    git status --short
+    ;;
+  *)
+    die "unknown command: $cmd (sync|branch|save|pr|status)"
+    ;;
+esac


### PR DESCRIPTION
## Summary
A fifth out-of-the-box skill bundle (after browser-use, computer-use, data-analysis, docker-services): a **safe, disciplined git + GitHub workflow** for agents changing code and shipping it as a PR (#34; supports #42 self-improvement).

- **`SKILL.md`** — the rules (never commit on `main`, one change per branch, clear messages, never force-push shared branches, open a PR don't self-merge), the `gh auth` preflight, and conflict resolution.
- **`scripts/gitflow.sh`** — `sync` (fetch + ff default branch), `branch`, `save` (add -A + commit — **refuses on the default branch**), `pr` (push + `gh pr create`), `status`. Resolves the default branch via `origin/HEAD` with a main/master fallback.
- **`reference/recipes.md`** — clone→PR end to end, auth checks, undo/amend, cherry-pick, rebase conflict resolution, throwaway worktrees, the self-improvement loop.

## Why it's conflict-free
Touches **only** `plugins/builtinskills/` (the seeder auto-loads it via `builtinBundles` + `go:embed`). No `cmd/agezt/main.go`, no `kernel/runtime`/`agent`/`governor`. No new Go dependency, no new env.

## Verification
- `go vet` + linux cross-build of `./plugins/builtinskills/` clean; `gofmt -l` empty; `sh -n gitflow.sh` clean.
- `TestSeedAll_InstallsGitOps` asserts the bundle seeds **active** and materializes `gitflow.sh` + `recipes.md`; bundle-count assertions now cover five bundles. Package suite green in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)