### PR TITLE
Feat: built-in pdf-tools skill bundle (M866)

### DIFF
--- a/.project/PHASE-M866-PDF-TOOLS-SKILL-REPORT.md
+++ b/.project/PHASE-M866-PDF-TOOLS-SKILL-REPORT.md
@@ -1,0 +1,50 @@
+# PHASE M866 — Built-in pdf-tools skill bundle
+
+**Status:** shipped
+**Milestone:** M866 (numbered to stay clear of concurrent in-progress
+M858/M859 work in the tree).
+**Theme:** Backlog #34 (more out-of-the-box capability) — closes a gap both the
+data-analysis (M861) and web-research (M865) bundles explicitly defer on: getting
+data out of PDFs.
+
+## What shipped
+
+A built-in `pdf-tools` bundle, seeded active at startup by the existing
+`plugins/builtinskills` seeder (no daemon wiring change — `builtinBundles` +
+`go:embed` only):
+
+- `SKILL.md` — when to mine a PDF programmatically, the helper ops, the scanned-PDF
+  (OCR) escalation path, and handoffs to data-analysis (tables → pandas) and
+  artifacts (generated PDFs → Files).
+- `scripts/setup.sh` — `pip install pypdf pdfplumber`.
+- `scripts/pdf.py` — one JSON-spec helper with five ops: `info` (pages +
+  metadata), `text` (per-page extract with a 1-based `pages` range + `max_chars`),
+  `tables` (pdfplumber rows per page), `merge` (inputs[] → out), `split` (page
+  range → out). Prints JSON; one shared `parse_pages` for `"1-3"`/`"2"`/`"1,4,6"`.
+- `reference/recipes.md` — invoices/statements, mining a section, merge/split,
+  OCR for scans (ocrmypdf / pymupdf+pytesseract), render-to-images for vision,
+  form-fill.
+
+## Why this milestone is conflict-free
+
+A new bundle touches **only** `plugins/builtinskills/` — never `cmd/agezt/main.go`
+or `kernel/runtime`/`agent`/`governor` (the files a concurrent session is editing
+for M858/M859). The seeder auto-loads it. It tests in isolation:
+`go test ./plugins/builtinskills/` compiles just this package + `kernel/skill`.
+
+## Verification
+
+- **Isolated gate:** `go vet` clean; linux cross-build of `./plugins/builtinskills/`
+  clean; `gofmt -l` empty; `python -m py_compile pdf.py` passes; `sh -n setup.sh`
+  clean. Package suite green — `TestSeedAll_InstallsPDFTools` asserts the bundle
+  seeds **active** and materializes `pdf.py` / `setup.sh` / `recipes.md`;
+  bundle-count assertions now cover seven bundles.
+- No new Go dep; no new env. `.gitattributes` already forces LF on
+  `plugins/builtinskills/**`. Full `go build ./...` / daemon smoke deliberately
+  skipped — they'd compile the concurrent in-progress Go edits.
+
+## Notes
+- Seven seeded bundles now ship out of the box: browser-use, computer-use,
+  data-analysis, docker-services, git-ops, web-research, pdf-tools. They compose:
+  web-research → pdf-tools for PDF links, pdf-tools → data-analysis for tables,
+  pdf-tools → computer-use for OCR.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
   `delegate` tool now coaches the leader pattern and prefers reusing an existing named agent. (M843)
 
 ### Added
+- **Built-in pdf-tools skill bundle (M866).** A seventh out-of-the-box skill that gets data out of PDFs —
+  the gap data-analysis and web-research both defer on (#34). `scripts/pdf.py` is one JSON-spec helper
+  with five ops: `info` (pages + metadata), `text` (per-page extract with a 1-based page range), `tables`
+  (pdfplumber rows), `merge`, and `split`; `setup.sh` installs pypdf + pdfplumber. The SKILL documents the
+  OCR path for scanned PDFs and handoffs to data-analysis (tables → pandas) and artifacts. Rides the
+  `plugins/builtinskills` seeder — no new Go dependency. (M866)
 - **Built-in web-research skill bundle (M865).** A sixth out-of-the-box skill: a disciplined multi-source
   web-research workflow — gather from several sources, extract the readable text, keep every URL as a
   citation, and synthesize a sourced answer (#34). `scripts/extract.py` fetches one or more URLs and

--- a/plugins/builtinskills/builtinskills.go
+++ b/plugins/builtinskills/builtinskills.go
@@ -24,7 +24,7 @@ import (
 	"github.com/agezt/agezt/kernel/skill"
 )
 
-//go:embed browseruse computeruse dataanalysis dockerservices gitops webresearch
+//go:embed browseruse computeruse dataanalysis dockerservices gitops webresearch pdftools
 var bundles embed.FS
 
 // Forge is the slice of *skill.Forge the seeder needs — an interface so it is
@@ -44,7 +44,7 @@ type Seeded struct {
 }
 
 // builtinBundles lists the embedded bundle directories to seed.
-var builtinBundles = []string{"browseruse", "computeruse", "dataanalysis", "dockerservices", "gitops", "webresearch"}
+var builtinBundles = []string{"browseruse", "computeruse", "dataanalysis", "dockerservices", "gitops", "webresearch", "pdftools"}
 
 // SeedAll installs every embedded bundle into the Forge and promotes each to
 // active. It is best-effort per bundle: an error on one is returned but does not

--- a/plugins/builtinskills/builtinskills_test.go
+++ b/plugins/builtinskills/builtinskills_test.go
@@ -232,6 +232,42 @@ func TestSeedAll_InstallsWebResearch(t *testing.T) {
 	}
 }
 
+func TestSeedAll_InstallsPDFTools(t *testing.T) {
+	f := newForge(t)
+	seeded, err := SeedAll(f, "")
+	if err != nil {
+		t.Fatalf("SeedAll: %v", err)
+	}
+	var got *Seeded
+	for i := range seeded {
+		if seeded[i].Name == "pdf-tools" {
+			got = &seeded[i]
+		}
+	}
+	if got == nil {
+		t.Fatalf("pdf-tools not seeded: %+v", seeded)
+	}
+	if got.Status != skill.StatusActive {
+		t.Errorf("pdf-tools status = %q, want active", got.Status)
+	}
+	drv, err := f.Bundles().Read("pdf-tools", "scripts/pdf.py")
+	if err != nil || len(drv) == 0 {
+		t.Fatalf("pdf-tools pdf.py unreadable/empty: %v", err)
+	}
+	files, _ := f.Bundles().List("pdf-tools")
+	want := map[string]bool{"scripts/pdf.py": false, "scripts/setup.sh": false, "reference/recipes.md": false}
+	for _, rel := range files {
+		if _, ok := want[rel]; ok {
+			want[rel] = true
+		}
+	}
+	for rel, found := range want {
+		if !found {
+			t.Errorf("pdf-tools bundle missing %q (got %v)", rel, files)
+		}
+	}
+}
+
 func TestSeedAll_Idempotent(t *testing.T) {
 	f := newForge(t)
 	if _, err := SeedAll(f, ""); err != nil {

--- a/plugins/builtinskills/pdftools/SKILL.md
+++ b/plugins/builtinskills/pdftools/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: pdf-tools
+description: Work with PDF files — pull out the text and tables, read metadata and page counts, merge or split documents, and extract pages — when a task hands you a PDF (a report, invoice, paper, statement) instead of clean data
+triggers: [pdf, document, invoice, report, statement, extract text, tables, merge, split, page, ocr, scan]
+tools: [code_exec, shell, artifacts]
+---
+
+# pdf-tools — get the data out of PDFs
+
+When a task hands you a PDF — an invoice to read, a report to mine, a paper to
+quote, statements to merge — don't guess at its contents. Pull the text and
+tables out programmatically. This skill runs through `code_exec` (python).
+
+## One-time setup
+
+Run `scripts/setup.sh` once (via code_exec or shell): installs `pypdf` (merge,
+split, metadata) and `pdfplumber` (text + tables). Use `skill op=files pdf-tools`
+to find the bundle directory.
+
+## The helper
+
+`scripts/pdf.py` takes a JSON spec with an `op` and prints JSON. Ops:
+
+```sh
+# Metadata + page count:
+python scripts/pdf.py '{"op":"info","path":"doc.pdf"}'
+
+# Extract text (all pages, or a range):
+python scripts/pdf.py '{"op":"text","path":"doc.pdf","pages":"1-3","max_chars":8000}'
+
+# Extract tables (per page, as rows):
+python scripts/pdf.py '{"op":"tables","path":"invoice.pdf","pages":"1"}'
+
+# Merge several PDFs into one:
+python scripts/pdf.py '{"op":"merge","inputs":["a.pdf","b.pdf"],"out":"merged.pdf"}'
+
+# Split out a page range into a new file:
+python scripts/pdf.py '{"op":"split","path":"doc.pdf","pages":"2-4","out":"slice.pdf"}'
+```
+
+### Spec fields
+- `op` (required) — `info` | `text` | `tables` | `merge` | `split`.
+- `path` — the source PDF (for info/text/tables/split).
+- `pages` — 1-based range like `"1-3"`, `"2"`, or `"1,4,6"`; omit for all.
+- `max_chars` — truncate extracted text (text op).
+- `inputs` / `out` — for merge (`inputs[]` → `out`) and split (`out`).
+
+### Output (JSON on stdout)
+```
+{ "ok": true, "op": "text", "pages": 3, "text": "...", "chars": 1234 }
+{ "ok": true, "op": "tables", "tables": [ {"page":1,"rows":[[...],[...]]} ] }
+{ "ok": true, "op": "merge", "out": "merged.pdf", "pages": 12 }
+```
+
+## Scanned PDFs (no extractable text)
+
+If `text` comes back nearly empty, the PDF is a **scan** (images, not text). OCR
+it: install `tesseract` via the computer-use skill, render pages to images, and
+run OCR — or convert with `ocrmypdf`:
+```sh
+ocrmypdf doc.pdf doc-ocr.pdf && python scripts/pdf.py '{"op":"text","path":"doc-ocr.pdf"}'
+```
+
+## Going further
+
+The helper is a fast start, not a cage — for form-filling, redaction, or
+image-per-page rendering, write `pypdf`/`pdfplumber`/`pymupdf` directly in
+`code_exec`. To analyze extracted tables, hand them to the **data-analysis**
+skill (load into pandas). Save any generated PDF with the `artifacts` tool so it
+shows in Files. See `reference/recipes.md`.

--- a/plugins/builtinskills/pdftools/reference/recipes.md
+++ b/plugins/builtinskills/pdftools/reference/recipes.md
@@ -1,0 +1,60 @@
+# pdf-tools recipes
+
+The helper (`scripts/pdf.py`) covers info/text/tables/merge/split. For anything
+else, write `pypdf`/`pdfplumber`/`pymupdf` directly in `code_exec`. Patterns:
+
+## Read an invoice / statement
+
+```sh
+python scripts/pdf.py '{"op":"text","path":"invoice.pdf"}'      # the prose
+python scripts/pdf.py '{"op":"tables","path":"invoice.pdf"}'    # line items as rows
+```
+Hand the rows to the **data-analysis** skill to total/aggregate them in pandas.
+
+## Mine a long report for a section
+
+```sh
+python scripts/pdf.py '{"op":"info","path":"report.pdf"}'             # how many pages?
+python scripts/pdf.py '{"op":"text","path":"report.pdf","pages":"10-14","max_chars":6000}'
+```
+
+## Merge / split
+
+```sh
+python scripts/pdf.py '{"op":"merge","inputs":["jan.pdf","feb.pdf","mar.pdf"],"out":"q1.pdf"}'
+python scripts/pdf.py '{"op":"split","path":"q1.pdf","pages":"1-4","out":"jan-only.pdf"}'
+```
+
+## Scanned PDF (text comes back empty) → OCR
+
+A scan is images, not text. Install tesseract via the computer-use skill, then:
+```sh
+# easiest: ocrmypdf adds a text layer in place
+pip install ocrmypdf && ocrmypdf in.pdf out.pdf
+python scripts/pdf.py '{"op":"text","path":"out.pdf"}'
+```
+Or render + OCR page by page with pymupdf + pytesseract if you need control.
+
+## Render pages to images (for vision / thumbnails)
+
+```python
+import fitz  # pymupdf
+doc = fitz.open("doc.pdf")
+for i, page in enumerate(doc):
+    page.get_pixmap(dpi=150).save(f"page-{i+1}.png")
+```
+Register the PNGs with the `artifacts` tool so they show in Files.
+
+## Fill a form
+
+```python
+from pypdf import PdfReader, PdfWriter
+r = PdfReader("form.pdf"); w = PdfWriter(); w.append(r)
+w.update_page_form_field_values(w.pages[0], {"name": "Ada Lovelace", "date": "2026-06-11"})
+with open("filled.pdf", "wb") as fh: w.write(fh)
+```
+
+## Tips
+- `pages` is 1-based: `"1-3"`, `"2"`, `"1,4,6"`. Omit it to act on the whole doc.
+- Extracted tables are raw rows — clean headers/types in pandas before computing.
+- Save generated PDFs with the `artifacts` tool so the operator sees them in Files.

--- a/plugins/builtinskills/pdftools/scripts/pdf.py
+++ b/plugins/builtinskills/pdftools/scripts/pdf.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""pdf-tools helper — extract text/tables, read info, merge/split PDFs.
+
+Usage:  python pdf.py '<json-spec>'   (or pipe the JSON on stdin)
+Ops:
+  info   {path}                          -> {pages, metadata}
+  text   {path, pages?, max_chars?}      -> {pages, text, chars}
+  tables {path, pages?}                  -> {tables:[{page, rows:[[...]]}]}
+  merge  {inputs:[...], out}             -> {out, pages}
+  split  {path, pages, out}              -> {out, pages}
+
+`pages` is a 1-based selection: "1-3", "2", or "1,4,6"; omit for all.
+A fast start, not a cage: for form-fill/redaction/render, use pypdf/pdfplumber
+directly in code_exec.
+"""
+import json
+import sys
+
+
+def read_spec():
+    if len(sys.argv) > 1 and sys.argv[1].strip():
+        return json.loads(sys.argv[1])
+    data = sys.stdin.read()
+    if data.strip():
+        return json.loads(data)
+    raise ValueError("no spec: pass a JSON spec as argv[1] or on stdin")
+
+
+def parse_pages(expr, total):
+    """1-based 'pages' expr -> sorted 0-based indices within [0, total)."""
+    if not expr:
+        return list(range(total))
+    idx = set()
+    for part in str(expr).split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "-" in part:
+            a, b = part.split("-", 1)
+            for n in range(int(a), int(b) + 1):
+                idx.add(n - 1)
+        else:
+            idx.add(int(part) - 1)
+    return sorted(i for i in idx if 0 <= i < total)
+
+
+def op_info(spec):
+    from pypdf import PdfReader
+
+    r = PdfReader(spec["path"])
+    meta = {k.lstrip("/"): str(v) for k, v in (r.metadata or {}).items()}
+    return {"pages": len(r.pages), "metadata": meta}
+
+
+def op_text(spec):
+    import pdfplumber
+
+    out = []
+    with pdfplumber.open(spec["path"]) as pdf:
+        total = len(pdf.pages)
+        for i in parse_pages(spec.get("pages"), total):
+            out.append(pdf.pages[i].extract_text() or "")
+    text = "\n\n".join(out).strip()
+    mc = spec.get("max_chars")
+    if mc and len(text) > int(mc):
+        text = text[: int(mc)].rstrip() + " …"
+    return {"pages": total, "text": text, "chars": len(text)}
+
+
+def op_tables(spec):
+    import pdfplumber
+
+    tables = []
+    with pdfplumber.open(spec["path"]) as pdf:
+        total = len(pdf.pages)
+        for i in parse_pages(spec.get("pages"), total):
+            for t in pdf.pages[i].extract_tables() or []:
+                tables.append({"page": i + 1, "rows": t})
+    return {"tables": tables, "count": len(tables)}
+
+
+def op_merge(spec):
+    from pypdf import PdfWriter
+
+    inputs = spec.get("inputs") or []
+    if not inputs:
+        raise ValueError("merge needs inputs[]")
+    out = spec.get("out", "merged.pdf")
+    w = PdfWriter()
+    for p in inputs:
+        w.append(p)
+    with open(out, "wb") as fh:
+        w.write(fh)
+    return {"out": out, "pages": len(w.pages)}
+
+
+def op_split(spec):
+    from pypdf import PdfReader, PdfWriter
+
+    r = PdfReader(spec["path"])
+    out = spec.get("out", "slice.pdf")
+    idx = parse_pages(spec.get("pages"), len(r.pages))
+    if not idx:
+        raise ValueError("split needs a non-empty 'pages' range")
+    w = PdfWriter()
+    for i in idx:
+        w.add_page(r.pages[i])
+    with open(out, "wb") as fh:
+        w.write(fh)
+    return {"out": out, "pages": len(idx)}
+
+
+OPS = {"info": op_info, "text": op_text, "tables": op_tables, "merge": op_merge, "split": op_split}
+
+
+def run(spec):
+    op = spec.get("op")
+    if op not in OPS:
+        raise ValueError("spec.op must be one of: " + ", ".join(OPS))
+    result = OPS[op](spec)
+    result.update({"ok": True, "op": op})
+    return result
+
+
+def main():
+    try:
+        print(json.dumps(run(read_spec()), default=str))
+    except Exception as e:  # noqa: BLE001
+        print(json.dumps({"ok": False, "error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/builtinskills/pdftools/scripts/setup.sh
+++ b/plugins/builtinskills/pdftools/scripts/setup.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# pdf-tools setup: install pypdf (merge/split/metadata) + pdfplumber (text/tables).
+# Idempotent. Run via code_exec or shell.
+set -e
+
+echo "installing pypdf + pdfplumber ..."
+python -m pip install --quiet pypdf pdfplumber 2>/dev/null \
+  || pip install --quiet pypdf pdfplumber 2>/dev/null \
+  || pip3 install pypdf pdfplumber
+
+echo "pdf-tools ready: run scripts/pdf.py '<json-spec>'"


### PR DESCRIPTION
## Summary
A seventh out-of-the-box skill bundle that **gets data out of PDFs** — the gap data-analysis (M861) and web-research (M865) both explicitly defer on (#34).

- **`scripts/pdf.py`** — one JSON-spec helper, five ops: `info` (pages + metadata), `text` (per-page extract, 1-based page range, `max_chars`), `tables` (pdfplumber rows per page), `merge` (inputs[] → out), `split` (range → out). Shared `parse_pages` for `"1-3"`/`"2"`/`"1,4,6"`.
- **`scripts/setup.sh`** — `pypdf` + `pdfplumber`.
- **`reference/recipes.md`** — invoices/statements, mining a section, merge/split, OCR for scans (ocrmypdf / pymupdf+pytesseract), render-to-images, form-fill.

The bundles compose: web-research → pdf-tools for PDF links, pdf-tools → data-analysis for tables, pdf-tools → computer-use for OCR.

## Why it's conflict-free
Touches **only** `plugins/builtinskills/` (the seeder auto-loads it via `builtinBundles` + `go:embed`). No `cmd/agezt/main.go`, no `kernel/runtime`/`agent`/`governor`. No new Go dependency, no new env.

## Verification
- `go vet` + linux cross-build of `./plugins/builtinskills/` clean; `gofmt -l` empty; `py_compile pdf.py` + `sh -n setup.sh` clean.
- `TestSeedAll_InstallsPDFTools` asserts the bundle seeds **active** and materializes `pdf.py`/`setup.sh`/`recipes.md`; bundle-count assertions now cover seven bundles. Package suite green in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)