### PR TITLE
Feat: built-in archive-tools skill bundle (M890)

### DIFF
--- a/.project/PHASE-M890-ARCHIVE-TOOLS-SKILL-REPORT.md
+++ b/.project/PHASE-M890-ARCHIVE-TOOLS-SKILL-REPORT.md
@@ -1,0 +1,51 @@
+# PHASE M890 — Built-in archive-tools skill bundle
+
+**Status:** shipped
+**Milestone:** M890 (this session's range is M889+; concurrent session holds
+M880–M888 + M900).
+**Theme:** Backlog **#34** (more out-of-the-box capability) — a tenth built-in
+skill bundle: pack/unpack zip and tar(.gz) archives, with a path-traversal guard.
+The natural last step of the output pipeline (bundle artifacts into one file).
+
+## What shipped
+
+A built-in `archive-tools` bundle, seeded active at startup by the existing
+`plugins/builtinskills` seeder (no daemon wiring change — `builtinBundles` +
+`go:embed` only). **Zero pip dependencies** — it uses only the Python stdlib
+(`zipfile`/`tarfile`/`shutil`), so there's no `setup.sh`:
+
+- `SKILL.md` — when to pack/unpack, the helper ops, and the zip-slip safety note.
+- `scripts/arc.py` — one JSON-spec helper, four ops: `list` (entries without
+  extracting), `extract` (path-traversal-guarded — refuses any member that would
+  land outside `dest`), `zip` (create from files/dirs, recursive), `tar` (`.tar`
+  or `.tar.gz` by extension). Archive names keep the input folder and use forward
+  slashes on every platform.
+- `reference/recipes.md` — peek/extract, bundle a deliverable, roll up logs,
+  password-protected zips (pyzipper), selective extraction, the output pipeline.
+
+## Why this milestone is conflict-free
+
+A new bundle touches **only** `plugins/builtinskills/` — never `cmd/agezt/main.go`
+or `kernel/runtime`/`agent`/`governor`. The seeder auto-loads it. It tests in
+isolation: `go test ./plugins/builtinskills/`.
+
+## Verification
+
+- **Isolated gate:** `go vet` clean; linux cross-build of `./plugins/builtinskills/`
+  clean; `gofmt -l` empty; `python -m py_compile arc.py` passes. Package suite green
+  — `TestSeedAll_InstallsArchiveTools` asserts the bundle seeds **active** and
+  materializes `arc.py` / `recipes.md`; bundle-count assertions now cover ten
+  bundles.
+- **Functional smoke (stdlib, ran locally):** zip a folder → `list` shows
+  `src/a.txt`,`src/b.txt` → `extract` restores `unpacked/src/{a,b}.txt`; tar.gz
+  round-trips the same. This caught and fixed a cross-platform `arcname` bug
+  (a trailing `/` collapsed the folder prefix when `os.sep` is `\`); now both
+  separators are stripped and paths normalize to `/`.
+- No new Go dep; no new env. `.gitattributes` already forces LF on
+  `plugins/builtinskills/**`. Full `go build ./...` deliberately skipped.
+
+## Notes
+- Ten seeded bundles now ship: browser-use, computer-use, data-analysis,
+  docker-services, git-ops, web-research, pdf-tools, image-tools, sql-db,
+  archive-tools. archive-tools closes the output pipeline — gather image-tools
+  PNGs / data-analysis CSVs / pdf-tools exports into one zip → artifacts → Files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
   the Runs view. Purely frontend — reuses the existing event provider and read routes. (M867)
 
 ### Added
+- **Built-in archive-tools skill bundle (M890).** A tenth out-of-the-box skill that packs/unpacks zip and
+  tar(.gz) archives (#34) — **zero pip deps** (Python stdlib only). `scripts/arc.py` has four ops: `list`
+  (entries without extracting), `extract` (path-traversal-guarded — refuses zip-slip members), `zip`, and
+  `tar`; archive names keep the input folder and normalize to forward slashes. Closes the output pipeline:
+  bundle image-tools PNGs / data-analysis CSVs / pdf-tools exports into one zip → artifacts → Files. Rides
+  the `plugins/builtinskills` seeder. (M890)
 - **Built-in sql-db skill bundle (M889).** A ninth out-of-the-box skill that queries SQL databases —
   SQLite, PostgreSQL, MySQL — completing the data story (#34). `scripts/db.py` is one SQLAlchemy helper
   with four ops: `tables`, `schema`, `query` (parameterised SELECT → JSON rows, capped + `truncated`

--- a/plugins/builtinskills/archivetools/SKILL.md
+++ b/plugins/builtinskills/archivetools/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: archive-tools
+description: Pack and unpack archives — zip and tar/tar.gz — list what's inside without extracting, create an archive from files, and extract safely (guarding against path-traversal), when a task hands you a .zip/.tar.gz or needs to bundle outputs
+triggers: [zip, unzip, archive, tar, tar.gz, tgz, compress, extract, unpack, bundle, gzip]
+tools: [code_exec, shell, artifacts]
+---
+
+# archive-tools — pack and unpack archives safely
+
+When a task hands you a `.zip` or `.tar.gz` to open, or needs to bundle a folder
+of outputs into one downloadable file, do it programmatically. This skill runs
+through `code_exec` (python) and uses only the **standard library** — no install.
+
+## No setup needed
+
+`zipfile`, `tarfile`, and `shutil` ship with Python. Use `skill op=files
+archive-tools` to find the bundle directory, then run the helper.
+
+## The helper
+
+`scripts/arc.py` takes a JSON spec with an `op` and prints JSON. Ops:
+
+```sh
+# List entries without extracting:
+python scripts/arc.py '{"op":"list","path":"bundle.zip"}'
+
+# Extract into a directory (path-traversal-guarded):
+python scripts/arc.py '{"op":"extract","path":"bundle.tar.gz","dest":"out"}'
+
+# Create a zip from files/folders:
+python scripts/arc.py '{"op":"zip","inputs":["report.pdf","charts/"],"out":"deliverable.zip"}'
+
+# Create a tar.gz:
+python scripts/arc.py '{"op":"tar","inputs":["logs/"],"out":"logs.tar.gz"}'
+```
+
+### Spec fields
+- `op` (required) — `list` | `extract` | `zip` | `tar`.
+- `path` — the archive (list/extract). Format inferred from the extension
+  (`.zip`, `.tar`, `.tar.gz`/`.tgz`).
+- `dest` — extract target dir (created if absent; default `"extracted"`).
+- `inputs` — files/dirs to pack (zip/tar). Folders are added recursively.
+- `out` — output archive path (zip/tar).
+
+### Output (JSON on stdout)
+```
+{ "ok": true, "op": "list", "entries": ["a.txt","sub/b.csv"], "count": 2 }
+{ "ok": true, "op": "extract", "dest": "out", "files": 12 }
+{ "ok": true, "op": "zip", "out": "deliverable.zip", "files": 5 }
+```
+
+## Safety: extract is path-traversal-guarded
+
+A malicious archive can carry entries like `../../etc/passwd` ("zip slip"). The
+helper **refuses** any member that would land outside `dest` and aborts the
+extract. When you write your own extraction in `code_exec`, do the same — resolve
+each member against `dest` and skip anything that escapes it.
+
+## Going further
+
+The helper is a fast start, not a cage — for password-protected zips, streaming
+large archives, or selective extraction, use `zipfile`/`tarfile` directly. Pairs
+with everything: bundle the PNGs from **image-tools**, the CSVs from
+**data-analysis**, or a **pdf-tools** export into one archive, then register it
+with the `artifacts` tool so it shows in the Files view. See
+`reference/recipes.md`.

--- a/plugins/builtinskills/archivetools/reference/recipes.md
+++ b/plugins/builtinskills/archivetools/reference/recipes.md
@@ -1,0 +1,57 @@
+# archive-tools recipes
+
+The helper (`scripts/arc.py`) covers list/extract/zip/tar with a zip-slip guard,
+using only the Python standard library. For more, use `zipfile`/`tarfile`
+directly. Patterns:
+
+## Peek inside before extracting
+
+```sh
+python scripts/arc.py '{"op":"list","path":"download.zip"}'
+```
+
+## Extract safely
+
+```sh
+python scripts/arc.py '{"op":"extract","path":"download.tar.gz","dest":"work"}'
+```
+The helper refuses any member whose path escapes `dest` (zip slip) and aborts.
+
+## Bundle outputs into one deliverable
+
+```sh
+python scripts/arc.py '{"op":"zip","inputs":["report.pdf","charts/","summary.csv"],"out":"deliverable.zip"}'
+```
+Folders are added recursively. Then register `deliverable.zip` with the
+`artifacts` tool so it appears in the Files view.
+
+## Roll up logs as tar.gz
+
+```sh
+python scripts/arc.py '{"op":"tar","inputs":["logs/"],"out":"logs-2026-06.tar.gz"}'
+```
+
+## Password-protected zip (helper doesn't cover it)
+
+```python
+import pyzipper  # pip install pyzipper
+with pyzipper.AESZipFile("secret.zip", "w", encryption=pyzipper.WZ_AES) as z:
+    z.setpassword(b"hunter2"); z.writestr("note.txt", "classified")
+```
+
+## Selective extraction
+
+```python
+import zipfile
+with zipfile.ZipFile("big.zip") as z:
+    for n in z.namelist():
+        if n.endswith(".csv"):
+            z.extract(n, "csvs")
+```
+
+## The output pipeline
+
+archive-tools is the last step of the visual/data pipelines: bundle the PNGs from
+**image-tools**, the CSVs/charts from **data-analysis**, or a **pdf-tools** export
+into one zip, then hand it to the `artifacts` tool. To gather a Data Lake export +
+its charts for the operator, zip them together.

--- a/plugins/builtinskills/archivetools/scripts/arc.py
+++ b/plugins/builtinskills/archivetools/scripts/arc.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""archive-tools helper — pack/unpack zip and tar(.gz). Standard library only.
+
+Usage:  python arc.py '<json-spec>'   (or pipe the JSON on stdin)
+Ops:
+  list    {path}                       -> {entries:[...], count}
+  extract {path, dest}                 -> {dest, files}   (path-traversal-guarded)
+  zip     {inputs:[...], out}          -> {out, files}
+  tar     {inputs:[...], out}          -> {out, files}    (.tar.gz if out ends .gz/.tgz)
+
+Format is inferred from the extension (.zip, .tar, .tar.gz/.tgz). A fast start,
+not a cage: for password-protected or streamed archives, use zipfile/tarfile.
+"""
+import json
+import os
+import sys
+import tarfile
+import zipfile
+
+
+def read_spec():
+    if len(sys.argv) > 1 and sys.argv[1].strip():
+        return json.loads(sys.argv[1])
+    data = sys.stdin.read()
+    if data.strip():
+        return json.loads(data)
+    raise ValueError("no spec: pass a JSON spec as argv[1] or on stdin")
+
+
+def is_tar(path):
+    low = path.lower()
+    return low.endswith((".tar", ".tar.gz", ".tgz"))
+
+
+def _within(dest, target):
+    """True if `target` resolves to a path inside `dest` (zip-slip guard)."""
+    dest_abs = os.path.realpath(dest)
+    target_abs = os.path.realpath(target)
+    return target_abs == dest_abs or target_abs.startswith(dest_abs + os.sep)
+
+
+def op_list(spec):
+    path = spec["path"]
+    if is_tar(path):
+        with tarfile.open(path, "r:*") as t:
+            names = [m.name for m in t.getmembers() if m.isfile() or m.isdir()]
+    else:
+        with zipfile.ZipFile(path) as z:
+            names = z.namelist()
+    return {"entries": names, "count": len(names)}
+
+
+def op_extract(spec):
+    path = spec["path"]
+    dest = spec.get("dest", "extracted")
+    os.makedirs(dest, exist_ok=True)
+    count = 0
+    if is_tar(path):
+        with tarfile.open(path, "r:*") as t:
+            for m in t.getmembers():
+                if not _within(dest, os.path.join(dest, m.name)):
+                    raise ValueError(f"unsafe path in archive (zip slip): {m.name}")
+            t.extractall(dest)
+            count = sum(1 for m in t.getmembers() if m.isfile())
+    else:
+        with zipfile.ZipFile(path) as z:
+            for name in z.namelist():
+                if not _within(dest, os.path.join(dest, name)):
+                    raise ValueError(f"unsafe path in archive (zip slip): {name}")
+            z.extractall(dest)
+            count = sum(1 for n in z.namelist() if not n.endswith("/"))
+    return {"dest": dest, "files": count}
+
+
+def _walk_inputs(inputs):
+    """Yield (abspath, arcname) for each file under the given files/dirs.
+
+    Archive names keep the input folder itself (so `inputs:["src/"]` stores
+    `src/a.txt`, not `a.txt`) and always use forward slashes. Strips both
+    separators so a trailing slash never collapses the prefix on any platform.
+    """
+    for item in inputs:
+        item = item.rstrip("/\\")
+        if os.path.isdir(item):
+            parent = os.path.dirname(item)  # "" when the dir is in the cwd
+            for root, _dirs, files in os.walk(item):
+                for fn in files:
+                    full = os.path.join(root, fn)
+                    arc = os.path.relpath(full, parent) if parent else full
+                    yield full, arc.replace(os.sep, "/")
+        elif os.path.isfile(item):
+            yield item, os.path.basename(item)
+        else:
+            raise ValueError(f"input not found: {item}")
+
+
+def op_zip(spec):
+    inputs = spec.get("inputs") or []
+    if not inputs:
+        raise ValueError("zip needs inputs[]")
+    out = spec.get("out", "archive.zip")
+    n = 0
+    with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as z:
+        for full, arc in _walk_inputs(inputs):
+            z.write(full, arc)
+            n += 1
+    return {"out": out, "files": n}
+
+
+def op_tar(spec):
+    inputs = spec.get("inputs") or []
+    if not inputs:
+        raise ValueError("tar needs inputs[]")
+    out = spec.get("out", "archive.tar.gz")
+    mode = "w:gz" if out.lower().endswith((".gz", ".tgz")) else "w"
+    n = 0
+    with tarfile.open(out, mode) as t:
+        for full, arc in _walk_inputs(inputs):
+            t.add(full, arcname=arc)
+            n += 1
+    return {"out": out, "files": n}
+
+
+OPS = {"list": op_list, "extract": op_extract, "zip": op_zip, "tar": op_tar}
+
+
+def run(spec):
+    op = spec.get("op")
+    if op not in OPS:
+        raise ValueError("spec.op must be one of: " + ", ".join(OPS))
+    result = OPS[op](spec)
+    result.update({"ok": True, "op": op})
+    return result
+
+
+def main():
+    try:
+        print(json.dumps(run(read_spec()), default=str))
+    except Exception as e:  # noqa: BLE001
+        print(json.dumps({"ok": False, "error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/builtinskills/builtinskills.go
+++ b/plugins/builtinskills/builtinskills.go
@@ -24,7 +24,7 @@ import (
 	"github.com/agezt/agezt/kernel/skill"
 )
 
-//go:embed browseruse computeruse dataanalysis dockerservices gitops webresearch pdftools imagetools sqldb
+//go:embed browseruse computeruse dataanalysis dockerservices gitops webresearch pdftools imagetools sqldb archivetools
 var bundles embed.FS
 
 // Forge is the slice of *skill.Forge the seeder needs — an interface so it is
@@ -44,7 +44,7 @@ type Seeded struct {
 }
 
 // builtinBundles lists the embedded bundle directories to seed.
-var builtinBundles = []string{"browseruse", "computeruse", "dataanalysis", "dockerservices", "gitops", "webresearch", "pdftools", "imagetools", "sqldb"}
+var builtinBundles = []string{"browseruse", "computeruse", "dataanalysis", "dockerservices", "gitops", "webresearch", "pdftools", "imagetools", "sqldb", "archivetools"}
 
 // SeedAll installs every embedded bundle into the Forge and promotes each to
 // active. It is best-effort per bundle: an error on one is returned but does not

--- a/plugins/builtinskills/builtinskills_test.go
+++ b/plugins/builtinskills/builtinskills_test.go
@@ -340,6 +340,42 @@ func TestSeedAll_InstallsSQLDB(t *testing.T) {
 	}
 }
 
+func TestSeedAll_InstallsArchiveTools(t *testing.T) {
+	f := newForge(t)
+	seeded, err := SeedAll(f, "")
+	if err != nil {
+		t.Fatalf("SeedAll: %v", err)
+	}
+	var got *Seeded
+	for i := range seeded {
+		if seeded[i].Name == "archive-tools" {
+			got = &seeded[i]
+		}
+	}
+	if got == nil {
+		t.Fatalf("archive-tools not seeded: %+v", seeded)
+	}
+	if got.Status != skill.StatusActive {
+		t.Errorf("archive-tools status = %q, want active", got.Status)
+	}
+	drv, err := f.Bundles().Read("archive-tools", "scripts/arc.py")
+	if err != nil || len(drv) == 0 {
+		t.Fatalf("archive-tools arc.py unreadable/empty: %v", err)
+	}
+	files, _ := f.Bundles().List("archive-tools")
+	want := map[string]bool{"scripts/arc.py": false, "reference/recipes.md": false}
+	for _, rel := range files {
+		if _, ok := want[rel]; ok {
+			want[rel] = true
+		}
+	}
+	for rel, found := range want {
+		if !found {
+			t.Errorf("archive-tools bundle missing %q (got %v)", rel, files)
+		}
+	}
+}
+
 func TestSeedAll_Idempotent(t *testing.T) {
 	f := newForge(t)
 	if _, err := SeedAll(f, ""); err != nil {


### PR DESCRIPTION
## Summary
A tenth out-of-the-box skill bundle that **packs/unpacks zip and tar(.gz) archives** (#34) — **zero pip dependencies** (Python stdlib only).

- **`scripts/arc.py`** — four ops: `list` (entries without extracting), `extract` (**path-traversal-guarded** — refuses any zip-slip member that escapes `dest`), `zip` (recursive, from files/dirs), `tar` (`.tar` or `.tar.gz` by extension). Archive names keep the input folder and normalize to forward slashes on every platform.
- **`reference/recipes.md`** — peek/extract, bundle a deliverable, roll up logs, password-protected zips, selective extraction, the output pipeline.

Closes the output pipeline: gather **image-tools** PNGs / **data-analysis** CSVs / **pdf-tools** exports into one zip → artifacts → Files.

## Why it's conflict-free
Touches **only** `plugins/builtinskills/` (the seeder auto-loads it via `builtinBundles` + `go:embed`). No `cmd/...`, no `kernel/...`. No new Go dependency, no new env, no `setup.sh` (stdlib).

## Verification
- `go vet` + linux cross-build of `./plugins/builtinskills/` clean; `gofmt -l` empty; `py_compile arc.py` clean.
- `TestSeedAll_InstallsArchiveTools` asserts the bundle seeds **active** and materializes `arc.py`/`recipes.md`; bundle-count assertions now cover ten bundles.
- **Functional smoke (ran locally):** zip a folder → `list` shows `src/a.txt` → `extract` restores `unpacked/src/{a,b}.txt`; tar.gz round-trips. Caught + fixed a cross-platform `arcname` bug (trailing `/` collapsed the folder prefix when `os.sep` is `\`).

Numbered **M890** (this session's M889+ range; concurrent session holds M880–M888+M900).

🤖 Generated with [Claude Code](https://claude.com/claude-code)