### PR TITLE
Feat: built-in calendar-tools skill bundle (M895)

### DIFF
--- a/.project/PHASE-M895-CALENDAR-TOOLS-SKILL-REPORT.md
+++ b/.project/PHASE-M895-CALENDAR-TOOLS-SKILL-REPORT.md
@@ -1,0 +1,48 @@
+# PHASE M895 — Built-in calendar-tools skill bundle
+
+**Status:** shipped
+**Milestone:** M895 (session range M889–M899; branched from `origin/main`,
+concurrent local-main arc untouched).
+**Theme:** Backlog **#34** — a fifteenth built-in skill bundle: create and parse
+iCalendar `.ics` events, the scheduling complement to email-tools.
+
+## What shipped
+
+A built-in `calendar-tools` bundle, seeded active at startup by the existing
+`plugins/builtinskills` seeder (`builtinBundles` + `go:embed` only). **Zero pip
+deps** — stdlib `datetime` + text, so there's no `setup.sh`:
+
+- `SKILL.md` — create/parse ops, time handling (ISO in; per-event `tz:"UTC"` or
+  floating; `all_day`), the "send an invite via email-tools" flow, and the
+  best-effort-parse / use-`icalendar`-for-RRULE caveat.
+- `scripts/cal.py` — one JSON-spec helper, two ops: `create` (writes a valid
+  VCALENDAR/VEVENT — UID/DTSTAMP/DTSTART/DTEND/SUMMARY/LOCATION/DESCRIPTION/
+  ORGANIZER/ATTENDEE, with RFC 5545 text escaping and 75-octet line folding),
+  `parse` (unfolds lines, extracts VEVENT fields back to structured events).
+- `reference/recipes.md` — meeting invite + email-tools, all-day reminder, multi
+  events, read a received invite, time handling, the `icalendar` RRULE pointer.
+
+## Why this milestone is conflict-free
+
+A new bundle touches **only** `plugins/builtinskills/`. The seeder auto-loads it.
+It tests in isolation: `go test ./plugins/builtinskills/`. Branched from
+`origin/main` (my M862–M894), concurrent local-main arc untouched.
+
+## Verification
+
+- **Isolated gate:** `go vet` clean; linux cross-build of `./plugins/builtinskills/`
+  clean; `gofmt -l` empty. Package suite green — `TestSeedAll_InstallsCalendarTools`
+  asserts the bundle seeds **active** and materializes `cal.py` / `recipes.md`;
+  bundle-count assertions now cover fifteen bundles.
+- **Functional smoke (stdlib, ran locally):** `create` an event with a comma in
+  the summary ("Sprint, review") + UTC times + location → `parse` round-trips it
+  back exactly (comma correctly escaped on write, unescaped on read; UID/DTSTART/
+  DTEND/LOCATION all present).
+- No new Go dep; no new env. `.gitattributes` already forces LF on
+  `plugins/builtinskills/**`. Full `go build ./...` deliberately skipped.
+
+## Notes
+- Fifteen seeded bundles now ship. calendar-tools + email-tools = "schedule a
+  meeting and send the invite"; parsed events can land in a Data Lake `calendar`
+  collection or feed data-analysis. RRULE recurrence is deliberately out of scope
+  (pointer to `icalendar`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
   the Runs view. Purely frontend — reuses the existing event provider and read routes. (M867)
 
 ### Added
+- **Built-in calendar-tools skill bundle (M895).** A fifteenth out-of-the-box skill that creates and
+  parses iCalendar `.ics` events (#34) — **zero pip deps** (Python stdlib). `scripts/cal.py` has two ops:
+  `create` (valid VCALENDAR/VEVENT with RFC 5545 text escaping + line folding) and `parse` (unfolds and
+  extracts VEVENT fields). Pairs with email-tools to send a meeting invite (attach the `.ics`); parsed
+  events can land in a Data Lake calendar collection. RRULE recurrence is out of scope (pointer to
+  `icalendar`). Rides the `plugins/builtinskills` seeder. (M895)
 - **Built-in crypto-tools skill bundle (M894).** A fourteenth out-of-the-box skill — cryptographic
   primitives (#34), **zero pip deps** (Python stdlib `hashlib`/`hmac`/`base64`/`secrets`).
   `scripts/crypto.py` has six ops: `hash` (file/text, any algo), `verify` (constant-time), `hmac` /

--- a/plugins/builtinskills/builtinskills.go
+++ b/plugins/builtinskills/builtinskills.go
@@ -24,7 +24,7 @@ import (
 	"github.com/agezt/agezt/kernel/skill"
 )
 
-//go:embed browseruse computeruse dataanalysis dockerservices gitops webresearch pdftools imagetools sqldb archivetools httpapi emailtools sshremote cryptotools
+//go:embed browseruse computeruse dataanalysis dockerservices gitops webresearch pdftools imagetools sqldb archivetools httpapi emailtools sshremote cryptotools calendartools
 var bundles embed.FS
 
 // Forge is the slice of *skill.Forge the seeder needs — an interface so it is
@@ -44,7 +44,7 @@ type Seeded struct {
 }
 
 // builtinBundles lists the embedded bundle directories to seed.
-var builtinBundles = []string{"browseruse", "computeruse", "dataanalysis", "dockerservices", "gitops", "webresearch", "pdftools", "imagetools", "sqldb", "archivetools", "httpapi", "emailtools", "sshremote", "cryptotools"}
+var builtinBundles = []string{"browseruse", "computeruse", "dataanalysis", "dockerservices", "gitops", "webresearch", "pdftools", "imagetools", "sqldb", "archivetools", "httpapi", "emailtools", "sshremote", "cryptotools", "calendartools"}
 
 // SeedAll installs every embedded bundle into the Forge and promotes each to
 // active. It is best-effort per bundle: an error on one is returned but does not

--- a/plugins/builtinskills/builtinskills_test.go
+++ b/plugins/builtinskills/builtinskills_test.go
@@ -520,6 +520,42 @@ func TestSeedAll_InstallsCryptoTools(t *testing.T) {
 	}
 }
 
+func TestSeedAll_InstallsCalendarTools(t *testing.T) {
+	f := newForge(t)
+	seeded, err := SeedAll(f, "")
+	if err != nil {
+		t.Fatalf("SeedAll: %v", err)
+	}
+	var got *Seeded
+	for i := range seeded {
+		if seeded[i].Name == "calendar-tools" {
+			got = &seeded[i]
+		}
+	}
+	if got == nil {
+		t.Fatalf("calendar-tools not seeded: %+v", seeded)
+	}
+	if got.Status != skill.StatusActive {
+		t.Errorf("calendar-tools status = %q, want active", got.Status)
+	}
+	drv, err := f.Bundles().Read("calendar-tools", "scripts/cal.py")
+	if err != nil || len(drv) == 0 {
+		t.Fatalf("calendar-tools cal.py unreadable/empty: %v", err)
+	}
+	files, _ := f.Bundles().List("calendar-tools")
+	want := map[string]bool{"scripts/cal.py": false, "reference/recipes.md": false}
+	for _, rel := range files {
+		if _, ok := want[rel]; ok {
+			want[rel] = true
+		}
+	}
+	for rel, found := range want {
+		if !found {
+			t.Errorf("calendar-tools bundle missing %q (got %v)", rel, files)
+		}
+	}
+}
+
 func TestSeedAll_Idempotent(t *testing.T) {
 	f := newForge(t)
 	if _, err := SeedAll(f, ""); err != nil {

--- a/plugins/builtinskills/calendartools/SKILL.md
+++ b/plugins/builtinskills/calendartools/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: calendar-tools
+description: Create and read calendar events — write a standards-compliant .ics file (VEVENT) for a meeting or reminder, and parse an .ics back into structured events — when a task needs to schedule something, send a meeting invite, or read a calendar file
+triggers: [calendar, ics, ical, event, meeting, invite, schedule, appointment, reminder, vevent]
+tools: [code_exec, shell, artifacts]
+---
+
+# calendar-tools — make and read .ics calendar events
+
+When a task needs to schedule something — send a meeting invite, drop a reminder
+on a calendar, or read events out of an `.ics` file — use this. It writes and
+parses the iCalendar (`.ics`) format using only the Python **standard library** —
+no install. Runs through `code_exec` (python).
+
+## No setup needed
+
+Built on `datetime` + plain text. Use `skill op=files calendar-tools` to find the
+bundle directory.
+
+## The helper
+
+`scripts/cal.py` takes a JSON spec with an `op` and prints JSON. Ops:
+
+```sh
+# Create an .ics with one or more events:
+python scripts/cal.py '{"op":"create","out":"meeting.ics","events":[
+  {"summary":"Sprint review","start":"2026-06-15T14:00:00","end":"2026-06-15T15:00:00",
+   "location":"Zoom","description":"Demo + retro","attendees":["a@x.com","b@x.com"]}
+]}'
+
+# Parse an .ics file back into structured events:
+python scripts/cal.py '{"op":"parse","path":"invite.ics"}'
+```
+
+### Spec fields
+- `op` — `create` | `parse`.
+- `out` (create) — output `.ics` path (default `event.ics`).
+- `events` (create) — list of `{summary, start, end?, location?, description?,
+  attendees?, organizer?, uid?, all_day?}`. `start`/`end` are ISO
+  (`2026-06-15T14:00:00`); add `"tz":"UTC"` per event to stamp UTC (`Z`),
+  otherwise the time is floating/local. `all_day:true` uses a date only.
+- `path` (parse) — the `.ics` file to read.
+
+### Output (JSON on stdout)
+```
+{ "ok": true, "op": "create", "out": "meeting.ics", "count": 1 }
+{ "ok": true, "op": "parse", "events": [ {uid, summary, start, end, location, description} ], "count": 2 }
+```
+
+## Send an invite (with email-tools)
+
+`create` an `.ics`, then attach it with the **email-tools** skill — most clients
+render an attached `.ics` as an accept/decline invite:
+
+```sh
+python scripts/cal.py '{"op":"create","out":"invite.ics","events":[{...}]}'
+# then email-tools send with "attachments":["invite.ics"]
+```
+
+## Notes
+
+- Text fields are escaped (`,` `;` `\` newlines) and long lines are folded per
+  RFC 5545, so the output validates in real calendar clients.
+- `parse` is best-effort over `VEVENT` blocks (handles line unfolding) — good for
+  reading invites; for recurring rules (`RRULE`), timezones (`VTIMEZONE`), or
+  complex calendars, use the `icalendar` library directly in `code_exec`.
+
+## Going further
+
+The helper is a fast start, not a cage — for RRULE recurrence, VTODO/VALARM, or
+timezone databases, `pip install icalendar` and use it directly. Save the `.ics`
+with the `artifacts` tool so it shows in Files. See `reference/recipes.md`.

--- a/plugins/builtinskills/calendartools/reference/recipes.md
+++ b/plugins/builtinskills/calendartools/reference/recipes.md
@@ -1,0 +1,61 @@
+# calendar-tools recipes
+
+The helper (`scripts/cal.py`) creates and parses `.ics` with stdlib only. For
+recurrence (RRULE), timezones (VTIMEZONE), or VTODO/VALARM, use the `icalendar`
+library directly.
+
+## Create a meeting and email it as an invite
+
+```sh
+python scripts/cal.py '{"op":"create","out":"invite.ics","events":[
+  {"summary":"Design sync","start":"2026-06-18T10:00:00","end":"2026-06-18T10:30:00",
+   "tz":"UTC","location":"Meet","organizer":"me@corp.com","attendees":["you@corp.com"]}
+]}'
+```
+Then send with **email-tools** (`"attachments":["invite.ics"]`). Most clients
+render an attached `.ics` as an accept/decline invite.
+
+## All-day event / reminder
+
+```sh
+python scripts/cal.py '{"op":"create","out":"holiday.ics","events":[
+  {"summary":"Release freeze","start":"2026-07-01","all_day":true}
+]}'
+```
+
+## Multiple events in one file
+
+```sh
+python scripts/cal.py '{"op":"create","out":"week.ics","events":[
+  {"summary":"Standup","start":"2026-06-15T09:00:00","end":"2026-06-15T09:15:00"},
+  {"summary":"Standup","start":"2026-06-16T09:00:00","end":"2026-06-16T09:15:00"}
+]}'
+```
+(For *true* recurrence with one VEVENT + RRULE, use the `icalendar` library.)
+
+## Read an invite you received
+
+```sh
+python scripts/cal.py '{"op":"parse","path":"invite.ics"}'
+# → {events:[{uid,summary,start,end,location,description,attendees}]}
+```
+Store the parsed events in the Data Lake (a `calendar` collection) or hand them
+to **data-analysis** to summarize a busy week.
+
+## Time handling
+- `start`/`end` are ISO: `2026-06-15T14:00:00`.
+- Add `"tz":"UTC"` per event to stamp UTC (`...Z`); without it the time is
+  floating (interpreted in the viewer's local zone).
+- `all_day:true` uses a date only (`VALUE=DATE`).
+
+## Recurrence (helper doesn't cover it)
+
+```python
+# pip install icalendar
+from icalendar import Calendar, Event
+from datetime import datetime
+cal = Calendar(); ev = Event()
+ev.add("summary", "Weekly 1:1"); ev.add("dtstart", datetime(2026,6,15,9,0))
+ev.add("rrule", {"freq": "weekly", "count": 12})
+cal.add_component(ev); open("recurring.ics","wb").write(cal.to_ical())
+```

--- a/plugins/builtinskills/calendartools/scripts/cal.py
+++ b/plugins/builtinskills/calendartools/scripts/cal.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""calendar-tools helper — create and parse .ics (iCalendar) files. Stdlib only.
+
+Usage:  python cal.py '<json-spec>'   (or pipe the JSON on stdin)
+Ops:
+  create {out, events:[{summary,start,end?,location?,description?,attendees?,
+          organizer?,uid?,all_day?,tz?}]}            -> {out, count}
+  parse  {path}                                       -> {events:[...], count}
+
+Text fields are escaped and long lines folded per RFC 5545. parse is best-effort
+over VEVENT blocks. For RRULE/VTIMEZONE, use the `icalendar` library directly.
+"""
+import datetime as dt
+import json
+import sys
+
+
+def read_spec():
+    if len(sys.argv) > 1 and sys.argv[1].strip():
+        return json.loads(sys.argv[1])
+    data = sys.stdin.read()
+    if data.strip():
+        return json.loads(data)
+    raise ValueError("no spec: pass a JSON spec as argv[1] or on stdin")
+
+
+def _esc(s):
+    return (
+        str(s)
+        .replace("\\", "\\\\")
+        .replace(";", "\\;")
+        .replace(",", "\\,")
+        .replace("\n", "\\n")
+    )
+
+
+def _fold(line):
+    """RFC 5545 line folding at 75 octets (continuation lines start with a space)."""
+    out = []
+    while len(line.encode("utf-8")) > 75:
+        # back off to <=75 bytes
+        cut = 75
+        while len(line[:cut].encode("utf-8")) > 75:
+            cut -= 1
+        out.append(line[:cut])
+        line = " " + line[cut:]
+    out.append(line)
+    return "\r\n".join(out)
+
+
+def _fmt_dt(value, all_day, tz):
+    if all_day:
+        d = dt.date.fromisoformat(value[:10])
+        return ";VALUE=DATE:" + d.strftime("%Y%m%d")
+    d = dt.datetime.fromisoformat(value)
+    if tz and tz.upper() == "UTC":
+        return ":" + d.strftime("%Y%m%dT%H%M%SZ")
+    return ":" + d.strftime("%Y%m%dT%H%M%S")
+
+
+def op_create(spec):
+    events = spec.get("events") or []
+    if not events:
+        raise ValueError("create needs events[]")
+    stamp = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    lines = ["BEGIN:VCALENDAR", "VERSION:2.0", "PRODID:-//agezt//calendar-tools//EN", "CALSCALE:GREGORIAN"]
+    for i, ev in enumerate(events):
+        if not ev.get("summary"):
+            raise ValueError("each event needs a summary")
+        if not ev.get("start"):
+            raise ValueError("each event needs a start")
+        all_day = bool(ev.get("all_day"))
+        tz = ev.get("tz")
+        uid = ev.get("uid") or f"agezt-{stamp}-{i}@agezt"
+        lines.append("BEGIN:VEVENT")
+        lines.append(_fold("UID:" + uid))
+        lines.append("DTSTAMP:" + stamp)
+        lines.append(_fold("DTSTART" + _fmt_dt(ev["start"], all_day, tz)))
+        if ev.get("end"):
+            lines.append(_fold("DTEND" + _fmt_dt(ev["end"], all_day, tz)))
+        lines.append(_fold("SUMMARY:" + _esc(ev["summary"])))
+        if ev.get("location"):
+            lines.append(_fold("LOCATION:" + _esc(ev["location"])))
+        if ev.get("description"):
+            lines.append(_fold("DESCRIPTION:" + _esc(ev["description"])))
+        if ev.get("organizer"):
+            lines.append(_fold("ORGANIZER:mailto:" + str(ev["organizer"])))
+        for a in ev.get("attendees") or []:
+            lines.append(_fold("ATTENDEE;RSVP=TRUE:mailto:" + str(a)))
+        lines.append("END:VEVENT")
+    lines.append("END:VCALENDAR")
+    out = spec.get("out", "event.ics")
+    with open(out, "w", encoding="utf-8", newline="") as fh:
+        fh.write("\r\n".join(lines) + "\r\n")
+    return {"out": out, "count": len(events)}
+
+
+def _unfold(text):
+    # Join continuation lines (a line starting with space/tab continues the prior).
+    raw = text.replace("\r\n", "\n").split("\n")
+    out = []
+    for line in raw:
+        if line[:1] in (" ", "\t") and out:
+            out[-1] += line[1:]
+        else:
+            out.append(line)
+    return out
+
+
+def _unesc(s):
+    return s.replace("\\n", "\n").replace("\\,", ",").replace("\\;", ";").replace("\\\\", "\\")
+
+
+def op_parse(spec):
+    path = spec.get("path")
+    if not path:
+        raise ValueError("parse needs path")
+    with open(path, "r", encoding="utf-8") as fh:
+        lines = _unfold(fh.read())
+    events, cur = [], None
+    for line in lines:
+        if line == "BEGIN:VEVENT":
+            cur = {}
+        elif line == "END:VEVENT":
+            if cur is not None:
+                events.append(cur)
+            cur = None
+        elif cur is not None and ":" in line:
+            key, val = line.split(":", 1)
+            name = key.split(";", 1)[0].upper()
+            if name == "SUMMARY":
+                cur["summary"] = _unesc(val)
+            elif name == "DTSTART":
+                cur["start"] = val
+            elif name == "DTEND":
+                cur["end"] = val
+            elif name == "LOCATION":
+                cur["location"] = _unesc(val)
+            elif name == "DESCRIPTION":
+                cur["description"] = _unesc(val)
+            elif name == "UID":
+                cur["uid"] = val
+            elif name == "ATTENDEE":
+                cur.setdefault("attendees", []).append(val.replace("mailto:", ""))
+    return {"events": events, "count": len(events)}
+
+
+OPS = {"create": op_create, "parse": op_parse}
+
+
+def run(spec):
+    op = spec.get("op")
+    if op not in OPS:
+        raise ValueError("spec.op must be one of: " + ", ".join(OPS))
+    result = OPS[op](spec)
+    result.update({"ok": True, "op": op})
+    return result
+
+
+def main():
+    try:
+        print(json.dumps(run(read_spec()), default=str))
+    except Exception as e:  # noqa: BLE001
+        print(json.dumps({"ok": False, "error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
A fifteenth out-of-the-box skill bundle that **creates and parses iCalendar `.ics` events** (#34) — **zero pip deps** (Python stdlib `datetime` + text).

- **`scripts/cal.py`** — two ops: `create` (writes a valid VCALENDAR/VEVENT — UID/DTSTAMP/DTSTART/DTEND/SUMMARY/LOCATION/DESCRIPTION/ORGANIZER/ATTENDEE, with RFC 5545 text escaping and 75-octet line folding), `parse` (unfolds lines, extracts VEVENT fields back to structured events).
- **`reference/recipes.md`** — meeting invite + email-tools, all-day reminder, multi events, read a received invite, time handling, the `icalendar` RRULE pointer.

Pairs with **email-tools** ("schedule a meeting and send the invite" — attach the `.ics`); parsed events can land in a Data Lake calendar collection or feed **data-analysis**.

## Why it's conflict-free
Touches **only** `plugins/builtinskills/`. No `cmd/...`, no `kernel/...`. No new Go dependency, no new env, no `setup.sh` (stdlib).

## Verification
- `go vet` + linux cross-build of `./plugins/builtinskills/` clean; `gofmt -l` empty.
- `TestSeedAll_InstallsCalendarTools` asserts the bundle seeds **active** and materializes `cal.py`/`recipes.md`; bundle-count assertions now cover fifteen bundles.
- **Functional smoke (ran locally):** `create` an event with a comma in the summary + UTC times + location → `parse` round-trips it exactly (comma escaped on write, unescaped on read; UID/DTSTART/DTEND/LOCATION all present).

Numbered **M895** (session range M889–M899).

🤖 Generated with [Claude Code](https://claude.com/claude-code)