### PR TITLE
Fix: abstractive context summaries on reasoning models — cap follows the catalog reasoning flag (M926)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,12 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
   shutdown forever. (M883)
 
 ### Fixed
+- **Abstractive context summaries work on reasoning models (M926).** The elided-output summary call
+  (M398, `ContextSummarize`) capped its response at 64 tokens — a reasoning model (deepseek-v4-pro,
+  o-series) spends output tokens on its chain of thought first, so the cap was entirely consumed and
+  the summary came back empty, silently degrading every stub to the extractive head snippet. The cap
+  now follows the model's catalog `reasoning` flag: plain models keep the tight 64 (spend stays
+  negligible), reasoning models get 1024 of headroom.
 - **"Needs attention" no longer shows stale halts/failures forever (M913).** The Dashboard strip and
   the nav badge derive alerts from the journal/event buffer, which backfills weeks of history — so an
   old `halt` or a run that failed days ago lingered indefinitely. Alerts are now resolution-aware (a

--- a/kernel/runtime/context_budget_test.go
+++ b/kernel/runtime/context_budget_test.go
@@ -228,3 +228,60 @@ func TestRun_AutoBudgetOffForUnknownModel(t *testing.T) {
 		t.Errorf("unknown model in auto mode must not compact, got %d", n)
 	}
 }
+
+// TestRun_ContextSummarizeReasoningHeadroom: the elided-summary call's token
+// cap follows the model's catalog reasoning flag (M926). A reasoning model
+// spends output tokens on its chain of thought before the summary line — at
+// the tight 64-token cap it returns empty content (observed live on
+// deepseek-v4-pro), silently degrading every abstractive summary to the
+// extractive head stub. Plain models keep the tight cap (spend stays
+// negligible); reasoning models get headroom.
+func TestRun_ContextSummarizeReasoningHeadroom(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		reasoning bool
+		wantMax   int
+	}{
+		{"reasoning model gets headroom", true, 1024},
+		{"plain model keeps the tight cap", false, 64},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cat := catalog.NewEmpty()
+			cat.Providers["p"] = &catalog.Provider{
+				ID:     "p",
+				Models: map[string]*catalog.Model{"mockmodel": {ID: "mockmodel", Reasoning: tc.reasoning}},
+			}
+
+			gotMax := 0
+			toolTurns := 0
+			prov := &mock.Provider{Responder: func(req agent.CompletionRequest) agent.CompletionResponse {
+				if len(req.Messages) == 1 && strings.HasPrefix(req.Messages[0].Content, "Summarize this tool output") {
+					gotMax = req.MaxTokens
+					return mock.FinalText("one-line summary")
+				}
+				if toolTurns < 3 {
+					toolTurns++
+					return mock.ToolUse("c", "dump", map[string]any{})
+				}
+				return mock.FinalText("done")
+			}}
+
+			k, err := runtime.Open(runtime.Config{
+				BaseDir: t.TempDir(), Provider: prov, Model: "mockmodel", Catalog: cat,
+				ContextBudget: 200, ContextSummarize: true, Edict: allowDump(),
+				Tools: map[string]agent.Tool{"dump": dumpTool{out: strings.Repeat("Z", 2000)}},
+			})
+			if err != nil {
+				t.Fatalf("Open: %v", err)
+			}
+			t.Cleanup(func() { k.Close() })
+
+			if _, _, err := k.Run(context.Background(), "dump repeatedly"); err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+			if gotMax != tc.wantMax {
+				t.Errorf("summary call MaxTokens = %d, want %d", gotMax, tc.wantMax)
+			}
+		})
+	}
+}

--- a/kernel/runtime/runtime.go
+++ b/kernel/runtime/runtime.go
@@ -2064,7 +2064,16 @@ func (k *Kernel) RunWith(ctx context.Context, corr, intent string) (string, erro
 	// wiring when compaction is actually active for this run.
 	var summarizeElided func(context.Context, string) (string, error)
 	if k.cfg.ContextSummarize && (ctxBudget > 0 || k.cfg.ContextBudgetAuto) {
-		summarizeElided = makeElidedSummarizer(k.cfg.Provider, model, corr)
+		maxTok := elidedSummaryMaxTokens
+		// A reasoning model needs headroom for its chain of thought or the
+		// summary comes back empty (M926). The catalog knows which models
+		// reason; locked accessor for the same M477 race reason as above.
+		if cat := k.Catalog(); cat != nil {
+			if _, m := cat.FindModel(model); m != nil && m.Reasoning {
+				maxTok = elidedSummaryReasoningMaxTokens
+			}
+		}
+		summarizeElided = makeElidedSummarizer(k.cfg.Provider, model, corr, maxTok)
 	}
 
 	answer, err := agent.Run(runCtx, agent.LoopConfig{
@@ -2167,6 +2176,15 @@ func (k *Kernel) maybeShadowEval(ctx context.Context, corr, intent, answer strin
 // line, so a small cap keeps the extra spend negligible and the latency low.
 const elidedSummaryMaxTokens = 64
 
+// elidedSummaryReasoningMaxTokens is the cap when the run's model is a
+// reasoning model (M926): such models spend output tokens on their chain of
+// thought BEFORE the summary line, so the tight cap gets entirely consumed and
+// Complete returns empty content — observed live on deepseek-v4-pro at 64
+// (every abstractive summary silently degraded to the extractive head stub).
+// The prompt still asks for one line; the headroom is only used by models that
+// actually reason.
+const elidedSummaryReasoningMaxTokens = 1024
+
 // elidedSummaryInputCap bounds how much of a dropped output is fed to the
 // summarizer — enough to summarise, while keeping the summary call's own input
 // (and therefore its cost) bounded regardless of how large the output was.
@@ -2177,7 +2195,9 @@ const elidedSummaryInputCap = 8 << 10
 // (M398). It routes through the same provider (the Governor) as the run, so the
 // extra call is billed and attributed to the run via corr. Errors propagate; the
 // loop swallows them and falls back to the deterministic head snippet.
-func makeElidedSummarizer(provider agent.Provider, model, corr string) func(context.Context, string) (string, error) {
+// maxTokens is caller-chosen: tight for plain models, roomy for reasoning
+// models whose chain of thought eats the budget first (M926).
+func makeElidedSummarizer(provider agent.Provider, model, corr string, maxTokens int) func(context.Context, string) (string, error) {
 	return func(ctx context.Context, output string) (string, error) {
 		in := output
 		if len(in) > elidedSummaryInputCap {
@@ -2187,7 +2207,7 @@ func makeElidedSummarizer(provider agent.Provider, model, corr string) func(cont
 			Model:         model,
 			CorrelationID: corr,
 			TaskType:      "summarize",
-			MaxTokens:     elidedSummaryMaxTokens,
+			MaxTokens:     maxTokens,
 			Messages: []agent.Message{{
 				Role:    agent.RoleUser,
 				Content: "Summarize this tool output in one short line for an agent's working memory. Output only the summary.\n\n" + in,


### PR DESCRIPTION
## What

`ContextSummarize` (M398) condenses elided tool outputs into one-line abstractive summaries via a bounded provider call capped at **64 output tokens**. On a reasoning model (deepseek-v4-pro — the owner's default — or o-series), the chain of thought consumes the output budget *before* the summary line, so the call returned **empty content** and every stub silently degraded to the extractive head snippet. The feature was effectively dead on the default setup.

## How

- `makeElidedSummarizer` now takes `maxTokens` from its caller.
- The run wiring looks the model up in the catalog (locked `k.Catalog()` accessor per the M477 race note) and picks **64** for plain models (spend unchanged) or **1024** for reasoning models (`Model.Reasoning` flag, synced from models.dev).
- Discovered live while building M925's `chat_summarize`, which hit the identical failure at 512 tokens and needed the same headroom.

## Tests

`TestRun_ContextSummarizeReasoningHeadroom` (table: reasoning → 1024, plain → 64) asserts the summary call's `MaxTokens` through the full `runtime.Open → Run → compaction → summarize` path with a capturing mock provider. `go build ./...` + full `kernel/runtime` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)