### PR TITLE
Feat: autonomous reaper — surface dead agents + stale artifacts (M903) (#53)

### DIFF
--- a/.project/PHASE-M903-AUTONOMOUS-REAPER-REPORT.md
+++ b/.project/PHASE-M903-AUTONOMOUS-REAPER-REPORT.md
@@ -1,0 +1,65 @@
+# Phase M903 — Autonomous Reaper (#53)
+
+## Goal
+Surface dead agents and stale artifacts **autonomously**, so the operator learns the
+pile is growing without having to ask. The destructive half of #53 — actually
+retiring an agent to the graveyard (M846) or collecting an artifact (M845) — stays
+operator-gated by design (default-allow posture governs capability, not irreversible
+cleanup). M903 ships the **detection** surface in three layers: a read-only kernel
+scan, an autonomous pulse observer, and an on-demand control-plane/UI query.
+
+## What shipped
+
+### 1. Kernel scan — `kernel/runtime/reaper.go`
+`Kernel.ReaperScan(agentIdleCutoffMs, artifactStaleCutoffMs int64) ReaperReport`,
+read-only:
+- **Dead agents:** walks the journal for `task.received` events (M854), mapping each
+  agent slug → its latest activity timestamp via `payload["agent"]`. For every roster
+  profile it flags those that are **enabled, not retired, created before the cutoff
+  (grace for brand-new agents), and last-active before the cutoff** (or never active).
+- **Stale artifacts:** `ArtifactIndex().StaleEntries(cutoff)` → count + summed bytes.
+- `ReaperReport.Empty()` is true when nothing is flagged.
+
+### 2. Autonomous observer — `kernel/pulse/reaper.go`
+`ReaperObserver` implements the pulse `Observer` interface (`Name()`/`Poll`). It is
+**transition-based**: a baseline beat records counts silently, then it fires exactly
+one `SevLow` delta **only when the dead-agent or stale-artifact count grows** above the
+previous beat. Stable counts are silent (no repeat spam); shrinking counts (operator
+cleaned up) are silent. A `nil` scan func no-ops. Wired in `cmd/agezt/main.go` inside
+the existing pulse block with a fixed 30-day window:
+```go
+eng.AddObserver(pulse.NewReaperObserver(func() (int, int) {
+    cut := time.Now().Add(-reaperWindow).UnixMilli()
+    r := k.ReaperScan(cut, cut)
+    return len(r.DeadAgents), r.StaleArtifacts
+}))
+```
+
+### 3. On-demand query — control plane + UI route
+- `protocol.go`: `CmdReaperScan = "reaper_scan"`; `server.go` dispatch case.
+- `kernel/controlplane/reaper.go`: `handleReaperScan` reads `idle_days`/`stale_days`
+  (default 30, floored at 1 via `intArg`), computes cutoffs, returns
+  `{dead_agents[], dead_count, stale_artifacts, stale_bytes, idle_days, stale_days}`.
+- `kernel/webui/webui.go`: `/api/reaper/scan` registered in `readArgsRoutes`
+  (allowlisted args `idle_days`, `stale_days`) — GET, read-only, like `agent_activity`.
+
+## Tests
+- `TestReaperScan_FlagsIdleFiltersRetiredPausedAndNew` — three agents (live/retired/
+  paused); a future cutoff flags only the live one; a past cutoff flags none. PASS.
+- `TestReaperObserver_FiresOnGrowthOnly` — baseline silent → growth fires one SevLow
+  delta naming both counts → stable silent → shrink silent. PASS.
+- `TestReaperObserver_NilScanNoOp`. PASS.
+
+## Gate
+- `go build ./...` ✓ · `go vet` (runtime/pulse/controlplane/webui) ✓
+- targeted tests runtime/pulse/controlplane/webui ✓
+- linux/amd64 cross-build ✓
+- gofmt clean on new files (webui.go/main.go flagged only by CRLF working-copy artifact;
+  git stores LF; `git diff --stat` shows only the intended additions)
+- go.mod unchanged · no new `AGEZT_*` env var (fixed 30-day const) → configEnvVars guard
+  not implicated
+
+## Notes
+Detection-only by intent. The pulse brief is the autonomous notification surface; the
+`/api/reaper/scan` route is the operator's drill-down. Retire/collect remain explicit
+operator actions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **Autonomous reaper — surface dead agents + stale artifacts (M903).** A pulse observer
+  (`system:reaper`) periodically scans for agents idle past a 30-day window and artifacts the
+  artifact index marks stale, emitting one low-severity brief only when the pile *grows* (#53) —
+  no repeat spam while counts are stable, silent on cleanup. Detection is read-only and
+  transition-based; retiring an agent to the graveyard (M846) and collecting artifacts (M845) stay
+  operator-gated. Backed by `Kernel.ReaperScan` (journal `task.received` → per-agent last-active,
+  skipping retired/paused/within-grace profiles) and a `reaper_scan` control-plane command with a
+  `/api/reaper/scan` read route (`idle_days`/`stale_days`, default 30) for on-demand detail.
 - **Forge bias — prefer deterministic tools + self-improvement (M902).** Each run's environment preamble
   now carries a short "prefer deterministic tools — and improve your own" nudge after the capability
   briefing (#42): for work that must be exact, is repeatable, or recurs, write a script (code_exec) for a

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -1308,6 +1308,16 @@ func runDaemon(stdout, stderr io.Writer) int {
 		srv.SetProbeWatch(func(name string, argv []string) (string, bool) {
 			return eng.AddObserver(pulse.NewProbeObserver(name, argv, ward, k.State())), true
 		})
+		// Reaper (#53, M903): each beat, scan for dead agents (enabled, non-retired,
+		// idle past the window) and stale artifacts, and surface a low-severity brief
+		// when the pile grows. Detection only — retire (graveyard) and collect stay
+		// operator-gated. Fixed 30-day idle/stale window.
+		const reaperWindow = 30 * 24 * time.Hour
+		eng.AddObserver(pulse.NewReaperObserver(func() (int, int) {
+			cut := time.Now().Add(-reaperWindow).UnixMilli()
+			r := k.ReaperScan(cut, cut)
+			return len(r.DeadAgents), r.StaleArtifacts
+		}))
 		fmt.Fprintf(stdout, "  pulse            : %s\n", pulseDesc)
 	} else {
 		fmt.Fprintf(stdout, "  pulse            : disabled (AGEZT_PULSE=off)\n")

--- a/kernel/controlplane/protocol.go
+++ b/kernel/controlplane/protocol.go
@@ -605,6 +605,12 @@ const (
 	//   - count : int
 	CmdRunsList = "runs_list"
 
+	// CmdReaperScan runs the reaper's read-only scan (#53, M903): dead-agent
+	// candidates (enabled, non-retired, idle past idle_days) + stale-artifact
+	// totals (older than stale_days). Detection only — the operator still retires
+	// (graveyard) / collects. Args: idle_days, stale_days (both default 30).
+	CmdReaperScan = "reaper_scan"
+
 	// CmdRunsStats aggregates the entire journal into a single
 	// agent-run health summary. Pure read-only fold over the same
 	// task.received/completed/abandoned events CmdRunsList pairs,

--- a/kernel/controlplane/reaper.go
+++ b/kernel/controlplane/reaper.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+
+package controlplane
+
+// Reaper on-demand scan (#53, M903) — the read-only detail behind the pulse
+// ReaperObserver and a future `agt reaper` / UI surface. Detection only; the
+// operator still retires (graveyard) or collects.
+
+import (
+	"net"
+	"time"
+)
+
+func (s *Server) handleReaperScan(conn net.Conn, req Request) {
+	idleDays := intArg(req.Args["idle_days"], 30)
+	staleDays := intArg(req.Args["stale_days"], 30)
+	now := time.Now()
+	agentCut := now.Add(-time.Duration(idleDays) * 24 * time.Hour).UnixMilli()
+	artifactCut := now.Add(-time.Duration(staleDays) * 24 * time.Hour).UnixMilli()
+
+	rep := s.k.ReaperScan(agentCut, artifactCut)
+
+	agents := make([]map[string]any, 0, len(rep.DeadAgents))
+	for _, a := range rep.DeadAgents {
+		agents = append(agents, map[string]any{
+			"slug": a.Slug, "name": a.Name, "last_active_ms": a.LastActiveMS,
+		})
+	}
+	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{
+		"dead_agents":     agents,
+		"dead_count":      len(agents),
+		"stale_artifacts": rep.StaleArtifacts,
+		"stale_bytes":     rep.StaleBytes,
+		"idle_days":       idleDays,
+		"stale_days":      staleDays,
+	}})
+}
+
+// intArg reads an integer-ish arg (JSON numbers arrive as float64), applying a
+// floor of 1 and a default when absent or non-positive.
+func intArg(raw any, def int) int {
+	n := def
+	switch v := raw.(type) {
+	case float64:
+		n = int(v)
+	case int:
+		n = v
+	case int64:
+		n = int(v)
+	}
+	if n < 1 {
+		n = def
+	}
+	return n
+}

--- a/kernel/controlplane/server.go
+++ b/kernel/controlplane/server.go
@@ -582,6 +582,8 @@ func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
 		s.handleStateGet(conn, req)
 	case CmdRunsList:
 		s.handleRunsList(conn, req)
+	case CmdReaperScan:
+		s.handleReaperScan(conn, req)
 	case CmdRunsStats:
 		s.handleRunsStats(conn, req)
 	case CmdCancelRun:

--- a/kernel/pulse/reaper.go
+++ b/kernel/pulse/reaper.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+
+package pulse
+
+import (
+	"context"
+	"fmt"
+)
+
+// ReaperScanFunc returns the current reaper candidate counts — dead agents and
+// stale artifacts. Injected so the observer is testable and pulse doesn't import
+// the runtime; the daemon wires k.ReaperScan with its configured cutoffs (M903).
+type ReaperScanFunc func() (deadAgents, staleArtifacts int)
+
+// ReaperObserver surfaces stale agents/artifacts on the pulse cadence (#53) —
+// detection only; the operator still chooses to retire (graveyard) or collect.
+// Transition-based like the disk observer: it fires when the pile of candidates
+// first appears or GROWS, not every beat, so a standing backlog doesn't spam the
+// briefing. Low severity — this is housekeeping, not an incident.
+type ReaperObserver struct {
+	scan     ReaperScanFunc
+	lastDead int
+	lastArt  int
+	hasState bool
+}
+
+// NewReaperObserver constructs a reaper observer over the given scan.
+func NewReaperObserver(scan ReaperScanFunc) *ReaperObserver {
+	return &ReaperObserver{scan: scan}
+}
+
+// Name implements Observer.
+func (o *ReaperObserver) Name() string { return "system:reaper" }
+
+// Poll implements Observer.
+func (o *ReaperObserver) Poll(_ context.Context) ([]Delta, error) {
+	if o.scan == nil {
+		return nil, nil
+	}
+	dead, art := o.scan()
+
+	prevDead, prevArt, known := o.lastDead, o.lastArt, o.hasState
+	o.lastDead, o.lastArt, o.hasState = dead, art, true
+
+	if !known {
+		return nil, nil // baseline beat: establish state silently
+	}
+	// Fire only when something NEW went stale (the pile grew), and only when
+	// there's actually something to reap now.
+	if (dead <= prevDead && art <= prevArt) || (dead == 0 && art == 0) {
+		return nil, nil
+	}
+	return []Delta{{
+		Source:  o.Name(),
+		Kind:    "reaper_candidates",
+		Summary: fmt.Sprintf("reaper: %d dead agent(s) and %d stale artifact(s) — retire or collect", dead, art),
+		Before:  fmt.Sprintf("%d agents / %d artifacts", prevDead, prevArt),
+		After:   fmt.Sprintf("%d agents / %d artifacts", dead, art),
+		Hints:   map[string]string{"severity": string(SevLow)},
+	}}, nil
+}

--- a/kernel/pulse/reaper_test.go
+++ b/kernel/pulse/reaper_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+
+package pulse
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestReaperObserver_FiresOnGrowthOnly(t *testing.T) {
+	var dead, art int
+	o := NewReaperObserver(func() (int, int) { return dead, art })
+	ctx := context.Background()
+
+	// Baseline beat establishes state silently.
+	if d, _ := o.Poll(ctx); len(d) != 0 {
+		t.Fatalf("baseline beat should be silent, got %v", d)
+	}
+
+	// The pile grows → one low-severity delta naming the counts.
+	dead, art = 2, 5
+	d, err := o.Poll(ctx)
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(d) != 1 {
+		t.Fatalf("growth should fire exactly one delta, got %d", len(d))
+	}
+	if !strings.Contains(d[0].Summary, "2 dead agent") || !strings.Contains(d[0].Summary, "5 stale artifact") {
+		t.Errorf("summary = %q", d[0].Summary)
+	}
+	if d[0].Hints["severity"] != string(SevLow) {
+		t.Errorf("severity = %q, want low", d[0].Hints["severity"])
+	}
+
+	// Stable → silent (no repeat spam).
+	if d, _ := o.Poll(ctx); len(d) != 0 {
+		t.Errorf("stable counts should be silent, got %v", d)
+	}
+
+	// Shrink (operator cleaned up) → silent.
+	dead, art = 0, 0
+	if d, _ := o.Poll(ctx); len(d) != 0 {
+		t.Errorf("shrinking counts should be silent, got %v", d)
+	}
+}
+
+func TestReaperObserver_NilScanNoOp(t *testing.T) {
+	o := NewReaperObserver(nil)
+	if d, err := o.Poll(context.Background()); d != nil || err != nil {
+		t.Fatalf("nil scan should no-op, got %v / %v", d, err)
+	}
+}

--- a/kernel/runtime/reaper.go
+++ b/kernel/runtime/reaper.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+
+package runtime
+
+// The reaper (#53) finds what's gone stale — agents that look abandoned and
+// artifacts past their useful life — so they can be retired to the graveyard
+// (roster.SetRetired, M846) or collected (artifact Collect, M845). This file is
+// the DETECTION half: read-only scans. It mutates nothing — retire/collect stay
+// operator-gated. The pulse ReaperObserver (kernel/pulse) runs ReaperScan on a
+// cadence to surface candidates autonomously; the control plane exposes it
+// on-demand for `agt reaper` and the UI.
+
+import (
+	"encoding/json"
+	"sort"
+
+	"github.com/agezt/agezt/kernel/event"
+)
+
+// ReaperAgent is a dead-agent candidate: an enabled, non-retired roster agent,
+// old enough to judge, with no task activity since the idle cutoff.
+type ReaperAgent struct {
+	Slug         string `json:"slug"`
+	Name         string `json:"name,omitempty"`
+	LastActiveMS int64  `json:"last_active_ms"` // 0 = never ran a task
+}
+
+// ReaperReport is the read-only result of a scan: dead-agent candidates plus
+// stale-artifact totals. Detection only.
+type ReaperReport struct {
+	DeadAgents     []ReaperAgent `json:"dead_agents"`
+	StaleArtifacts int           `json:"stale_artifacts"`
+	StaleBytes     int64         `json:"stale_bytes"`
+}
+
+// Empty reports whether the scan found nothing to reap.
+func (r ReaperReport) Empty() bool {
+	return len(r.DeadAgents) == 0 && r.StaleArtifacts == 0
+}
+
+// ReaperScan finds dead-agent candidates (enabled, non-retired, created before
+// agentIdleCutoffMs, and with no task activity at/after it) and counts stale
+// artifacts (created before artifactStaleCutoffMs). Both cutoffs are absolute
+// wall-clock ms — the caller passes `now - grace`. Read-only.
+//
+// "Created before the cutoff" is a grace window: a freshly-added agent that
+// hasn't run yet is not reaped until it's been idle past the threshold, so the
+// scan never flags an agent the operator just set up.
+func (k *Kernel) ReaperScan(agentIdleCutoffMs, artifactStaleCutoffMs int64) ReaperReport {
+	// Last task.received timestamp per agent slug — task.received carries the
+	// acting agent's slug since M854 (same source the activity log uses).
+	lastActive := map[string]int64{}
+	_ = k.Journal().Range(func(e *event.Event) error {
+		if e.Kind != event.KindTaskReceived {
+			return nil
+		}
+		var pl map[string]any
+		if json.Unmarshal(e.Payload, &pl) == nil {
+			if slug, _ := pl["agent"].(string); slug != "" && e.TSUnixMS > lastActive[slug] {
+				lastActive[slug] = e.TSUnixMS
+			}
+		}
+		return nil
+	})
+
+	var dead []ReaperAgent
+	for _, p := range k.Roster().List() {
+		if !p.Enabled || p.Retired {
+			continue // paused/retired agents aren't "dead", just inactive on purpose
+		}
+		if p.CreatedMS == 0 || p.CreatedMS >= agentIdleCutoffMs {
+			continue // too new to judge (within the grace window)
+		}
+		if last := lastActive[p.Slug]; last >= agentIdleCutoffMs {
+			continue // ran a task recently enough
+		}
+		dead = append(dead, ReaperAgent{Slug: p.Slug, Name: p.Name, LastActiveMS: lastActive[p.Slug]})
+	}
+	sort.Slice(dead, func(i, j int) bool { return dead[i].Slug < dead[j].Slug })
+
+	var staleN int
+	var staleBytes int64
+	if idx := k.ArtifactIndex(); idx != nil {
+		for _, e := range idx.StaleEntries(artifactStaleCutoffMs) {
+			staleN++
+			staleBytes += e.Size
+		}
+	}
+	return ReaperReport{DeadAgents: dead, StaleArtifacts: staleN, StaleBytes: staleBytes}
+}

--- a/kernel/runtime/reaper_test.go
+++ b/kernel/runtime/reaper_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+
+package runtime
+
+import (
+	"testing"
+	"time"
+
+	"github.com/agezt/agezt/kernel/roster"
+)
+
+// A future cutoff makes every existing agent "old enough to judge", so the scan
+// flags exactly the enabled, non-retired one with no activity — and a past cutoff
+// (everything within the grace window) flags nothing.
+func TestReaperScan_FlagsIdleFiltersRetiredPausedAndNew(t *testing.T) {
+	k := openCausesKernel(t)
+	for _, slug := range []string{"live", "retired", "paused"} {
+		if _, err := k.Roster().Add(roster.Profile{Slug: slug}); err != nil {
+			t.Fatalf("add %s: %v", slug, err)
+		}
+	}
+	if _, err := k.Roster().SetRetired("retired", true); err != nil {
+		t.Fatalf("retire: %v", err)
+	}
+	if _, err := k.Roster().SetEnabled("paused", false); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+
+	future := time.Now().Add(time.Hour).UnixMilli()
+	rep := k.ReaperScan(future, future)
+	if len(rep.DeadAgents) != 1 || rep.DeadAgents[0].Slug != "live" {
+		t.Fatalf("dead agents = %+v, want exactly [live]", rep.DeadAgents)
+	}
+	if rep.Empty() {
+		t.Errorf("report with a dead agent should not be Empty()")
+	}
+
+	// Past cutoff: every agent is within the grace window → nothing flagged.
+	past := time.Now().Add(-time.Hour).UnixMilli()
+	if rep2 := k.ReaperScan(past, past); len(rep2.DeadAgents) != 0 || !rep2.Empty() {
+		t.Errorf("past cutoff should flag nothing, got %+v", rep2.DeadAgents)
+	}
+}

--- a/kernel/webui/webui.go
+++ b/kernel/webui/webui.go
@@ -179,6 +179,8 @@ var readArgsRoutes = map[string]writeRoute{
 	"/api/agents/impact": {controlplane.CmdAgentImpact, []string{"ref"}},
 	// Per-agent activity timeline (M854): what the agent did, from the journal. Read-only.
 	"/api/agents/activity": {controlplane.CmdAgentActivity, []string{"ref", "limit"}},
+	// Reaper scan (M903): dead-agent + stale-artifact candidates. Read-only detection. (#53)
+	"/api/reaper/scan": {controlplane.CmdReaperScan, []string{"idle_days", "stale_days"}},
 	// Skill bundle resources (M847): list a skill's reference files + scripts, and
 	// read one resource's content. Both read-only; the daemon path-confines reads.
 	"/api/skill/files": {controlplane.CmdSkillFiles, []string{"id"}},


### PR DESCRIPTION
## What
Autonomous detection for **#53**: surface dead agents and stale artifacts without the operator having to ask. The destructive half (retire-to-graveyard M846, collect M845) stays operator-gated by design.

Three layers:
1. **`Kernel.ReaperScan`** (`kernel/runtime/reaper.go`) — read-only. Journal `task.received` (M854) → per-agent last-active; flags roster profiles that are enabled, not retired, created before the cutoff (grace for new agents), and idle past the cutoff. Stale artifacts via `ArtifactIndex().StaleEntries`.
2. **`ReaperObserver`** (`kernel/pulse/reaper.go`) — autonomous pulse observer. Transition-based: a baseline beat is silent, then one `SevLow` brief fires **only when the count grows**. Stable → silent (no spam); shrink → silent. Wired in `cmd/agezt/main.go` with a fixed 30-day window.
3. **On-demand query** — `reaper_scan` control-plane command + `/api/reaper/scan` read route (`idle_days`/`stale_days`, default 30) for operator drill-down.

## Tests
- `TestReaperScan_FlagsIdleFiltersRetiredPausedAndNew`
- `TestReaperObserver_FiresOnGrowthOnly`, `TestReaperObserver_NilScanNoOp`

## Gate
`go build ./...` ✓ · vet ✓ · targeted runtime/pulse/controlplane/webui tests ✓ · linux/amd64 cross-build ✓ · go.mod unchanged · no new env var (fixed 30-day const).

🤖 Generated with [Claude Code](https://claude.com/claude-code)