### PR TITLE
Feat: built-in office-docs skill bundle (M896)

### DIFF
--- a/.project/PHASE-M896-OFFICE-DOCS-SKILL-REPORT.md
+++ b/.project/PHASE-M896-OFFICE-DOCS-SKILL-REPORT.md
@@ -1,0 +1,46 @@
+# PHASE M896 — Built-in office-docs skill bundle
+
+**Status:** shipped
+**Milestone:** M896 (session range M889–M899; branched from `origin/main`,
+concurrent local-main arc untouched).
+**Theme:** Backlog **#34** — a sixteenth built-in skill bundle: generate Word
+`.docx` and Excel `.xlsx` deliverables — the polished-output step the data/PDF
+bundles stop short of.
+
+## What shipped
+
+A built-in `office-docs` bundle, seeded active at startup by the existing
+`plugins/builtinskills` seeder (`builtinBundles` + `go:embed` only):
+
+- `SKILL.md` — the two ops, the block/sheet specs, the reporting pipeline
+  (data-analysis → office-docs → email/archive → artifacts), and the
+  use-the-library-directly pointer for images/styles/templates.
+- `scripts/setup.sh` — `pip install python-docx openpyxl`.
+- `scripts/office.py` — one JSON-spec helper, two ops: `docx` (build a Word doc
+  from typed blocks — heading / para / bullets / table, with a styled table),
+  `xlsx` (build a workbook from `sheets{name:[[row]]}` or `rows[]`, bolding the
+  header row and freezing the top row; sheet names capped at Excel's 31 chars).
+- `reference/recipes.md` — report with table, multi-sheet workbook, from a pandas
+  DataFrame, embed a chart image in Word, charts inside Excel, the pipeline.
+
+## Why this milestone is conflict-free
+
+A new bundle touches **only** `plugins/builtinskills/`. The seeder auto-loads it.
+It tests in isolation: `go test ./plugins/builtinskills/`. Branched from
+`origin/main` (my M862–M895), concurrent local-main arc untouched.
+
+## Verification
+
+- **Isolated gate:** `go vet` clean; linux cross-build of `./plugins/builtinskills/`
+  clean; `gofmt -l` empty; `python -m py_compile office.py` passes; `sh -n setup.sh`
+  clean. Package suite green — `TestSeedAll_InstallsOfficeDocs` asserts the bundle
+  seeds **active** and materializes `office.py` / `setup.sh` / `recipes.md`;
+  bundle-count assertions now cover sixteen bundles.
+- No new Go dep; no new env. `.gitattributes` already forces LF on
+  `plugins/builtinskills/**`. Full `go build ./...` deliberately skipped.
+
+## Notes
+- Sixteen seeded bundles now ship. office-docs completes the reporting pipeline:
+  data-analysis crunches → office-docs formats a `.docx`/`.xlsx` → email-tools
+  sends or archive-tools bundles → artifacts surfaces it in Files. The
+  agent-level upgrade is "hand the operator a real document," not just a CSV/PDF.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
   the Runs view. Purely frontend — reuses the existing event provider and read routes. (M867)
 
 ### Added
+- **Built-in office-docs skill bundle (M896).** A sixteenth out-of-the-box skill that generates Word
+  `.docx` and Excel `.xlsx` deliverables (#34) — the polished-output step beyond raw CSV/PDF.
+  `scripts/office.py` has two ops: `docx` (build from typed blocks — heading/para/bullets/table) and
+  `xlsx` (workbook from sheets/rows, bold + frozen header row); `setup.sh` installs python-docx + openpyxl.
+  Completes the reporting pipeline: data-analysis → office-docs → email-tools/archive-tools → artifacts.
+  Rides the `plugins/builtinskills` seeder. (M896)
 - **Built-in calendar-tools skill bundle (M895).** A fifteenth out-of-the-box skill that creates and
   parses iCalendar `.ics` events (#34) — **zero pip deps** (Python stdlib). `scripts/cal.py` has two ops:
   `create` (valid VCALENDAR/VEVENT with RFC 5545 text escaping + line folding) and `parse` (unfolds and

--- a/plugins/builtinskills/builtinskills.go
+++ b/plugins/builtinskills/builtinskills.go
@@ -24,7 +24,7 @@ import (
 	"github.com/agezt/agezt/kernel/skill"
 )
 
-//go:embed browseruse computeruse dataanalysis dockerservices gitops webresearch pdftools imagetools sqldb archivetools httpapi emailtools sshremote cryptotools calendartools
+//go:embed browseruse computeruse dataanalysis dockerservices gitops webresearch pdftools imagetools sqldb archivetools httpapi emailtools sshremote cryptotools calendartools officedocs
 var bundles embed.FS
 
 // Forge is the slice of *skill.Forge the seeder needs — an interface so it is
@@ -44,7 +44,7 @@ type Seeded struct {
 }
 
 // builtinBundles lists the embedded bundle directories to seed.
-var builtinBundles = []string{"browseruse", "computeruse", "dataanalysis", "dockerservices", "gitops", "webresearch", "pdftools", "imagetools", "sqldb", "archivetools", "httpapi", "emailtools", "sshremote", "cryptotools", "calendartools"}
+var builtinBundles = []string{"browseruse", "computeruse", "dataanalysis", "dockerservices", "gitops", "webresearch", "pdftools", "imagetools", "sqldb", "archivetools", "httpapi", "emailtools", "sshremote", "cryptotools", "calendartools", "officedocs"}
 
 // SeedAll installs every embedded bundle into the Forge and promotes each to
 // active. It is best-effort per bundle: an error on one is returned but does not

--- a/plugins/builtinskills/builtinskills_test.go
+++ b/plugins/builtinskills/builtinskills_test.go
@@ -556,6 +556,42 @@ func TestSeedAll_InstallsCalendarTools(t *testing.T) {
 	}
 }
 
+func TestSeedAll_InstallsOfficeDocs(t *testing.T) {
+	f := newForge(t)
+	seeded, err := SeedAll(f, "")
+	if err != nil {
+		t.Fatalf("SeedAll: %v", err)
+	}
+	var got *Seeded
+	for i := range seeded {
+		if seeded[i].Name == "office-docs" {
+			got = &seeded[i]
+		}
+	}
+	if got == nil {
+		t.Fatalf("office-docs not seeded: %+v", seeded)
+	}
+	if got.Status != skill.StatusActive {
+		t.Errorf("office-docs status = %q, want active", got.Status)
+	}
+	drv, err := f.Bundles().Read("office-docs", "scripts/office.py")
+	if err != nil || len(drv) == 0 {
+		t.Fatalf("office-docs office.py unreadable/empty: %v", err)
+	}
+	files, _ := f.Bundles().List("office-docs")
+	want := map[string]bool{"scripts/office.py": false, "scripts/setup.sh": false, "reference/recipes.md": false}
+	for _, rel := range files {
+		if _, ok := want[rel]; ok {
+			want[rel] = true
+		}
+	}
+	for rel, found := range want {
+		if !found {
+			t.Errorf("office-docs bundle missing %q (got %v)", rel, files)
+		}
+	}
+}
+
 func TestSeedAll_Idempotent(t *testing.T) {
 	f := newForge(t)
 	if _, err := SeedAll(f, ""); err != nil {

--- a/plugins/builtinskills/officedocs/SKILL.md
+++ b/plugins/builtinskills/officedocs/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: office-docs
+description: Generate Microsoft Office documents — a Word .docx (headings, paragraphs, bullet lists, tables) and an Excel .xlsx workbook (sheets of rows with a styled header) — when a task needs a polished, shareable report or spreadsheet instead of raw CSV, PDF, or plain text
+triggers: [docx, word, xlsx, excel, spreadsheet, report, document, office, workbook, deliverable]
+tools: [code_exec, shell, artifacts]
+---
+
+# office-docs — produce Word and Excel deliverables
+
+When a task should hand someone a real **document** — a formatted report in Word,
+a spreadsheet in Excel — don't stop at CSV or plain text. This skill builds
+`.docx` and `.xlsx` files via `python-docx` and `openpyxl`, through `code_exec`
+(python).
+
+## One-time setup
+
+Run `scripts/setup.sh` once (via code_exec or shell): installs `python-docx` and
+`openpyxl`. Use `skill op=files office-docs` to find the bundle directory.
+
+## The helper
+
+`scripts/office.py` takes a JSON spec with an `op` and prints JSON. Ops:
+
+```sh
+# Build a Word document from blocks:
+python scripts/office.py '{"op":"docx","out":"report.docx","title":"Weekly report","blocks":[
+  {"type":"heading","text":"Summary","level":1},
+  {"type":"para","text":"Revenue is up 12% week over week."},
+  {"type":"bullets","items":["Signups +8%","Churn -2%","NPS 41"]},
+  {"type":"table","header":["Metric","Value"],"rows":[["Revenue","$42k"],["Users","1,203"]]}
+]}'
+
+# Build an Excel workbook (one or more sheets of rows):
+python scripts/office.py '{"op":"xlsx","out":"data.xlsx","sheets":{
+  "Sales":[["Month","Amount"],["Jun","42000"],["Jul","51000"]],
+  "Users":[["Day","Signups"],["Mon","8"],["Tue","11"]]
+}}'
+```
+
+### Spec fields
+- `op` — `docx` | `xlsx`.
+- **docx:** `out` (default `document.docx`), `title` (optional document title),
+  `blocks` — a list of `{type, …}`:
+  - `heading` `{text, level=1}`, `para` `{text}`, `bullets` `{items:[…]}`,
+    `table` `{header:[…], rows:[[…]]}`.
+- **xlsx:** `out` (default `workbook.xlsx`), and either `sheets`
+  (`{name: [[row],[row]]}`) or `rows` (`[[…]]`, written to a sheet named by
+  `sheet`, default `Sheet1`). The first row of each sheet is styled as a bold
+  header with a frozen top row.
+
+### Output (JSON on stdout)
+```
+{ "ok": true, "op": "docx", "out": "report.docx", "blocks": 4 }
+{ "ok": true, "op": "xlsx", "out": "data.xlsx", "sheets": ["Sales","Users"] }
+```
+
+## The reporting pipeline
+
+office-docs is the polished-output step:
+- Crunch numbers with **data-analysis** → write the table into an `.xlsx`/`.docx`.
+- Chart with data-analysis / **image-tools** → embed the PNG (write `python-docx`
+  directly: `doc.add_picture("chart.png")`).
+- Then **email-tools** to send it, or **archive-tools** to bundle several.
+- Save the file with the `artifacts` tool so it shows in the Files view.
+
+## Going further
+
+The helper is a fast start, not a cage — for styles, headers/footers, images,
+charts-in-Excel, cell formatting, or templates, use `python-docx`/`openpyxl`
+directly in `code_exec`. See `reference/recipes.md`.

--- a/plugins/builtinskills/officedocs/reference/recipes.md
+++ b/plugins/builtinskills/officedocs/reference/recipes.md
@@ -1,0 +1,62 @@
+# office-docs recipes
+
+The helper (`scripts/office.py`) builds `.docx` and `.xlsx` from a JSON spec. For
+images, charts-in-Excel, styles, or templates, use `python-docx`/`openpyxl`
+directly. Patterns:
+
+## A report with a heading, prose, and a table
+
+```sh
+python scripts/office.py '{"op":"docx","out":"weekly.docx","title":"Weekly Report",
+  "blocks":[
+    {"type":"heading","text":"Highlights","level":1},
+    {"type":"para","text":"Strong week across the board."},
+    {"type":"bullets","items":["Revenue +12%","Churn -2%"]},
+    {"type":"table","header":["Metric","Value"],"rows":[["MRR","$42k"],["Users","1203"]]}
+  ]}'
+```
+
+## A multi-sheet workbook
+
+```sh
+python scripts/office.py '{"op":"xlsx","out":"q2.xlsx","sheets":{
+  "Revenue":[["Month","Amount"],["Apr","38000"],["May","45000"],["Jun","51000"]],
+  "Headcount":[["Team","People"],["Eng","12"],["Sales","6"]]
+}}'
+```
+The first row of each sheet is bolded and the top row is frozen.
+
+## From a pandas DataFrame (with data-analysis)
+
+```python
+import pandas as pd
+df = pd.read_csv("sales.csv")
+df.to_excel("sales.xlsx", index=False)          # openpyxl backend
+# or as a Word table: pass df.columns + df.values.tolist() as header/rows to the helper
+```
+
+## Embed a chart image in a Word doc
+
+```python
+from docx import Document
+doc = Document(); doc.add_heading("Spend", 1)
+doc.add_picture("spend.png")                      # a chart from data-analysis/image-tools
+doc.save("report.docx")
+```
+
+## Charts inside Excel
+
+```python
+from openpyxl import Workbook
+from openpyxl.chart import BarChart, Reference
+wb = Workbook(); ws = wb.active
+for row in [["M","V"],["Jun",42],["Jul",51]]: ws.append(row)
+ch = BarChart(); ch.add_data(Reference(ws, min_col=2, min_row=1, max_row=3), titles_from_data=True)
+ch.set_categories(Reference(ws, min_col=1, min_row=2, max_row=3))
+ws.add_chart(ch, "D2"); wb.save("charted.xlsx")
+```
+
+## The reporting pipeline
+data-analysis (numbers) → office-docs (.docx/.xlsx) → email-tools (send) /
+archive-tools (bundle) → artifacts tool (Files). Save the file with `artifacts`
+so the operator sees it in the Files view.

--- a/plugins/builtinskills/officedocs/scripts/office.py
+++ b/plugins/builtinskills/officedocs/scripts/office.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""office-docs helper — build Word .docx and Excel .xlsx files.
+
+Usage:  python office.py '<json-spec>'   (or pipe the JSON on stdin)
+Ops:
+  docx {out, title?, blocks:[{type:heading|para|bullets|table, ...}]}  -> {out, blocks}
+  xlsx {out, sheets:{name:[[row]]}} | {out, rows:[[...]], sheet?}       -> {out, sheets}
+
+A fast start, not a cage: for styles, images, headers/footers, or cell formatting,
+use python-docx / openpyxl directly.
+"""
+import json
+import sys
+
+
+def read_spec():
+    if len(sys.argv) > 1 and sys.argv[1].strip():
+        return json.loads(sys.argv[1])
+    data = sys.stdin.read()
+    if data.strip():
+        return json.loads(data)
+    raise ValueError("no spec: pass a JSON spec as argv[1] or on stdin")
+
+
+def op_docx(spec):
+    from docx import Document
+
+    doc = Document()
+    if spec.get("title"):
+        doc.add_heading(str(spec["title"]), level=0)
+    blocks = spec.get("blocks") or []
+    for b in blocks:
+        kind = b.get("type")
+        if kind == "heading":
+            doc.add_heading(str(b.get("text", "")), level=int(b.get("level", 1)))
+        elif kind == "para":
+            doc.add_paragraph(str(b.get("text", "")))
+        elif kind == "bullets":
+            for item in b.get("items") or []:
+                doc.add_paragraph(str(item), style="List Bullet")
+        elif kind == "table":
+            header = b.get("header") or []
+            rows = b.get("rows") or []
+            ncols = len(header) if header else (len(rows[0]) if rows else 0)
+            if ncols:
+                t = doc.add_table(rows=0, cols=ncols)
+                t.style = "Light Grid Accent 1"
+                if header:
+                    cells = t.add_row().cells
+                    for i, h in enumerate(header):
+                        cells[i].text = str(h)
+                for r in rows:
+                    cells = t.add_row().cells
+                    for i in range(ncols):
+                        cells[i].text = str(r[i]) if i < len(r) else ""
+        else:
+            raise ValueError(f"unknown block type: {kind}")
+    out = spec.get("out", "document.docx")
+    doc.save(out)
+    return {"out": out, "blocks": len(blocks)}
+
+
+def op_xlsx(spec):
+    from openpyxl import Workbook
+    from openpyxl.styles import Font
+
+    sheets = spec.get("sheets")
+    if not sheets:
+        rows = spec.get("rows")
+        if rows is None:
+            raise ValueError("xlsx needs sheets{} or rows[]")
+        sheets = {spec.get("sheet", "Sheet1"): rows}
+
+    wb = Workbook()
+    wb.remove(wb.active)  # drop the default sheet; we add our own
+    for name, rows in sheets.items():
+        ws = wb.create_sheet(title=str(name)[:31])  # Excel caps sheet names at 31
+        for r in rows or []:
+            ws.append(list(r))
+        if rows:
+            for cell in ws[1]:  # bold the header row
+                cell.font = Font(bold=True)
+            ws.freeze_panes = "A2"
+    out = spec.get("out", "workbook.xlsx")
+    wb.save(out)
+    return {"out": out, "sheets": list(sheets.keys())}
+
+
+OPS = {"docx": op_docx, "xlsx": op_xlsx}
+
+
+def run(spec):
+    op = spec.get("op")
+    if op not in OPS:
+        raise ValueError("spec.op must be one of: " + ", ".join(OPS))
+    result = OPS[op](spec)
+    result.update({"ok": True, "op": op})
+    return result
+
+
+def main():
+    try:
+        print(json.dumps(run(read_spec()), default=str))
+    except Exception as e:  # noqa: BLE001
+        print(json.dumps({"ok": False, "error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/builtinskills/officedocs/scripts/setup.sh
+++ b/plugins/builtinskills/officedocs/scripts/setup.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# office-docs setup: install python-docx + openpyxl. Idempotent. Run via code_exec or shell.
+set -e
+
+echo "installing python-docx + openpyxl ..."
+python -m pip install --quiet python-docx openpyxl 2>/dev/null \
+  || pip install --quiet python-docx openpyxl 2>/dev/null \
+  || pip3 install python-docx openpyxl
+
+echo "office-docs ready: run scripts/office.py '<json-spec>'"


### PR DESCRIPTION
## Summary
A sixteenth out-of-the-box skill bundle that generates **Word `.docx` and Excel `.xlsx` deliverables** (#34) — the polished-output step the data/PDF bundles stop short of.

- **`scripts/office.py`** — two ops: `docx` (build a Word doc from typed blocks — `heading`/`para`/`bullets`/`table`, with a styled table) and `xlsx` (build a workbook from `sheets{name:[[row]]}` or `rows[]`, bolding + freezing the header row; sheet names capped at Excel's 31 chars).
- **`scripts/setup.sh`** — `pip install python-docx openpyxl`.
- **`reference/recipes.md`** — report with table, multi-sheet workbook, from a pandas DataFrame, embed a chart image in Word, charts inside Excel, the pipeline.

Completes the reporting pipeline: **data-analysis** (numbers) → **office-docs** (`.docx`/`.xlsx`) → **email-tools** (send) / **archive-tools** (bundle) → artifacts (Files).

## Why it's conflict-free
Touches **only** `plugins/builtinskills/`. No `cmd/...`, no `kernel/...`. No new Go dependency, no new env.

## Verification
- `go vet` + linux cross-build of `./plugins/builtinskills/` clean; `gofmt -l` empty; `py_compile office.py` + `sh -n setup.sh` clean.
- `TestSeedAll_InstallsOfficeDocs` asserts the bundle seeds **active** and materializes `office.py`/`setup.sh`/`recipes.md`; bundle-count assertions now cover sixteen bundles. Package suite green in isolation.

Numbered **M896** (session range M889–M899).

🤖 Generated with [Claude Code](https://claude.com/claude-code)