### PR TITLE
Feat: built-in email-tools skill bundle (M892)

### DIFF
--- a/.project/PHASE-M892-EMAIL-TOOLS-SKILL-REPORT.md
+++ b/.project/PHASE-M892-EMAIL-TOOLS-SKILL-REPORT.md
@@ -1,0 +1,47 @@
+# PHASE M892 — Built-in email-tools skill bundle
+
+**Status:** shipped
+**Milestone:** M892 (this session's range is M889–M899; branched from
+`origin/main` to keep clear of the concurrent session's diverged local `main`).
+**Theme:** Backlog **#34** — a twelfth built-in skill bundle: send (SMTP) and
+read (IMAP) email, the delivery step of the reporting pipeline.
+
+## What shipped
+
+A built-in `email-tools` bundle, seeded active at startup by the existing
+`plugins/builtinskills` seeder (`builtinBundles` + `go:embed` only). **Zero pip
+dependencies** — stdlib `smtplib`/`imaplib`/`email`, so there's no `setup.sh`:
+
+- `SKILL.md` — send/list/read ops, common provider host table, app-password
+  guidance, the "recipient is outward-facing, double-check" note.
+- `scripts/mail.py` — one JSON-spec helper, three ops: `send` (SMTP with
+  STARTTLS/SSL, plain + optional HTML alternative, file attachments), `list`
+  (IMAP-over-SSL, newest-first summaries with uid/from/subject/date, honours an
+  IMAP `search` like `UNSEEN`), `read` (full message by uid → decoded text body).
+  Headers are RFC2047-decoded; the password is never echoed back.
+- `reference/recipes.md` — provider hosts, send-a-report-with-attachment, notify,
+  check-unread-then-read, IMAP search syntax, HTML email, the reporting pipeline.
+
+## Why this milestone is conflict-free
+
+A new bundle touches **only** `plugins/builtinskills/`. The seeder auto-loads it.
+It tests in isolation: `go test ./plugins/builtinskills/`. Branched from
+`origin/main` (which carries my M862–M891), leaving the concurrent session's
+local `main` (their M880–M901 arc, unpushed) untouched per the owner's call.
+
+## Verification
+
+- **Isolated gate:** `go vet` clean; linux cross-build of `./plugins/builtinskills/`
+  clean; `gofmt -l` empty; `python -m py_compile mail.py` passes. Package suite
+  green — `TestSeedAll_InstallsEmailTools` asserts the bundle seeds **active** and
+  materializes `mail.py` / `recipes.md`; bundle-count assertions now cover twelve
+  bundles.
+- No new Go dep; no new env. `.gitattributes` already forces LF on
+  `plugins/builtinskills/**`. Full `go build ./...` deliberately skipped (the
+  concurrent kernel arc lives on local `main`, not this branch's base).
+
+## Notes
+- Twelve seeded bundles now ship. email-tools is the reporting pipeline's delivery
+  step: generate a chart (data-analysis) / PDF (pdf-tools) / zip (archive-tools),
+  then attach and send it. SMTP-send is outward-facing — the SKILL flags the
+  recipient double-check.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,13 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
   the Runs view. Purely frontend — reuses the existing event provider and read routes. (M867)
 
 ### Added
+- **Built-in email-tools skill bundle (M892).** A twelfth out-of-the-box skill that sends (SMTP) and reads
+  (IMAP) email (#34) — **zero pip deps** (Python stdlib `smtplib`/`imaplib`/`email`). `scripts/mail.py`
+  has three ops: `send` (STARTTLS/SSL, plain + optional HTML, file attachments), `list` (newest-first IMAP
+  summaries honouring a `search` like `UNSEEN`), and `read` (full message by uid → decoded text). Headers
+  are RFC2047-decoded; the password is never echoed back. The delivery step of the reporting pipeline:
+  data-analysis / pdf-tools / archive-tools output → attach → send. Rides the `plugins/builtinskills`
+  seeder. (M892)
 - **Built-in http-api-client skill bundle (M891).** An eleventh out-of-the-box skill — the write-capable
   complement to `fetch`/web-research — that calls REST/JSON APIs (#34). `scripts/api.py` does any method
   with headers, query params, JSON or form bodies, and bearer/basic auth, returning

--- a/plugins/builtinskills/builtinskills.go
+++ b/plugins/builtinskills/builtinskills.go
@@ -24,7 +24,7 @@ import (
 	"github.com/agezt/agezt/kernel/skill"
 )
 
-//go:embed browseruse computeruse dataanalysis dockerservices gitops webresearch pdftools imagetools sqldb archivetools httpapi
+//go:embed browseruse computeruse dataanalysis dockerservices gitops webresearch pdftools imagetools sqldb archivetools httpapi emailtools
 var bundles embed.FS
 
 // Forge is the slice of *skill.Forge the seeder needs — an interface so it is
@@ -44,7 +44,7 @@ type Seeded struct {
 }
 
 // builtinBundles lists the embedded bundle directories to seed.
-var builtinBundles = []string{"browseruse", "computeruse", "dataanalysis", "dockerservices", "gitops", "webresearch", "pdftools", "imagetools", "sqldb", "archivetools", "httpapi"}
+var builtinBundles = []string{"browseruse", "computeruse", "dataanalysis", "dockerservices", "gitops", "webresearch", "pdftools", "imagetools", "sqldb", "archivetools", "httpapi", "emailtools"}
 
 // SeedAll installs every embedded bundle into the Forge and promotes each to
 // active. It is best-effort per bundle: an error on one is returned but does not

--- a/plugins/builtinskills/builtinskills_test.go
+++ b/plugins/builtinskills/builtinskills_test.go
@@ -412,6 +412,42 @@ func TestSeedAll_InstallsHTTPAPI(t *testing.T) {
 	}
 }
 
+func TestSeedAll_InstallsEmailTools(t *testing.T) {
+	f := newForge(t)
+	seeded, err := SeedAll(f, "")
+	if err != nil {
+		t.Fatalf("SeedAll: %v", err)
+	}
+	var got *Seeded
+	for i := range seeded {
+		if seeded[i].Name == "email-tools" {
+			got = &seeded[i]
+		}
+	}
+	if got == nil {
+		t.Fatalf("email-tools not seeded: %+v", seeded)
+	}
+	if got.Status != skill.StatusActive {
+		t.Errorf("email-tools status = %q, want active", got.Status)
+	}
+	drv, err := f.Bundles().Read("email-tools", "scripts/mail.py")
+	if err != nil || len(drv) == 0 {
+		t.Fatalf("email-tools mail.py unreadable/empty: %v", err)
+	}
+	files, _ := f.Bundles().List("email-tools")
+	want := map[string]bool{"scripts/mail.py": false, "reference/recipes.md": false}
+	for _, rel := range files {
+		if _, ok := want[rel]; ok {
+			want[rel] = true
+		}
+	}
+	for rel, found := range want {
+		if !found {
+			t.Errorf("email-tools bundle missing %q (got %v)", rel, files)
+		}
+	}
+}
+
 func TestSeedAll_Idempotent(t *testing.T) {
 	f := newForge(t)
 	if _, err := SeedAll(f, ""); err != nil {

--- a/plugins/builtinskills/emailtools/SKILL.md
+++ b/plugins/builtinskills/emailtools/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: email-tools
+description: Send and read email — send a message (with attachments) over SMTP, and list or read messages over IMAP — when a task needs to email a report or notification, or check an inbox, using an account's own SMTP/IMAP credentials
+triggers: [email, mail, smtp, imap, inbox, send mail, notify, report, attachment, message]
+tools: [code_exec, shell]
+---
+
+# email-tools — send and read email
+
+When a task needs to email something — deliver a report, notify on completion,
+or check an inbox for a reply — use this. It speaks SMTP (send) and IMAP (read)
+with an account's own credentials, using only the Python **standard library** —
+no install. Runs through `code_exec` (python).
+
+## No setup needed
+
+`smtplib`, `imaplib`, and `email` ship with Python. Use `skill op=files
+email-tools` to find the bundle directory.
+
+## The helper
+
+`scripts/mail.py` takes a JSON spec with an `op` and prints JSON. Ops:
+
+```sh
+# Send a message (with optional attachments):
+python scripts/mail.py '{"op":"send",
+  "smtp":{"host":"smtp.example.com","port":587,"user":"me@example.com","pass":"$APP_PW","starttls":true},
+  "from":"me@example.com","to":["you@example.com"],"subject":"Report","body":"See attached.",
+  "attachments":["report.pdf"]}'
+
+# List recent messages in a folder:
+python scripts/mail.py '{"op":"list",
+  "imap":{"host":"imap.example.com","user":"me@example.com","pass":"$APP_PW"},
+  "folder":"INBOX","search":"UNSEEN","limit":20}'
+
+# Read one message by uid:
+python scripts/mail.py '{"op":"read",
+  "imap":{"host":"imap.example.com","user":"me@example.com","pass":"$APP_PW"},
+  "folder":"INBOX","uid":"1234"}'
+```
+
+### Spec fields
+- `op` — `send` | `list` | `read`.
+- `smtp` (send) — `{host, port=587, user, pass, starttls=true, ssl=false}`.
+- `from`, `to` (string or list), `cc`, `subject`, `body` (plain), `html`
+  (optional HTML alternative), `attachments` (file paths).
+- `imap` (list/read) — `{host, port=993, user, pass}` (IMAP-over-SSL).
+- `folder` (default `INBOX`), `search` (IMAP search, default `ALL`; e.g.
+  `UNSEEN`, `FROM "x@y"`), `limit` (list, default 20), `uid` (read).
+
+### Output (JSON on stdout)
+```
+{ "ok": true, "op": "send", "to": ["you@example.com"] }
+{ "ok": true, "op": "list", "messages": [ {uid, from, subject, date} ], "count": 7 }
+{ "ok": true, "op": "read", "from": "...", "subject": "...", "date": "...", "text": "..." }
+```
+
+## Credentials & safety
+
+- Use an **app password** (Gmail/Outlook require one for SMTP/IMAP), not the main
+  account password. Pass it via the spec, ideally from an env var you set first
+  (`export APP_PW=...` then `$APP_PW` — expand it in the shell before the call).
+- The helper never echoes the password back in its output.
+- Sending email is outward-facing — double-check the recipient before a `send`.
+
+## Going further
+
+The helper is a fast start, not a cage — for OAuth2 (XOAUTH2), calendar invites,
+or rich multipart, use `smtplib`/`imaplib`/`email` directly. Pair with
+**pdf-tools**/**data-analysis** (generate a report, then attach + send it) and
+**archive-tools** (zip outputs into one attachment). See `reference/recipes.md`.

--- a/plugins/builtinskills/emailtools/reference/recipes.md
+++ b/plugins/builtinskills/emailtools/reference/recipes.md
@@ -1,0 +1,62 @@
+# email-tools recipes
+
+The helper (`scripts/mail.py`) covers send/list/read with stdlib only. For OAuth2,
+calendar invites, or rich multipart, use `smtplib`/`imaplib`/`email` directly.
+
+## Common providers (use an app password)
+
+| Provider | SMTP host / port | IMAP host / port |
+|----------|------------------|------------------|
+| Gmail    | smtp.gmail.com / 587 (STARTTLS) | imap.gmail.com / 993 |
+| Outlook  | smtp.office365.com / 587 | outlook.office365.com / 993 |
+| Yahoo    | smtp.mail.yahoo.com / 587 | imap.mail.yahoo.com / 993 |
+
+Gmail/Outlook require an **app password** (2FA accounts) — generate one in account
+settings and use it as `pass`.
+
+## Send a report with an attachment
+
+```sh
+export APP_PW=...   # set the secret in the shell first
+python scripts/mail.py '{"op":"send",
+  "smtp":{"host":"smtp.gmail.com","port":587,"user":"me@gmail.com","pass":"'"$APP_PW"'"},
+  "from":"me@gmail.com","to":["boss@corp.com"],"subject":"Weekly report",
+  "body":"Numbers attached.","attachments":["report.pdf"]}'
+```
+
+## Notify on task completion
+
+```sh
+python scripts/mail.py '{"op":"send",
+  "smtp":{"host":"smtp.gmail.com","port":587,"user":"me@gmail.com","pass":"'"$APP_PW"'"},
+  "from":"me@gmail.com","to":["me@gmail.com"],"subject":"Job done","body":"The pipeline finished."}'
+```
+
+## Check for unread mail, then read one
+
+```sh
+python scripts/mail.py '{"op":"list",
+  "imap":{"host":"imap.gmail.com","user":"me@gmail.com","pass":"'"$APP_PW"'"},
+  "search":"UNSEEN","limit":10}'
+# then, with a uid from the list:
+python scripts/mail.py '{"op":"read",
+  "imap":{"host":"imap.gmail.com","user":"me@gmail.com","pass":"'"$APP_PW"'"},"uid":"1234"}'
+```
+
+## IMAP search examples
+
+`ALL`, `UNSEEN`, `FROM "alerts@x.com"`, `SUBJECT "invoice"`,
+`SINCE 01-Jun-2026`. Combine: `(UNSEEN FROM "boss@corp.com")`.
+
+## HTML email
+
+```sh
+python scripts/mail.py '{"op":"send", "smtp":{...}, "from":"...","to":["..."],
+  "subject":"Styled","body":"plain fallback","html":"<h1>Hi</h1><p>Rich body.</p>"}'
+```
+
+## The reporting pipeline
+
+email-tools is the delivery step: generate a chart with **data-analysis**, a PDF
+with **pdf-tools**, or zip a folder with **archive-tools**, then attach and send
+it here. Reference secrets via env vars; the helper never echoes the password.

--- a/plugins/builtinskills/emailtools/scripts/mail.py
+++ b/plugins/builtinskills/emailtools/scripts/mail.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""email-tools helper — send (SMTP) and read (IMAP) email. Standard library only.
+
+Usage:  python mail.py '<json-spec>'   (or pipe the JSON on stdin)
+Ops:
+  send {smtp:{host,port,user,pass,starttls,ssl}, from, to, cc?, subject, body,
+        html?, attachments?[paths]}                -> {to}
+  list {imap:{host,port,user,pass}, folder, search, limit}
+                                                    -> {messages:[{uid,from,subject,date}], count}
+  read {imap:{...}, folder, uid}                    -> {from,subject,date,text}
+
+Use an app password (not the main account password). The password is never echoed
+back. A fast start, not a cage: for OAuth2/calendar invites, use smtplib/imaplib.
+"""
+import json
+import sys
+
+
+def read_spec():
+    if len(sys.argv) > 1 and sys.argv[1].strip():
+        return json.loads(sys.argv[1])
+    data = sys.stdin.read()
+    if data.strip():
+        return json.loads(data)
+    raise ValueError("no spec: pass a JSON spec as argv[1] or on stdin")
+
+
+def _as_list(v):
+    if v is None:
+        return []
+    return v if isinstance(v, list) else [v]
+
+
+def op_send(spec):
+    import os
+    import smtplib
+    from email.message import EmailMessage
+
+    smtp = spec.get("smtp") or {}
+    host = smtp.get("host")
+    if not host:
+        raise ValueError("send needs smtp.host")
+    to = _as_list(spec.get("to"))
+    if not to:
+        raise ValueError("send needs to")
+    cc = _as_list(spec.get("cc"))
+
+    msg = EmailMessage()
+    msg["From"] = spec.get("from") or smtp.get("user", "")
+    msg["To"] = ", ".join(to)
+    if cc:
+        msg["Cc"] = ", ".join(cc)
+    msg["Subject"] = spec.get("subject", "")
+    msg.set_content(spec.get("body", ""))
+    if spec.get("html"):
+        msg.add_alternative(spec["html"], subtype="html")
+
+    for path in _as_list(spec.get("attachments")):
+        with open(path, "rb") as fh:
+            data = fh.read()
+        msg.add_attachment(
+            data, maintype="application", subtype="octet-stream", filename=os.path.basename(path)
+        )
+
+    port = int(smtp.get("port", 587))
+    user, pw = smtp.get("user"), smtp.get("pass")
+    if smtp.get("ssl"):
+        with smtplib.SMTP_SSL(host, port) as s:
+            if user:
+                s.login(user, pw)
+            s.send_message(msg, to_addrs=to + cc)
+    else:
+        with smtplib.SMTP(host, port) as s:
+            if smtp.get("starttls", True):
+                s.starttls()
+            if user:
+                s.login(user, pw)
+            s.send_message(msg, to_addrs=to + cc)
+    return {"to": to, "cc": cc}
+
+
+def _imap_login(spec):
+    import imaplib
+
+    im = spec.get("imap") or {}
+    host = im.get("host")
+    if not host:
+        raise ValueError("needs imap.host")
+    m = imaplib.IMAP4_SSL(host, int(im.get("port", 993)))
+    m.login(im.get("user"), im.get("pass"))
+    return m
+
+
+def _decode(s):
+    from email.header import decode_header
+
+    if not s:
+        return ""
+    parts = []
+    for text, enc in decode_header(s):
+        if isinstance(text, bytes):
+            parts.append(text.decode(enc or "utf-8", errors="replace"))
+        else:
+            parts.append(text)
+    return "".join(parts)
+
+
+def op_list(spec):
+    m = _imap_login(spec)
+    try:
+        m.select(spec.get("folder", "INBOX"), readonly=True)
+        typ, data = m.uid("search", None, spec.get("search", "ALL"))
+        uids = data[0].split() if data and data[0] else []
+        limit = int(spec.get("limit", 20))
+        uids = uids[-limit:][::-1]  # newest first
+        out = []
+        for uid in uids:
+            typ, md = m.uid("fetch", uid, "(BODY.PEEK[HEADER.FIELDS (FROM SUBJECT DATE)])")
+            raw = md[0][1] if md and md[0] else b""
+            import email
+
+            hdr = email.message_from_bytes(raw)
+            out.append(
+                {
+                    "uid": uid.decode(),
+                    "from": _decode(hdr.get("From")),
+                    "subject": _decode(hdr.get("Subject")),
+                    "date": hdr.get("Date", ""),
+                }
+            )
+        return {"messages": out, "count": len(out)}
+    finally:
+        try:
+            m.logout()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def op_read(spec):
+    import email
+
+    uid = spec.get("uid")
+    if not uid:
+        raise ValueError("read needs uid")
+    m = _imap_login(spec)
+    try:
+        m.select(spec.get("folder", "INBOX"), readonly=True)
+        typ, md = m.uid("fetch", str(uid), "(RFC822)")
+        raw = md[0][1] if md and md[0] else b""
+        msg = email.message_from_bytes(raw)
+        text = ""
+        if msg.is_multipart():
+            for part in msg.walk():
+                if part.get_content_type() == "text/plain" and "attachment" not in str(
+                    part.get("Content-Disposition", "")
+                ):
+                    text = part.get_payload(decode=True).decode(
+                        part.get_content_charset() or "utf-8", errors="replace"
+                    )
+                    break
+        else:
+            text = msg.get_payload(decode=True).decode(
+                msg.get_content_charset() or "utf-8", errors="replace"
+            )
+        mc = int(spec.get("max_chars", 8000))
+        return {
+            "from": _decode(msg.get("From")),
+            "subject": _decode(msg.get("Subject")),
+            "date": msg.get("Date", ""),
+            "text": text[:mc] + (" …" if len(text) > mc else ""),
+        }
+    finally:
+        try:
+            m.logout()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+OPS = {"send": op_send, "list": op_list, "read": op_read}
+
+
+def run(spec):
+    op = spec.get("op")
+    if op not in OPS:
+        raise ValueError("spec.op must be one of: " + ", ".join(OPS))
+    result = OPS[op](spec)
+    result.update({"ok": True, "op": op})
+    return result
+
+
+def main():
+    try:
+        print(json.dumps(run(read_spec()), default=str))
+    except Exception as e:  # noqa: BLE001
+        print(json.dumps({"ok": False, "error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
A twelfth out-of-the-box skill bundle that **sends (SMTP) and reads (IMAP) email** (#34) — **zero pip dependencies** (Python stdlib `smtplib`/`imaplib`/`email`).

- **`scripts/mail.py`** — three ops: `send` (STARTTLS/SSL, plain + optional HTML alternative, file attachments), `list` (newest-first IMAP-over-SSL summaries with uid/from/subject/date, honours an IMAP `search` like `UNSEEN`), `read` (full message by uid → decoded text body). Headers are RFC2047-decoded; the password is **never echoed back**.
- **`reference/recipes.md`** — provider host table (Gmail/Outlook/Yahoo), send-with-attachment, notify, check-unread-then-read, IMAP search syntax, HTML email, the reporting pipeline.

The delivery step of the reporting pipeline: generate a chart (data-analysis) / PDF (pdf-tools) / zip (archive-tools) → attach → send.

## Why it's conflict-free
Touches **only** `plugins/builtinskills/`. No `cmd/...`, no `kernel/...`. No new Go dependency, no new env, no `setup.sh` (stdlib). Branched from `origin/main`, leaving the concurrent session's diverged local `main` untouched.

## Verification
- `go vet` + linux cross-build of `./plugins/builtinskills/` clean; `gofmt -l` empty; `py_compile mail.py` clean.
- `TestSeedAll_InstallsEmailTools` asserts the bundle seeds **active** and materializes `mail.py`/`recipes.md`; bundle-count assertions now cover twelve bundles. Package suite green in isolation.

Numbered **M892** (session range M889–M899; concurrent session holds M880–M888 + M900–M909).

🤖 Generated with [Claude Code](https://claude.com/claude-code)