### PR TITLE
Feat: remote MCP servers over Streamable HTTP (M904) (#39)

### DIFF
--- a/.project/PHASE-M904-REMOTE-MCP-HTTP-REPORT.md
+++ b/.project/PHASE-M904-REMOTE-MCP-HTTP-REPORT.md
@@ -1,0 +1,84 @@
+# Phase M904 — Remote MCP servers over Streamable HTTP (#39)
+
+## Goal
+Close the registry's transport gap (#39, "3rd-party tool/MCP parity"): until now
+the kernel MCP registry (`kernel/mcp`, M796) could only spawn **local stdio**
+processes. Many popular MCP servers are **remote HTTP endpoints** (hosted
+GitHub/Linear/etc.). M904 teaches the registry the **MCP Streamable HTTP
+transport** (the 2025-03-26 spec's transport), so a registration can be a URL
+instead of a command — attached, governed, and bridged into runs exactly like a
+stdio server.
+
+## What shipped
+
+### Transport — `kernel/mcp/http.go`
+A minimal Streamable HTTP client implementing the same `Conn` interface as the
+stdio client:
+- `DialHTTP(ctx, endpoint, headers)` → `initialize` → `notifications/initialized`
+  → `tools/list`, then forwards `tools/call`.
+- Each JSON-RPC request is **POSTed** to the one endpoint; the reply is decoded
+  from **either** an `application/json` body **or** a `text/event-stream` (the
+  client scans SSE `data:` lines for the message matching the request id).
+- Captures the `Mcp-Session-Id` from `initialize` and echoes it (plus
+  `MCP-Protocol-Version`) on every later request; `Close()` best-effort `DELETE`s
+  the session.
+- **Scope mirrors stdio deliberately:** request/reply only — no long-lived GET
+  listening stream (this client makes no use of server-initiated
+  requests/resources/prompts). Calls serialize under a mutex; frames are
+  size-capped (`maxFrameBytes`); the SSE reader bounds total bytes.
+- Operator opt-in `headers` (e.g. `Authorization: Bearer …`) ride every request.
+
+### Registry — `kernel/mcp/store.go`
+- `Server.URL` (remote endpoint) + `Server.Headers` (opt-in auth headers).
+- `Validate`: **exactly one** of `Command` (stdio) / `URL` (http); URL must be
+  http/https with a host; header names must be valid HTTP tokens; `maxHeaders`
+  cap. `Command`/`url` JSON tags became `omitempty`.
+
+### Wiring — `kernel/runtime`
+- New `dialMCP(srv)` routes on transport: a URL attaches via the
+  `MCPHTTPDialer` seam (default `mcp.DialHTTP`), everything else via the stdio
+  `MCPDialer`. From there it's the same path — tools bridged as
+  `mcp_<server>_<tool>`, the M899 allowlist, detach kill-switch, journal events.
+- `mcp.added` payload now carries `transport` + `url`.
+- `Config.MCPHTTPDialer` added (nil → production dialer; tests inject fakes).
+
+### Surfaces — controlplane + CLI
+- `mcpServerView` redacts `headers` like `env` (exposes sorted `header_keys`
+  only) and adds a `transport` badge (`stdio`/`http`).
+- `agt mcp add <name> --url URL [--header "K: V" ...]` registers a remote server;
+  `agt mcp list` shows `http <url>` for remote rows. Usage updated.
+
+## Tests
+- `kernel/mcp/http_test.go` — a `httptest` Streamable HTTP server exercised over
+  **both** JSON and SSE framings: tool discovery, a forwarded call, the opt-in
+  header riding the request, the session id echoed back, `Close` issuing the
+  `DELETE`, and a 401 propagating from the handshake.
+- `kernel/mcp/store_test.go::TestValidateServer_Transport` — both/neither
+  command+url rejected, non-http scheme rejected, hostless url rejected, bad
+  header name rejected; remote+headers accepted.
+- `kernel/runtime/mcptool_test.go::TestAttach_RemoteRoutesThroughHTTPDialer` — a
+  URL registration routes through the HTTP dialer (never stdio), carrying its
+  headers, and bridges `mcp_remote_<tool>`.
+- `kernel/controlplane/mcp_test.go::TestMCP_RemoteServerViewRedactsHeaders` — the
+  wire view badges `transport:http`, omits raw `headers`, exposes sorted
+  `header_keys`, and never serializes the secret value.
+
+## Gate
+`go build ./...` ✓ · vet (mcp/runtime/controlplane/agt) ✓ · targeted + full
+mcp/runtime/controlplane/webui suites ✓ · linux/amd64 cross-build ✓ · new files
+gofmt-clean, all edits gofmt-clean modulo CRLF working copy · go.mod unchanged ·
+no new `AGEZT_*` env var.
+
+## Security posture
+Default-allow holds: registering/attaching stays gated by `mcp.install` (Ask),
+every call exercises `mcp.call`. No SSRF host-block on the URL — legitimate
+self-hosted MCP servers run on localhost/LAN (task #51), and the URL is operator
+config behind the install gate; only scheme/host are validated. Header values
+are secrets: stored plaintext in the registry (use a low-scope token) and
+**redacted** from every read API.
+
+## Follow-up
+- **M905 (UI):** Mcp.tsx form gains a stdio/remote toggle (URL + headers fields)
+  and remote catalog presets, with a `transport` badge + `header_keys` on cards.
+- Still deferred under #39: the old HTTP+SSE two-stream transport (the
+  `mcpbridge` plugin already speaks it) and a fully-lazy on-demand MCP dispatcher.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 ## [Unreleased]
 
 ### Added
+- **Remote MCP servers over Streamable HTTP (M904).** The MCP registry can now attach a server
+  by URL, not just by spawned command (#39): a registration with a `url` speaks the MCP Streamable
+  HTTP transport (2025-03-26 spec) — JSON-RPC POSTed to the endpoint, replies decoded from either an
+  `application/json` body or a `text/event-stream`, with the `Mcp-Session-Id` captured and echoed
+  and the session `DELETE`d on close. Exactly one of command (stdio) or url (http) per server;
+  opt-in request headers (e.g. `Authorization: Bearer …`) ride every request and are redacted from
+  read APIs like env (only sorted `header_keys` are exposed). Attached, governed (`mcp.install` /
+  `mcp.call`), bridged as `mcp_<server>_<tool>`, and journaled exactly like a stdio server. Reachable
+  via `agt mcp add <name> --url URL [--header "K: V" …]`; the wire view badges `transport` stdio/http.
 - **Autonomous reaper — surface dead agents + stale artifacts (M903).** A pulse observer
   (`system:reaper`) periodically scans for agents idle past a 30-day window and artifacts the
   artifact index marks stale, emitting one low-severity brief only when the pile *grows* (#53) —

--- a/cmd/agt/mcp.go
+++ b/cmd/agt/mcp.go
@@ -50,6 +50,8 @@ func mcpUsage(w io.Writer) int {
 	fmt.Fprintf(w, "  list [--json]                              registrations + live attachment status\n")
 	fmt.Fprintf(w, "  add <name> --cmd EXE [--arg A ...] [--desc TEXT]\n")
 	fmt.Fprintf(w, "      register a stdio MCP server, e.g. %s mcp add everything --cmd npx --arg -y --arg @modelcontextprotocol/server-everything\n", brand.CLI)
+	fmt.Fprintf(w, "  add <name> --url URL [--header \"K: V\" ...] [--desc TEXT]\n")
+	fmt.Fprintf(w, "      register a remote (Streamable HTTP) MCP server, e.g. %s mcp add github --url https://api.example.com/mcp --header \"Authorization: Bearer ghp_...\"\n", brand.CLI)
 	fmt.Fprintf(w, "  attach <name|id>                           spawn + handshake NOW; its tools become callable as mcp_<name>_<tool>\n")
 	fmt.Fprintf(w, "  detach <name|id>                           stop it (kill switch); its tools vanish from the next run\n")
 	fmt.Fprintf(w, "  enable|disable <name|id>                   auto-attach at daemon start on/off\n")
@@ -98,6 +100,9 @@ func cmdMCPList(args []string, stdout, stderr io.Writer) int {
 			auto = " auto-attach"
 		}
 		argv := str(srv["command"])
+		if u := str(srv["url"]); u != "" {
+			argv = "http " + u // remote (Streamable HTTP) server, M904
+		}
 		if list, _ := srv["args"].([]any); len(list) > 0 {
 			parts := make([]string, 0, len(list))
 			for _, a := range list {
@@ -112,8 +117,9 @@ func cmdMCPList(args []string, stdout, stderr io.Writer) int {
 }
 
 func cmdMCPAdd(args []string, stdout, stderr io.Writer) int {
-	name, command, desc := "", "", ""
+	name, command, desc, url := "", "", "", ""
 	var srvArgs []string
+	headers := map[string]any{}
 	for i := 0; i < len(args); i++ {
 		a := args[i]
 		need := func() bool {
@@ -130,12 +136,30 @@ func cmdMCPAdd(args []string, stdout, stderr io.Writer) int {
 			}
 			i++
 			command = args[i]
+		case "--url":
+			if !need() {
+				return 2
+			}
+			i++
+			url = args[i]
 		case "--arg":
 			if !need() {
 				return 2
 			}
 			i++
 			srvArgs = append(srvArgs, args[i])
+		case "--header":
+			// --header "Authorization: Bearer ..." (remote servers, M904).
+			if !need() {
+				return 2
+			}
+			i++
+			k, v, ok := strings.Cut(args[i], ":")
+			if !ok || strings.TrimSpace(k) == "" {
+				fmt.Fprintf(stderr, "%s mcp add: --header wants \"Name: value\"\n", brand.CLI)
+				return 2
+			}
+			headers[strings.TrimSpace(k)] = strings.TrimSpace(v)
 		case "--desc", "--description":
 			if !need() {
 				return 2
@@ -148,11 +172,19 @@ func cmdMCPAdd(args []string, stdout, stderr io.Writer) int {
 			}
 		}
 	}
-	if name == "" || command == "" {
-		fmt.Fprintf(stderr, "usage: %s mcp add <name> --cmd EXE [--arg A ...] [--desc TEXT]\n", brand.CLI)
+	if name == "" || (command == "" && url == "") {
+		fmt.Fprintf(stderr, "usage: %s mcp add <name> (--cmd EXE [--arg A ...] | --url URL [--header \"K: V\" ...]) [--desc TEXT]\n", brand.CLI)
 		return 2
 	}
-	server := map[string]any{"name": name, "command": command, "description": desc}
+	server := map[string]any{"name": name, "description": desc}
+	if url != "" {
+		server["url"] = url
+		if len(headers) > 0 {
+			server["headers"] = headers
+		}
+	} else {
+		server["command"] = command
+	}
 	if len(srvArgs) > 0 {
 		list := make([]any, len(srvArgs))
 		for i, a := range srvArgs {

--- a/kernel/controlplane/mcp.go
+++ b/kernel/controlplane/mcp.go
@@ -37,6 +37,23 @@ func (s *Server) mcpServerView(srv mcp.Server) map[string]any {
 		sort.Strings(keys)
 		m["env_keys"] = keys
 	}
+	// Same for remote-server request headers (M904): they may carry an auth
+	// token, so echo only the sorted key names, never the values.
+	delete(m, "headers")
+	if len(srv.Headers) > 0 {
+		keys := make([]string, 0, len(srv.Headers))
+		for k := range srv.Headers {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		m["header_keys"] = keys
+	}
+	// Surface the transport so the UI can badge stdio vs http without parsing.
+	if srv.URL != "" {
+		m["transport"] = "http"
+	} else {
+		m["transport"] = "stdio"
+	}
 	attached := s.k.MCPAttached()
 	if n, live := attached[srv.Name]; live {
 		m["attached"] = true

--- a/kernel/controlplane/mcp_test.go
+++ b/kernel/controlplane/mcp_test.go
@@ -5,6 +5,7 @@ package controlplane_test
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -99,5 +100,46 @@ func TestMCP_WireRoundTrip(t *testing.T) {
 	// Ghost refs are honest errors.
 	if _, err := c.Call(ctx, controlplane.CmdMCPAttach, map[string]any{"ref": "ghost"}); err == nil {
 		t.Fatal("ghost attach accepted")
+	}
+}
+
+// TestMCP_RemoteServerViewRedactsHeaders (M904, #39): a remote (URL)
+// registration round-trips with a transport badge and its header VALUES
+// redacted — only sorted key names are exposed, like env.
+func TestMCP_RemoteServerViewRedactsHeaders(t *testing.T) {
+	_, _, c, _ := startPairWithConfig(t, runtime.Config{
+		Provider: mock.New(mock.FinalText("unused")),
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	res, err := c.Call(ctx, controlplane.CmdMCPAdd, map[string]any{
+		"server": map[string]any{
+			"name": "remote",
+			"url":  "https://mcp.example.com/v1",
+			"headers": map[string]any{
+				"Authorization": "Bearer super-secret",
+				"X-Trace-Id":    "abc",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("add remote: %v", err)
+	}
+	srv, _ := res["server"].(map[string]any)
+	if srv["transport"] != "http" {
+		t.Errorf("transport = %v, want http", srv["transport"])
+	}
+	if _, leaked := srv["headers"]; leaked {
+		t.Error("raw header values leaked over the wire")
+	}
+	keys, _ := srv["header_keys"].([]any)
+	if len(keys) != 2 || keys[0] != "Authorization" || keys[1] != "X-Trace-Id" {
+		t.Errorf("header_keys = %v, want sorted [Authorization X-Trace-Id]", keys)
+	}
+	// And the secret value must appear nowhere in the serialized view.
+	blob, _ := json.Marshal(srv)
+	if strings.Contains(string(blob), "super-secret") {
+		t.Error("serialized view contained the header secret")
 	}
 }

--- a/kernel/mcp/client.go
+++ b/kernel/mcp/client.go
@@ -64,6 +64,12 @@ type Conn interface {
 // server's opt-in extra environment (M898), injected on top of the scrubbed base.
 type Dialer func(ctx context.Context, command string, args []string, env map[string]string) (Conn, error)
 
+// HTTPDialer handshakes one REMOTE server over Streamable HTTP (M904). The
+// runtime takes it as a seam so tests can attach fakes; DialHTTP is the
+// production implementation. headers are the operator's opt-in request headers
+// (e.g. an Authorization bearer token), applied to every request.
+type HTTPDialer func(ctx context.Context, url string, headers map[string]string) (Conn, error)
+
 // jsonrpc wire shapes (only what this client speaks).
 type rpcRequest struct {
 	JSONRPC string `json:"jsonrpc"`

--- a/kernel/mcp/http.go
+++ b/kernel/mcp/http.go
@@ -1,0 +1,327 @@
+// SPDX-License-Identifier: MIT
+
+package mcp
+
+// A minimal MCP client over the Streamable HTTP transport (MCP 2025-03-26):
+// the same JSON-RPC handshake the stdio client speaks, but framed over HTTP
+// instead of a child process's pipes. One endpoint URL; each JSON-RPC request
+// is POSTed there, and the reply comes back either as a single
+// `application/json` body or as a `text/event-stream` carrying one or more
+// JSON-RPC messages. This is the transport popular remote servers run today
+// (e.g. hosted GitHub/Linear endpoints) — the registry's parity with stdio
+// (#39).
+//
+// Scope mirrors the stdio client deliberately: request/reply only. We do NOT
+// open the optional long-lived GET listening stream (server-initiated
+// requests/notifications) — like the stdio client, this one makes no use of
+// resources/prompts/sampling, so there's nothing to receive out-of-band.
+// Calls are serialized (one outstanding request), frames are size-capped, and
+// the operator's opt-in auth headers (M904) ride every request.
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// httpProtocolVersion is what we advertise on the HTTP transport. The
+// Streamable HTTP transport was introduced in the 2025-03-26 revision, so a
+// server that speaks it negotiates from at least this version; it is also sent
+// back as the MCP-Protocol-Version header on every post-handshake request, per
+// spec.
+const httpProtocolVersion = "2025-03-26"
+
+// httpConn is the production Conn over Streamable HTTP. Calls serialize under
+// mu (one outstanding id), matching the stdio client's contract.
+type httpConn struct {
+	client   *http.Client
+	endpoint string
+	headers  map[string]string // operator opt-in (e.g. Authorization), M904
+
+	mu        sync.Mutex // serializes round-trips; guards sessionID
+	sessionID string     // Mcp-Session-Id, echoed back after initialize
+	nextID    atomic.Int64
+
+	tools []ToolDef
+}
+
+// DialHTTP completes the MCP handshake + tool discovery against a remote
+// Streamable HTTP endpoint. headers (M904) are the operator's explicit opt-in
+// request headers — typically an Authorization bearer token — applied to every
+// request including the handshake. Unlike the stdio dialer there is no process
+// to scrub: the only thing reaching the remote is what the operator put in
+// headers plus the JSON-RPC body.
+func DialHTTP(ctx context.Context, endpoint string, headers map[string]string) (Conn, error) {
+	if _, err := url.Parse(endpoint); err != nil {
+		return nil, fmt.Errorf("mcp http: bad url %q: %w", endpoint, err)
+	}
+	c := &httpConn{
+		client:   &http.Client{Timeout: callTimeout},
+		endpoint: endpoint,
+		headers:  headers,
+	}
+	hctx, cancel := context.WithTimeout(ctx, handshakeTimeout)
+	defer cancel()
+	if err := c.handshake(hctx); err != nil {
+		_ = c.Close()
+		return nil, err
+	}
+	return c, nil
+}
+
+// handshake: initialize (captures the session id) → initialized notification →
+// tools/list. Same sequence as the stdio client.
+func (c *httpConn) handshake(ctx context.Context) error {
+	var initRes json.RawMessage
+	err := c.roundTrip(ctx, "initialize", map[string]any{
+		"protocolVersion": httpProtocolVersion,
+		"capabilities":    map[string]any{},
+		"clientInfo":      map[string]any{"name": clientName, "version": "1"},
+	}, &initRes)
+	if err != nil {
+		return fmt.Errorf("mcp http: initialize: %w", err)
+	}
+	if err := c.notify(ctx, "notifications/initialized", nil); err != nil {
+		return fmt.Errorf("mcp http: initialized notification: %w", err)
+	}
+	var listRes struct {
+		Tools []ToolDef `json:"tools"`
+	}
+	if err := c.roundTrip(ctx, "tools/list", map[string]any{}, &listRes); err != nil {
+		return fmt.Errorf("mcp http: tools/list: %w", err)
+	}
+	c.tools = listRes.Tools
+	return nil
+}
+
+// Tools implements Conn.
+func (c *httpConn) Tools() []ToolDef {
+	out := make([]ToolDef, len(c.tools))
+	copy(out, c.tools)
+	return out
+}
+
+// Call implements Conn: one tools/call, content flattened to text.
+func (c *httpConn) Call(ctx context.Context, tool string, args json.RawMessage) (string, bool, error) {
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, callTimeout)
+		defer cancel()
+	}
+	if len(args) == 0 {
+		args = json.RawMessage(`{}`)
+	}
+	var res struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+		IsError bool `json:"isError"`
+	}
+	err := c.roundTrip(ctx, "tools/call", map[string]any{"name": tool, "arguments": json.RawMessage(args)}, &res)
+	if err != nil {
+		return "", false, err
+	}
+	var parts []string
+	for _, blk := range res.Content {
+		if blk.Text != "" {
+			parts = append(parts, blk.Text)
+		}
+	}
+	return strings.Join(parts, "\n"), res.IsError, nil
+}
+
+// Close implements Conn: best-effort DELETE to terminate the server session
+// (spec-optional), then nothing else to reap — there's no child process.
+func (c *httpConn) Close() error {
+	c.mu.Lock()
+	sid := c.sessionID
+	c.mu.Unlock()
+	if sid == "" {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.endpoint, nil)
+	if err != nil {
+		return nil
+	}
+	c.applyHeaders(req, sid)
+	if resp, err := c.client.Do(req); err == nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}
+	return nil
+}
+
+// roundTrip POSTs one JSON-RPC request and returns ITS response, handling both
+// a single application/json body and a text/event-stream reply. Serialized
+// under mu so at most one id is outstanding.
+func (c *httpConn) roundTrip(ctx context.Context, method string, params any, out any) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	id := c.nextID.Add(1)
+	body, err := json.Marshal(rpcRequest{JSONRPC: "2.0", ID: &id, Method: method, Params: params})
+	if err != nil {
+		return err
+	}
+	resp, err := c.postLocked(ctx, body)
+	if err != nil {
+		return fmt.Errorf("mcp http: %s: %w", method, err)
+	}
+	defer resp.Body.Close()
+	// The initialize response carries the session id we must echo on every
+	// later request; capture it whenever present.
+	if sid := resp.Header.Get("Mcp-Session-Id"); sid != "" {
+		c.sessionID = sid
+	}
+	if resp.StatusCode >= 300 {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return fmt.Errorf("mcp http: %s: server returned %s: %s", method, resp.Status, strings.TrimSpace(string(snippet)))
+	}
+	rr, err := c.readResponse(resp, id)
+	if err != nil {
+		return fmt.Errorf("mcp http: %s: %w", method, err)
+	}
+	if rr.Error != nil {
+		return fmt.Errorf("mcp http: %s: server error %d: %s", method, rr.Error.Code, rr.Error.Message)
+	}
+	if out != nil {
+		if err := json.Unmarshal(rr.Result, out); err != nil {
+			return fmt.Errorf("mcp http: %s: parse result: %w", method, err)
+		}
+	}
+	return nil
+}
+
+// notify POSTs a JSON-RPC notification (no id, no reply expected). The server
+// answers 202 Accepted (or 200) with no JSON-RPC body.
+func (c *httpConn) notify(ctx context.Context, method string, params any) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	body, err := json.Marshal(rpcRequest{JSONRPC: "2.0", Method: method, Params: params})
+	if err != nil {
+		return err
+	}
+	resp, err := c.postLocked(ctx, body)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("server returned %s", resp.Status)
+	}
+	return nil
+}
+
+// postLocked issues one POST. Caller holds mu (so sessionID is read race-free).
+func (c *httpConn) postLocked(ctx context.Context, body []byte) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	c.applyHeaders(req, c.sessionID)
+	return c.client.Do(req)
+}
+
+// applyHeaders sets the protocol-version + session headers and overlays the
+// operator's opt-in headers last (so they can't be silently dropped, and an
+// explicit Authorization always wins).
+func (c *httpConn) applyHeaders(req *http.Request, sid string) {
+	req.Header.Set("MCP-Protocol-Version", httpProtocolVersion)
+	if sid != "" {
+		req.Header.Set("Mcp-Session-Id", sid)
+	}
+	for k, v := range c.headers {
+		req.Header.Set(k, v)
+	}
+}
+
+// readResponse decodes the reply for request id, dispatching on content type.
+// A JSON body is one response; an SSE body is scanned for the message whose id
+// matches (skipping notifications and unrelated ids), like the stdio reader.
+func (c *httpConn) readResponse(resp *http.Response, id int64) (*rpcResponse, error) {
+	ct := strings.ToLower(strings.TrimSpace(resp.Header.Get("Content-Type")))
+	if strings.HasPrefix(ct, "text/event-stream") {
+		return readSSEResponse(resp.Body, id)
+	}
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxFrameBytes))
+	if err != nil {
+		return nil, err
+	}
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return nil, errors.New("empty response body")
+	}
+	var rr rpcResponse
+	if err := json.Unmarshal(raw, &rr); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	return &rr, nil
+}
+
+// readSSEResponse scans an event stream and returns the first JSON-RPC message
+// matching id. Notifications and unrelated ids are skipped. The total bytes
+// read are bounded — a hostile server must not stream forever.
+func readSSEResponse(body io.Reader, id int64) (*rpcResponse, error) {
+	sc := bufio.NewScanner(body)
+	sc.Buffer(make([]byte, 64*1024), maxFrameBytes)
+	var data strings.Builder
+	var total int
+	flush := func() (*rpcResponse, bool) {
+		if data.Len() == 0 {
+			return nil, false
+		}
+		payload := data.String()
+		data.Reset()
+		var rr rpcResponse
+		if err := json.Unmarshal([]byte(payload), &rr); err != nil || rr.ID == nil || *rr.ID != id {
+			return nil, false // notification / unrelated id / junk
+		}
+		return &rr, true
+	}
+	for sc.Scan() {
+		line := strings.TrimRight(sc.Text(), "\r")
+		total += len(line) + 1
+		if total > maxFrameBytes {
+			return nil, errors.New("sse response exceeded frame cap")
+		}
+		if line == "" { // blank line dispatches the accumulated event
+			if rr, ok := flush(); ok {
+				return rr, nil
+			}
+			continue
+		}
+		if strings.HasPrefix(line, ":") { // comment / keep-alive
+			continue
+		}
+		field, value, ok := strings.Cut(line, ":")
+		if !ok || field != "data" {
+			continue // we only care about data: lines
+		}
+		value = strings.TrimPrefix(value, " ")
+		if data.Len() > 0 {
+			data.WriteByte('\n')
+		}
+		data.WriteString(value)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	if rr, ok := flush(); ok { // stream ended without a trailing blank line
+		return rr, nil
+	}
+	return nil, errors.New("sse stream ended before a matching response")
+}

--- a/kernel/mcp/http_test.go
+++ b/kernel/mcp/http_test.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// fakeStreamableServer is a tiny MCP Streamable HTTP server: it answers
+// initialize/tools/list/tools/call over JSON-RPC. It can reply either as a
+// single application/json body or as a text/event-stream, toggled per test, to
+// exercise both reply framings the client must handle.
+type fakeStreamableServer struct {
+	sse        bool   // reply with text/event-stream instead of application/json
+	sessionID  string // handed out on initialize, expected back afterwards
+	gotHeaders http.Header
+	gotSession []string // Mcp-Session-Id seen on each non-initialize request
+	deleted    bool
+}
+
+func (f *fakeStreamableServer) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			f.deleted = true
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			ID     *int64          `json:"id"`
+			Method string          `json:"method"`
+			Params json.RawMessage `json:"params"`
+		}
+		_ = json.Unmarshal(body, &req)
+		f.gotHeaders = r.Header.Clone()
+
+		// Notification (no id): 202, no body.
+		if req.ID == nil {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+
+		if req.Method != "initialize" {
+			f.gotSession = append(f.gotSession, r.Header.Get("Mcp-Session-Id"))
+		}
+
+		var result any
+		switch req.Method {
+		case "initialize":
+			if f.sessionID != "" {
+				w.Header().Set("Mcp-Session-Id", f.sessionID)
+			}
+			result = map[string]any{"protocolVersion": httpProtocolVersion, "capabilities": map[string]any{}}
+		case "tools/list":
+			result = map[string]any{"tools": []map[string]any{
+				{"name": "echo", "description": "echoes input", "inputSchema": map[string]any{"type": "object"}},
+			}}
+		case "tools/call":
+			result = map[string]any{"content": []map[string]any{{"type": "text", "text": "pong"}}, "isError": false}
+		default:
+			http.Error(w, "unknown method", http.StatusBadRequest)
+			return
+		}
+		resp := map[string]any{"jsonrpc": "2.0", "id": req.ID, "result": result}
+		raw, _ := json.Marshal(resp)
+		if f.sse {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			// A keep-alive comment + the event, terminated by a blank line.
+			_, _ = io.WriteString(w, ": keep-alive\n")
+			_, _ = io.WriteString(w, "event: message\ndata: "+string(raw)+"\n\n")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(raw)
+	}
+}
+
+func TestDialHTTP_JSONFraming(t *testing.T) {
+	fake := &fakeStreamableServer{sessionID: "sess-123"}
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	conn, err := DialHTTP(context.Background(), srv.URL, map[string]string{"Authorization": "Bearer tok"})
+	if err != nil {
+		t.Fatalf("DialHTTP: %v", err)
+	}
+	defer conn.Close()
+
+	tools := conn.Tools()
+	if len(tools) != 1 || tools[0].Name != "echo" {
+		t.Fatalf("tools = %+v, want one named echo", tools)
+	}
+	out, isErr, err := conn.Call(context.Background(), "echo", json.RawMessage(`{"x":1}`))
+	if err != nil || isErr || out != "pong" {
+		t.Fatalf("Call = %q,%v,%v; want pong,false,nil", out, isErr, err)
+	}
+
+	// The opt-in header rode the request, and the session id from initialize
+	// was echoed back on the later calls.
+	if got := fake.gotHeaders.Get("Authorization"); got != "Bearer tok" {
+		t.Errorf("Authorization header = %q, want Bearer tok", got)
+	}
+	for _, s := range fake.gotSession {
+		if s != "sess-123" {
+			t.Errorf("Mcp-Session-Id echoed = %q, want sess-123", s)
+		}
+	}
+	if len(fake.gotSession) == 0 {
+		t.Error("no non-initialize requests recorded")
+	}
+
+	if err := conn.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+	if !fake.deleted {
+		t.Error("Close should have issued a session DELETE")
+	}
+}
+
+func TestDialHTTP_SSEFraming(t *testing.T) {
+	fake := &fakeStreamableServer{sse: true}
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	conn, err := DialHTTP(context.Background(), srv.URL, nil)
+	if err != nil {
+		t.Fatalf("DialHTTP (sse): %v", err)
+	}
+	defer conn.Close()
+
+	if len(conn.Tools()) != 1 {
+		t.Fatalf("tools over sse = %+v", conn.Tools())
+	}
+	out, _, err := conn.Call(context.Background(), "echo", nil)
+	if err != nil || out != "pong" {
+		t.Fatalf("Call over sse = %q,%v; want pong", out, err)
+	}
+}
+
+func TestDialHTTP_ServerErrorPropagates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	_, err := DialHTTP(context.Background(), srv.URL, nil)
+	if err == nil || !strings.Contains(err.Error(), "401") {
+		t.Fatalf("want a 401 handshake error, got %v", err)
+	}
+}

--- a/kernel/mcp/store.go
+++ b/kernel/mcp/store.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -46,9 +47,15 @@ type Server struct {
 	// (it becomes a tool-name segment, parsed by prefix).
 	Name string `json:"name"`
 	// Command + Args spawn the server process (stdio transport), e.g.
-	// "npx" ["-y","@modelcontextprotocol/server-everything"].
-	Command string   `json:"command"`
+	// "npx" ["-y","@modelcontextprotocol/server-everything"]. Mutually
+	// exclusive with URL: a server is either a local process (stdio) or a
+	// remote endpoint (http).
+	Command string   `json:"command,omitempty"`
 	Args    []string `json:"args,omitempty"`
+	// URL, when set, makes this a REMOTE server over the MCP Streamable HTTP
+	// transport (M904, #39) — JSON-RPC POSTed to this endpoint — instead of a
+	// spawned process. Exactly one of Command / URL must be set.
+	URL string `json:"url,omitempty"`
 	// Enabled means "attach automatically when the daemon starts". A live
 	// attach/detach is a runtime operation independent of this flag.
 	Enabled     bool   `json:"enabled"`
@@ -61,6 +68,12 @@ type Server struct {
 	// Stored like Args (plaintext in the registry) — use a dedicated low-scope
 	// token. Redacted out of read APIs.
 	Env map[string]string `json:"env,omitempty"`
+	// Headers is an OPT-IN set of HTTP request headers for a remote (URL)
+	// server (M904) — e.g. {"Authorization": "Bearer ..."}. Applied to every
+	// request including the handshake. Like Env, these may be secrets, so they
+	// are stored plaintext in the registry but redacted out of read APIs (only
+	// the key names are exposed). Meaningless for stdio servers.
+	Headers map[string]string `json:"headers,omitempty"`
 	// ToolAllow is an OPT-IN allowlist of the server's own tool names to expose
 	// to runs (M899) — context-efficient MCP management. A chatty server (github
 	// exposes ~30 tools) can be trimmed to the few a run actually needs, so its
@@ -81,11 +94,18 @@ var nameRe = regexp.MustCompile(`^[a-z][a-z0-9]{0,15}$`)
 // not starting with a digit). Keeps a malformed key from reaching exec.
 var envKeyRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
+// headerNameRe: an HTTP field-name (RFC 7230 token). Keeps a malformed header
+// name from reaching the request.
+var headerNameRe = regexp.MustCompile(`^[A-Za-z0-9!#$%&'*+\-.^_` + "`" + `|~]+$`)
+
 const maxArgs = 32
 
 // maxEnv caps how many env vars one server may carry (a sanity bound, not a
 // security boundary).
 const maxEnv = 32
+
+// maxHeaders caps how many request headers a remote server may carry.
+const maxHeaders = 32
 
 // maxToolAllow caps the per-server tool allowlist length.
 const maxToolAllow = 128
@@ -95,8 +115,25 @@ func Validate(s Server) error {
 	if !nameRe.MatchString(s.Name) {
 		return fmt.Errorf("mcp: name must match %s (it becomes the mcp_<name>_* tool prefix)", nameRe)
 	}
-	if strings.TrimSpace(s.Command) == "" {
-		return errors.New("mcp: command is required")
+	// Transport: exactly one of Command (stdio) or URL (remote http).
+	hasCmd := strings.TrimSpace(s.Command) != ""
+	hasURL := strings.TrimSpace(s.URL) != ""
+	switch {
+	case hasCmd && hasURL:
+		return errors.New("mcp: set either command (stdio) or url (http), not both")
+	case !hasCmd && !hasURL:
+		return errors.New("mcp: command (stdio) or url (http) is required")
+	case hasURL:
+		u, err := url.Parse(strings.TrimSpace(s.URL))
+		if err != nil {
+			return fmt.Errorf("mcp: invalid url: %w", err)
+		}
+		if u.Scheme != "http" && u.Scheme != "https" {
+			return errors.New("mcp: url must be http or https")
+		}
+		if u.Host == "" {
+			return errors.New("mcp: url must have a host")
+		}
 	}
 	if len(s.Args) > maxArgs {
 		return fmt.Errorf("mcp: at most %d args", maxArgs)
@@ -104,6 +141,14 @@ func Validate(s Server) error {
 	for _, a := range s.Args {
 		if strings.TrimSpace(a) == "" {
 			return errors.New("mcp: empty arg")
+		}
+	}
+	if len(s.Headers) > maxHeaders {
+		return fmt.Errorf("mcp: at most %d headers", maxHeaders)
+	}
+	for k := range s.Headers {
+		if !headerNameRe.MatchString(k) {
+			return fmt.Errorf("mcp: invalid header name %q", k)
 		}
 	}
 	if len(s.Env) > maxEnv {
@@ -161,6 +206,7 @@ func OpenStore(dir string) (*Store, error) {
 func (s *Store) Add(srv Server) (Server, error) {
 	srv.Name = strings.TrimSpace(srv.Name)
 	srv.Command = strings.TrimSpace(srv.Command)
+	srv.URL = strings.TrimSpace(srv.URL)
 	if err := Validate(srv); err != nil {
 		return Server{}, err
 	}

--- a/kernel/mcp/store_test.go
+++ b/kernel/mcp/store_test.go
@@ -108,6 +108,35 @@ func TestValidateServer(t *testing.T) {
 	}
 }
 
+func TestValidateServer_Transport(t *testing.T) {
+	// A remote (URL) server with no command is valid.
+	remote := Server{Name: "remote9", URL: "https://mcp.example.com/v1"}
+	if err := Validate(remote); err != nil {
+		t.Fatalf("valid remote server rejected: %v", err)
+	}
+	// With opt-in auth headers, still valid.
+	remote.Headers = map[string]string{"Authorization": "Bearer x", "X-Trace-Id": "abc"}
+	if err := Validate(remote); err != nil {
+		t.Fatalf("remote + headers rejected: %v", err)
+	}
+
+	bad := []struct {
+		label string
+		srv   Server
+	}{
+		{"both command and url", Server{Name: "both9", Command: "python", URL: "https://x.example"}},
+		{"neither command nor url", Server{Name: "none9"}},
+		{"non-http scheme", Server{Name: "ftp9", URL: "ftp://x.example/v1"}},
+		{"url without host", Server{Name: "nohost9", URL: "http:///v1"}},
+		{"bad header name", Server{Name: "badhdr9", URL: "https://x.example", Headers: map[string]string{"Bad Header": "v"}}},
+	}
+	for _, tc := range bad {
+		if err := Validate(tc.srv); err == nil {
+			t.Errorf("%s: accepted, want rejected", tc.label)
+		}
+	}
+}
+
 func TestAppendEnv(t *testing.T) {
 	base := []string{"PATH=/bin", "HOME=/home/me"}
 	out := appendEnv(base, map[string]string{"TOKEN": "secret"})

--- a/kernel/runtime/mcptool.go
+++ b/kernel/runtime/mcptool.go
@@ -33,10 +33,14 @@ func (k *Kernel) AddMCPServer(corr string, srv mcp.Server) (mcp.Server, error) {
 	if err != nil {
 		return mcp.Server{}, err
 	}
+	transport := "stdio"
+	if saved.URL != "" {
+		transport = "http"
+	}
 	_, _ = k.bus.Publish(event.Spec{
 		Subject: "mcp." + saved.Name, Kind: event.KindMCPAdded, Actor: "mcp",
 		CorrelationID: corr,
-		Payload:       map[string]any{"id": saved.ID, "name": saved.Name, "command": saved.Command, "args": saved.Args},
+		Payload:       map[string]any{"id": saved.ID, "name": saved.Name, "transport": transport, "command": saved.Command, "args": saved.Args, "url": saved.URL},
 	})
 	return saved, nil
 }
@@ -73,11 +77,7 @@ func (k *Kernel) AttachMCPServer(ctx context.Context, corr, ref string) (mcp.Ser
 	}
 	k.mu.Unlock()
 
-	dial := k.cfg.MCPDialer
-	if dial == nil {
-		dial = mcp.Dial
-	}
-	conn, err := dial(ctx, srv.Command, srv.Args, srv.Env)
+	conn, err := k.dialMCP(ctx, srv)
 	if err != nil {
 		return mcp.Server{}, nil, err
 	}
@@ -101,6 +101,25 @@ func (k *Kernel) AttachMCPServer(ctx context.Context, corr, ref string) (mcp.Ser
 		Payload:       map[string]any{"id": srv.ID, "name": srv.Name, "tools": names},
 	})
 	return srv, names, nil
+}
+
+// dialMCP attaches one registered server over the transport its registration
+// implies: a remote endpoint (URL) speaks Streamable HTTP (M904), everything
+// else is a spawned stdio process (M796). Both seams default to the production
+// dialer and are overridable for tests.
+func (k *Kernel) dialMCP(ctx context.Context, srv mcp.Server) (mcp.Conn, error) {
+	if strings.TrimSpace(srv.URL) != "" {
+		dial := k.cfg.MCPHTTPDialer
+		if dial == nil {
+			dial = mcp.DialHTTP
+		}
+		return dial(ctx, srv.URL, srv.Headers)
+	}
+	dial := k.cfg.MCPDialer
+	if dial == nil {
+		dial = mcp.Dial
+	}
+	return dial(ctx, srv.Command, srv.Args, srv.Env)
 }
 
 // DetachMCPServer closes a live attachment — the kill switch: its tools

--- a/kernel/runtime/mcptool_test.go
+++ b/kernel/runtime/mcptool_test.go
@@ -105,6 +105,57 @@ func TestAttach_OffersAndForwardsBridgedTool(t *testing.T) {
 	}
 }
 
+// TestAttach_RemoteRoutesThroughHTTPDialer (M904, #39): a registration with a
+// URL (not a command) attaches over the HTTP dialer seam, carrying the opt-in
+// headers — never the stdio dialer.
+func TestAttach_RemoteRoutesThroughHTTPDialer(t *testing.T) {
+	prov := mock.New(mock.FinalText("ok"))
+	conn := &fakeMCPConn{tools: []mcp.ToolDef{{Name: "search"}}}
+
+	stdioDials, httpDials := 0, 0
+	var gotURL string
+	var gotHeaders map[string]string
+	k, err := runtime.Open(runtime.Config{
+		BaseDir:  t.TempDir(),
+		Provider: prov,
+		MCPDialer: func(_ context.Context, _ string, _ []string, _ map[string]string) (mcp.Conn, error) {
+			stdioDials++
+			return conn, nil
+		},
+		MCPHTTPDialer: func(_ context.Context, url string, headers map[string]string) (mcp.Conn, error) {
+			httpDials++
+			gotURL, gotHeaders = url, headers
+			return conn, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { k.Close() })
+
+	reg := mcp.Server{
+		Name:    "remote",
+		URL:     "https://mcp.example.com/v1",
+		Headers: map[string]string{"Authorization": "Bearer tok"},
+	}
+	if _, err := k.AddMCPServer("", reg); err != nil {
+		t.Fatalf("AddMCPServer: %v", err)
+	}
+	_, names, err := k.AttachMCPServer(context.Background(), "", "remote")
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	if httpDials != 1 || stdioDials != 0 {
+		t.Fatalf("dial routing wrong: http=%d stdio=%d", httpDials, stdioDials)
+	}
+	if gotURL != "https://mcp.example.com/v1" || gotHeaders["Authorization"] != "Bearer tok" {
+		t.Fatalf("http dialer got url=%q headers=%v", gotURL, gotHeaders)
+	}
+	if len(names) != 1 || names[0] != "mcp_remote_search" {
+		t.Fatalf("discovered names = %v", names)
+	}
+}
+
 // TestAttach_ToolAllowFilters: a server with a ToolAllow allowlist exposes only
 // the listed tools to a run — the others are kept out of context (M899).
 func TestAttach_ToolAllowFilters(t *testing.T) {

--- a/kernel/runtime/runtime.go
+++ b/kernel/runtime/runtime.go
@@ -104,6 +104,11 @@ type Config struct {
 	// means the production stdio dialer (mcp.Dial); tests inject fakes.
 	MCPDialer mcp.Dialer
 
+	// MCPHTTPDialer handshakes one REMOTE MCP server over Streamable HTTP on
+	// attach (M904, #39) — used when a registration carries a URL instead of a
+	// command. Nil means the production dialer (mcp.DialHTTP); tests inject fakes.
+	MCPHTTPDialer mcp.HTTPDialer
+
 	// Model is the default model name passed to the provider.
 	Model string
 


### PR DESCRIPTION
## What
Closes the kernel MCP registry's transport gap (#39). Until now `kernel/mcp` (M796) could only spawn **local stdio** processes; many popular MCP servers are **remote HTTP endpoints**. A registration may now carry a **`url`** instead of a `command` and is attached over the **MCP Streamable HTTP transport** (2025-03-26 spec).

## How
- **`kernel/mcp/http.go`** — `DialHTTP` implements the same `Conn` interface as the stdio client. JSON-RPC POSTed to the one endpoint; replies decoded from **either** `application/json` **or** `text/event-stream` (SSE scanned for the matching id). `Mcp-Session-Id` captured on initialize and echoed (with `MCP-Protocol-Version`) thereafter; `Close()` `DELETE`s the session. Request/reply only — same scope as stdio (no listening stream). Serialized calls, size-capped frames.
- **`kernel/mcp/store.go`** — `Server.URL` + `Server.Headers`; `Validate` enforces exactly one of command/url, http(s) scheme + host, valid header names, `maxHeaders`.
- **`kernel/runtime`** — `dialMCP` routes URL→`MCPHTTPDialer` (default `mcp.DialHTTP`), else stdio; rest of the path (bridging, M899 allowlist, detach, journal) unchanged. `mcp.added` carries `transport`+`url`.
- **controlplane** — view redacts `headers` like `env` (sorted `header_keys` only) + `transport` badge.
- **CLI** — `agt mcp add <name> --url URL [--header "K: V" …]`; `agt mcp list` shows `http <url>`.

## Security
Default-allow holds: register/attach gated by `mcp.install` (Ask), calls by `mcp.call`. Header values are secrets — stored plaintext (use a low-scope token), redacted from every read API. No SSRF host-block: self-hosted MCP runs on localhost/LAN (#51) and the URL is operator config behind the install gate; scheme/host validated.

## Tests
- `http_test.go` — httptest server over **both** JSON and SSE framing: discovery, forwarded call, opt-in header, session echo, Close→DELETE, 401 propagation.
- `store_test.go::TestValidateServer_Transport` — transport-rule matrix.
- `mcptool_test.go::TestAttach_RemoteRoutesThroughHTTPDialer` — URL routes through the HTTP dialer with headers.
- `mcp_test.go::TestMCP_RemoteServerViewRedactsHeaders` — badge + header redaction over the wire.

## Gate
`go build ./...` ✓ · vet ✓ · mcp/runtime/controlplane/webui suites ✓ · linux/amd64 cross-build ✓ · gofmt-clean · go.mod unchanged · no new env var.

Follow-up M905 adds the Mcp.tsx UI (remote toggle + headers + presets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)