### PR TITLE
Fix: agt <cmd> -h is safe and uniform; short unknown-command errors (M936)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
 
 ## [Unreleased]
 
+### Fixed
+- **`agt <cmd> -h` is now safe and uniform for every command (M936).** Commands that treat their
+  first argument as data used to EXECUTE on `-h` — `agt run -h` literally sent "-h" to the live
+  agent as an intent and billed a completion for it. A central interception now answers
+  `-h`/`--help` from the help table for every documented command before any command code runs
+  (guarded by a test that walks all of them against an empty home). An unknown top-level command
+  also gets a one-line error + did-you-mean + a pointer at `agt help`, instead of an 80-line help
+  dump that buried the error. (M936)
+
 ### Added
 - **`agt` help overhauled — grouped overview + `agt help <command>` (M935).** The old help was one
   flat 100+-line dump that mixed per-flag detail for some commands while omitting ~20 dispatched

--- a/cmd/agt/help.go
+++ b/cmd/agt/help.go
@@ -293,6 +293,19 @@ func printHelp(w io.Writer) {
 	}
 }
 
+// helpHas reports whether the help table documents the command — the gate for
+// the uniform `agt <cmd> -h` interception in main.go.
+func helpHas(name string) bool {
+	for _, g := range helpGroups() {
+		for _, c := range g.commands {
+			if c.name == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // cmdHelp implements `agt help [<command>]`: the overview without an argument,
 // one command's detail block with one. Reads only the table — it never runs
 // the command, so `agt help halt` can't halt anything.

--- a/cmd/agt/help_test.go
+++ b/cmd/agt/help_test.go
@@ -89,6 +89,51 @@ func TestHelp_EntriesAreComplete(t *testing.T) {
 	}
 }
 
+// TestUniformDashH (M936): `agt <cmd> -h` answers from the help table for
+// EVERY documented command, exits 0, and never reaches the command's own code.
+// This is the regression guard for the class of bug where a command treats its
+// first arg as data — `agt run -h` used to send "-h" to the live agent as an
+// intent and bill a completion for it.
+func TestUniformDashH(t *testing.T) {
+	// No daemon, fresh home: if interception leaked through to a command that
+	// dials the control plane, it would error (non-zero) — failing this test.
+	t.Setenv("AGEZT_HOME", t.TempDir())
+	for _, g := range helpGroups() {
+		for _, c := range g.commands {
+			for _, flag := range []string{"-h", "--help"} {
+				var out, errOut bytes.Buffer
+				if code := run([]string{c.name, flag}, &out, &errOut); code != 0 {
+					t.Errorf("agt %s %s: exit=%d stderr=%s (must answer from the help table)", c.name, flag, code, errOut.String())
+					continue
+				}
+				if !strings.Contains(out.String(), c.name) {
+					t.Errorf("agt %s %s output does not mention the command:\n%s", c.name, flag, out.String())
+				}
+			}
+		}
+	}
+}
+
+// TestUnknownCommand_ShortErrorWithSuggestion: a typo'd top-level command gets
+// a one-line error + did-you-mean + a pointer at `agt help` — not an 80-line
+// help dump that buries the error.
+func TestUnknownCommand_ShortErrorWithSuggestion(t *testing.T) {
+	var out, errOut bytes.Buffer
+	if code := run([]string{"jurnal"}, &out, &errOut); code != 2 {
+		t.Fatalf("exit=%d, want 2", code)
+	}
+	msg := errOut.String()
+	if !strings.Contains(msg, "journal") {
+		t.Errorf("no did-you-mean suggestion in: %s", msg)
+	}
+	if !strings.Contains(msg, "help") {
+		t.Errorf("no pointer at `agt help` in: %s", msg)
+	}
+	if lines := strings.Count(msg, "\n"); lines > 3 {
+		t.Errorf("error is %d lines — the old full-help dump is back?", lines)
+	}
+}
+
 // TestCmdHelp_OverviewAndDetail: the overview lists groups; `help <cmd>`
 // prints that command's detail; an unknown command suggests near-misses.
 func TestCmdHelp_OverviewAndDetail(t *testing.T) {

--- a/cmd/agt/main.go
+++ b/cmd/agt/main.go
@@ -45,6 +45,14 @@ func run(args []string, stdout, stderr io.Writer) int {
 		printHelp(stdout)
 		return 0
 	}
+	// Uniform `-h` (M936): `agt <cmd> -h|--help` answers from the help table
+	// for EVERY command, before the command's own code runs. This is a safety
+	// property, not just consistency — commands that treat their first arg as
+	// data would otherwise EXECUTE on "-h" (`agt run -h` used to send "-h" to
+	// the live agent as an intent and bill a completion for it).
+	if len(args) >= 2 && (args[1] == "-h" || args[1] == "--help") && helpHas(args[0]) {
+		return cmdHelp(args[:1], stdout, stderr)
+	}
 	switch args[0] {
 	case "-v", "--version", "version":
 		fmt.Fprintf(stdout, "%s %s (protocol v%d)\n", brand.CLI, brand.Version, brand.ProtocolVersion)
@@ -162,8 +170,13 @@ func run(args []string, stdout, stderr io.Writer) int {
 	case "tenant":
 		return cmdTenant(args[1:], stdout, stderr)
 	default:
-		fmt.Fprintf(stderr, "%s: unknown command %q\n", brand.CLI, args[0])
-		printHelp(stderr)
+		// Short and actionable (M936) — the old path dumped the entire help to
+		// stderr, burying the error line it started with.
+		fmt.Fprintf(stderr, "%s: unknown command %q", brand.CLI, args[0])
+		if sug := suggestCommands(args[0]); len(sug) > 0 {
+			fmt.Fprintf(stderr, " — did you mean %s?", strings.Join(sug, ", "))
+		}
+		fmt.Fprintf(stderr, "\nrun `%s help` for the command list\n", brand.CLI)
 		return 2
 	}
 }


### PR DESCRIPTION
## Problem (found while verifying M935)

Commands that treat their first argument as data **executed on `-h`**: `agt run -h` sent the literal string `-h` to the live agent as an intent — spawned a real run, billed a completion, and answered in persona. Other commands without their own `-h` handling errored in inconsistent ways.

## What changed

- **Central interception**: `run()` answers `-h`/`--help` (as the first argument after any documented command) from the M935 help table **before any command code runs**. Uniform help for all ~50 commands, and a structural guarantee that `-h` can never execute, dial the daemon, or spend.
- **Unknown top-level command**: one-line error + did-you-mean suggestions + a pointer at `agt help` — instead of dumping the full 80-line help to stderr and burying the error.

Built on #362 (M935 — the help table); this PR's diff is the interception + error path + tests.

## Tests

- `TestUniformDashH` — walks every documented command with `-h` and `--help` against an empty `AGEZT_HOME`; a leak into command code would dial/error and fail.
- `TestUnknownCommand_ShortErrorWithSuggestion` — exit 2, suggestion present, ≤3 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)