### PR TITLE
Feat: built-in ssh-remote skill bundle (M893)

### DIFF
--- a/.project/PHASE-M893-SSH-REMOTE-SKILL-REPORT.md
+++ b/.project/PHASE-M893-SSH-REMOTE-SKILL-REPORT.md
@@ -1,0 +1,48 @@
+# PHASE M893 — Built-in ssh-remote skill bundle
+
+**Status:** shipped
+**Milestone:** M893 (this session's range M889–M899; branched from `origin/main`,
+concurrent session's local-main arc untouched).
+**Theme:** Backlog **#34** — a thirteenth built-in skill bundle: operate remote
+hosts over SSH (run commands, move files), extending the machine-control reach
+beyond the local box.
+
+## What shipped
+
+A built-in `ssh-remote` bundle, seeded active at startup by the existing
+`plugins/builtinskills` seeder (`builtinBundles` + `go:embed` only):
+
+- `SKILL.md` — the ops, key-vs-password auth, the host-key auto-accept caveat,
+  and the "remote run can change a live server — double-check" safety note.
+- `scripts/setup.sh` — `pip install paramiko`.
+- `scripts/ssh.py` — one JSON-spec helper over paramiko, four ops: `run`
+  (exec a command → exit_code/stdout/stderr), `put`/`get` (SFTP upload/download),
+  `ls` (remote dir listing with trailing `/` for dirs). Key (`key_path`,
+  optional `key_pass`) or `password` auth; the password is never echoed back;
+  `ok` reflects the transport while a non-zero command still returns its code.
+- `reference/recipes.md` — run+read output, deploy (put → extract remotely),
+  pull a log, manage remote Docker (with the docker-services `agezt.service=1`
+  label), password auth, multi-command via paramiko, safety.
+
+## Why this milestone is conflict-free
+
+A new bundle touches **only** `plugins/builtinskills/`. The seeder auto-loads it.
+It tests in isolation: `go test ./plugins/builtinskills/`. Branched from
+`origin/main` (my M862–M892), leaving the concurrent session's diverged local
+`main` (their M880–M901 arc, preserved on the feat/m891 branch) untouched.
+
+## Verification
+
+- **Isolated gate:** `go vet` clean; linux cross-build of `./plugins/builtinskills/`
+  clean; `gofmt -l` empty; `python -m py_compile ssh.py` passes; `sh -n setup.sh`
+  clean. Package suite green — `TestSeedAll_InstallsSSHRemote` asserts the bundle
+  seeds **active** and materializes `ssh.py` / `setup.sh` / `recipes.md`;
+  bundle-count assertions now cover thirteen bundles.
+- No new Go dep; no new env. `.gitattributes` already forces LF on
+  `plugins/builtinskills/**`. Full `go build ./...` deliberately skipped.
+
+## Notes
+- Thirteen seeded bundles now ship. ssh-remote extends docker-services to remote
+  hosts (run a `docker …` over SSH) and pairs with archive-tools (zip → put →
+  extract) for deploys. Remote `run` is outward-facing — the SKILL flags the
+  host/command double-check.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
   the Runs view. Purely frontend — reuses the existing event provider and read routes. (M867)
 
 ### Added
+- **Built-in ssh-remote skill bundle (M893).** A thirteenth out-of-the-box skill that operates remote
+  hosts over SSH (#34). `scripts/ssh.py` (paramiko) has four ops: `run` (exec → exit_code/stdout/stderr),
+  `put`/`get` (SFTP upload/download), `ls` (remote dir); key or password auth, password never echoed back,
+  a non-zero command still returns its code. `setup.sh` installs paramiko. Extends docker-services to
+  remote hosts and pairs with archive-tools for deploys (zip → put → extract). Rides the
+  `plugins/builtinskills` seeder. (M893)
 - **Built-in email-tools skill bundle (M892).** A twelfth out-of-the-box skill that sends (SMTP) and reads
   (IMAP) email (#34) — **zero pip deps** (Python stdlib `smtplib`/`imaplib`/`email`). `scripts/mail.py`
   has three ops: `send` (STARTTLS/SSL, plain + optional HTML, file attachments), `list` (newest-first IMAP

--- a/plugins/builtinskills/builtinskills.go
+++ b/plugins/builtinskills/builtinskills.go
@@ -24,7 +24,7 @@ import (
 	"github.com/agezt/agezt/kernel/skill"
 )
 
-//go:embed browseruse computeruse dataanalysis dockerservices gitops webresearch pdftools imagetools sqldb archivetools httpapi emailtools
+//go:embed browseruse computeruse dataanalysis dockerservices gitops webresearch pdftools imagetools sqldb archivetools httpapi emailtools sshremote
 var bundles embed.FS
 
 // Forge is the slice of *skill.Forge the seeder needs — an interface so it is
@@ -44,7 +44,7 @@ type Seeded struct {
 }
 
 // builtinBundles lists the embedded bundle directories to seed.
-var builtinBundles = []string{"browseruse", "computeruse", "dataanalysis", "dockerservices", "gitops", "webresearch", "pdftools", "imagetools", "sqldb", "archivetools", "httpapi", "emailtools"}
+var builtinBundles = []string{"browseruse", "computeruse", "dataanalysis", "dockerservices", "gitops", "webresearch", "pdftools", "imagetools", "sqldb", "archivetools", "httpapi", "emailtools", "sshremote"}
 
 // SeedAll installs every embedded bundle into the Forge and promotes each to
 // active. It is best-effort per bundle: an error on one is returned but does not

--- a/plugins/builtinskills/builtinskills_test.go
+++ b/plugins/builtinskills/builtinskills_test.go
@@ -448,6 +448,42 @@ func TestSeedAll_InstallsEmailTools(t *testing.T) {
 	}
 }
 
+func TestSeedAll_InstallsSSHRemote(t *testing.T) {
+	f := newForge(t)
+	seeded, err := SeedAll(f, "")
+	if err != nil {
+		t.Fatalf("SeedAll: %v", err)
+	}
+	var got *Seeded
+	for i := range seeded {
+		if seeded[i].Name == "ssh-remote" {
+			got = &seeded[i]
+		}
+	}
+	if got == nil {
+		t.Fatalf("ssh-remote not seeded: %+v", seeded)
+	}
+	if got.Status != skill.StatusActive {
+		t.Errorf("ssh-remote status = %q, want active", got.Status)
+	}
+	drv, err := f.Bundles().Read("ssh-remote", "scripts/ssh.py")
+	if err != nil || len(drv) == 0 {
+		t.Fatalf("ssh-remote ssh.py unreadable/empty: %v", err)
+	}
+	files, _ := f.Bundles().List("ssh-remote")
+	want := map[string]bool{"scripts/ssh.py": false, "scripts/setup.sh": false, "reference/recipes.md": false}
+	for _, rel := range files {
+		if _, ok := want[rel]; ok {
+			want[rel] = true
+		}
+	}
+	for rel, found := range want {
+		if !found {
+			t.Errorf("ssh-remote bundle missing %q (got %v)", rel, files)
+		}
+	}
+}
+
 func TestSeedAll_Idempotent(t *testing.T) {
 	f := newForge(t)
 	if _, err := SeedAll(f, ""); err != nil {

--- a/plugins/builtinskills/sshremote/SKILL.md
+++ b/plugins/builtinskills/sshremote/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: ssh-remote
+description: Run commands and move files on remote hosts over SSH — execute a command and capture its output, upload/download files via SFTP, list a remote directory — with key or password auth, when a task needs to operate a server you reach over SSH rather than the local machine
+triggers: [ssh, remote, server, scp, sftp, deploy, host, vps, paramiko, remote command]
+tools: [code_exec, shell]
+---
+
+# ssh-remote — operate remote hosts over SSH
+
+When a task needs to act on a *remote* machine — run a command on a VPS, deploy
+to a server, pull a log file, restart a service — use this. It speaks SSH (run
+commands) and SFTP (move files), with key or password auth. Runs through
+`code_exec` (python).
+
+## One-time setup
+
+Run `scripts/setup.sh` once (via code_exec or shell): installs `paramiko`. Use
+`skill op=files ssh-remote` to find the bundle directory.
+
+## The helper
+
+`scripts/ssh.py` takes a JSON spec with `host`/`user` auth and an `op`, and prints
+JSON. Ops:
+
+```sh
+# Run a command, capture output + exit code:
+python scripts/ssh.py '{"op":"run","host":"1.2.3.4","user":"deploy",
+  "key_path":"~/.ssh/id_ed25519","cmd":"docker ps --format \"{{.Names}}\""}'
+
+# Upload a file (SFTP):
+python scripts/ssh.py '{"op":"put","host":"1.2.3.4","user":"deploy",
+  "key_path":"~/.ssh/id_ed25519","local":"app.tar.gz","remote":"/srv/app.tar.gz"}'
+
+# Download a file:
+python scripts/ssh.py '{"op":"get","host":"1.2.3.4","user":"deploy",
+  "password":"$SSH_PW","remote":"/var/log/app.log","local":"app.log"}'
+
+# List a remote directory:
+python scripts/ssh.py '{"op":"ls","host":"1.2.3.4","user":"deploy","key_path":"~/.ssh/id_rsa","remote":"/srv"}'
+```
+
+### Spec fields
+- `op` — `run` | `put` | `get` | `ls`.
+- `host` (required), `port` (default 22), `user` (required).
+- Auth: `key_path` (private key file) **or** `password`. A `key_pass` decrypts an
+  encrypted key.
+- `cmd` (run), `local` + `remote` (put/get), `remote` dir (ls), `timeout`
+  (seconds, default 30).
+
+### Output (JSON on stdout)
+```
+{ "ok": true, "op": "run", "exit_code": 0, "stdout": "...", "stderr": "" }
+{ "ok": true, "op": "put", "local": "...", "remote": "..." }
+{ "ok": true, "op": "ls", "entries": ["a","b/"] }
+```
+`ok` reflects the SSH transport; a command that exits non-zero still returns its
+`exit_code`/`stderr` so you can read the failure.
+
+## Security
+
+- Prefer **key auth** over passwords. Pass a `password` via an env var you set
+  first (`export SSH_PW=...` → `$SSH_PW`); the helper never echoes it back.
+- The helper auto-accepts unknown host keys (AutoAddPolicy) for convenience — fine
+  for hosts you own; for untrusted hosts, pin the host key in your own paramiko
+  code instead.
+- Running remote commands is outward-facing and can change a live server —
+  double-check the host and command before a destructive `run`.
+
+## Going further
+
+The helper is a fast start, not a cage — for an interactive shell, port
+forwarding, recursive SFTP, or jump hosts, use `paramiko` directly. Pairs with
+**docker-services** (manage containers on a remote host: `run` a `docker …`
+command) and **archive-tools** (zip locally, `put`, extract remotely). See
+`reference/recipes.md`.

--- a/plugins/builtinskills/sshremote/reference/recipes.md
+++ b/plugins/builtinskills/sshremote/reference/recipes.md
@@ -1,0 +1,65 @@
+# ssh-remote recipes
+
+The helper (`scripts/ssh.py`) covers run/put/get/ls with key or password auth.
+For interactive shells, port forwarding, recursive SFTP, or jump hosts, use
+`paramiko` directly. Patterns:
+
+## Run a command, read its output
+
+```sh
+python scripts/ssh.py '{"op":"run","host":"vps.example.com","user":"deploy",
+  "key_path":"~/.ssh/id_ed25519","cmd":"df -h /"}'
+```
+A non-zero `exit_code` still returns with `stderr` — read the failure rather than
+assuming success.
+
+## Deploy: upload, then extract remotely
+
+```sh
+# zip locally with archive-tools, then:
+python scripts/ssh.py '{"op":"put","host":"H","user":"deploy","key_path":"~/.ssh/id_ed25519",
+  "local":"build.tar.gz","remote":"/srv/build.tar.gz"}'
+python scripts/ssh.py '{"op":"run","host":"H","user":"deploy","key_path":"~/.ssh/id_ed25519",
+  "cmd":"cd /srv && tar xzf build.tar.gz && systemctl restart app"}'
+```
+
+## Pull a log file
+
+```sh
+python scripts/ssh.py '{"op":"get","host":"H","user":"deploy","key_path":"~/.ssh/id_ed25519",
+  "remote":"/var/log/app.log","local":"app.log"}'
+```
+Then analyze it with **data-analysis** or grep it locally.
+
+## Manage remote Docker (with docker-services patterns)
+
+```sh
+python scripts/ssh.py '{"op":"run","host":"H","user":"deploy","key_path":"~/.ssh/id_ed25519",
+  "cmd":"docker ps -a --filter label=agezt.service=1 --format \"{{.Names}}: {{.Status}}\""}'
+```
+
+## Password auth (prefer keys)
+
+```sh
+export SSH_PW=...   # set the secret in the shell first
+python scripts/ssh.py '{"op":"run","host":"H","user":"root","password":"'"$SSH_PW"'","cmd":"uptime"}'
+```
+The helper never echoes the password back.
+
+## Many commands in one connection (write it directly)
+
+The helper opens one connection per call. To run a sequence efficiently, use
+paramiko directly:
+```python
+import paramiko
+c = paramiko.SSHClient(); c.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+c.connect("H", username="deploy", key_filename="/home/me/.ssh/id_ed25519")
+for cmd in ["whoami", "hostname", "uptime"]:
+    _, out, _ = c.exec_command(cmd); print(out.read().decode().strip())
+c.close()
+```
+
+## Safety
+`run` can change a live server. Double-check the host and command before anything
+destructive. Prefer key auth; pin host keys in your own code for untrusted hosts
+(the helper auto-accepts unknown keys for convenience on hosts you own).

--- a/plugins/builtinskills/sshremote/scripts/setup.sh
+++ b/plugins/builtinskills/sshremote/scripts/setup.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# ssh-remote setup: install paramiko. Idempotent. Run via code_exec or shell.
+set -e
+
+echo "installing paramiko ..."
+python -m pip install --quiet paramiko 2>/dev/null \
+  || pip install --quiet paramiko 2>/dev/null \
+  || pip3 install paramiko
+
+echo "ssh-remote ready: run scripts/ssh.py '<json-spec>'"

--- a/plugins/builtinskills/sshremote/scripts/ssh.py
+++ b/plugins/builtinskills/sshremote/scripts/ssh.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""ssh-remote helper — run commands and move files on a remote host over SSH.
+
+Usage:  python ssh.py '<json-spec>'   (or pipe the JSON on stdin)
+Spec:   { "op":"run|put|get|ls", "host":"...", "port":22, "user":"...",
+          "key_path":"~/.ssh/id_ed25519" | "password":"...", "key_pass":"...",
+          "cmd":"...", "local":"...", "remote":"...", "timeout":30 }
+Output: one JSON object on stdout.
+
+Prefer key auth; a password passed in is never echoed back. A fast start, not a
+cage: for interactive shells, port forwarding, or jump hosts, use paramiko.
+"""
+import json
+import os
+import sys
+
+
+def read_spec():
+    if len(sys.argv) > 1 and sys.argv[1].strip():
+        return json.loads(sys.argv[1])
+    data = sys.stdin.read()
+    if data.strip():
+        return json.loads(data)
+    raise ValueError("no spec: pass a JSON spec as argv[1] or on stdin")
+
+
+def connect(spec):
+    import paramiko
+
+    host = spec.get("host")
+    user = spec.get("user")
+    if not host or not user:
+        raise ValueError("needs host and user")
+    client = paramiko.SSHClient()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    kwargs = {
+        "hostname": host,
+        "port": int(spec.get("port", 22)),
+        "username": user,
+        "timeout": float(spec.get("timeout", 30)),
+    }
+    key_path = spec.get("key_path")
+    if key_path:
+        kwargs["key_filename"] = os.path.expanduser(key_path)
+        if spec.get("key_pass"):
+            kwargs["passphrase"] = spec["key_pass"]
+    elif spec.get("password"):
+        kwargs["password"] = spec["password"]
+    client.connect(**kwargs)
+    return client
+
+
+def op_run(client, spec):
+    cmd = spec.get("cmd")
+    if not cmd:
+        raise ValueError("run needs cmd")
+    stdin, stdout, stderr = client.exec_command(cmd, timeout=float(spec.get("timeout", 30)))
+    out = stdout.read().decode("utf-8", errors="replace")
+    err = stderr.read().decode("utf-8", errors="replace")
+    code = stdout.channel.recv_exit_status()
+    mc = int(spec.get("max_chars", 8000))
+    return {
+        "exit_code": code,
+        "stdout": out[:mc] + (" …" if len(out) > mc else ""),
+        "stderr": err[:mc] + (" …" if len(err) > mc else ""),
+    }
+
+
+def op_put(client, spec):
+    local, remote = spec.get("local"), spec.get("remote")
+    if not local or not remote:
+        raise ValueError("put needs local and remote")
+    sftp = client.open_sftp()
+    try:
+        sftp.put(os.path.expanduser(local), remote)
+    finally:
+        sftp.close()
+    return {"local": local, "remote": remote}
+
+
+def op_get(client, spec):
+    local, remote = spec.get("local"), spec.get("remote")
+    if not local or not remote:
+        raise ValueError("get needs local and remote")
+    sftp = client.open_sftp()
+    try:
+        sftp.get(remote, os.path.expanduser(local))
+    finally:
+        sftp.close()
+    return {"remote": remote, "local": local}
+
+
+def op_ls(client, spec):
+    remote = spec.get("remote", ".")
+    sftp = client.open_sftp()
+    try:
+        import stat as statmod
+
+        entries = []
+        for attr in sftp.listdir_attr(remote):
+            name = attr.filename
+            if statmod.S_ISDIR(attr.st_mode):
+                name += "/"
+            entries.append(name)
+        entries.sort()
+    finally:
+        sftp.close()
+    return {"remote": remote, "entries": entries}
+
+
+OPS = {"run": op_run, "put": op_put, "get": op_get, "ls": op_ls}
+
+
+def run(spec):
+    op = spec.get("op")
+    if op not in OPS:
+        raise ValueError("spec.op must be one of: " + ", ".join(OPS))
+    client = connect(spec)
+    try:
+        result = OPS[op](client, spec)
+    finally:
+        client.close()
+    result.update({"ok": True, "op": op})
+    return result
+
+
+def main():
+    try:
+        print(json.dumps(run(read_spec()), default=str))
+    except Exception as e:  # noqa: BLE001
+        print(json.dumps({"ok": False, "error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
A thirteenth out-of-the-box skill bundle that **operates remote hosts over SSH** (#34).

- **`scripts/ssh.py`** (paramiko) — four ops: `run` (exec a command → `exit_code`/`stdout`/`stderr`), `put`/`get` (SFTP upload/download), `ls` (remote dir listing). Key (`key_path` + optional `key_pass`) or `password` auth; the password is **never echoed back**; `ok` reflects the transport while a non-zero command still returns its code.
- **`scripts/setup.sh`** — `pip install paramiko`.
- **`reference/recipes.md`** — run+read, deploy (put → extract remotely), pull a log, manage remote Docker (with the `agezt.service=1` label), password auth, multi-command via paramiko, safety.

Extends **docker-services** to remote hosts (run `docker …` over SSH) and pairs with **archive-tools** for deploys (zip → put → extract).

## Why it's conflict-free
Touches **only** `plugins/builtinskills/`. No `cmd/...`, no `kernel/...`. No new Go dependency, no new env. Branched from `origin/main`, leaving the concurrent session's diverged local `main` untouched.

## Verification
- `go vet` + linux cross-build of `./plugins/builtinskills/` clean; `gofmt -l` empty; `py_compile ssh.py` + `sh -n setup.sh` clean.
- `TestSeedAll_InstallsSSHRemote` asserts the bundle seeds **active** and materializes `ssh.py`/`setup.sh`/`recipes.md`; bundle-count assertions now cover thirteen bundles. Package suite green in isolation.

Numbered **M893** (session range M889–M899).

🤖 Generated with [Claude Code](https://claude.com/claude-code)