### PR TITLE
Feat: built-in crypto-tools skill bundle (M894)

### DIFF
--- a/.project/PHASE-M894-CRYPTO-TOOLS-SKILL-REPORT.md
+++ b/.project/PHASE-M894-CRYPTO-TOOLS-SKILL-REPORT.md
@@ -1,0 +1,50 @@
+# PHASE M894 — Built-in crypto-tools skill bundle
+
+**Status:** shipped
+**Milestone:** M894 (session range M889–M899; branched from `origin/main`,
+concurrent local-main arc untouched).
+**Theme:** Backlog **#34** — a fourteenth built-in skill bundle: cryptographic
+primitives (hash/verify, HMAC, base64, secure tokens), stdlib-only.
+
+## What shipped
+
+A built-in `crypto-tools` bundle, seeded active at startup by the existing
+`plugins/builtinskills` seeder (`builtinBundles` + `go:embed` only). **Zero pip
+deps** — stdlib `hashlib`/`hmac`/`base64`/`secrets`, so there's no `setup.sh`:
+
+- `SKILL.md` — the ops, the constant-time-compare note, key-via-env guidance, the
+  md5/sha1-for-checksums-not-security caveat, and the explicit scope line (this is
+  hashing/encoding/signing, not file encryption).
+- `scripts/crypto.py` — one JSON-spec helper, six ops: `hash` (file or text, any
+  `hashlib` algo), `verify` (constant-time digest check), `hmac` / `hmac_verify`
+  (sign / constant-time-verify, for webhook signatures), `base64`
+  (encode/decode, std or urlsafe), `token` (CSPRNG hex/urlsafe secrets). Keys are
+  never echoed back.
+- `reference/recipes.md` — verify a download, verify/sign a webhook HMAC, base64
+  for an API, mint a token, the (out-of-scope) Fernet encryption pointer, and an
+  algorithm-choice guide.
+
+## Why this milestone is conflict-free
+
+A new bundle touches **only** `plugins/builtinskills/`. The seeder auto-loads it.
+It tests in isolation: `go test ./plugins/builtinskills/`. Branched from
+`origin/main` (my M862–M893), leaving the concurrent session's local-main arc
+untouched.
+
+## Verification
+
+- **Isolated gate:** `go vet` clean; linux cross-build of `./plugins/builtinskills/`
+  clean; `gofmt -l` empty. Package suite green — `TestSeedAll_InstallsCryptoTools`
+  asserts the bundle seeds **active** and materializes `crypto.py` / `recipes.md`;
+  bundle-count assertions now cover fourteen bundles.
+- **Functional smoke (stdlib, ran locally):** `sha256("hello")` →
+  `2cf24dba…938b9824` (matches the known digest); `base64("user:pass")` →
+  `dXNlcjpwYXNz`; an HMAC sign→verify round-trip returns `match:true`.
+- No new Go dep; no new env. `.gitattributes` already forces LF on
+  `plugins/builtinskills/**`. Full `go build ./...` deliberately skipped.
+
+## Notes
+- Fourteen seeded bundles now ship. crypto-tools pairs with http-api-client
+  (sign/verify webhooks), archive-tools (checksum a bundle), and ssh-remote
+  (verify a transferred file). Verify ops use `hmac.compare_digest` so signature
+  checks aren't timing-leaky.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,13 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
   the Runs view. Purely frontend — reuses the existing event provider and read routes. (M867)
 
 ### Added
+- **Built-in crypto-tools skill bundle (M894).** A fourteenth out-of-the-box skill — cryptographic
+  primitives (#34), **zero pip deps** (Python stdlib `hashlib`/`hmac`/`base64`/`secrets`).
+  `scripts/crypto.py` has six ops: `hash` (file/text, any algo), `verify` (constant-time), `hmac` /
+  `hmac_verify` (webhook signatures, constant-time), `base64` (encode/decode, std or urlsafe), `token`
+  (CSPRNG secrets). Keys never echoed back; verify uses `hmac.compare_digest`. Pairs with http-api-client
+  (sign/verify webhooks), archive-tools (checksum a bundle), ssh-remote (verify a transferred file). Rides
+  the `plugins/builtinskills` seeder. (M894)
 - **Built-in ssh-remote skill bundle (M893).** A thirteenth out-of-the-box skill that operates remote
   hosts over SSH (#34). `scripts/ssh.py` (paramiko) has four ops: `run` (exec → exit_code/stdout/stderr),
   `put`/`get` (SFTP upload/download), `ls` (remote dir); key or password auth, password never echoed back,

--- a/plugins/builtinskills/builtinskills.go
+++ b/plugins/builtinskills/builtinskills.go
@@ -24,7 +24,7 @@ import (
 	"github.com/agezt/agezt/kernel/skill"
 )
 
-//go:embed browseruse computeruse dataanalysis dockerservices gitops webresearch pdftools imagetools sqldb archivetools httpapi emailtools sshremote
+//go:embed browseruse computeruse dataanalysis dockerservices gitops webresearch pdftools imagetools sqldb archivetools httpapi emailtools sshremote cryptotools
 var bundles embed.FS
 
 // Forge is the slice of *skill.Forge the seeder needs — an interface so it is
@@ -44,7 +44,7 @@ type Seeded struct {
 }
 
 // builtinBundles lists the embedded bundle directories to seed.
-var builtinBundles = []string{"browseruse", "computeruse", "dataanalysis", "dockerservices", "gitops", "webresearch", "pdftools", "imagetools", "sqldb", "archivetools", "httpapi", "emailtools", "sshremote"}
+var builtinBundles = []string{"browseruse", "computeruse", "dataanalysis", "dockerservices", "gitops", "webresearch", "pdftools", "imagetools", "sqldb", "archivetools", "httpapi", "emailtools", "sshremote", "cryptotools"}
 
 // SeedAll installs every embedded bundle into the Forge and promotes each to
 // active. It is best-effort per bundle: an error on one is returned but does not

--- a/plugins/builtinskills/builtinskills_test.go
+++ b/plugins/builtinskills/builtinskills_test.go
@@ -484,6 +484,42 @@ func TestSeedAll_InstallsSSHRemote(t *testing.T) {
 	}
 }
 
+func TestSeedAll_InstallsCryptoTools(t *testing.T) {
+	f := newForge(t)
+	seeded, err := SeedAll(f, "")
+	if err != nil {
+		t.Fatalf("SeedAll: %v", err)
+	}
+	var got *Seeded
+	for i := range seeded {
+		if seeded[i].Name == "crypto-tools" {
+			got = &seeded[i]
+		}
+	}
+	if got == nil {
+		t.Fatalf("crypto-tools not seeded: %+v", seeded)
+	}
+	if got.Status != skill.StatusActive {
+		t.Errorf("crypto-tools status = %q, want active", got.Status)
+	}
+	drv, err := f.Bundles().Read("crypto-tools", "scripts/crypto.py")
+	if err != nil || len(drv) == 0 {
+		t.Fatalf("crypto-tools crypto.py unreadable/empty: %v", err)
+	}
+	files, _ := f.Bundles().List("crypto-tools")
+	want := map[string]bool{"scripts/crypto.py": false, "reference/recipes.md": false}
+	for _, rel := range files {
+		if _, ok := want[rel]; ok {
+			want[rel] = true
+		}
+	}
+	for rel, found := range want {
+		if !found {
+			t.Errorf("crypto-tools bundle missing %q (got %v)", rel, files)
+		}
+	}
+}
+
 func TestSeedAll_Idempotent(t *testing.T) {
 	f := newForge(t)
 	if _, err := SeedAll(f, ""); err != nil {

--- a/plugins/builtinskills/cryptotools/SKILL.md
+++ b/plugins/builtinskills/cryptotools/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: crypto-tools
+description: Hash and verify data, compute and check HMAC signatures, encode/decode base64, and generate secure random tokens — when a task needs a checksum, a webhook signature, base64 for an API, or a random secret, using fast standard-library primitives
+triggers: [hash, checksum, sha256, md5, hmac, signature, base64, encode, token, secret, verify, digest]
+tools: [code_exec, shell]
+---
+
+# crypto-tools — hashes, signatures, encoding, tokens
+
+When a task needs cryptographic *primitives* — verify a download's checksum, sign
+or check a webhook's HMAC, base64-encode a payload for an API, or mint a secure
+random token — use this. It's fast, exact, and uses only the Python **standard
+library** (`hashlib`/`hmac`/`base64`/`secrets`) — no install.
+
+> Scope: this is hashing/encoding/signing, **not** file encryption. For symmetric
+> encryption (protect a file with a password), write `cryptography.fernet`
+> directly in `code_exec`.
+
+## No setup needed
+
+`hashlib`, `hmac`, `base64`, `secrets` ship with Python. Use `skill op=files
+crypto-tools` to find the bundle directory.
+
+## The helper
+
+`scripts/crypto.py` takes a JSON spec with an `op` and prints JSON. Ops:
+
+```sh
+# Hash a file (verify a download) or a string:
+python scripts/crypto.py '{"op":"hash","path":"app.tar.gz","algo":"sha256"}'
+python scripts/crypto.py '{"op":"hash","text":"hello","algo":"sha256"}'
+
+# Verify a file against an expected digest:
+python scripts/crypto.py '{"op":"verify","path":"app.tar.gz","algo":"sha256","expected":"abc123…"}'
+
+# HMAC sign / verify (webhook signatures):
+python scripts/crypto.py '{"op":"hmac","text":"payload","key":"$SECRET","algo":"sha256"}'
+python scripts/crypto.py '{"op":"hmac_verify","text":"payload","key":"$SECRET","algo":"sha256","expected":"…"}'
+
+# base64 encode / decode:
+python scripts/crypto.py '{"op":"base64","mode":"encode","text":"hello"}'
+python scripts/crypto.py '{"op":"base64","mode":"decode","text":"aGVsbG8="}'
+
+# Generate a secure random token:
+python scripts/crypto.py '{"op":"token","bytes":32,"format":"hex"}'
+```
+
+### Spec fields
+- `op` — `hash` | `verify` | `hmac` | `hmac_verify` | `base64` | `token`.
+- `path` **or** `text` (hash/verify/hmac). `algo` (default `sha256`; any
+  `hashlib` name — sha256/sha1/md5/sha512…).
+- `expected` (verify/hmac_verify — compared in constant time).
+- `key` (hmac), `mode` (`encode`/`decode`, base64), `urlsafe` (base64, default
+  false), `bytes` (token, default 32), `format` (token: `hex`|`urlsafe`).
+
+### Output (JSON on stdout)
+```
+{ "ok": true, "op": "hash", "algo": "sha256", "digest": "…" }
+{ "ok": true, "op": "verify", "match": true }
+{ "ok": true, "op": "token", "token": "…" }
+```
+
+## Notes
+
+- **Verify/hmac_verify compare in constant time** (`hmac.compare_digest`) — use
+  them rather than `==` so signature checks aren't timing-leaky.
+- Pass an HMAC `key` / secret via an env var you set first (`export SECRET=…` →
+  `$SECRET`); the helper never echoes the key back.
+- MD5/SHA1 are fine for **checksums** but not for security — use SHA-256+ for
+  signatures and anything trust-bearing.
+
+## Going further
+
+The helper is a fast start, not a cage — for symmetric encryption, key
+derivation (PBKDF2/scrypt), JWT, or asymmetric signing, use `cryptography`/`PyJWT`
+directly. Pairs with **http-api-client** (sign a request / verify a webhook),
+**archive-tools** (checksum a bundle), and **ssh-remote** (verify a file you
+transferred). See `reference/recipes.md`.

--- a/plugins/builtinskills/cryptotools/reference/recipes.md
+++ b/plugins/builtinskills/cryptotools/reference/recipes.md
@@ -1,0 +1,62 @@
+# crypto-tools recipes
+
+The helper (`scripts/crypto.py`) covers hash/verify/hmac/base64/token with stdlib
+only. For encryption, key derivation, or JWT, use `cryptography`/`PyJWT` directly.
+
+## Verify a downloaded file's checksum
+
+```sh
+python scripts/crypto.py '{"op":"verify","path":"app.tar.gz","algo":"sha256",
+  "expected":"9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"}'
+```
+Returns `{"match": true|false}` (constant-time compare).
+
+## Verify a webhook HMAC signature
+
+Many APIs sign the request body with a shared secret (e.g. GitHub's
+`X-Hub-Signature-256`):
+```sh
+export SECRET=...   # the shared webhook secret
+python scripts/crypto.py '{"op":"hmac_verify","text":"<raw-body>","key":"'"$SECRET"'",
+  "algo":"sha256","expected":"<sig-from-header>"}'
+```
+
+## Sign an outgoing request
+
+```sh
+python scripts/crypto.py '{"op":"hmac","text":"<body>","key":"'"$SECRET"'","algo":"sha256"}'
+# → put the digest in your signature header via http-api-client
+```
+
+## base64 for an API payload
+
+```sh
+python scripts/crypto.py '{"op":"base64","mode":"encode","text":"user:pass"}'   # Basic auth value
+python scripts/crypto.py '{"op":"base64","mode":"decode","text":"dXNlcjpwYXNz"}'
+```
+Use `"urlsafe": true` for URL-safe base64 (JWT segments, tokens in URLs).
+
+## Mint a secure token / API key
+
+```sh
+python scripts/crypto.py '{"op":"token","bytes":32,"format":"urlsafe"}'   # session/api key
+python scripts/crypto.py '{"op":"token","bytes":16,"format":"hex"}'       # idempotency key
+```
+Uses `secrets` (CSPRNG) — safe for credentials, unlike `random`.
+
+## Symmetric file encryption (helper doesn't cover it)
+
+```python
+# pip install cryptography
+from cryptography.fernet import Fernet
+key = Fernet.generate_key()           # store this safely; losing it = losing the data
+f = Fernet(key)
+token = f.encrypt(open("secret.txt","rb").read())
+open("secret.enc","wb").write(token)
+# decrypt: f.decrypt(open("secret.enc","rb").read())
+```
+
+## Which algorithm?
+- **Checksums / dedup:** sha256 (md5/sha1 OK for non-security integrity only).
+- **Signatures / HMAC / anything trust-bearing:** sha256 or stronger — never md5/sha1.
+- **Random secrets:** always `token` (CSPRNG), never `random`.

--- a/plugins/builtinskills/cryptotools/scripts/crypto.py
+++ b/plugins/builtinskills/cryptotools/scripts/crypto.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""crypto-tools helper — hashes, HMAC, base64, secure tokens. Standard library only.
+
+Usage:  python crypto.py '<json-spec>'   (or pipe the JSON on stdin)
+Ops:
+  hash        {path|text, algo=sha256}                  -> {algo, digest}
+  verify      {path|text, algo, expected}               -> {match}        (constant-time)
+  hmac        {text, key, algo=sha256}                  -> {algo, digest}
+  hmac_verify {text, key, algo, expected}               -> {match}        (constant-time)
+  base64      {mode:"encode|decode", text, urlsafe?}    -> {result}
+  token       {bytes=32, format:"hex|urlsafe"}          -> {token}
+
+Verify/hmac_verify use hmac.compare_digest (not ==) so checks aren't timing-leaky.
+Keys/secrets passed in are never echoed back.
+"""
+import base64 as b64
+import hashlib
+import hmac
+import json
+import secrets
+import sys
+
+
+def read_spec():
+    if len(sys.argv) > 1 and sys.argv[1].strip():
+        return json.loads(sys.argv[1])
+    data = sys.stdin.read()
+    if data.strip():
+        return json.loads(data)
+    raise ValueError("no spec: pass a JSON spec as argv[1] or on stdin")
+
+
+def _data_bytes(spec):
+    if spec.get("path"):
+        with open(spec["path"], "rb") as fh:
+            return fh.read()
+    if "text" in spec:
+        return str(spec["text"]).encode("utf-8")
+    raise ValueError("needs path or text")
+
+
+def _algo(spec):
+    name = spec.get("algo", "sha256")
+    if name not in hashlib.algorithms_available:
+        raise ValueError(f"unknown algo: {name}")
+    return name
+
+
+def op_hash(spec):
+    algo = _algo(spec)
+    h = hashlib.new(algo)
+    h.update(_data_bytes(spec))
+    return {"algo": algo, "digest": h.hexdigest()}
+
+
+def op_verify(spec):
+    expected = spec.get("expected")
+    if not expected:
+        raise ValueError("verify needs expected")
+    got = op_hash(spec)["digest"]
+    return {"match": hmac.compare_digest(got, str(expected).strip().lower())}
+
+
+def op_hmac(spec):
+    key = spec.get("key")
+    if key is None:
+        raise ValueError("hmac needs key")
+    if "text" not in spec and not spec.get("path"):
+        raise ValueError("hmac needs text or path")
+    algo = _algo(spec)
+    mac = hmac.new(str(key).encode("utf-8"), _data_bytes(spec), algo)
+    return {"algo": algo, "digest": mac.hexdigest()}
+
+
+def op_hmac_verify(spec):
+    expected = spec.get("expected")
+    if not expected:
+        raise ValueError("hmac_verify needs expected")
+    got = op_hmac(spec)["digest"]
+    return {"match": hmac.compare_digest(got, str(expected).strip().lower())}
+
+
+def op_base64(spec):
+    mode = spec.get("mode", "encode")
+    text = spec.get("text", "")
+    urlsafe = bool(spec.get("urlsafe", False))
+    if mode == "encode":
+        raw = str(text).encode("utf-8")
+        enc = b64.urlsafe_b64encode(raw) if urlsafe else b64.b64encode(raw)
+        return {"result": enc.decode("ascii")}
+    if mode == "decode":
+        raw = str(text).encode("ascii")
+        dec = b64.urlsafe_b64decode(raw) if urlsafe else b64.b64decode(raw)
+        return {"result": dec.decode("utf-8", errors="replace")}
+    raise ValueError("base64 mode must be encode or decode")
+
+
+def op_token(spec):
+    n = int(spec.get("bytes", 32))
+    fmt = spec.get("format", "hex")
+    if fmt == "urlsafe":
+        return {"token": secrets.token_urlsafe(n)}
+    return {"token": secrets.token_hex(n)}
+
+
+OPS = {
+    "hash": op_hash,
+    "verify": op_verify,
+    "hmac": op_hmac,
+    "hmac_verify": op_hmac_verify,
+    "base64": op_base64,
+    "token": op_token,
+}
+
+
+def run(spec):
+    op = spec.get("op")
+    if op not in OPS:
+        raise ValueError("spec.op must be one of: " + ", ".join(OPS))
+    result = OPS[op](spec)
+    result.update({"ok": True, "op": op})
+    return result
+
+
+def main():
+    try:
+        print(json.dumps(run(read_spec()), default=str))
+    except Exception as e:  # noqa: BLE001
+        print(json.dumps({"ok": False, "error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
A fourteenth out-of-the-box skill bundle — **cryptographic primitives** (#34), **zero pip deps** (Python stdlib `hashlib`/`hmac`/`base64`/`secrets`).

- **`scripts/crypto.py`** — six ops: `hash` (file/text, any `hashlib` algo), `verify` (constant-time digest check), `hmac` / `hmac_verify` (sign / constant-time-verify — webhook signatures), `base64` (encode/decode, std or urlsafe), `token` (CSPRNG hex/urlsafe secrets). Keys never echoed back; verify uses `hmac.compare_digest`.
- **`reference/recipes.md`** — verify a download, verify/sign a webhook HMAC, base64 for an API, mint a token, the Fernet encryption pointer (out of scope), algorithm-choice guide.

Pairs with **http-api-client** (sign/verify webhooks), **archive-tools** (checksum a bundle), **ssh-remote** (verify a transferred file).

## Why it's conflict-free
Touches **only** `plugins/builtinskills/`. No `cmd/...`, no `kernel/...`. No new Go dependency, no new env, no `setup.sh` (stdlib).

## Verification
- `go vet` + linux cross-build of `./plugins/builtinskills/` clean; `gofmt -l` empty.
- `TestSeedAll_InstallsCryptoTools` asserts the bundle seeds **active** and materializes `crypto.py`/`recipes.md`; bundle-count assertions now cover fourteen bundles.
- **Functional smoke (ran locally):** `sha256("hello")` → `2cf24dba…938b9824` (known digest); `base64("user:pass")` → `dXNlcjpwYXNz`; HMAC sign→verify round-trip → `match:true`.

Numbered **M894** (session range M889–M899).

🤖 Generated with [Claude Code](https://claude.com/claude-code)