### PR TITLE
Feat: forge bias — prefer deterministic tools + self-improvement (M902)

### DIFF
--- a/.project/PHASE-M902-FORGE-BIAS-REPORT.md
+++ b/.project/PHASE-M902-FORGE-BIAS-REPORT.md
@@ -1,0 +1,47 @@
+# PHASE M902 — Forge bias: prefer deterministic tools + self-improvement
+
+**Status:** shipped
+**Milestone:** M902 (first milestone after the M880–M901 reconcile; main was
+unified so the runtime is editable again).
+**Theme:** Backlog **#42** — bias agents toward code / tool-forge for
+deterministic work and self-improvement.
+
+## What shipped
+
+A `forgeBias(tools)` section appended to each run's environment preamble
+(`injectEnvironment` in `kernel/runtime/runtime.go`), right after the M848
+capability briefing. Where the capability briefing says what the agent *can* do,
+the forge bias says how to work *well*:
+
+> **## Prefer deterministic tools — and improve your own**
+> For work that must be exact, is repeatable, or you'll likely do again, reach
+> for a tool instead of reasoning it out by hand each time:
+> - Write a script (code_exec) so the result is deterministic, checkable, and
+>   re-runnable — computation/parsing/transforms/exact-rule work belong in code.
+> - When a one-off script recurs, forge it into a durable tool (tool_forge).
+> - Check existing skills/tools before re-deriving; capture a working approach as
+>   a reusable skill (skill op=learn).
+> Treat each run as self-improvement: when you hit a capability gap, build the
+> tool that closes it.
+
+- **Tuned to the tools present:** each line emits only when its tool
+  (`code_exec` / `tool_forge` / `skill`) is in the run's tool set; returns `""`
+  when none are — no empty nudge.
+- Reaches **every run path** because it rides `injectEnvironment` (the main loop,
+  sub-agents, and workflow runs all call it).
+
+## Verification
+
+- `go build ./...` + linux/amd64 cross-build clean; `go vet ./kernel/runtime/`
+  clean; my two files `gofmt`-clean. The full `kernel/runtime` suite passes
+  (7.3s). New `TestForgeBias_TunedToTools` asserts: full set emits all three
+  lines + the self-improvement close; absent tools drop their line; no relevant
+  tool → empty.
+- No new dep, no new env var, no config surface — a pure system-prompt addition,
+  consistent with the M848 capability-briefing pattern.
+
+## Notes
+- Descriptive guidance, not a hard rail — it nudges the model toward determinism
+  and compounding self-improvement (forge → reuse) without forbidding ad-hoc
+  reasoning when that's the right call. Complements [[default-allow-posture]]:
+  the agent already *may* do anything; this tells it *what's usually wiser*.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **Forge bias — prefer deterministic tools + self-improvement (M902).** Each run's environment preamble
+  now carries a short "prefer deterministic tools — and improve your own" nudge after the capability
+  briefing (#42): for work that must be exact, is repeatable, or recurs, write a script (code_exec) for a
+  deterministic re-runnable result, forge a recurring script into a durable tool (tool_forge), and capture
+  a working approach as a reusable skill — checking existing skills/tools before re-deriving. Tuned to the
+  tools present (no nudge for absent tools); reaches main, sub-agent, and workflow runs via
+  `injectEnvironment`. Descriptive guidance, not a hard rail. (M902)
 - **In-turn parallel tool dispatch (M880).** When the model issues several tool calls in one assistant
   turn, the loop now executes them concurrently (default cap 4; `AGEZT_PARALLEL_TOOLS` overrides, `1` =
   strictly sequential) instead of one-at-a-time. Gating (loop guard, policy) and its journaling stay

--- a/kernel/runtime/environment_internal_test.go
+++ b/kernel/runtime/environment_internal_test.go
@@ -108,6 +108,41 @@ func TestCapabilityBriefing_TunedToTools(t *testing.T) {
 	}
 }
 
+func TestForgeBias_TunedToTools(t *testing.T) {
+	full := map[string]agent.Tool{
+		"code_exec":  envFakeTool{name: "code_exec", desc: "Run code."},
+		"tool_forge": envFakeTool{name: "tool_forge", desc: "Forge tools."},
+		"skill":      envFakeTool{name: "skill", desc: "Skills."},
+	}
+	out := forgeBias(full)
+	for _, want := range []string{
+		"Prefer deterministic tools",
+		"Write a script (code_exec)",                     // code line
+		"forge it into a durable tool",                   // tool_forge line
+		"capture a working approach as a reusable skill", // skill line
+		"self-improvement",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("forge bias missing %q\n---\n%s", want, out)
+		}
+	}
+
+	// Tuned: no tool_forge → no forge line; no code_exec → no script line.
+	noForge := map[string]agent.Tool{"code_exec": full["code_exec"]}
+	if strings.Contains(forgeBias(noForge), "durable tool") {
+		t.Errorf("forge bias promised tool_forge when absent")
+	}
+	noCode := map[string]agent.Tool{"skill": full["skill"]}
+	if strings.Contains(forgeBias(noCode), "Write a script") {
+		t.Errorf("forge bias promised code_exec when absent")
+	}
+
+	// None of code_exec/tool_forge/skill → empty (nothing to bias toward).
+	if got := forgeBias(map[string]agent.Tool{"notify": full["skill"]}); got != "" {
+		t.Errorf("expected empty forge bias with no relevant tools, got:\n%s", got)
+	}
+}
+
 func TestShellGuidance_ByInterpreter(t *testing.T) {
 	cases := map[string]string{
 		"cmd":            "Windows",

--- a/kernel/runtime/runtime.go
+++ b/kernel/runtime/runtime.go
@@ -2304,6 +2304,9 @@ func injectEnvironment(system, workspaceRoot string, tools map[string]agent.Tool
 	if brief := capabilityBriefing(tools); brief != "" {
 		b.WriteString(brief)
 	}
+	if bias := forgeBias(tools); bias != "" {
+		b.WriteString(bias)
+	}
 	b.WriteString("Some capabilities require operator approval and may be denied; if a call is denied, adapt your approach rather than repeating it.\n")
 
 	if system != "" {
@@ -2350,6 +2353,37 @@ func capabilityBriefing(tools map[string]agent.Tool) string {
 		b.WriteString("- Capture what works as a reusable skill — including bundled reference files and scripts — so future runs reuse it (skill op=learn / op=files / op=read).\n")
 	}
 	b.WriteString("Default to action: prefer doing the work over asking whether you're allowed. The only real limits are explicit — a denied approval, a spend budget, and the network/secret guards (no SSRF, secrets stay redacted). Everything else is yours to use.\n")
+	return b.String()
+}
+
+// forgeBias nudges the agent toward DETERMINISM and SELF-IMPROVEMENT (M902): for
+// work that must be exact, is repeatable, or you'll likely do again, prefer a
+// tool over ad-hoc reasoning — write a script so the result is deterministic and
+// re-runnable, forge a recurring script into a durable tool, and capture what
+// works as a skill so it compounds across runs. Tuned to the tools present;
+// returns "" when none of code_exec / tool_forge / skill is available (nothing
+// to bias toward). Complements capabilityBriefing (which says what you CAN do)
+// with how to work well.
+func forgeBias(tools map[string]agent.Tool) string {
+	_, hasCode := tools["code_exec"]
+	_, hasForge := tools["tool_forge"]
+	_, hasSkill := tools["skill"]
+	if !hasCode && !hasForge && !hasSkill {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("## Prefer deterministic tools — and improve your own\n")
+	b.WriteString("For work that must be exact, is repeatable, or you'll likely do again, reach for a tool instead of reasoning it out by hand each time:\n")
+	if hasCode {
+		b.WriteString("- Write a script (code_exec) so the result is deterministic, checkable, and re-runnable — not re-derived (and error-prone) each turn. Computation, parsing, transforms, and anything with exact rules belong in code.\n")
+	}
+	if hasForge {
+		b.WriteString("- When a one-off script recurs, forge it into a durable tool (tool_forge) so the capability persists and the next run just calls it.\n")
+	}
+	if hasSkill {
+		b.WriteString("- Check existing skills/tools before re-deriving one, and capture a working approach as a reusable skill (skill op=learn) so it's there next time.\n")
+	}
+	b.WriteString("Treat each run as self-improvement: when you hit a capability gap, build the tool that closes it — you finish faster and more reliably every time after.\n")
 	return b.String()
 }
 


### PR DESCRIPTION
## Summary
Backlog **#42** — biases agents toward code / tool-forge for deterministic work and self-improvement. A `forgeBias(tools)` section is appended to each run's environment preamble (`injectEnvironment`), right after the M848 capability briefing. Where the capability briefing says what the agent *can* do, this says how to work *well*:

> **## Prefer deterministic tools — and improve your own**
> For work that must be exact, is repeatable, or you'll likely do again, reach for a tool instead of reasoning it out by hand:
> - Write a script (code_exec) — deterministic, checkable, re-runnable.
> - When a one-off script recurs, forge it into a durable tool (tool_forge).
> - Check existing skills/tools before re-deriving; capture a working approach as a reusable skill.
> Treat each run as self-improvement: when you hit a capability gap, build the tool that closes it.

- **Tuned to the tools present** — each line emits only when its tool (`code_exec`/`tool_forge`/`skill`) is in the run's set; returns `""` when none are.
- Rides `injectEnvironment`, so it reaches **main, sub-agent, and workflow runs**.
- Descriptive guidance, not a hard rail (consistent with default-allow).

## Verification
- `go build ./...` + linux/amd64 cross-build clean; `go vet ./kernel/runtime/` clean; my two files `gofmt`-clean.
- New `TestForgeBias_TunedToTools` (full set emits all lines + the self-improvement close; absent tools drop their line; no relevant tool → empty). Full `kernel/runtime` suite green.
- No new dep/env/config — a pure system-prompt addition.

First milestone (**M902**) after the M880–M901 reconcile, now that main is unified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)