### PR TITLE
Feat: built-in web-research skill bundle (M865)

### DIFF
--- a/.project/PHASE-M865-WEB-RESEARCH-SKILL-REPORT.md
+++ b/.project/PHASE-M865-WEB-RESEARCH-SKILL-REPORT.md
@@ -1,0 +1,52 @@
+# PHASE M865 — Built-in web-research skill bundle
+
+**Status:** shipped
+**Milestone:** M865 (numbered to stay clear of concurrent in-progress
+M858/M859 work in the tree).
+**Theme:** Backlog #34 (more out-of-the-box capability): a sixth built-in skill
+bundle that gives agents a disciplined multi-source web-research workflow —
+gather, extract, cite, synthesize — instead of answering from memory or trusting
+one page.
+
+## What shipped
+
+A built-in `web-research` bundle, seeded active at startup by the existing
+`plugins/builtinskills` seeder (no daemon wiring change — `builtinBundles` +
+`go:embed` only):
+
+- `SKILL.md` — the discipline (frame the question, diversify sources, extract
+  don't skim, cite as you go, note disagreement), when to use the `fetch` tool vs
+  the batch helper vs escalating to **browser-use** for JS/gated pages, and how to
+  synthesize a sourced answer.
+- `scripts/setup.sh` — `pip install requests beautifulsoup4` (+ optional
+  `trafilatura` for cleaner main-text extraction; non-fatal if it won't install).
+- `scripts/extract.py` — fetches one or more URLs and prints title + clean main
+  text per URL as JSON (`{results:[{url,status,title,text,chars}], errors:[…]}`).
+  Uses trafilatura when present, falls back to BeautifulSoup (drops
+  script/style/nav, collapses whitespace); one bad URL never sinks the batch.
+- `reference/recipes.md` — search strategy, batch extract, citation format,
+  handling JS-heavy/gated pages and PDFs, summarize-before-synthesize, honest gaps.
+
+## Why this milestone is conflict-free
+
+A new bundle touches **only** `plugins/builtinskills/` — never `cmd/agezt/main.go`
+or `kernel/runtime`/`agent`/`governor` (the files a concurrent session is editing
+for M858/M859). The seeder auto-loads it. It tests in isolation:
+`go test ./plugins/builtinskills/` compiles just this package + `kernel/skill`.
+
+## Verification
+
+- **Isolated gate:** `go vet` clean; linux cross-build of `./plugins/builtinskills/`
+  clean; `gofmt -l` empty; `python -m py_compile extract.py` passes; `sh -n setup.sh`
+  clean. Package suite green — `TestSeedAll_InstallsWebResearch` asserts the bundle
+  seeds **active** and materializes `extract.py` / `setup.sh` / `recipes.md`;
+  bundle-count assertions now cover six bundles.
+- No new Go dep; no new env. `.gitattributes` already forces LF on
+  `plugins/builtinskills/**`. Full `go build ./...` / daemon smoke deliberately
+  skipped — they'd compile the concurrent in-progress Go edits.
+
+## Notes
+- Six seeded bundles now ship out of the box: browser-use, computer-use,
+  data-analysis, docker-services, git-ops, web-research. The skill explicitly
+  hands off to browser-use when raw fetch returns too little — the bundles
+  compose rather than overlap.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
   `delegate` tool now coaches the leader pattern and prefers reusing an existing named agent. (M843)
 
 ### Added
+- **Built-in web-research skill bundle (M865).** A sixth out-of-the-box skill: a disciplined multi-source
+  web-research workflow — gather from several sources, extract the readable text, keep every URL as a
+  citation, and synthesize a sourced answer (#34). `scripts/extract.py` fetches one or more URLs and
+  returns title + clean main text per URL as JSON (trafilatura when present, BeautifulSoup fallback; one
+  bad URL never sinks the batch); `setup.sh` installs the deps. The SKILL explicitly hands off to
+  browser-use for JS-heavy/gated pages, so the bundles compose. Rides the `plugins/builtinskills` seeder
+  — no new Go dependency. (M865)
 - **Built-in git-ops skill bundle (M864).** A fifth out-of-the-box skill that gives agents a safe,
   disciplined git + GitHub workflow for changing code and shipping it as a PR (#34, supports #42
   self-improvement). `scripts/gitflow.sh` wraps `sync`/`branch`/`save`/`pr`/`status` and **refuses to

--- a/plugins/builtinskills/builtinskills.go
+++ b/plugins/builtinskills/builtinskills.go
@@ -24,7 +24,7 @@ import (
 	"github.com/agezt/agezt/kernel/skill"
 )
 
-//go:embed browseruse computeruse dataanalysis dockerservices gitops
+//go:embed browseruse computeruse dataanalysis dockerservices gitops webresearch
 var bundles embed.FS
 
 // Forge is the slice of *skill.Forge the seeder needs — an interface so it is
@@ -44,7 +44,7 @@ type Seeded struct {
 }
 
 // builtinBundles lists the embedded bundle directories to seed.
-var builtinBundles = []string{"browseruse", "computeruse", "dataanalysis", "dockerservices", "gitops"}
+var builtinBundles = []string{"browseruse", "computeruse", "dataanalysis", "dockerservices", "gitops", "webresearch"}
 
 // SeedAll installs every embedded bundle into the Forge and promotes each to
 // active. It is best-effort per bundle: an error on one is returned but does not

--- a/plugins/builtinskills/builtinskills_test.go
+++ b/plugins/builtinskills/builtinskills_test.go
@@ -196,6 +196,42 @@ func TestSeedAll_InstallsGitOps(t *testing.T) {
 	}
 }
 
+func TestSeedAll_InstallsWebResearch(t *testing.T) {
+	f := newForge(t)
+	seeded, err := SeedAll(f, "")
+	if err != nil {
+		t.Fatalf("SeedAll: %v", err)
+	}
+	var got *Seeded
+	for i := range seeded {
+		if seeded[i].Name == "web-research" {
+			got = &seeded[i]
+		}
+	}
+	if got == nil {
+		t.Fatalf("web-research not seeded: %+v", seeded)
+	}
+	if got.Status != skill.StatusActive {
+		t.Errorf("web-research status = %q, want active", got.Status)
+	}
+	ex, err := f.Bundles().Read("web-research", "scripts/extract.py")
+	if err != nil || len(ex) == 0 {
+		t.Fatalf("web-research extract.py unreadable/empty: %v", err)
+	}
+	files, _ := f.Bundles().List("web-research")
+	want := map[string]bool{"scripts/extract.py": false, "scripts/setup.sh": false, "reference/recipes.md": false}
+	for _, rel := range files {
+		if _, ok := want[rel]; ok {
+			want[rel] = true
+		}
+	}
+	for rel, found := range want {
+		if !found {
+			t.Errorf("web-research bundle missing %q (got %v)", rel, files)
+		}
+	}
+}
+
 func TestSeedAll_Idempotent(t *testing.T) {
 	f := newForge(t)
 	if _, err := SeedAll(f, ""); err != nil {

--- a/plugins/builtinskills/webresearch/SKILL.md
+++ b/plugins/builtinskills/webresearch/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: web-research
+description: Research a question across the open web — gather from several sources, pull the readable text out of pages, keep track of every URL as a citation, and synthesize a sourced answer instead of trusting one page — when a task needs current facts, comparisons, or anything you should verify against real sources
+triggers: [research, web, search, source, cite, fact, compare, look up, gather, article, news, documentation]
+tools: [fetch, code_exec, shell, browser]
+---
+
+# web-research — gather, extract, cite, synthesize
+
+When a task needs facts you should verify — current events, library docs, a
+product comparison, "is X still true" — don't answer from memory and don't trust
+a single page. Gather from **several** sources, pull out the real text, keep
+every URL, and synthesize an answer that says where each claim came from.
+
+## The discipline
+
+1. **Frame the question** into 2–4 concrete sub-questions before searching.
+2. **Diversify sources** — at least 2–3 independent pages per claim; prefer
+   primary/official sources (docs, the project itself, the standards body) over
+   aggregators.
+3. **Extract, don't skim** — pull the readable text so you quote accurately.
+4. **Cite as you go** — keep a list of `{claim → url}`. Every non-obvious fact in
+   the final answer must trace to a URL.
+5. **Note disagreement** — if sources conflict, say so and prefer the more
+   authoritative/recent one rather than silently picking one.
+
+## Fetching pages
+
+- A single known page → the **`fetch`** tool (it returns readable content directly).
+- A batch of URLs, or when you want title + clean main text as JSON →
+  `scripts/extract.py` (below).
+- A **JavaScript-heavy or login-gated** page that returns little text → switch to
+  the **browser-use** skill (real browser, sees rendered content). Don't fight a
+  SPA with raw fetch.
+
+## One-time setup
+
+Run `scripts/setup.sh` once (via code_exec or shell): installs `requests` and
+`beautifulsoup4` (and `trafilatura` if available, for better main-text
+extraction). Use `skill op=files web-research` to find the bundle directory.
+
+## Extract with the helper
+
+`scripts/extract.py` fetches one or more URLs and prints, per URL, the title and
+the main readable text as JSON — so you can quote and cite precisely:
+
+```
+python scripts/extract.py '{"urls":["https://example.com/article"],"max_chars":4000}'
+```
+
+### Spec fields
+- `urls` (required) — one URL string or a list of them.
+- `max_chars` (optional, default 6000) — truncate each page's text.
+- `timeout` (optional, default 20) — per-request seconds.
+
+### Output (JSON on stdout)
+```
+{ "ok": true, "results": [ { "url": "...", "status": 200, "title": "...",
+  "text": "...", "chars": 1234 } ], "errors": [ {"url":"...","error":"..."} ] }
+```
+
+## Synthesizing
+
+Write the answer first, sources second. Lead with the conclusion, then back each
+claim inline or in a short **Sources** list of the URLs you actually used. If you
+couldn't verify something, say so — an honest gap beats a confident guess.
+
+See `reference/recipes.md` for search strategies, a citation format, handling
+paywalls/PDFs, and when to escalate to the browser.

--- a/plugins/builtinskills/webresearch/reference/recipes.md
+++ b/plugins/builtinskills/webresearch/reference/recipes.md
@@ -1,0 +1,65 @@
+# web-research recipes
+
+The helper (`scripts/extract.py`) covers fetch → clean-text. The judgment —
+what to search, which sources to trust, how to cite — is the skill. Patterns:
+
+## Search strategy
+
+- Turn the question into **specific queries**, not the whole question. "fastest
+  JSON parser Go 2025 benchmark" beats "what is the best way to parse JSON".
+- Use the available search/fetch tools to find candidate pages, then `extract.py`
+  to pull their text.
+- Prefer **primary sources**: the project's own docs/repo, the standards body,
+  the vendor — over blogs and aggregators that summarize them.
+- Cross-check a surprising claim against a second independent source before you
+  rely on it.
+
+## Batch extract several candidates
+
+```sh
+python scripts/extract.py '{"urls":[
+  "https://a.example/post",
+  "https://b.example/docs",
+  "https://c.example/spec"
+], "max_chars":4000}'
+```
+Each result carries `url`, `status`, `title`, and clean `text` you can quote.
+
+## Citation format
+
+Keep a running list while you read, then end the answer with:
+
+```
+Sources:
+- [Title](https://url-1)
+- [Title](https://url-2)
+```
+Every non-obvious claim in the answer should map to one of these.
+
+## When fetch returns almost nothing
+
+A page that returns a few hundred chars of boilerplate is usually JS-rendered or
+gated. Don't retry raw fetch — switch to the **browser-use** skill, which drives a
+real browser and sees the rendered DOM. For infinite-scroll/lazy content, scroll
+in the browser before reading.
+
+## PDFs and docs
+
+`extract.py` handles HTML. For a PDF link, download it and read it with a PDF
+tool/pandas/pdfminer in `code_exec`:
+```sh
+curl -L -o paper.pdf "https://example.com/paper.pdf"
+python -c "import pdfminer.high_level as h; print(h.extract_text('paper.pdf')[:4000])"
+```
+
+## Long sources — summarize before synthesizing
+
+For a long article, extract it, then summarize *that text* into the 3–5 points
+relevant to your sub-question before combining sources. Synthesize from your
+notes, not from raw page dumps — it keeps the final answer tight and traceable.
+
+## Be honest about gaps
+
+If the sources don't answer the question, say what you found and what's still
+open. A sourced "couldn't confirm X; closest is Y" is more useful than a
+confident guess.

--- a/plugins/builtinskills/webresearch/scripts/extract.py
+++ b/plugins/builtinskills/webresearch/scripts/extract.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""web-research helper — fetch one or more URLs and extract title + main text.
+
+Usage:  python extract.py '<json-spec>'   (or pipe the JSON on stdin)
+Spec:   { "urls": "https://..." | ["https://...", ...],
+          "max_chars": 6000, "timeout": 20 }
+Output: one JSON object on stdout:
+        { "ok": true, "results": [ {url,status,title,text,chars} ],
+          "errors": [ {url,error} ] }
+
+Uses trafilatura for clean main-text extraction when installed, else falls back
+to BeautifulSoup (drop script/style/nav, collapse whitespace). A fast start, not
+a cage: for JS-heavy or gated pages, use the browser-use skill instead.
+"""
+import json
+import re
+import sys
+
+UA = "Mozilla/5.0 (compatible; agezt-web-research/1.0; +https://github.com/agezt/agezt)"
+
+
+def read_spec():
+    if len(sys.argv) > 1 and sys.argv[1].strip():
+        return json.loads(sys.argv[1])
+    data = sys.stdin.read()
+    if data.strip():
+        return json.loads(data)
+    raise ValueError("no spec: pass a JSON spec as argv[1] or on stdin")
+
+
+def soup_extract(html):
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(html, "html.parser")
+    title = soup.title.get_text(strip=True) if soup.title else ""
+    for tag in soup(["script", "style", "noscript", "nav", "header", "footer", "form"]):
+        tag.decompose()
+    text = soup.get_text(separator="\n")
+    text = re.sub(r"\n\s*\n+", "\n\n", text)
+    text = re.sub(r"[ \t]+", " ", text).strip()
+    return title, text
+
+
+def extract(url, html):
+    try:
+        import trafilatura
+
+        text = trafilatura.extract(html, include_comments=False, include_tables=True)
+        if text:
+            md = trafilatura.extract_metadata(html)
+            title = (md.title if md and md.title else "") or ""
+            if not title:
+                title, _ = soup_extract(html)
+            return title, text
+    except Exception:  # noqa: BLE001 — trafilatura missing or failed; fall back
+        pass
+    return soup_extract(html)
+
+
+def fetch_one(url, timeout, max_chars):
+    import requests
+
+    resp = requests.get(url, headers={"User-Agent": UA}, timeout=timeout)
+    title, text = extract(url, resp.text)
+    if max_chars and len(text) > max_chars:
+        text = text[:max_chars].rstrip() + " …"
+    return {
+        "url": url,
+        "status": resp.status_code,
+        "title": title,
+        "text": text,
+        "chars": len(text),
+    }
+
+
+def run(spec):
+    urls = spec.get("urls")
+    if not urls:
+        raise ValueError("spec.urls is required")
+    if isinstance(urls, str):
+        urls = [urls]
+    timeout = float(spec.get("timeout", 20))
+    max_chars = int(spec.get("max_chars", 6000))
+
+    results, errors = [], []
+    for url in urls:
+        try:
+            results.append(fetch_one(url, timeout, max_chars))
+        except Exception as e:  # noqa: BLE001 — one bad URL must not sink the batch
+            errors.append({"url": url, "error": str(e)})
+    return {"ok": True, "results": results, "errors": errors}
+
+
+def main():
+    try:
+        print(json.dumps(run(read_spec()), default=str))
+    except Exception as e:  # noqa: BLE001
+        print(json.dumps({"ok": False, "error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/builtinskills/webresearch/scripts/setup.sh
+++ b/plugins/builtinskills/webresearch/scripts/setup.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# web-research setup: install HTTP + HTML-extraction deps.
+# trafilatura gives much cleaner main-text extraction; it's optional — the
+# helper falls back to BeautifulSoup if it isn't present. Idempotent.
+set -e
+
+echo "installing requests + beautifulsoup4 (+ trafilatura) ..."
+python -m pip install --quiet requests beautifulsoup4 2>/dev/null \
+  || pip install --quiet requests beautifulsoup4 2>/dev/null \
+  || pip3 install requests beautifulsoup4
+
+# Best-effort: better extraction when available, never fatal if it won't build.
+python -m pip install --quiet trafilatura 2>/dev/null \
+  || pip install --quiet trafilatura 2>/dev/null \
+  || echo "(trafilatura not installed — falling back to BeautifulSoup extraction)"
+
+echo "web-research ready: run scripts/extract.py '<json-spec>'"


### PR DESCRIPTION
## Summary
A sixth out-of-the-box skill bundle (after browser-use, computer-use, data-analysis, docker-services, git-ops): a **disciplined multi-source web-research workflow** — gather, extract, cite, synthesize (#34).

- **`SKILL.md`** — the discipline (frame the question, diversify sources, extract don't skim, cite as you go, note disagreement), when to use `fetch` vs the batch helper vs escalating to **browser-use** for JS/gated pages.
- **`scripts/extract.py`** — fetches one or more URLs, returns title + clean main text per URL as JSON. Uses trafilatura when present, falls back to BeautifulSoup; one bad URL never sinks the batch.
- **`scripts/setup.sh`** — `requests` + `beautifulsoup4` (+ optional trafilatura).
- **`reference/recipes.md`** — search strategy, batch extract, citation format, PDFs, summarize-before-synthesize, honest gaps.

## Why it's conflict-free
Touches **only** `plugins/builtinskills/` (the seeder auto-loads it via `builtinBundles` + `go:embed`). No `cmd/agezt/main.go`, no `kernel/runtime`/`agent`/`governor`. No new Go dependency, no new env.

## Verification
- `go vet` + linux cross-build of `./plugins/builtinskills/` clean; `gofmt -l` empty; `py_compile extract.py` + `sh -n setup.sh` clean.
- `TestSeedAll_InstallsWebResearch` asserts the bundle seeds **active** and materializes `extract.py`/`setup.sh`/`recipes.md`; bundle-count assertions now cover six bundles. Package suite green in isolation.
- The skill explicitly hands off to browser-use when raw fetch returns too little — bundles compose rather than overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)