### PR TITLE
Feat: built-in image-tools skill bundle (M879)

### DIFF
--- a/.project/PHASE-M879-IMAGE-TOOLS-SKILL-REPORT.md
+++ b/.project/PHASE-M879-IMAGE-TOOLS-SKILL-REPORT.md
@@ -1,0 +1,47 @@
+# PHASE M879 — Built-in image-tools skill bundle
+
+**Status:** shipped
+**Milestone:** M879 (numbered above the concurrent session's M868–M876 arc).
+**Theme:** Backlog **#34** (more out-of-the-box capability) — an eighth built-in
+skill bundle that completes the visual pipeline: manipulate images with Pillow.
+
+## What shipped
+
+A built-in `image-tools` bundle, seeded active at startup by the existing
+`plugins/builtinskills` seeder (no daemon wiring change — `builtinBundles` +
+`go:embed` only):
+
+- `SKILL.md` — when to transform an image programmatically, the helper ops, the
+  OCR escalation (tesseract via computer-use), and handoffs to artifacts/Files.
+- `scripts/setup.sh` — `pip install Pillow`.
+- `scripts/img.py` — one JSON-spec helper, eight ops: `info` (size/mode/format/
+  EXIF), `resize` (aspect-preserving when one of w/h given), `convert` (format
+  from out extension, RGBA→RGB for JPEG), `crop`, `thumb`, `rotate`, `grayscale`,
+  `annotate` (stamp text). Prints JSON.
+- `reference/recipes.md` — shrink screenshots, batch thumbnails, OCR, EXIF
+  stripping, watermark/compose, and the visual pipeline (browser-use → image-tools,
+  pdf-tools → image-tools, data-analysis charts → image-tools).
+
+## Why this milestone is conflict-free
+
+A new bundle touches **only** `plugins/builtinskills/` — never `cmd/agezt/main.go`
+or `kernel/runtime`/`agent`/`governor` (the files a concurrent session is editing).
+The seeder auto-loads it. It tests in isolation:
+`go test ./plugins/builtinskills/` compiles just this package + `kernel/skill`.
+
+## Verification
+
+- **Isolated gate:** `go vet` clean; linux cross-build of `./plugins/builtinskills/`
+  clean; `gofmt -l` empty; `python -m py_compile img.py` passes; `sh -n setup.sh`
+  clean. Package suite green — `TestSeedAll_InstallsImageTools` asserts the bundle
+  seeds **active** and materializes `img.py` / `setup.sh` / `recipes.md`;
+  bundle-count assertions now cover eight bundles.
+- No new Go dep; no new env. `.gitattributes` already forces LF on
+  `plugins/builtinskills/**`. Full `go build ./...` / daemon smoke deliberately
+  skipped — they'd compile the concurrent in-progress Go edits.
+
+## Notes
+- Eight seeded bundles now ship out of the box: browser-use, computer-use,
+  data-analysis, docker-services, git-ops, web-research, pdf-tools, image-tools.
+  The visual ones compose: a browser screenshot or a rendered PDF page flows into
+  image-tools for crop/resize/annotate, then to the artifacts tool for Files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
   the Runs view. Purely frontend — reuses the existing event provider and read routes. (M867)
 
 ### Added
+- **Built-in image-tools skill bundle (M879).** An eighth out-of-the-box skill that manipulates images
+  with Pillow, completing the visual pipeline (#34). `scripts/img.py` is one JSON-spec helper with eight
+  ops: `info` (size/mode/format/EXIF), `resize`, `convert`, `crop`, `thumb`, `rotate`, `grayscale`,
+  `annotate`; `setup.sh` installs Pillow. The SKILL documents OCR (tesseract via computer-use) and the
+  visual pipeline — browser screenshots / rendered PDF pages / chart PNGs flow through image-tools to the
+  artifacts tool. Rides the `plugins/builtinskills` seeder — no new Go dependency. (M879)
 - **Built-in pdf-tools skill bundle (M866).** A seventh out-of-the-box skill that gets data out of PDFs —
   the gap data-analysis and web-research both defer on (#34). `scripts/pdf.py` is one JSON-spec helper
   with five ops: `info` (pages + metadata), `text` (per-page extract with a 1-based page range), `tables`

--- a/plugins/builtinskills/builtinskills.go
+++ b/plugins/builtinskills/builtinskills.go
@@ -24,7 +24,7 @@ import (
 	"github.com/agezt/agezt/kernel/skill"
 )
 
-//go:embed browseruse computeruse dataanalysis dockerservices gitops webresearch pdftools
+//go:embed browseruse computeruse dataanalysis dockerservices gitops webresearch pdftools imagetools
 var bundles embed.FS
 
 // Forge is the slice of *skill.Forge the seeder needs — an interface so it is
@@ -44,7 +44,7 @@ type Seeded struct {
 }
 
 // builtinBundles lists the embedded bundle directories to seed.
-var builtinBundles = []string{"browseruse", "computeruse", "dataanalysis", "dockerservices", "gitops", "webresearch", "pdftools"}
+var builtinBundles = []string{"browseruse", "computeruse", "dataanalysis", "dockerservices", "gitops", "webresearch", "pdftools", "imagetools"}
 
 // SeedAll installs every embedded bundle into the Forge and promotes each to
 // active. It is best-effort per bundle: an error on one is returned but does not

--- a/plugins/builtinskills/builtinskills_test.go
+++ b/plugins/builtinskills/builtinskills_test.go
@@ -268,6 +268,42 @@ func TestSeedAll_InstallsPDFTools(t *testing.T) {
 	}
 }
 
+func TestSeedAll_InstallsImageTools(t *testing.T) {
+	f := newForge(t)
+	seeded, err := SeedAll(f, "")
+	if err != nil {
+		t.Fatalf("SeedAll: %v", err)
+	}
+	var got *Seeded
+	for i := range seeded {
+		if seeded[i].Name == "image-tools" {
+			got = &seeded[i]
+		}
+	}
+	if got == nil {
+		t.Fatalf("image-tools not seeded: %+v", seeded)
+	}
+	if got.Status != skill.StatusActive {
+		t.Errorf("image-tools status = %q, want active", got.Status)
+	}
+	drv, err := f.Bundles().Read("image-tools", "scripts/img.py")
+	if err != nil || len(drv) == 0 {
+		t.Fatalf("image-tools img.py unreadable/empty: %v", err)
+	}
+	files, _ := f.Bundles().List("image-tools")
+	want := map[string]bool{"scripts/img.py": false, "scripts/setup.sh": false, "reference/recipes.md": false}
+	for _, rel := range files {
+		if _, ok := want[rel]; ok {
+			want[rel] = true
+		}
+	}
+	for rel, found := range want {
+		if !found {
+			t.Errorf("image-tools bundle missing %q (got %v)", rel, files)
+		}
+	}
+}
+
 func TestSeedAll_Idempotent(t *testing.T) {
 	f := newForge(t)
 	if _, err := SeedAll(f, ""); err != nil {

--- a/plugins/builtinskills/imagetools/SKILL.md
+++ b/plugins/builtinskills/imagetools/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: image-tools
+description: Work with images — read their size/format/EXIF, resize, convert between formats, crop, make thumbnails, rotate, grayscale, and stamp text on them — when a task hands you a photo, screenshot, or chart instead of clean data
+triggers: [image, photo, screenshot, png, jpg, jpeg, resize, thumbnail, crop, convert, exif, watermark, rotate]
+tools: [code_exec, shell, artifacts]
+---
+
+# image-tools — manipulate images programmatically
+
+When a task involves an image — a screenshot to crop, a photo to resize, a batch
+to convert, a chart to thumbnail — don't hand-wave it. Load it with Pillow and
+transform it. This skill runs through the `code_exec` tool (python).
+
+## One-time setup
+
+Run `scripts/setup.sh` once (via code_exec or shell): it installs `Pillow`. Use
+`skill op=files image-tools` to find the bundle directory.
+
+## The helper
+
+`scripts/img.py` takes a JSON spec with an `op` and prints JSON. Ops:
+
+```sh
+# Metadata (size, mode, format, EXIF):
+python scripts/img.py '{"op":"info","path":"photo.jpg"}'
+
+# Resize (keeps aspect if only one of w/h given):
+python scripts/img.py '{"op":"resize","path":"photo.jpg","w":800,"out":"small.jpg"}'
+
+# Convert format (inferred from out extension):
+python scripts/img.py '{"op":"convert","path":"photo.png","out":"photo.jpg","quality":85}'
+
+# Crop a box [left,top,right,bottom]:
+python scripts/img.py '{"op":"crop","path":"shot.png","box":[0,0,400,300],"out":"crop.png"}'
+
+# Thumbnail (longest side <= max):
+python scripts/img.py '{"op":"thumb","path":"big.png","max":256,"out":"thumb.png"}'
+
+# Rotate / grayscale / stamp text:
+python scripts/img.py '{"op":"rotate","path":"a.png","deg":90,"out":"r.png"}'
+python scripts/img.py '{"op":"grayscale","path":"a.png","out":"g.png"}'
+python scripts/img.py '{"op":"annotate","path":"a.png","text":"DRAFT","xy":[12,12],"out":"a2.png"}'
+```
+
+### Spec fields
+- `op` (required) — `info` | `resize` | `convert` | `crop` | `thumb` | `rotate` |
+  `grayscale` | `annotate`.
+- `path` (required) — the source image.
+- `out` — output path (format inferred from its extension). Defaults vary by op.
+- `w` / `h` (resize), `box` (crop), `max` (thumb), `deg` (rotate),
+  `text` + `xy` + `size` (annotate), `quality` (convert/resize JPEG).
+
+### Output (JSON on stdout)
+```
+{ "ok": true, "op": "resize", "out": "small.jpg", "w": 800, "h": 600 }
+{ "ok": true, "op": "info", "w": 1920, "h": 1080, "mode": "RGB",
+  "format": "JPEG", "exif": {...} }
+```
+
+## OCR (text in an image)
+
+Pillow doesn't read text. To pull text out of a screenshot/scan, install
+`tesseract` via the computer-use skill, then `pytesseract.image_to_string(img)`.
+For PDFs, render pages first with the pdf-tools / pymupdf path.
+
+## Going further
+
+The helper is a fast start, not a cage — for compositing, filters, drawing, or
+EXIF stripping, write Pillow directly in `code_exec`. Save any produced image with
+the `artifacts` tool so it shows in the Files view. Pairs with browser-use
+(screenshots), pdf-tools (rendered pages), and data-analysis (chart PNGs). See
+`reference/recipes.md`.

--- a/plugins/builtinskills/imagetools/reference/recipes.md
+++ b/plugins/builtinskills/imagetools/reference/recipes.md
@@ -1,0 +1,56 @@
+# image-tools recipes
+
+The helper (`scripts/img.py`) covers info/resize/convert/crop/thumb/rotate/
+grayscale/annotate. For anything else, write Pillow directly in `code_exec`.
+
+## Shrink a screenshot for sharing
+
+```sh
+python scripts/img.py '{"op":"resize","path":"shot.png","w":1200,"out":"shot-sm.png"}'
+```
+
+## Batch convert a folder to JPEG thumbnails
+
+```python
+import glob, os
+from PIL import Image
+os.makedirs("thumbs", exist_ok=True)
+for p in glob.glob("imgs/*.png"):
+    im = Image.open(p).convert("RGB"); im.thumbnail((256, 256))
+    im.save(f"thumbs/{os.path.splitext(os.path.basename(p))[0]}.jpg", quality=82)
+```
+
+## OCR — read text from an image
+
+Pillow doesn't OCR. Install tesseract via the computer-use skill, then:
+```sh
+pip install pytesseract
+python -c "import pytesseract; from PIL import Image; print(pytesseract.image_to_string(Image.open('shot.png')))"
+```
+
+## Strip EXIF (privacy) before sharing a photo
+
+```python
+from PIL import Image
+im = Image.open("photo.jpg")
+data = list(im.getdata()); clean = Image.new(im.mode, im.size); clean.putdata(data)
+clean.save("photo-clean.jpg", quality=90)   # no EXIF copied
+```
+
+## Compose / watermark
+
+```python
+from PIL import Image
+base = Image.open("base.png").convert("RGBA")
+logo = Image.open("logo.png").convert("RGBA")
+base.alpha_composite(logo, (base.width - logo.width - 12, base.height - logo.height - 12))
+base.convert("RGB").save("branded.jpg", quality=88)
+```
+
+## The visual pipeline
+
+image-tools composes with the other built-ins:
+- **browser-use** takes screenshots → crop/resize them here.
+- **pdf-tools** renders PDF pages to PNG → thumbnail/annotate them here.
+- **data-analysis** saves chart PNGs → resize for a report here.
+- Save any result with the `artifacts` tool so it appears in the Files view.

--- a/plugins/builtinskills/imagetools/scripts/img.py
+++ b/plugins/builtinskills/imagetools/scripts/img.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""image-tools helper — inspect and transform images with Pillow.
+
+Usage:  python img.py '<json-spec>'   (or pipe the JSON on stdin)
+Ops:
+  info      {path}                                  -> {w,h,mode,format,exif}
+  resize    {path, w?, h?, out, quality?}           -> {out,w,h}   (keeps aspect if one of w/h)
+  convert   {path, out, quality?}                   -> {out,format}
+  crop      {path, box:[l,t,r,b], out}              -> {out,w,h}
+  thumb     {path, max, out}                        -> {out,w,h}   (longest side <= max)
+  rotate    {path, deg, out}                        -> {out}
+  grayscale {path, out}                             -> {out}
+  annotate  {path, text, xy?, size?, out}           -> {out}       (stamp text on the image)
+
+A fast start, not a cage: for compositing/filters/drawing, use Pillow directly
+in code_exec. Output format is inferred from `out`'s extension.
+"""
+import json
+import sys
+
+
+def read_spec():
+    if len(sys.argv) > 1 and sys.argv[1].strip():
+        return json.loads(sys.argv[1])
+    data = sys.stdin.read()
+    if data.strip():
+        return json.loads(data)
+    raise ValueError("no spec: pass a JSON spec as argv[1] or on stdin")
+
+
+def _open(spec):
+    from PIL import Image
+
+    if not spec.get("path"):
+        raise ValueError("spec.path is required")
+    return Image.open(spec["path"])
+
+
+def _save(img, out, quality=None):
+    params = {}
+    if quality is not None:
+        params["quality"] = int(quality)
+    img.save(out, **params)
+
+
+def op_info(spec):
+    img = _open(spec)
+    exif = {}
+    try:
+        raw = img.getexif()
+        from PIL.ExifTags import TAGS
+
+        exif = {TAGS.get(k, str(k)): str(v) for k, v in raw.items()}
+    except Exception:  # noqa: BLE001 — no/again-unreadable EXIF is fine
+        exif = {}
+    return {"w": img.width, "h": img.height, "mode": img.mode, "format": img.format, "exif": exif}
+
+
+def op_resize(spec):
+    img = _open(spec)
+    w, h = spec.get("w"), spec.get("h")
+    if not w and not h:
+        raise ValueError("resize needs w and/or h")
+    if w and not h:
+        h = round(img.height * (int(w) / img.width))
+    elif h and not w:
+        w = round(img.width * (int(h) / img.height))
+    img = img.resize((int(w), int(h)))
+    out = spec.get("out", "resized.png")
+    _save(img, out, spec.get("quality"))
+    return {"out": out, "w": img.width, "h": img.height}
+
+
+def op_convert(spec):
+    img = _open(spec)
+    out = spec.get("out")
+    if not out:
+        raise ValueError("convert needs out (its extension picks the format)")
+    if out.lower().endswith((".jpg", ".jpeg")) and img.mode in ("RGBA", "P"):
+        img = img.convert("RGB")  # JPEG has no alpha
+    _save(img, out, spec.get("quality"))
+    return {"out": out, "format": (img.format or out.rsplit(".", 1)[-1].upper())}
+
+
+def op_crop(spec):
+    box = spec.get("box")
+    if not box or len(box) != 4:
+        raise ValueError("crop needs box:[left,top,right,bottom]")
+    img = _open(spec).crop(tuple(int(x) for x in box))
+    out = spec.get("out", "crop.png")
+    _save(img, out)
+    return {"out": out, "w": img.width, "h": img.height}
+
+
+def op_thumb(spec):
+    img = _open(spec)
+    m = int(spec.get("max", 256))
+    img.thumbnail((m, m))
+    out = spec.get("out", "thumb.png")
+    _save(img, out)
+    return {"out": out, "w": img.width, "h": img.height}
+
+
+def op_rotate(spec):
+    img = _open(spec).rotate(float(spec.get("deg", 90)), expand=True)
+    out = spec.get("out", "rotated.png")
+    _save(img, out)
+    return {"out": out, "w": img.width, "h": img.height}
+
+
+def op_grayscale(spec):
+    img = _open(spec).convert("L")
+    out = spec.get("out", "gray.png")
+    _save(img, out)
+    return {"out": out}
+
+
+def op_annotate(spec):
+    from PIL import ImageDraw
+
+    text = spec.get("text")
+    if not text:
+        raise ValueError("annotate needs text")
+    img = _open(spec).convert("RGBA")
+    draw = ImageDraw.Draw(img)
+    xy = spec.get("xy", [10, 10])
+    draw.text((int(xy[0]), int(xy[1])), str(text), fill=(255, 0, 0, 255))
+    out = spec.get("out", "annotated.png")
+    if out.lower().endswith((".jpg", ".jpeg")):
+        img = img.convert("RGB")
+    _save(img, out)
+    return {"out": out}
+
+
+OPS = {
+    "info": op_info,
+    "resize": op_resize,
+    "convert": op_convert,
+    "crop": op_crop,
+    "thumb": op_thumb,
+    "rotate": op_rotate,
+    "grayscale": op_grayscale,
+    "annotate": op_annotate,
+}
+
+
+def run(spec):
+    op = spec.get("op")
+    if op not in OPS:
+        raise ValueError("spec.op must be one of: " + ", ".join(OPS))
+    result = OPS[op](spec)
+    result.update({"ok": True, "op": op})
+    return result
+
+
+def main():
+    try:
+        print(json.dumps(run(read_spec()), default=str))
+    except Exception as e:  # noqa: BLE001
+        print(json.dumps({"ok": False, "error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/builtinskills/imagetools/scripts/setup.sh
+++ b/plugins/builtinskills/imagetools/scripts/setup.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# image-tools setup: install Pillow. Idempotent. Run via code_exec or shell.
+set -e
+
+echo "installing Pillow ..."
+python -m pip install --quiet Pillow 2>/dev/null \
+  || pip install --quiet Pillow 2>/dev/null \
+  || pip3 install Pillow
+
+echo "image-tools ready: run scripts/img.py '<json-spec>'"


### PR DESCRIPTION
## Summary
An eighth out-of-the-box skill bundle that **manipulates images with Pillow**, completing the visual pipeline (#34).

- **`scripts/img.py`** — one JSON-spec helper, eight ops: `info` (size/mode/format/EXIF), `resize` (aspect-preserving), `convert` (RGBA→RGB for JPEG), `crop`, `thumb`, `rotate`, `grayscale`, `annotate` (stamp text).
- **`scripts/setup.sh`** — `pip install Pillow`.
- **`reference/recipes.md`** — shrink screenshots, batch thumbnails, OCR (tesseract via computer-use), EXIF stripping, watermark/compose, the visual pipeline.

The visual bundles compose: a browser screenshot or a rendered PDF page → image-tools (crop/resize/annotate) → artifacts tool → Files.

## Why it's conflict-free
Touches **only** `plugins/builtinskills/` (the seeder auto-loads it via `builtinBundles` + `go:embed`). No `cmd/agezt/main.go`, no `kernel/...`. No new Go dependency, no new env.

## Verification
- `go vet` + linux cross-build of `./plugins/builtinskills/` clean; `gofmt -l` empty; `py_compile img.py` + `sh -n setup.sh` clean.
- `TestSeedAll_InstallsImageTools` asserts the bundle seeds **active** and materializes `img.py`/`setup.sh`/`recipes.md`; bundle-count assertions now cover eight bundles. Package suite green in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)