### PR TITLE
Feat: mailbox — the shared board opens to SDK apps (M937)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
   dump that buried the error. (M936)
 
 ### Added
+- **Mailbox for SDK apps — the shared board opens to the outside (M937).** The inter-agent message
+  board (post/DM/broadcast/reply, M647/M788) is now reachable from OUTSIDE a run, so apps written
+  with the SDKs can talk to agents (and each other) by name. New REST surface
+  `/api/v1/mailbox/*` (send, inbox, replies, ack, topics — same Bearer token), new control-plane
+  commands (`board_send` / `board_inbox` / `board_ack` / `board_replies`), and mailbox clients in
+  all four SDKs (Go `SendMail`/`Inbox`/`AckMail`/…, Python/TypeScript/Rust `mailbox_*`). External
+  sends publish the same `board.posted` event as agent sends — a DM journals `board.dm.<name>`, so
+  external mail can wake a standing order and trigger an agent. New `ack` everywhere (kernel store,
+  the agents' `board` tool, REST, SDKs): mark a message read without replying — per-reader, so a
+  broadcast acked by one agent still waits for the rest. The daemon now opens ONE board store
+  shared by the `board` tool, the control plane, and REST (separate instances would clobber each
+  other's last write).
 - **`agt` help overhauled — grouped overview + `agt help <command>` (M935).** The old help was one
   flat 100+-line dump that mixed per-flag detail for some commands while omitting ~20 dispatched
   commands entirely (`backup`, `warden`, `standing`, `workflow`, `mcp`, `agent`, `toolforge`, …).

--- a/README.md
+++ b/README.md
@@ -188,7 +188,11 @@ first-party `/api/v1` surface with Agezt-native semantics: `POST /api/v1/runs`
 submits an intent (sync JSON, or an SSE event stream with `"stream":true`) and
 returns a `correlation_id`; `GET /api/v1/runs/{correlation_id}` returns that
 run's full journaled event arc; plus `GET /api/v1/health` and
-`GET /api/v1/models`. Same governed loop, loopback-bound + Bearer-token:
+`GET /api/v1/models`. The `/api/v1/mailbox` routes open the shared inter-agent
+message board to apps: send a DM to an agent by name (or broadcast with
+`"to":"*"`), read an inbox, reply, and acknowledge — a directed message wakes a
+standing order watching `board.dm.<name>`, so external mail can trigger an
+agent. Same governed loop, loopback-bound + Bearer-token:
 
 ```bash
 curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
@@ -196,8 +200,9 @@ curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
 ```
 
 **Or use an official client SDK.** Dependency-light clients wrap `/api/v1` —
-`health` / `models` / `run` / `run_stream` (SSE) / `get_run`, bearer auth,
-multi-tenant aware — in **Python** (`pip install agezt`; sync `Client` + asyncio
+`health` / `models` / `run` / `run_stream` (SSE) / `get_run`, the mailbox
+(`mailbox_send` / `mailbox_inbox` / `mailbox_ack` / replies / topics), bearer
+auth, multi-tenant aware — in **Python** (`pip install agezt`; sync `Client` + asyncio
 `AsyncClient`), **TypeScript** (`@agezt/sdk`, zero runtime deps over `fetch`), and
 **Rust** (the `agezt` crate, standard-library only). See [`sdk/`](sdk/).
 

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -1045,8 +1045,60 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// alongside inbound images. Best-effort; lives on the daemon ctx.
 	wireArtifactIndexer(ctx, k)
 
+	// Shared message board (M647/M937): ONE store instance serves every writer —
+	// the `board` tool, the control plane's board_send/board_ack, and the REST
+	// mailbox. Each store holds the whole message list in memory and saves it
+	// whole, so a second instance would silently clobber the other's last write.
+	// boardNotify publishes the board.posted event for ANY door's write: subject
+	// routing (board.dm.<slug> / board.help[.<slug>] / board.broadcast /
+	// board.<topic>) is what lets a standing order wake the addressed agent.
+	boardStore, boardErr := board.Open(filepath.Join(baseDir, "board"))
+	boardNotify := func(m board.Message, corr string) {
+		// Help takes precedence so a help-flagged message wakes responders
+		// watching board.help.
+		subject := "board." + boardSubjectSlug(m.Topic)
+		switch {
+		case m.Help && m.To != "" && m.To != board.Everyone:
+			subject = "board.help." + boardSubjectSlug(m.To)
+		case m.Help:
+			subject = "board.help"
+		case m.To == board.Everyone:
+			subject = "board.broadcast"
+		case m.To != "":
+			subject = "board.dm." + boardSubjectSlug(m.To)
+		}
+		payload := map[string]any{"topic": m.Topic, "chars": len(m.Text)}
+		if m.ID != "" {
+			payload["id"] = m.ID
+		}
+		if m.From != "" {
+			payload["from"] = m.From
+		}
+		if m.To != "" {
+			payload["to"] = m.To
+		}
+		if m.ReplyTo != "" {
+			payload["reply_to"] = m.ReplyTo
+		}
+		if m.Help {
+			payload["help"] = true
+		}
+		_, _ = k.Bus().Publish(event.Spec{
+			Subject:       subject,
+			Kind:          event.KindBoardPosted,
+			Actor:         "board",
+			CorrelationID: corr,
+			Payload:       payload,
+		})
+	}
+
 	srv := controlplane.NewServer(k, baseDir)
 	srv.SetConfigEnvPinned(configPinned) // M693: Config Center marks env-pinned fields read-only
+	if boardErr == nil {
+		// Board writes over the control plane (M937): `agt`/Go-SDK board_send,
+		// board_ack go through the shared instance and fire the same notifier.
+		srv.SetBoard(boardStore, boardNotify)
+	}
 	// Cancel-on-disconnect (M35): when AGEZT_CANCEL_ON_DISCONNECT=on, a
 	// streaming `agt run` whose client drops (Ctrl-C / killed) cancels its run
 	// server-side instead of running on headless. Off by default so a
@@ -1425,7 +1477,11 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// Native REST API (P7-API-02) — first-party /api/v1 surface: submit runs
 	// (sync or SSE), inspect a run's journaled arc, health/models. Same governed
 	// loop as `agt run`. Off unless AGEZT_REST_ADDR is set; loopback + token.
-	if restDesc := buildRESTAPI(ctx, k, tenantReg, &draining, stdout); restDesc != "" {
+	var restBoard *board.Store
+	if boardErr == nil {
+		restBoard = boardStore
+	}
+	if restDesc := buildRESTAPI(ctx, k, tenantReg, &draining, restBoard, boardNotify, stdout); restDesc != "" {
 		fmt.Fprintf(stdout, "  rest api         : %s\n", restDesc)
 	} else {
 		fmt.Fprintf(stdout, "  rest api         : disabled (set AGEZT_REST_ADDR, e.g. 127.0.0.1:8800)\n")
@@ -1533,57 +1589,17 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// journaled AddStanding / RemoveStanding / Standing() surface.
 	standingToolInst.Bind(k)
 
-	// Bind the shared message board to its on-disk store under the base dir (M647),
-	// so every agent on this daemon posts to and reads from one common board.
-	if err := boardToolInst.Bind(filepath.Join(baseDir, "board")); err != nil {
-		fmt.Fprintf(stderr, "%s: board tool unavailable: %v\n", brand.Binary, err)
+	// Bind the shared message board (M647): the SAME store instance the control
+	// plane and REST mailbox write through (opened once, before the servers).
+	// Each post journals a board.posted event (M656) via boardNotify, so a
+	// standing order can trigger on a topic — or on board.dm.<recipient> for an
+	// addressed message (M788) — and one agent's post wakes another. The posting
+	// run's correlation ties into `agt why`.
+	if boardErr != nil {
+		fmt.Fprintf(stderr, "%s: board tool unavailable: %v\n", brand.Binary, boardErr)
 	} else {
-		// Journal each post as a board.posted event under subject "board.<topic>"
-		// (M656), so a standing order can trigger on a topic and one agent's post
-		// wakes another. An ADDRESSED message (M788) publishes under
-		// "board.dm.<recipient>" instead, so a standing order can wake exactly
-		// the agent being asked. The posting run's correlation ties into `agt why`.
-		boardToolInst.OnPost(func(m board.Message, corr string) {
-			// Subject carries the routing so standing orders can wake the right
-			// agent: a directed message → board.dm.<slug>; a help request →
-			// board.help[.<slug>] (M849); a broadcast → board.broadcast; a plain
-			// topic post → board.<topic>. Help takes precedence so a help-flagged
-			// message wakes responders watching board.help.
-			subject := "board." + boardSubjectSlug(m.Topic)
-			switch {
-			case m.Help && m.To != "" && m.To != board.Everyone:
-				subject = "board.help." + boardSubjectSlug(m.To)
-			case m.Help:
-				subject = "board.help"
-			case m.To == board.Everyone:
-				subject = "board.broadcast"
-			case m.To != "":
-				subject = "board.dm." + boardSubjectSlug(m.To)
-			}
-			payload := map[string]any{"topic": m.Topic, "chars": len(m.Text)}
-			if m.ID != "" {
-				payload["id"] = m.ID
-			}
-			if m.From != "" {
-				payload["from"] = m.From
-			}
-			if m.To != "" {
-				payload["to"] = m.To
-			}
-			if m.ReplyTo != "" {
-				payload["reply_to"] = m.ReplyTo
-			}
-			if m.Help {
-				payload["help"] = true
-			}
-			_, _ = k.Bus().Publish(event.Spec{
-				Subject:       subject,
-				Kind:          event.KindBoardPosted,
-				Actor:         "board",
-				CorrelationID: corr,
-				Payload:       payload,
-			})
-		})
+		boardToolInst.BindStore(boardStore)
+		boardToolInst.OnPost(boardNotify)
 		fmt.Fprintf(stdout, "  board tool       : enabled (agents share a persistent message board)\n")
 	}
 
@@ -3384,7 +3400,7 @@ func buildOpenAIAPI(ctx context.Context, k *kernelruntime.Kernel, reg *tenant.Re
 // buildRESTAPI starts the native REST resident when AGEZT_REST_ADDR is set,
 // mirroring buildOpenAIAPI's lifecycle (daemon ctx, graceful shutdown, minted
 // token, loopback warning). Returns the banner description or "".
-func buildRESTAPI(ctx context.Context, k *kernelruntime.Kernel, reg *tenant.Registry, draining *atomic.Bool, stdout io.Writer) string {
+func buildRESTAPI(ctx context.Context, k *kernelruntime.Kernel, reg *tenant.Registry, draining *atomic.Bool, boardStore *board.Store, boardNotify func(board.Message, string), stdout io.Writer) string {
 	addr := os.Getenv(brand.EnvPrefix + "REST_ADDR")
 	if addr == "" {
 		return ""
@@ -3402,6 +3418,12 @@ func buildRESTAPI(ctx context.Context, k *kernelruntime.Kernel, reg *tenant.Regi
 		return ""
 	}
 	rest := restapi.New(kernelAPIEngine{k}, k.Bus(), token, brand.Version)
+	// Mailbox (M937): the shared message board for SDK apps — the same store
+	// instance the `board` tool writes, so external sends wake standing orders
+	// exactly like agent sends. Nil when the board failed to open.
+	if boardStore != nil {
+		rest.SetMailbox(boardStore, boardNotify)
+	}
 	// Readiness probe (M134): /readyz reports not-ready while the daemon is
 	// halted, so a load balancer / k8s readiness probe pulls it from rotation
 	// without the process dying. Liveness (/healthz) stays up regardless.

--- a/kernel/board/ack_test.go
+++ b/kernel/board/ack_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+
+package board
+
+import "testing"
+
+// TestAck_ClearsInboxPerReaderAndPersists: an acked message leaves only the
+// acker's unanswered inbox (a broadcast stays for the others), acking is
+// idempotent, unknown ids report !found, and acks survive a reopen.
+func TestAck_ClearsInboxPerReaderAndPersists(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	dm, err := s.Send(Message{Topic: "dm", From: "planner", To: "researcher", Text: "ping"}, 1000)
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	bc, err := s.Broadcast("planner", "heads-up", 1001)
+	if err != nil {
+		t.Fatalf("Broadcast: %v", err)
+	}
+
+	// Both wait for researcher; the broadcast also waits for a third agent.
+	if got := len(s.Inbox("researcher", 0, false)); got != 2 {
+		t.Fatalf("inbox before ack: %d", got)
+	}
+
+	// Ack the DM: it leaves the unanswered inbox without a reply.
+	if _, ok, err := s.Ack(dm.ID, "Researcher"); !ok || err != nil {
+		t.Fatalf("Ack dm: ok=%v err=%v", ok, err)
+	}
+	in := s.Inbox("researcher", 0, false)
+	if len(in) != 1 || in[0].ID != bc.ID {
+		t.Fatalf("acked DM should leave the inbox: %+v", in)
+	}
+	// includeAnswered still shows it.
+	if got := len(s.Inbox("researcher", 0, true)); got != 2 {
+		t.Fatalf("includeAnswered should show both: %d", got)
+	}
+
+	// Acking the broadcast hides it for researcher ONLY.
+	if _, ok, err := s.Ack(bc.ID, "researcher"); !ok || err != nil {
+		t.Fatalf("Ack broadcast: ok=%v err=%v", ok, err)
+	}
+	if got := len(s.Inbox("researcher", 0, false)); got != 0 {
+		t.Fatalf("researcher inbox should be empty: %d", got)
+	}
+	if got := len(s.Inbox("writer", 0, false)); got != 1 {
+		t.Fatalf("broadcast must still wait for writer: %d", got)
+	}
+
+	// Idempotent re-ack, blank acker is a no-op, unknown id reports !found.
+	if m, ok, err := s.Ack(bc.ID, "researcher"); !ok || err != nil || len(m.AckedBy) != 1 {
+		t.Fatalf("re-ack: ok=%v err=%v acked_by=%v", ok, err, m.AckedBy)
+	}
+	if m, ok, _ := s.Ack(dm.ID, "  "); !ok || len(m.AckedBy) != 1 {
+		t.Fatalf("blank acker must not append: %+v", m.AckedBy)
+	}
+	if _, ok, _ := s.Ack("nope", "researcher"); ok {
+		t.Fatal("unknown id should report !found")
+	}
+
+	// Reopen: acks survive.
+	s2, err := Open(dir)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	if got := len(s2.Inbox("researcher", 0, false)); got != 0 {
+		t.Fatalf("acks lost on reopen: %d", got)
+	}
+	if got := len(s2.Inbox("writer", 0, false)); got != 1 {
+		t.Fatalf("writer's broadcast lost on reopen: %d", got)
+	}
+}

--- a/kernel/board/board.go
+++ b/kernel/board/board.go
@@ -51,6 +51,11 @@ type Message struct {
 	// responder.
 	Help bool  `json:"help,omitempty"`
 	TSMS int64 `json:"ts_ms"`
+	// AckedBy lists the readers that explicitly acknowledged this message
+	// (M937 mailbox): an acked message leaves that reader's unanswered Inbox
+	// without needing a reply. Per-reader, so a broadcast acked by one agent
+	// still shows for every other recipient.
+	AckedBy []string `json:"acked_by,omitempty"`
 }
 
 // Everyone is the wildcard recipient for a broadcast (M849): a message To this
@@ -161,9 +166,40 @@ func (s *Store) Get(id string) (Message, bool) {
 	return Message{}, false
 }
 
+// Ack marks the message id as read by `by` (M937): it leaves by's unanswered
+// Inbox without a reply being written. Per-reader and idempotent. Reports
+// whether the id exists; a blank `by` acks nothing (the caller validates).
+func (s *Store) Ack(id, by string) (Message, bool, error) {
+	by = strings.TrimSpace(by)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i := range s.msgs {
+		if s.msgs[i].ID != id {
+			continue
+		}
+		if by == "" || ackedBy(s.msgs[i], strings.ToLower(by)) {
+			return s.msgs[i], true, nil
+		}
+		s.msgs[i].AckedBy = append(s.msgs[i].AckedBy, by)
+		return s.msgs[i], true, s.save()
+	}
+	return Message{}, false, nil
+}
+
+// ackedBy reports whether reader (already lowercased) acknowledged m.
+func ackedBy(m Message, reader string) bool {
+	for _, a := range m.AckedBy {
+		if strings.ToLower(strings.TrimSpace(a)) == reader {
+			return true
+		}
+	}
+	return false
+}
+
 // Inbox returns up to limit messages ADDRESSED to `to` (case-insensitive),
 // newest first. With includeAnswered=false (the usual call), messages that
-// already have a reply on the board are dropped — "what's waiting for me".
+// already have a reply on the board — or that `to` explicitly acknowledged
+// via Ack — are dropped: "what's waiting for me".
 func (s *Store) Inbox(to string, limit int, includeAnswered bool) []Message {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -186,7 +222,7 @@ func (s *Store) Inbox(to string, limit int, includeAnswered bool) []Message {
 		if !directed && !broadcast {
 			continue
 		}
-		if !includeAnswered && answered[m.ID] {
+		if !includeAnswered && (answered[m.ID] || ackedBy(m, to)) {
 			continue
 		}
 		out = append(out, m)

--- a/kernel/controlplane/board.go
+++ b/kernel/controlplane/board.go
@@ -5,6 +5,7 @@ package controlplane
 import (
 	"net"
 	"path/filepath"
+	"time"
 
 	"github.com/agezt/agezt/kernel/board"
 )
@@ -15,53 +16,78 @@ const (
 	boardReadMaxLimit     = 500
 )
 
+// boardReader returns a store for READ handlers: the daemon's shared instance
+// when wired (SetBoard), else a fresh read-only Open — writes are atomic, so a
+// fresh Open sees the latest committed state.
+func (s *Server) boardReader() (*board.Store, error) {
+	if s.boardStore != nil {
+		return s.boardStore, nil
+	}
+	return board.Open(filepath.Join(s.baseDir, "board"))
+}
+
+// boardWriter returns the store for WRITE handlers: ONLY the shared instance.
+// A fresh Open here would race the `board` tool's instance — each holds the
+// whole message list in memory and saves it whole, so the last writer would
+// silently drop the other's message.
+func (s *Server) boardWriter() (*board.Store, bool) {
+	return s.boardStore, s.boardStore != nil
+}
+
+// boardLimitArg reads the clamped limit argument shared by the board handlers.
+func boardLimitArg(args map[string]any) int {
+	limit := boardReadDefaultLimit
+	if raw, ok := args["limit"]; ok {
+		if v, ok := raw.(float64); ok && v > 0 {
+			limit = int(v)
+		}
+	}
+	if limit > boardReadMaxLimit {
+		limit = boardReadMaxLimit
+	}
+	return limit
+}
+
+// boardMsgView renders one message for a control-plane response.
+func boardMsgView(m board.Message) map[string]any {
+	v := map[string]any{"topic": m.Topic, "text": m.Text, "ts_unix_ms": m.TSMS}
+	if m.ID != "" {
+		v["id"] = m.ID
+	}
+	if m.From != "" {
+		v["from"] = m.From
+	}
+	if m.To != "" {
+		v["to"] = m.To
+	}
+	if m.ReplyTo != "" {
+		v["reply_to"] = m.ReplyTo
+	}
+	if m.Help {
+		v["help"] = true
+	}
+	return v
+}
+
 // handleBoardRead serves CmdBoardRead: a read-only view of the shared inter-agent
 // message board so the Web UI can show agents talking to each other. The board
 // is the `board` tool's store (kernel/board) under <baseDir>/board; we Open it
 // fresh per request — writes are atomic, so a fresh Open sees the latest
 // committed state without sharing the tool's in-process instance.
 func (s *Server) handleBoardRead(conn net.Conn, req Request) {
-	st, err := board.Open(filepath.Join(s.baseDir, "board"))
+	st, err := s.boardReader()
 	if err != nil {
 		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
 		return
 	}
-
-	limit := boardReadDefaultLimit
-	if raw, ok := req.Args["limit"]; ok {
-		if v, ok := raw.(float64); ok {
-			limit = int(v)
-		}
-	}
-	if limit < 1 {
-		limit = 1
-	}
-	if limit > boardReadMaxLimit {
-		limit = boardReadMaxLimit
-	}
 	topic, _ := req.Args["topic"].(string)
 
-	msgs := st.Read(topic, limit)
+	// Addressed messaging (M788/M791): the views carry id/to/reply_to so the
+	// console threads DMs and replies.
+	msgs := st.Read(topic, boardLimitArg(req.Args))
 	views := make([]map[string]any, 0, len(msgs))
 	for _, m := range msgs {
-		v := map[string]any{"topic": m.Topic, "text": m.Text, "ts_unix_ms": m.TSMS}
-		if m.From != "" {
-			v["from"] = m.From
-		}
-		// Addressed messaging (M788/M791): the console threads DMs and replies.
-		if m.ID != "" {
-			v["id"] = m.ID
-		}
-		if m.To != "" {
-			v["to"] = m.To
-		}
-		if m.ReplyTo != "" {
-			v["reply_to"] = m.ReplyTo
-		}
-		if m.Help {
-			v["help"] = true
-		}
-		views = append(views, v)
+		views = append(views, boardMsgView(m))
 	}
 
 	s.writeResp(conn, Response{
@@ -75,35 +101,162 @@ func (s *Server) handleBoardRead(conn net.Conn, req Request) {
 // agents have raised (M849), newest first — the "who needs help" view for the
 // Web UI and an overseer agent. Read-only, fresh Open per request like the read.
 func (s *Server) handleBoardHelp(conn net.Conn, req Request) {
-	st, err := board.Open(filepath.Join(s.baseDir, "board"))
+	st, err := s.boardReader()
 	if err != nil {
 		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
 		return
 	}
-	limit := boardReadDefaultLimit
-	if raw, ok := req.Args["limit"]; ok {
-		if v, ok := raw.(float64); ok && v > 0 {
-			limit = int(v)
-		}
-	}
-	if limit > boardReadMaxLimit {
-		limit = boardReadMaxLimit
-	}
-	msgs := st.OpenHelp(limit)
+	msgs := st.OpenHelp(boardLimitArg(req.Args))
 	views := make([]map[string]any, 0, len(msgs))
 	for _, m := range msgs {
-		v := map[string]any{"id": m.ID, "topic": m.Topic, "text": m.Text, "ts_unix_ms": m.TSMS}
-		if m.From != "" {
-			v["from"] = m.From
-		}
-		if m.To != "" {
-			v["to"] = m.To
-		}
-		views = append(views, v)
+		views = append(views, boardMsgView(m))
 	}
 	s.writeResp(conn, Response{
 		ID:     req.ID,
 		Type:   RespResult,
 		Result: map[string]any{"open_help": views, "count": len(views)},
+	})
+}
+
+// handleBoardSend serves CmdBoardSend (M937): a board write from outside a run
+// — an SDK app or script posting, DMing, broadcasting, replying, or raising
+// help. Mirrors the `board` tool's write semantics and fires the same
+// board.posted notifier, so external mail wakes standing orders identically.
+func (s *Server) handleBoardSend(conn net.Conn, req Request) {
+	st, ok := s.boardWriter()
+	if !ok {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError,
+			Error: "the board is not available on this daemon"})
+		return
+	}
+	text := stringArg(req.Args, "text")
+	if text == "" {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "board_send requires text"})
+		return
+	}
+	from := stringArg(req.Args, "from")
+	to := stringArg(req.Args, "to")
+	topic := stringArg(req.Args, "topic")
+	replyTo := stringArg(req.Args, "reply_to")
+	help, _ := req.Args["help"].(bool)
+	now := time.Now().UnixMilli()
+
+	var m board.Message
+	var err error
+	switch {
+	case replyTo != "":
+		// A reply goes back to the asker on the original topic (the board tool's
+		// op=reply semantics), so op=replies on the original id finds it.
+		orig, found := st.Get(replyTo)
+		if !found {
+			s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "no message with id " + replyTo})
+			return
+		}
+		m, err = st.Send(board.Message{Topic: orig.Topic, From: from, To: orig.From, ReplyTo: orig.ID, Text: text}, now)
+	case help:
+		m, err = st.HelpRequest(from, to, text, now)
+	case to == board.Everyone:
+		m, err = st.Broadcast(from, text, now)
+	case to != "":
+		if topic == "" {
+			topic = "dm"
+		}
+		m, err = st.Send(board.Message{Topic: topic, From: from, To: to, Text: text}, now)
+	default:
+		if topic == "" {
+			s.writeResp(conn, Response{ID: req.ID, Type: RespError,
+				Error: "board_send requires a topic (for a post) or a to (for a DM / \"*\" broadcast)"})
+			return
+		}
+		m, err = st.Post(topic, from, text, now)
+	}
+	if err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
+		return
+	}
+	if s.boardNotify != nil {
+		s.boardNotify(m, "")
+	}
+	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{"sent": boardMsgView(m)}})
+}
+
+// handleBoardInbox serves CmdBoardInbox (M937): what is waiting for a named
+// agent/app — addressed messages plus broadcasts it didn't send, unanswered
+// and unacked first. Read-only.
+func (s *Server) handleBoardInbox(conn net.Conn, req Request) {
+	st, err := s.boardReader()
+	if err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
+		return
+	}
+	to := stringArg(req.Args, "to")
+	if to == "" {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "board_inbox requires to (whose inbox)"})
+		return
+	}
+	all, _ := req.Args["all"].(bool)
+	msgs := st.Inbox(to, boardLimitArg(req.Args), all)
+	views := make([]map[string]any, 0, len(msgs))
+	for _, m := range msgs {
+		views = append(views, boardMsgView(m))
+	}
+	s.writeResp(conn, Response{
+		ID:     req.ID,
+		Type:   RespResult,
+		Result: map[string]any{"to": to, "waiting": views, "count": len(views)},
+	})
+}
+
+// handleBoardAck serves CmdBoardAck (M937): mark a message read for one reader
+// so it leaves that reader's unanswered inbox without a reply. A write — it
+// requires the shared store like board_send.
+func (s *Server) handleBoardAck(conn net.Conn, req Request) {
+	st, ok := s.boardWriter()
+	if !ok {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError,
+			Error: "the board is not available on this daemon"})
+		return
+	}
+	id := stringArg(req.Args, "id")
+	by := stringArg(req.Args, "by")
+	if id == "" || by == "" {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "board_ack requires id and by"})
+		return
+	}
+	_, found, err := st.Ack(id, by)
+	if err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
+		return
+	}
+	if !found {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "no message with id " + id})
+		return
+	}
+	s.writeResp(conn, Response{ID: req.ID, Type: RespResult,
+		Result: map[string]any{"acked": true, "id": id, "by": by}})
+}
+
+// handleBoardReplies serves CmdBoardReplies (M937): the answers to a message,
+// oldest first — what the asker reads back. Read-only.
+func (s *Server) handleBoardReplies(conn net.Conn, req Request) {
+	st, err := s.boardReader()
+	if err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
+		return
+	}
+	id := stringArg(req.Args, "id")
+	if id == "" {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "board_replies requires id"})
+		return
+	}
+	msgs := st.Replies(id, boardLimitArg(req.Args))
+	views := make([]map[string]any, 0, len(msgs))
+	for _, m := range msgs {
+		views = append(views, boardMsgView(m))
+	}
+	s.writeResp(conn, Response{
+		ID:     req.ID,
+		Type:   RespResult,
+		Result: map[string]any{"id": id, "replies": views, "count": len(views)},
 	})
 }

--- a/kernel/controlplane/board_write_test.go
+++ b/kernel/controlplane/board_write_test.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: MIT
+
+package controlplane_test
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/agezt/agezt/kernel/board"
+	"github.com/agezt/agezt/kernel/controlplane"
+	"github.com/agezt/agezt/plugins/providers/mock"
+)
+
+// TestBoardWrite_SendInboxAckReplies drives the M937 mailbox commands end to
+// end over the control plane: an external sender DMs an agent, the inbox shows
+// it, a reply threads back, ack clears a broadcast, and the notifier fires for
+// every write.
+func TestBoardWrite_SendInboxAckReplies(t *testing.T) {
+	_, srv, c, dir := startPair(t, mock.New(mock.FinalText("ok")))
+
+	st, err := board.Open(filepath.Join(dir, "board"))
+	if err != nil {
+		t.Fatalf("board.Open: %v", err)
+	}
+	var notified []board.Message
+	srv.SetBoard(st, func(m board.Message, _ string) { notified = append(notified, m) })
+
+	ctx := context.Background()
+
+	// DM an agent by name (topic defaults to "dm").
+	res, err := c.Call(ctx, controlplane.CmdBoardSend, map[string]any{
+		"from": "myapp", "to": "researcher", "text": "deploy target?"})
+	if err != nil {
+		t.Fatalf("board_send: %v", err)
+	}
+	sent, _ := res["sent"].(map[string]any)
+	id, _ := sent["id"].(string)
+	if id == "" || sent["topic"] != "dm" || sent["to"] != "researcher" {
+		t.Fatalf("sent view wrong: %+v", sent)
+	}
+
+	// The recipient's inbox shows it.
+	res, err = c.Call(ctx, controlplane.CmdBoardInbox, map[string]any{"to": "researcher"})
+	if err != nil {
+		t.Fatalf("board_inbox: %v", err)
+	}
+	if res["count"].(float64) != 1 {
+		t.Fatalf("inbox count = %v, want 1", res["count"])
+	}
+
+	// Reply threads back to the sender without naming to/topic.
+	res, err = c.Call(ctx, controlplane.CmdBoardSend, map[string]any{
+		"from": "researcher", "reply_to": id, "text": "prod-eu"})
+	if err != nil {
+		t.Fatalf("reply send: %v", err)
+	}
+	if rep := res["sent"].(map[string]any); rep["to"] != "myapp" || rep["reply_to"] != id {
+		t.Fatalf("reply view wrong: %+v", rep)
+	}
+	res, err = c.Call(ctx, controlplane.CmdBoardReplies, map[string]any{"id": id})
+	if err != nil {
+		t.Fatalf("board_replies: %v", err)
+	}
+	if res["count"].(float64) != 1 {
+		t.Fatalf("replies count = %v, want 1", res["count"])
+	}
+	// Answered → leaves the unanswered inbox.
+	res, _ = c.Call(ctx, controlplane.CmdBoardInbox, map[string]any{"to": "researcher"})
+	if res["count"].(float64) != 0 {
+		t.Fatalf("answered DM should leave the inbox: %v", res["count"])
+	}
+
+	// Broadcast lands in every inbox except the sender's; ack clears it for
+	// the acker only.
+	res, err = c.Call(ctx, controlplane.CmdBoardSend, map[string]any{
+		"from": "myapp", "to": "*", "text": "heads-up"})
+	if err != nil {
+		t.Fatalf("broadcast: %v", err)
+	}
+	bcID := res["sent"].(map[string]any)["id"].(string)
+	if _, err := c.Call(ctx, controlplane.CmdBoardAck, map[string]any{"id": bcID, "by": "researcher"}); err != nil {
+		t.Fatalf("board_ack: %v", err)
+	}
+	res, _ = c.Call(ctx, controlplane.CmdBoardInbox, map[string]any{"to": "researcher"})
+	if res["count"].(float64) != 0 {
+		t.Fatalf("acked broadcast should leave researcher's inbox: %v", res["count"])
+	}
+	res, _ = c.Call(ctx, controlplane.CmdBoardInbox, map[string]any{"to": "writer"})
+	if res["count"].(float64) != 1 {
+		t.Fatalf("broadcast must still wait for writer: %v", res["count"])
+	}
+
+	// Topic post is readable via the existing board_read.
+	if _, err := c.Call(ctx, controlplane.CmdBoardSend, map[string]any{
+		"from": "myapp", "topic": "status", "text": "shipped"}); err != nil {
+		t.Fatalf("topic post: %v", err)
+	}
+	res, err = c.Call(ctx, controlplane.CmdBoardRead, map[string]any{"topic": "status"})
+	if err != nil {
+		t.Fatalf("board_read: %v", err)
+	}
+	if res["count"].(float64) != 1 {
+		t.Fatalf("board_read count = %v, want 1", res["count"])
+	}
+
+	// Every write fired the notifier (DM, reply, broadcast, topic post).
+	if len(notified) != 4 {
+		t.Fatalf("notifier fired %d times, want 4", len(notified))
+	}
+}
+
+// TestBoardWrite_Validation covers the error paths: writes without the shared
+// store, missing text, a post with neither topic nor recipient, a reply to an
+// unknown id, and an ack without its required args.
+func TestBoardWrite_Validation(t *testing.T) {
+	_, srv, c, dir := startPair(t, mock.New(mock.FinalText("ok")))
+	ctx := context.Background()
+
+	// Not wired → writes refuse (reads still work via the fresh-Open fallback).
+	if _, err := c.Call(ctx, controlplane.CmdBoardSend, map[string]any{"topic": "x", "text": "y"}); err == nil ||
+		!strings.Contains(err.Error(), "not available") {
+		t.Fatalf("unwired send: err = %v, want board-unavailable", err)
+	}
+	if _, err := c.Call(ctx, controlplane.CmdBoardInbox, map[string]any{"to": "a"}); err != nil {
+		t.Fatalf("unwired inbox should fall back to a read-only open: %v", err)
+	}
+
+	st, err := board.Open(filepath.Join(dir, "board"))
+	if err != nil {
+		t.Fatalf("board.Open: %v", err)
+	}
+	srv.SetBoard(st, nil)
+
+	if _, err := c.Call(ctx, controlplane.CmdBoardSend, map[string]any{"topic": "x"}); err == nil ||
+		!strings.Contains(err.Error(), "text") {
+		t.Fatalf("missing text: err = %v", err)
+	}
+	if _, err := c.Call(ctx, controlplane.CmdBoardSend, map[string]any{"text": "x"}); err == nil ||
+		!strings.Contains(err.Error(), "topic") {
+		t.Fatalf("missing topic and to: err = %v", err)
+	}
+	if _, err := c.Call(ctx, controlplane.CmdBoardSend, map[string]any{"text": "x", "reply_to": "nope"}); err == nil ||
+		!strings.Contains(err.Error(), "no message") {
+		t.Fatalf("reply to unknown id: err = %v", err)
+	}
+	if _, err := c.Call(ctx, controlplane.CmdBoardAck, map[string]any{"id": "only-id"}); err == nil ||
+		!strings.Contains(err.Error(), "by") {
+		t.Fatalf("ack without by: err = %v", err)
+	}
+	if _, err := c.Call(ctx, controlplane.CmdBoardAck, map[string]any{"id": "nope", "by": "a"}); err == nil ||
+		!strings.Contains(err.Error(), "no message") {
+		t.Fatalf("ack unknown id: err = %v", err)
+	}
+	if _, err := c.Call(ctx, controlplane.CmdBoardInbox, map[string]any{}); err == nil ||
+		!strings.Contains(err.Error(), "to") {
+		t.Fatalf("inbox without to: err = %v", err)
+	}
+	if _, err := c.Call(ctx, controlplane.CmdBoardReplies, map[string]any{}); err == nil ||
+		!strings.Contains(err.Error(), "id") {
+		t.Fatalf("replies without id: err = %v", err)
+	}
+}

--- a/kernel/controlplane/protocol.go
+++ b/kernel/controlplane/protocol.go
@@ -1156,8 +1156,7 @@ const (
 	CmdAutonomyFeed = "autonomy_feed"
 
 	// CmdBoardRead surfaces the shared inter-agent message board (kernel/board,
-	// M647) so the Web UI can show agents talking to each other. Read-only: the
-	// board is written by the `board` tool, never the control plane.
+	// M647) so the Web UI can show agents talking to each other. Read-only.
 	// Args: topic (optional; case-insensitive exact filter); limit (optional;
 	// default 50, clamped 1..500).
 	// Returns: { messages: [{topic, from?, text, ts_unix_ms}], topics: {name:count},
@@ -1169,6 +1168,42 @@ const (
 	// view. Read-only. Args: limit (optional; default 50, clamped ..500).
 	// Returns: { open_help: [{id, from?, to?, topic, text, ts_unix_ms}], count }
 	CmdBoardHelp = "board_help"
+
+	// CmdBoardSend leaves a message on the shared board from OUTSIDE a run (M937
+	// mailbox): an SDK app or script posts to a topic, DMs an agent by name, or
+	// broadcasts to every inbox — the external counterpart of the `board` tool's
+	// post/send/broadcast/reply ops. The write goes through the daemon's shared
+	// store instance (SetBoard) and publishes the same board.posted event, so a
+	// standing order wakes exactly as if an agent had sent it.
+	// Args: text (required); from (sender name, recommended so replies can find
+	// you); to (recipient agent name, "*" for everyone, empty for a topic post);
+	// topic (defaults to "dm" when addressed; required for a plain topic post);
+	// reply_to (message id being answered — the reply goes back to the original's
+	// sender on its topic, like the board tool's op=reply); help (bool — raise an
+	// assistance request that stays open until answered).
+	// Returns: { sent: {id, topic, from?, to?, reply_to?, help?, text, ts_unix_ms} }
+	CmdBoardSend = "board_send"
+
+	// CmdBoardInbox lists what is waiting for a named agent/app on the board
+	// (M937): messages addressed to it plus broadcasts it didn't send, newest
+	// first; answered and acked messages are dropped unless all=true. Read-only.
+	// Args: to (required — whose inbox); all (optional bool); limit (optional;
+	// default 50, clamped 1..500).
+	// Returns: { to, waiting: [msg…], count }
+	CmdBoardInbox = "board_inbox"
+
+	// CmdBoardAck marks a board message read for one reader (M937): it leaves
+	// that reader's unanswered inbox without a reply being written. Per-reader
+	// (a broadcast acked by one agent still waits for the others) and idempotent.
+	// Args: id (required), by (required — the reader's name).
+	// Returns: { acked: true, id, by }
+	CmdBoardAck = "board_ack"
+
+	// CmdBoardReplies returns the answers to a board message, oldest first
+	// (conversation order) — what the asker reads back (M937). Read-only.
+	// Args: id (required); limit (optional; default 50, clamped 1..500).
+	// Returns: { id, replies: [msg…], count }
+	CmdBoardReplies = "board_replies"
 )
 
 // Request is the wire shape sent by the client.

--- a/kernel/controlplane/server.go
+++ b/kernel/controlplane/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/agezt/agezt/internal/brand"
 	"github.com/agezt/agezt/kernel/agent"
 	"github.com/agezt/agezt/kernel/approval"
+	"github.com/agezt/agezt/kernel/board"
 	"github.com/agezt/agezt/kernel/event"
 	"github.com/agezt/agezt/kernel/memory"
 	"github.com/agezt/agezt/kernel/roster"
@@ -125,6 +126,18 @@ type Server struct {
 	// surfaces it so an operator on EKS can confirm IRSA actually engaged without
 	// grepping the boot banner. Empty when AWS credentials aren't in play.
 	credChain string
+
+	// boardStore is the daemon's ONE shared kernel/board instance, injected via
+	// SetBoard (M937 mailbox). Board WRITES must go through this instance — the
+	// `board` tool holds the same one, and a second instance would clobber its
+	// last write (each holds the whole message list and saves it whole). Reads
+	// fall back to a fresh read-only Open when nil (tests, older daemons).
+	boardStore *board.Store
+
+	// boardNotify publishes the board.posted event for a board write (same
+	// closure the `board` tool's OnPost uses), so a control-plane or SDK send
+	// wakes standing orders exactly like an agent's send. Nil-safe.
+	boardNotify func(m board.Message, corr string)
 }
 
 // ChannelSender delivers text out a named channel kind to a channel/chat id. The
@@ -161,6 +174,15 @@ func (s *Server) SetChannelSender(send ChannelSender) { s.channelSend = send }
 // SetCredChain records the resolved AWS credential-chain description so
 // `agt status` can report which credential layer engaged (M307).
 func (s *Server) SetCredChain(desc string) { s.credChain = desc }
+
+// SetBoard wires the daemon's shared message-board instance and its post
+// notifier (M937 mailbox). Board write commands (board_send/board_ack) require
+// it — a fresh per-request Open would clobber the `board` tool's writes; notify
+// publishes board.posted so SDK sends wake standing orders like agent sends.
+func (s *Server) SetBoard(st *board.Store, notify func(m board.Message, corr string)) {
+	s.boardStore = st
+	s.boardNotify = notify
+}
 
 // DiskFreeFunc returns the free (available) and total bytes for the filesystem
 // containing path (M131). The daemon injects a real implementation
@@ -868,6 +890,14 @@ func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
 		s.handleBoardRead(conn, req)
 	case CmdBoardHelp:
 		s.handleBoardHelp(conn, req)
+	case CmdBoardSend:
+		s.handleBoardSend(conn, req)
+	case CmdBoardInbox:
+		s.handleBoardInbox(conn, req)
+	case CmdBoardAck:
+		s.handleBoardAck(conn, req)
+	case CmdBoardReplies:
+		s.handleBoardReplies(conn, req)
 	case CmdAutonomyFeed:
 		s.handleAutonomyFeed(conn, req)
 	default:

--- a/kernel/restapi/mailbox.go
+++ b/kernel/restapi/mailbox.go
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: MIT
+
+package restapi
+
+// The mailbox surface (M937): the shared inter-agent message board
+// (kernel/board) exposed over REST, so apps written with the SDKs — or plain
+// curl — can leave messages for agents (or each other), read an inbox, reply,
+// and acknowledge, without being inside a run. Same store the `board` tool
+// writes; a send here publishes the same board.posted event, so it wakes
+// standing orders exactly like an agent's send.
+//
+// Routes (token-authed like the rest of /api/v1):
+//
+//	POST /api/v1/mailbox/messages              — send: topic post, DM (to),
+//	                                             broadcast (to "*"), reply
+//	                                             (reply_to), or help request
+//	GET  /api/v1/mailbox/messages?topic=&limit= — recent messages, newest first
+//	GET  /api/v1/mailbox/inbox?name=&all=&limit= — what waits for a named
+//	                                             agent/app, newest first
+//	GET  /api/v1/mailbox/messages/{id}/replies — answers, oldest first
+//	POST /api/v1/mailbox/messages/{id}/ack     — mark read for one reader
+//	GET  /api/v1/mailbox/topics                — topic → message count
+//
+// The mailbox is daemon-global (one board per daemon), so the X-Agezt-Tenant
+// header does not partition it.
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/agezt/agezt/kernel/board"
+)
+
+// mailboxDefaultLimit / mailboxMaxLimit bound the list endpoints (mirrors the
+// control plane's board limits).
+const (
+	mailboxDefaultLimit = 50
+	mailboxMaxLimit     = 500
+)
+
+// SetMailbox wires the daemon's ONE shared board store and its post notifier.
+// The store must be the same instance the `board` tool holds — a second
+// instance would clobber its last write (each holds the whole message list in
+// memory and saves it whole). notify publishes board.posted (nil-safe); corr is
+// always empty here (no run owns an external send).
+func (s *Server) SetMailbox(st *board.Store, notify func(m board.Message, corr string)) {
+	s.board = st
+	s.boardNotify = notify
+}
+
+// mailbox returns the wired store or writes a 503 and reports false.
+func (s *Server) mailbox(w http.ResponseWriter) (*board.Store, bool) {
+	if s.board == nil {
+		writeErr(w, http.StatusServiceUnavailable, "mailbox_unavailable",
+			"the mailbox is not available on this daemon")
+		return nil, false
+	}
+	return s.board, true
+}
+
+// mailboxLimit reads ?limit=, clamped to 1..mailboxMaxLimit.
+func mailboxLimit(r *http.Request) int {
+	limit := mailboxDefaultLimit
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		if v, err := strconv.Atoi(raw); err == nil && v > 0 {
+			limit = v
+		}
+	}
+	if limit > mailboxMaxLimit {
+		limit = mailboxMaxLimit
+	}
+	return limit
+}
+
+// mailMsgView renders one message for a REST response.
+func mailMsgView(m board.Message) map[string]any {
+	v := map[string]any{"topic": m.Topic, "text": m.Text, "ts_unix_ms": m.TSMS}
+	if m.ID != "" {
+		v["id"] = m.ID
+	}
+	if m.From != "" {
+		v["from"] = m.From
+	}
+	if m.To != "" {
+		v["to"] = m.To
+	}
+	if m.ReplyTo != "" {
+		v["reply_to"] = m.ReplyTo
+	}
+	if m.Help {
+		v["help"] = true
+	}
+	return v
+}
+
+// --- POST + GET /api/v1/mailbox/messages ---
+
+type mailboxSendRequest struct {
+	From    string `json:"from"`
+	To      string `json:"to"`
+	Topic   string `json:"topic"`
+	ReplyTo string `json:"reply_to"`
+	Text    string `json:"text"`
+	Help    bool   `json:"help"`
+}
+
+func (s *Server) handleMailboxMessages(w http.ResponseWriter, r *http.Request) {
+	st, ok := s.mailbox(w)
+	if !ok {
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		msgs := st.Read(r.URL.Query().Get("topic"), mailboxLimit(r))
+		views := make([]map[string]any, 0, len(msgs))
+		for _, m := range msgs {
+			views = append(views, mailMsgView(m))
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"messages": views, "count": len(views)})
+
+	case http.MethodPost:
+		var req mailboxSendRequest
+		r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			var mbe *http.MaxBytesError
+			if errors.As(err, &mbe) {
+				writeErr(w, http.StatusRequestEntityTooLarge, "request_too_large",
+					"request body exceeds the size limit")
+				return
+			}
+			writeErr(w, http.StatusBadRequest, "invalid_request", "invalid JSON body: "+err.Error())
+			return
+		}
+		if strings.TrimSpace(req.Text) == "" {
+			writeErr(w, http.StatusBadRequest, "invalid_request", "text is required")
+			return
+		}
+		now := time.Now().UnixMilli()
+		var m board.Message
+		var err error
+		switch {
+		case strings.TrimSpace(req.ReplyTo) != "":
+			// A reply goes back to the asker on the original topic (the board
+			// tool's op=reply semantics), so the asker's replies view finds it.
+			orig, found := st.Get(strings.TrimSpace(req.ReplyTo))
+			if !found {
+				writeErr(w, http.StatusNotFound, "not_found", "no message with id "+req.ReplyTo)
+				return
+			}
+			m, err = st.Send(board.Message{
+				Topic: orig.Topic, From: req.From, To: orig.From, ReplyTo: orig.ID, Text: req.Text,
+			}, now)
+		case req.Help:
+			m, err = st.HelpRequest(req.From, req.To, req.Text, now)
+		case strings.TrimSpace(req.To) == board.Everyone:
+			m, err = st.Broadcast(req.From, req.Text, now)
+		case strings.TrimSpace(req.To) != "":
+			topic := strings.TrimSpace(req.Topic)
+			if topic == "" {
+				topic = "dm"
+			}
+			m, err = st.Send(board.Message{Topic: topic, From: req.From, To: req.To, Text: req.Text}, now)
+		default:
+			if strings.TrimSpace(req.Topic) == "" {
+				writeErr(w, http.StatusBadRequest, "invalid_request",
+					`a message needs a "topic" (post), a "to" (DM, or "*" to broadcast), a "reply_to", or "help": true`)
+				return
+			}
+			m, err = st.Post(req.Topic, req.From, req.Text, now)
+		}
+		if err != nil {
+			writeErr(w, http.StatusInternalServerError, "store_error", err.Error())
+			return
+		}
+		if s.boardNotify != nil {
+			s.boardNotify(m, "")
+		}
+		writeJSON(w, http.StatusCreated, map[string]any{"message": mailMsgView(m)})
+
+	default:
+		methodNotAllowed(w, "GET, POST")
+	}
+}
+
+// --- GET /api/v1/mailbox/inbox ---
+
+func (s *Server) handleMailboxInbox(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w, http.MethodGet)
+		return
+	}
+	st, ok := s.mailbox(w)
+	if !ok {
+		return
+	}
+	name := strings.TrimSpace(r.URL.Query().Get("name"))
+	if name == "" {
+		writeErr(w, http.StatusBadRequest, "invalid_request", "name is required (whose inbox)")
+		return
+	}
+	all := r.URL.Query().Get("all") == "true"
+	msgs := st.Inbox(name, mailboxLimit(r), all)
+	views := make([]map[string]any, 0, len(msgs))
+	for _, m := range msgs {
+		views = append(views, mailMsgView(m))
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"name": name, "waiting": views, "count": len(views)})
+}
+
+// --- GET /api/v1/mailbox/messages/{id}/replies, POST .../{id}/ack ---
+
+func (s *Server) handleMailboxMessageSub(w http.ResponseWriter, r *http.Request) {
+	st, ok := s.mailbox(w)
+	if !ok {
+		return
+	}
+	rest := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/v1/mailbox/messages/"), "/")
+	id, action, found := strings.Cut(rest, "/")
+	if !found || id == "" {
+		writeErr(w, http.StatusNotFound, "not_found", "use /api/v1/mailbox/messages/{id}/replies or .../{id}/ack")
+		return
+	}
+	switch action {
+	case "replies":
+		if r.Method != http.MethodGet {
+			methodNotAllowed(w, http.MethodGet)
+			return
+		}
+		msgs := st.Replies(id, mailboxLimit(r))
+		views := make([]map[string]any, 0, len(msgs))
+		for _, m := range msgs {
+			views = append(views, mailMsgView(m))
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"id": id, "replies": views, "count": len(views)})
+
+	case "ack":
+		if r.Method != http.MethodPost {
+			methodNotAllowed(w, http.MethodPost)
+			return
+		}
+		var req struct {
+			By string `json:"by"`
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeErr(w, http.StatusBadRequest, "invalid_request", "invalid JSON body: "+err.Error())
+			return
+		}
+		if strings.TrimSpace(req.By) == "" {
+			writeErr(w, http.StatusBadRequest, "invalid_request", `"by" is required (whose inbox to clear)`)
+			return
+		}
+		_, foundMsg, err := st.Ack(id, req.By)
+		if err != nil {
+			writeErr(w, http.StatusInternalServerError, "store_error", err.Error())
+			return
+		}
+		if !foundMsg {
+			writeErr(w, http.StatusNotFound, "not_found", "no message with id "+id)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"acked": true, "id": id, "by": strings.TrimSpace(req.By)})
+
+	default:
+		writeErr(w, http.StatusNotFound, "not_found", "unknown action "+action+" (replies|ack)")
+	}
+}
+
+// --- GET /api/v1/mailbox/topics ---
+
+func (s *Server) handleMailboxTopics(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w, http.MethodGet)
+		return
+	}
+	st, ok := s.mailbox(w)
+	if !ok {
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"topics": st.Topics()})
+}

--- a/kernel/restapi/mailbox_test.go
+++ b/kernel/restapi/mailbox_test.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: MIT
+
+package restapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/agezt/agezt/kernel/board"
+)
+
+// mailboxServer is newServer plus a wired board store, mirroring the daemon's
+// SetMailbox call. Returns the server and the collected notifications.
+func mailboxServer(t *testing.T, token string) (*Server, *[]board.Message) {
+	t.Helper()
+	s := newServer(t, &fakeEngine{model: "m"}, token)
+	st, err := board.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("board.Open: %v", err)
+	}
+	var notified []board.Message
+	s.SetMailbox(st, func(m board.Message, _ string) { notified = append(notified, m) })
+	return s, &notified
+}
+
+func decode(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+	var v map[string]any
+	if err := json.Unmarshal(body, &v); err != nil {
+		t.Fatalf("decode %s: %v", body, err)
+	}
+	return v
+}
+
+// TestMailbox_SendInboxReplyAck walks the full app-facing arc: DM an agent,
+// see it in the inbox, reply back, broadcast + ack, and the notifier fires for
+// every write.
+func TestMailbox_SendInboxReplyAck(t *testing.T) {
+	s, notified := mailboxServer(t, "tok")
+
+	// DM: to + text, topic defaults to "dm".
+	rec := do(t, s, http.MethodPost, "/api/v1/mailbox/messages",
+		`{"from":"myapp","to":"researcher","text":"deploy target?"}`, "tok")
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("send: %d %s", rec.Code, rec.Body.String())
+	}
+	msg := decode(t, rec.Body.Bytes())["message"].(map[string]any)
+	id, _ := msg["id"].(string)
+	if id == "" || msg["topic"] != "dm" || msg["to"] != "researcher" {
+		t.Fatalf("message view wrong: %+v", msg)
+	}
+
+	// Inbox shows it.
+	rec = do(t, s, http.MethodGet, "/api/v1/mailbox/inbox?name=researcher", "", "tok")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("inbox: %d", rec.Code)
+	}
+	if got := decode(t, rec.Body.Bytes())["count"].(float64); got != 1 {
+		t.Fatalf("inbox count = %v, want 1", got)
+	}
+
+	// Reply threads back to the sender automatically.
+	rec = do(t, s, http.MethodPost, "/api/v1/mailbox/messages",
+		`{"from":"researcher","reply_to":"`+id+`","text":"prod-eu"}`, "tok")
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("reply: %d %s", rec.Code, rec.Body.String())
+	}
+	rep := decode(t, rec.Body.Bytes())["message"].(map[string]any)
+	if rep["to"] != "myapp" || rep["reply_to"] != id {
+		t.Fatalf("reply view wrong: %+v", rep)
+	}
+	rec = do(t, s, http.MethodGet, "/api/v1/mailbox/messages/"+id+"/replies", "", "tok")
+	if got := decode(t, rec.Body.Bytes())["count"].(float64); got != 1 {
+		t.Fatalf("replies count = %v, want 1", got)
+	}
+
+	// Broadcast, then ack clears it for the acker only.
+	rec = do(t, s, http.MethodPost, "/api/v1/mailbox/messages",
+		`{"from":"myapp","to":"*","text":"heads-up"}`, "tok")
+	bcID := decode(t, rec.Body.Bytes())["message"].(map[string]any)["id"].(string)
+	rec = do(t, s, http.MethodPost, "/api/v1/mailbox/messages/"+bcID+"/ack",
+		`{"by":"researcher"}`, "tok")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("ack: %d %s", rec.Code, rec.Body.String())
+	}
+	rec = do(t, s, http.MethodGet, "/api/v1/mailbox/inbox?name=researcher", "", "tok")
+	if got := decode(t, rec.Body.Bytes())["count"].(float64); got != 0 {
+		t.Fatalf("acked+answered inbox should be empty: %v", got)
+	}
+	rec = do(t, s, http.MethodGet, "/api/v1/mailbox/inbox?name=writer", "", "tok")
+	if got := decode(t, rec.Body.Bytes())["count"].(float64); got != 1 {
+		t.Fatalf("broadcast must still wait for writer: %v", got)
+	}
+
+	// Topic post + read + topics.
+	rec = do(t, s, http.MethodPost, "/api/v1/mailbox/messages",
+		`{"from":"myapp","topic":"status","text":"shipped"}`, "tok")
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("post: %d", rec.Code)
+	}
+	rec = do(t, s, http.MethodGet, "/api/v1/mailbox/messages?topic=status", "", "tok")
+	if got := decode(t, rec.Body.Bytes())["count"].(float64); got != 1 {
+		t.Fatalf("read count = %v, want 1", got)
+	}
+	rec = do(t, s, http.MethodGet, "/api/v1/mailbox/topics", "", "tok")
+	topics := decode(t, rec.Body.Bytes())["topics"].(map[string]any)
+	if topics["status"].(float64) != 1 {
+		t.Fatalf("topics wrong: %+v", topics)
+	}
+
+	// DM, reply, broadcast, topic post — four writes, four notifications.
+	if len(*notified) != 4 {
+		t.Fatalf("notifier fired %d times, want 4", len(*notified))
+	}
+}
+
+// TestMailbox_ValidationAndAuth covers the unhappy paths: auth required, 503
+// when unwired, missing fields, unknown ids, wrong methods.
+func TestMailbox_ValidationAndAuth(t *testing.T) {
+	s, _ := mailboxServer(t, "tok")
+
+	// Token required on every mailbox route.
+	for _, path := range []string{"/api/v1/mailbox/messages", "/api/v1/mailbox/inbox", "/api/v1/mailbox/topics"} {
+		if rec := do(t, s, http.MethodGet, path, "", ""); rec.Code != http.StatusUnauthorized {
+			t.Fatalf("%s without token: %d, want 401", path, rec.Code)
+		}
+	}
+
+	// Unwired mailbox answers 503.
+	bare := newServer(t, &fakeEngine{model: "m"}, "tok")
+	if rec := do(t, bare, http.MethodGet, "/api/v1/mailbox/messages", "", "tok"); rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("unwired: %d, want 503", rec.Code)
+	}
+
+	// Missing text / missing topic+to / unknown reply target.
+	if rec := do(t, s, http.MethodPost, "/api/v1/mailbox/messages", `{"topic":"x"}`, "tok"); rec.Code != http.StatusBadRequest {
+		t.Fatalf("missing text: %d", rec.Code)
+	}
+	if rec := do(t, s, http.MethodPost, "/api/v1/mailbox/messages", `{"text":"x"}`, "tok"); rec.Code != http.StatusBadRequest {
+		t.Fatalf("missing topic and to: %d", rec.Code)
+	}
+	if rec := do(t, s, http.MethodPost, "/api/v1/mailbox/messages", `{"text":"x","reply_to":"nope"}`, "tok"); rec.Code != http.StatusNotFound {
+		t.Fatalf("unknown reply target: %d", rec.Code)
+	}
+
+	// Inbox needs a name; ack needs by and a real id; unknown sub-action 404s.
+	if rec := do(t, s, http.MethodGet, "/api/v1/mailbox/inbox", "", "tok"); rec.Code != http.StatusBadRequest {
+		t.Fatalf("inbox without name: %d", rec.Code)
+	}
+	if rec := do(t, s, http.MethodPost, "/api/v1/mailbox/messages/some-id/ack", `{}`, "tok"); rec.Code != http.StatusBadRequest {
+		t.Fatalf("ack without by: %d", rec.Code)
+	}
+	if rec := do(t, s, http.MethodPost, "/api/v1/mailbox/messages/nope/ack", `{"by":"a"}`, "tok"); rec.Code != http.StatusNotFound {
+		t.Fatalf("ack unknown id: %d", rec.Code)
+	}
+	if rec := do(t, s, http.MethodGet, "/api/v1/mailbox/messages/nope/wat", "", "tok"); rec.Code != http.StatusNotFound {
+		t.Fatalf("unknown action: %d", rec.Code)
+	}
+
+	// Method discipline.
+	if rec := do(t, s, http.MethodDelete, "/api/v1/mailbox/messages", "", "tok"); rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("DELETE messages: %d", rec.Code)
+	}
+	if rec := do(t, s, http.MethodPost, "/api/v1/mailbox/topics", "", "tok"); rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("POST topics: %d", rec.Code)
+	}
+}

--- a/kernel/restapi/restapi.go
+++ b/kernel/restapi/restapi.go
@@ -16,6 +16,8 @@
 //	GET  /api/v1/models            — the model ids the daemon can route
 //	POST /api/v1/runs              — submit an intent; sync JSON or SSE stream
 //	GET  /api/v1/runs/{corr}       — the journaled event arc of a past run
+//	/api/v1/mailbox/*              — the shared message board for SDK apps
+//	                                 (see mailbox.go, M937)
 //
 // Security (SPEC-06): loopback-bound by the operator, token-authed on every
 // request (Authorization: Bearer <token>, or ?token= for convenience). Empty
@@ -31,6 +33,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/agezt/agezt/kernel/board"
 	"github.com/agezt/agezt/kernel/bus"
 	"github.com/agezt/agezt/kernel/event"
 	"github.com/agezt/agezt/kernel/meshctx"
@@ -92,6 +95,17 @@ type Server struct {
 	// text format. Injected by the daemon (it has the kernel + governor); this
 	// package only formats. Nil → /metrics reports no samples.
 	metrics func() []Metric
+
+	// board is the daemon's ONE shared message-board instance behind the
+	// /api/v1/mailbox surface (M937), injected via SetMailbox. It must be the
+	// same instance the `board` tool writes — see SetMailbox. Nil → the mailbox
+	// endpoints answer 503.
+	board *board.Store
+
+	// boardNotify publishes board.posted for a mailbox write (the same closure
+	// the `board` tool's OnPost uses), so an SDK send wakes standing orders
+	// exactly like an agent's send. Nil-safe.
+	boardNotify func(m board.Message, corr string)
 }
 
 // Metric is one Prometheus sample exposed at /metrics. Name is the suffix after
@@ -155,6 +169,12 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/api/v1/models", s.auth(s.handleModels))
 	mux.HandleFunc("/api/v1/runs", s.auth(s.handleRunsRoot))
 	mux.HandleFunc("/api/v1/runs/", s.auth(s.handleRunByID))
+	// Mailbox (M937): the shared inter-agent message board for SDK apps —
+	// send/read messages, an inbox per name, replies, ack, topics.
+	mux.HandleFunc("/api/v1/mailbox/messages", s.auth(s.handleMailboxMessages))
+	mux.HandleFunc("/api/v1/mailbox/messages/", s.auth(s.handleMailboxMessageSub))
+	mux.HandleFunc("/api/v1/mailbox/inbox", s.auth(s.handleMailboxInbox))
+	mux.HandleFunc("/api/v1/mailbox/topics", s.auth(s.handleMailboxTopics))
 	return mux
 }
 

--- a/plugins/tools/boardtool/board.go
+++ b/plugins/tools/boardtool/board.go
@@ -38,6 +38,7 @@ type boardStore interface {
 	Replies(id string, limit int) []board.Message
 	Get(id string) (board.Message, bool)
 	Topics() map[string]int
+	Ack(id, by string) (board.Message, bool, error)
 }
 
 // PostNotifier is called after a successful post/send so the host can journal a
@@ -71,6 +72,12 @@ func (t *Tool) Bind(dir string) error {
 	t.mu.Unlock()
 	return nil
 }
+
+// BindStore wires a pre-built store (M937): the daemon opens ONE kernel/board
+// store and hands the same instance to this tool, the control plane, and the
+// REST mailbox — separate instances would silently clobber each other's last
+// write (each holds the full message list in memory and saves it whole).
+func (t *Tool) BindStore(st *board.Store) { t.bindStore(st) }
 
 // bindStore wires a pre-built store (used by tests).
 func (t *Tool) bindStore(b boardStore) {

--- a/plugins/tools/boardtool/board_test.go
+++ b/plugins/tools/boardtool/board_test.go
@@ -131,6 +131,16 @@ func (f *fakeStore) Topics() map[string]int {
 	return c
 }
 
+func (f *fakeStore) Ack(id, by string) (board.Message, bool, error) {
+	for i := range f.msgs {
+		if f.msgs[i].ID == id {
+			f.msgs[i].AckedBy = append(f.msgs[i].AckedBy, by)
+			return f.msgs[i], true, nil
+		}
+	}
+	return board.Message{}, false, nil
+}
+
 func newTool(t *testing.T) *Tool {
 	t.Helper()
 	tool := New()
@@ -428,6 +438,33 @@ func TestBroadcastHelp_BadInputs(t *testing.T) {
 	}
 	if _, isErr := invoke(t, tool, map[string]any{"op": "help"}); isErr {
 		t.Error("op=help with no text should LIST, not error")
+	}
+}
+
+func TestAck_MarksReadAndValidates(t *testing.T) {
+	tool := newTool(t)
+
+	sent, _ := invoke(t, tool, map[string]any{
+		"op": "send", "to": "researcher", "from": "planner", "text": "fyi"})
+	id := sent["sent"].(map[string]any)["id"].(string)
+
+	// ack needs both id and from.
+	if out, isErr := invoke(t, tool, map[string]any{"op": "ack", "from": "researcher"}); !isErr {
+		t.Fatalf("ack without id should error: %v", out)
+	}
+	if out, isErr := invoke(t, tool, map[string]any{"op": "ack", "id": id}); !isErr {
+		t.Fatalf("ack without from should error: %v", out)
+	}
+	if out, isErr := invoke(t, tool, map[string]any{"op": "ack", "id": "nope", "from": "researcher"}); !isErr {
+		t.Fatalf("ack of unknown id should error: %v", out)
+	}
+
+	out, isErr := invoke(t, tool, map[string]any{"op": "ack", "id": id, "from": "researcher"})
+	if isErr {
+		t.Fatalf("ack errored: %v", out)
+	}
+	if out["by"] != "researcher" || out["acked"].(map[string]any)["id"] != id {
+		t.Fatalf("ack result wrong: %+v", out)
 	}
 }
 

--- a/plugins/tools/boardtool/tool.go
+++ b/plugins/tools/boardtool/tool.go
@@ -24,19 +24,21 @@ func (t *Tool) Definition() agent.ToolDef {
 			"— it journals board.dm.<slug>, so a standing order can wake that agent; op=inbox lists what " +
 			"is waiting for an agent (unanswered first; includes broadcasts to everyone); op=reply answers " +
 			"a message by id; op=replies reads the answers to a message you sent. " +
-			"op=broadcast sends a message to EVERY agent's inbox (an announcement); op=help asks for " +
+			"op=broadcast sends a message to EVERY agent's inbox (an announcement); op=ack marks a message " +
+			"as read (id = the message, from = YOUR slug) so it leaves your inbox without a reply — use it to " +
+			"clear announcements you've seen; op=help asks for " +
 			"assistance — broadcast to all (or directed with to=<slug>), it stays open until someone answers " +
 			"and journals board.help so a responder can be woken; op=help with no text LISTS the open help " +
 			"requests (what needs answering). The board is shared and persistent.",
 		InputSchema: json.RawMessage(`{
   "type": "object",
   "properties": {
-    "op":    {"type":"string", "enum":["post","read","topics","send","inbox","reply","replies","broadcast","help"], "description":"What to do. Optional — if omitted it is inferred: text+to → send, text+id → reply, text (alone/with topic) → post, otherwise read."},
+    "op":    {"type":"string", "enum":["post","read","topics","send","inbox","reply","replies","broadcast","ack","help"], "description":"What to do. Optional — if omitted it is inferred: text+to → send, text+id → reply, text (alone/with topic) → post, otherwise read."},
     "topic": {"type":"string", "description":"The topic to post under, or to filter reads by (a short label). For op=send: optional, defaults to \"dm\"."},
     "text":  {"type":"string", "description":"For op=post/send/reply/broadcast/help: the message body. For op=help with no text: list the open help requests instead."},
     "from":  {"type":"string", "description":"Who is posting/sending/replying — use YOUR agent slug so replies can find you."},
     "to":    {"type":"string", "description":"For op=send: the recipient agent's slug. For op=help: optional — direct the ask to one agent (default: anyone). For op=inbox: whose inbox to read (your slug)."},
-    "id":    {"type":"string", "description":"For op=reply: the message id being answered. For op=replies: the message id whose answers to read."},
+    "id":    {"type":"string", "description":"For op=reply: the message id being answered. For op=replies: the message id whose answers to read. For op=ack: the message id to mark read."},
     "all":   {"type":"boolean", "description":"For op=inbox: include already-answered messages too (default false = only what's waiting)."},
     "limit": {"type":"integer", "description":"For op=read/inbox/replies/help-list: max messages (default 20, max 100)."}
   }
@@ -209,6 +211,24 @@ func (t *Tool) Invoke(ctx context.Context, raw json.RawMessage) (agent.Result, e
 		return okJSON(map[string]any{"broadcast": msgView(m),
 			"hint": "delivered to every agent's inbox; an agent answers with op=reply id=" + m.ID}), nil
 
+	case "ack":
+		// Mark a message read without replying (M937): it leaves YOUR unanswered
+		// inbox only — a broadcast acked here still waits for every other agent.
+		if strings.TrimSpace(in.ID) == "" {
+			return errResult(`op=ack needs "id" (the message to mark read)`), nil
+		}
+		if strings.TrimSpace(in.From) == "" {
+			return errResult(`op=ack needs "from" (your agent slug — whose inbox to clear)`), nil
+		}
+		m, ok, err := st.Ack(strings.TrimSpace(in.ID), in.From)
+		if err != nil {
+			return errResult(err.Error()), nil
+		}
+		if !ok {
+			return errResult("no message with id " + in.ID), nil
+		}
+		return okJSON(map[string]any{"acked": msgView(m), "by": strings.TrimSpace(in.From)}), nil
+
 	case "help":
 		// op=help with no text LISTS the open help requests (what needs answering);
 		// with text it RAISES one (broadcast, or directed via to).
@@ -232,9 +252,9 @@ func (t *Tool) Invoke(ctx context.Context, raw json.RawMessage) (agent.Result, e
 			"hint": "stays open until answered; read answers with op=replies id=" + m.ID}), nil
 
 	case "":
-		return errResult("op required (post|read|topics|send|inbox|reply|replies|broadcast|help)"), nil
+		return errResult("op required (post|read|topics|send|inbox|reply|replies|broadcast|ack|help)"), nil
 	default:
-		return errResult("unknown op " + in.Op + " (post|read|topics|send|inbox|reply|replies|broadcast|help)"), nil
+		return errResult("unknown op " + in.Op + " (post|read|topics|send|inbox|reply|replies|broadcast|ack|help)"), nil
 	}
 }
 

--- a/sdk/mailbox.go
+++ b/sdk/mailbox.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: MIT
+
+package sdk
+
+import (
+	"context"
+	"time"
+
+	"github.com/agezt/agezt/kernel/controlplane"
+)
+
+// Mail is one message on the daemon's shared mailbox (the inter-agent message
+// board, M937): agents and SDK apps leave messages for each other by name,
+// broadcast announcements, and read what waits for them.
+type Mail struct {
+	// ID identifies the message; pass it to Reply, Ack, or Replies.
+	ID string
+	// Topic groups messages ("dm" for direct messages by default).
+	Topic string
+	// From is the sender's name (an agent slug or an app's chosen name).
+	From string
+	// To is the recipient's name; "*" means every inbox (a broadcast).
+	To string
+	// ReplyTo links an answer back to the message it answers.
+	ReplyTo string
+	// Text is the message body.
+	Text string
+	// Help marks an assistance request: it stays open until someone answers.
+	Help bool
+	// At is when the message was sent.
+	At time.Time
+}
+
+// MailDraft describes a message to send. Text is required. Addressing:
+//   - To = an agent/app name → a direct message (Topic defaults to "dm")
+//   - To = "*"               → a broadcast to every inbox
+//   - To empty, Topic set    → a plain topic post
+//   - ReplyTo = a message id → a reply (it goes back to the original sender
+//     on its topic; To/Topic are ignored)
+//   - Help = true            → an assistance request, broadcast or directed
+//
+// A directed message journals board.dm.<recipient>, so a standing order can
+// wake the addressed agent the moment mail lands.
+type MailDraft struct {
+	From    string
+	To      string
+	Topic   string
+	ReplyTo string
+	Text    string
+	Help    bool
+}
+
+// SendMail leaves a message on the shared mailbox. See MailDraft for the
+// addressing rules.
+func (c *Client) SendMail(ctx context.Context, d MailDraft) (Mail, error) {
+	res, err := c.cp.Call(ctx, controlplane.CmdBoardSend, map[string]any{
+		"from": d.From, "to": d.To, "topic": d.Topic, "reply_to": d.ReplyTo,
+		"text": d.Text, "help": d.Help,
+	})
+	if err != nil {
+		return Mail{}, err
+	}
+	m, _ := res["sent"].(map[string]any)
+	return parseMail(m), nil
+}
+
+// Broadcast sends an announcement to EVERY inbox except the sender's.
+func (c *Client) Broadcast(ctx context.Context, from, text string) (Mail, error) {
+	return c.SendMail(ctx, MailDraft{From: from, To: "*", Text: text})
+}
+
+// Inbox returns what waits for name, newest first: messages addressed to it
+// plus broadcasts it didn't send. Answered and acked messages are dropped
+// unless includeRead is true. limit <= 0 uses the daemon default (50).
+func (c *Client) Inbox(ctx context.Context, name string, includeRead bool, limit int) ([]Mail, error) {
+	args := map[string]any{"to": name, "all": includeRead}
+	if limit > 0 {
+		args["limit"] = limit
+	}
+	res, err := c.cp.Call(ctx, controlplane.CmdBoardInbox, args)
+	if err != nil {
+		return nil, err
+	}
+	return parseMails(res["waiting"]), nil
+}
+
+// AckMail marks a message read for one reader: it leaves that reader's inbox
+// without a reply being written. Per-reader (a broadcast acked by one agent
+// still waits for the others) and idempotent.
+func (c *Client) AckMail(ctx context.Context, id, by string) error {
+	_, err := c.cp.Call(ctx, controlplane.CmdBoardAck, map[string]any{"id": id, "by": by})
+	return err
+}
+
+// MailReplies returns the answers to a sent message, oldest first
+// (conversation order). limit <= 0 uses the daemon default (50).
+func (c *Client) MailReplies(ctx context.Context, id string, limit int) ([]Mail, error) {
+	args := map[string]any{"id": id}
+	if limit > 0 {
+		args["limit"] = limit
+	}
+	res, err := c.cp.Call(ctx, controlplane.CmdBoardReplies, args)
+	if err != nil {
+		return nil, err
+	}
+	return parseMails(res["replies"]), nil
+}
+
+// MailMessages returns recent mailbox messages, newest first, optionally
+// filtered to one topic (case-insensitive). limit <= 0 uses the daemon
+// default (50).
+func (c *Client) MailMessages(ctx context.Context, topic string, limit int) ([]Mail, error) {
+	args := map[string]any{}
+	if topic != "" {
+		args["topic"] = topic
+	}
+	if limit > 0 {
+		args["limit"] = limit
+	}
+	res, err := c.cp.Call(ctx, controlplane.CmdBoardRead, args)
+	if err != nil {
+		return nil, err
+	}
+	return parseMails(res["messages"]), nil
+}
+
+// parseMails maps a []any of message views to typed Mail values.
+func parseMails(raw any) []Mail {
+	items, _ := raw.([]any)
+	out := make([]Mail, 0, len(items))
+	for _, it := range items {
+		m, ok := it.(map[string]any)
+		if !ok {
+			continue
+		}
+		out = append(out, parseMail(m))
+	}
+	return out
+}
+
+// parseMail maps one message view to a Mail.
+func parseMail(m map[string]any) Mail {
+	var out Mail
+	out.ID, _ = m["id"].(string)
+	out.Topic, _ = m["topic"].(string)
+	out.From, _ = m["from"].(string)
+	out.To, _ = m["to"].(string)
+	out.ReplyTo, _ = m["reply_to"].(string)
+	out.Text, _ = m["text"].(string)
+	out.Help, _ = m["help"].(bool)
+	if ts := intFromAny(m["ts_unix_ms"]); ts > 0 {
+		out.At = time.UnixMilli(ts)
+	}
+	return out
+}

--- a/sdk/mailbox_test.go
+++ b/sdk/mailbox_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+
+package sdk
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseMails(t *testing.T) {
+	raw := []any{
+		map[string]any{
+			"id": "m-1", "topic": "dm", "from": "planner", "to": "researcher",
+			"text": "deploy target?", "ts_unix_ms": float64(1_700_000_000_000),
+		},
+		map[string]any{
+			"id": "m-2", "topic": "help", "from": "worker", "to": "*",
+			"text": "stuck", "help": true, "reply_to": "m-1",
+		},
+		"not-a-map", // tolerated, skipped
+	}
+
+	mails := parseMails(raw)
+	if len(mails) != 2 {
+		t.Fatalf("want 2 mails, got %d", len(mails))
+	}
+
+	a := mails[0]
+	if a.ID != "m-1" || a.Topic != "dm" || a.From != "planner" || a.To != "researcher" || a.Text != "deploy target?" {
+		t.Errorf("mail[0] fields wrong: %+v", a)
+	}
+	if !a.At.Equal(time.UnixMilli(1_700_000_000_000)) {
+		t.Errorf("at = %v", a.At)
+	}
+	if a.Help || a.ReplyTo != "" {
+		t.Errorf("mail[0] flags wrong: %+v", a)
+	}
+
+	b := mails[1]
+	if !b.Help || b.ReplyTo != "m-1" || b.To != "*" {
+		t.Errorf("mail[1] fields wrong: %+v", b)
+	}
+	// Missing timestamp is the zero time.
+	if !b.At.IsZero() {
+		t.Errorf("missing ts should be zero time: %v", b.At)
+	}
+}
+
+func TestParseMails_Empty(t *testing.T) {
+	if got := parseMails(nil); len(got) != 0 {
+		t.Fatalf("nil input: %d", len(got))
+	}
+	if got := parseMails(map[string]any{}); len(got) != 0 {
+		t.Fatalf("non-list input: %d", len(got))
+	}
+}

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -82,6 +82,13 @@ asyncio.run(main())
 | `run(intent, model=None)` | `POST /api/v1/runs` | `RunResult` (correlation_id, model, status, answer) |
 | `run_stream(intent, model=None)` | `POST /api/v1/runs` (SSE) | iterator of `StreamEvent` (`start`/`token`/`done`/`error`) |
 | `get_run(correlation_id)` | `GET /api/v1/runs/{id}` | `dict` (correlation_id, count, events) |
+| `mailbox_send(text, from_=, to=, topic=, reply_to=, help=)` | `POST /api/v1/mailbox/messages` | `Mail` — DM an agent by name, broadcast (`to="*"`), post, reply, or ask for help |
+| `mailbox_broadcast(from_, text)` | `POST /api/v1/mailbox/messages` | `Mail` (lands in every inbox) |
+| `mailbox_inbox(name, include_read=False, limit=0)` | `GET /api/v1/mailbox/inbox` | `list[Mail]` waiting for `name` |
+| `mailbox_ack(message_id, by)` | `POST /api/v1/mailbox/messages/{id}/ack` | marks it read for `by` |
+| `mailbox_replies(message_id, limit=0)` | `GET /api/v1/mailbox/messages/{id}/replies` | `list[Mail]`, oldest first |
+| `mailbox_messages(topic="", limit=0)` | `GET /api/v1/mailbox/messages` | `list[Mail]`, newest first |
+| `mailbox_topics()` | `GET /api/v1/mailbox/topics` | `dict` topic → count |
 
 `Client(base_url, token, timeout=30, tenant=None)` — pass `tenant` to target an
 isolated tenant (sent as the `X-Agezt-Tenant` header) on a multi-tenant daemon.

--- a/sdk/python/agezt/__init__.py
+++ b/sdk/python/agezt/__init__.py
@@ -33,12 +33,13 @@ and never blocks the event loop::
 """
 
 from .aio import AsyncClient
-from .client import Client, RunResult, StreamEvent
+from .client import Client, Mail, RunResult, StreamEvent
 from .errors import AgeztError, APIError
 
 __all__ = [
     "Client",
     "AsyncClient",
+    "Mail",
     "RunResult",
     "StreamEvent",
     "AgeztError",

--- a/sdk/python/agezt/aio.py
+++ b/sdk/python/agezt/aio.py
@@ -28,7 +28,9 @@ from __future__ import annotations
 import asyncio
 from typing import Any, AsyncIterator, Dict, Optional
 
-from .client import Client, RunResult, StreamEvent
+from typing import Dict as _Dict, List as _List
+
+from .client import Client, Mail, RunResult, StreamEvent
 
 __all__ = ["AsyncClient"]
 
@@ -135,6 +137,53 @@ class AsyncClient:
             if isinstance(item, BaseException):
                 raise item
             yield item
+
+    # --- mailbox (mirrors the sync client) ---------------------------------
+
+    async def mailbox_send(
+        self,
+        text: str,
+        *,
+        from_: str = "",
+        to: str = "",
+        topic: str = "",
+        reply_to: str = "",
+        help: bool = False,
+    ) -> Mail:
+        """Leave a message on the shared mailbox (see :meth:`Client.mailbox_send`)."""
+        return await self._in_thread(
+            lambda: self._sync.mailbox_send(
+                text, from_=from_, to=to, topic=topic, reply_to=reply_to, help=help
+            )
+        )
+
+    async def mailbox_broadcast(self, from_: str, text: str) -> Mail:
+        """Send an announcement to EVERY inbox except the sender's."""
+        return await self._in_thread(lambda: self._sync.mailbox_broadcast(from_, text))
+
+    async def mailbox_inbox(
+        self, name: str, include_read: bool = False, limit: int = 0
+    ) -> "_List[Mail]":
+        """Return what waits for ``name`` (see :meth:`Client.mailbox_inbox`)."""
+        return await self._in_thread(
+            lambda: self._sync.mailbox_inbox(name, include_read, limit)
+        )
+
+    async def mailbox_ack(self, message_id: str, by: str) -> None:
+        """Mark a message read for one reader."""
+        return await self._in_thread(lambda: self._sync.mailbox_ack(message_id, by))
+
+    async def mailbox_replies(self, message_id: str, limit: int = 0) -> "_List[Mail]":
+        """Return the answers to a sent message, oldest first."""
+        return await self._in_thread(lambda: self._sync.mailbox_replies(message_id, limit))
+
+    async def mailbox_messages(self, topic: str = "", limit: int = 0) -> "_List[Mail]":
+        """Return recent mailbox messages, newest first."""
+        return await self._in_thread(lambda: self._sync.mailbox_messages(topic, limit))
+
+    async def mailbox_topics(self) -> "_Dict[str, int]":
+        """Return the mailbox's topics with their message counts."""
+        return await self._in_thread(self._sync.mailbox_topics)
 
     async def aclose(self) -> None:
         """No-op: the client holds no persistent resources. Provided for symmetry."""

--- a/sdk/python/agezt/client.py
+++ b/sdk/python/agezt/client.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, Iterator, List, Optional
 
 from .errors import APIError
 
-__all__ = ["Client", "RunResult", "StreamEvent"]
+__all__ = ["Client", "Mail", "RunResult", "StreamEvent"]
 
 
 @dataclass
@@ -31,6 +31,42 @@ class RunResult:
             status=d.get("status", ""),
             answer=d.get("answer", ""),
         )
+
+
+@dataclass
+class Mail:
+    """One message on the daemon's shared mailbox (the inter-agent board).
+
+    Agents and SDK apps leave messages for each other by name (``to``),
+    broadcast to every inbox (``to="*"``), or post under a ``topic``;
+    ``reply_to`` threads an answer back to the message it answers.
+    """
+
+    id: str = ""
+    topic: str = ""
+    text: str = ""
+    from_: str = ""
+    to: str = ""
+    reply_to: str = ""
+    help: bool = False
+    ts_unix_ms: int = 0
+
+    @classmethod
+    def _from(cls, d: Dict[str, Any]) -> "Mail":
+        return cls(
+            id=d.get("id", ""),
+            topic=d.get("topic", ""),
+            text=d.get("text", ""),
+            from_=d.get("from", ""),
+            to=d.get("to", ""),
+            reply_to=d.get("reply_to", ""),
+            help=bool(d.get("help", False)),
+            ts_unix_ms=int(d.get("ts_unix_ms", 0)),
+        )
+
+
+def _mails(raw: Any) -> List[Mail]:
+    return [Mail._from(m) for m in raw or [] if isinstance(m, dict)]
 
 
 @dataclass
@@ -108,6 +144,90 @@ class Client:
     def get_run(self, correlation_id: str) -> Dict[str, Any]:
         """Return the journaled event arc of a past run."""
         return self._get("/api/v1/runs/" + urllib.parse.quote(correlation_id))
+
+    # --- mailbox (the shared inter-agent message board) --------------------
+
+    def mailbox_send(
+        self,
+        text: str,
+        *,
+        from_: str = "",
+        to: str = "",
+        topic: str = "",
+        reply_to: str = "",
+        help: bool = False,
+    ) -> Mail:
+        """Leave a message on the shared mailbox.
+
+        Addressing: ``to`` names a recipient agent/app (topic defaults to
+        ``dm``); ``to="*"`` broadcasts to every inbox; ``to`` empty with a
+        ``topic`` is a plain post; ``reply_to`` answers a message (it goes back
+        to the original sender); ``help=True`` raises an assistance request.
+        A directed message wakes a standing order watching ``board.dm.<name>``.
+        """
+        body: Dict[str, Any] = {"text": text}
+        if from_:
+            body["from"] = from_
+        if to:
+            body["to"] = to
+        if topic:
+            body["topic"] = topic
+        if reply_to:
+            body["reply_to"] = reply_to
+        if help:
+            body["help"] = True
+        res = self._post_json("/api/v1/mailbox/messages", body)
+        return Mail._from(res.get("message", {}))
+
+    def mailbox_broadcast(self, from_: str, text: str) -> Mail:
+        """Send an announcement to EVERY inbox except the sender's."""
+        return self.mailbox_send(text, from_=from_, to="*")
+
+    def mailbox_inbox(
+        self, name: str, include_read: bool = False, limit: int = 0
+    ) -> List[Mail]:
+        """Return what waits for ``name``, newest first: messages addressed to
+        it plus broadcasts it didn't send. Answered/acked messages are dropped
+        unless ``include_read``."""
+        q = {"name": name}
+        if include_read:
+            q["all"] = "true"
+        if limit > 0:
+            q["limit"] = str(limit)
+        res = self._get("/api/v1/mailbox/inbox?" + urllib.parse.urlencode(q))
+        return _mails(res.get("waiting"))
+
+    def mailbox_ack(self, message_id: str, by: str) -> None:
+        """Mark a message read for one reader (it leaves that reader's inbox
+        without a reply). Per-reader and idempotent."""
+        self._post_json(
+            "/api/v1/mailbox/messages/" + urllib.parse.quote(message_id) + "/ack",
+            {"by": by},
+        )
+
+    def mailbox_replies(self, message_id: str, limit: int = 0) -> List[Mail]:
+        """Return the answers to a sent message, oldest first."""
+        path = "/api/v1/mailbox/messages/" + urllib.parse.quote(message_id) + "/replies"
+        if limit > 0:
+            path += "?limit=" + str(limit)
+        return _mails(self._get(path).get("replies"))
+
+    def mailbox_messages(self, topic: str = "", limit: int = 0) -> List[Mail]:
+        """Return recent mailbox messages, newest first, optionally filtered to
+        one topic."""
+        q: Dict[str, str] = {}
+        if topic:
+            q["topic"] = topic
+        if limit > 0:
+            q["limit"] = str(limit)
+        path = "/api/v1/mailbox/messages"
+        if q:
+            path += "?" + urllib.parse.urlencode(q)
+        return _mails(self._get(path).get("messages"))
+
+    def mailbox_topics(self) -> Dict[str, int]:
+        """Return the mailbox's topics with their message counts."""
+        return self._get("/api/v1/mailbox/topics").get("topics", {})
 
     # --- internals --------------------------------------------------------
 

--- a/sdk/python/tests/test_mailbox.py
+++ b/sdk/python/tests/test_mailbox.py
@@ -1,0 +1,128 @@
+"""Tests for the mailbox surface of the Agezt Python client (M937).
+
+Stdlib-only, like test_client.py: a tiny http.server stub answers the
+/api/v1/mailbox routes with canned shapes; the tests assert the client sends
+the right bodies/queries and maps the responses to Mail values.
+"""
+
+import json
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs, urlparse
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agezt import APIError, Client, Mail  # noqa: E402
+
+_MSG = {
+    "id": "m-1",
+    "topic": "dm",
+    "from": "myapp",
+    "to": "researcher",
+    "text": "deploy target?",
+    "ts_unix_ms": 1700000000000,
+}
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def log_message(self, *args):
+        pass
+
+    def _json(self, code, obj):
+        body = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        u = urlparse(self.path)
+        self.server.last_query = parse_qs(u.query)
+        if u.path == "/api/v1/mailbox/inbox":
+            self._json(200, {"name": "researcher", "waiting": [_MSG], "count": 1})
+        elif u.path == "/api/v1/mailbox/messages/m-1/replies":
+            rep = dict(_MSG, id="m-2", reply_to="m-1", to="myapp", **{"from": "researcher"})
+            self._json(200, {"id": "m-1", "replies": [rep], "count": 1})
+        elif u.path == "/api/v1/mailbox/messages":
+            self._json(200, {"messages": [_MSG], "count": 1})
+        elif u.path == "/api/v1/mailbox/topics":
+            self._json(200, {"topics": {"dm": 2, "status": 1}})
+        else:
+            self._json(404, {"error": {"type": "not_found", "message": "nope"}})
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        body = json.loads(self.rfile.read(length) or b"{}")
+        self.server.last_body = body
+        self.server.last_path = self.path
+        if self.path == "/api/v1/mailbox/messages":
+            sent = dict(_MSG)
+            sent.update({k: v for k, v in body.items() if k != "from"})
+            if "from" in body:
+                sent["from"] = body["from"]
+            self._json(201, {"message": sent})
+        elif self.path == "/api/v1/mailbox/messages/m-1/ack":
+            self._json(200, {"acked": True, "id": "m-1", "by": body.get("by", "")})
+        elif self.path.endswith("/ack"):
+            self._json(404, {"error": {"type": "not_found", "message": "no message"}})
+        else:
+            self._json(404, {"error": {"type": "not_found", "message": "nope"}})
+
+
+class MailboxTest(unittest.TestCase):
+    def setUp(self):
+        self.srv = HTTPServer(("127.0.0.1", 0), _Handler)
+        self.srv.last_body = None
+        self.srv.last_query = None
+        self.srv.last_path = None
+        self.t = threading.Thread(target=self.srv.serve_forever, daemon=True)
+        self.t.start()
+        port = self.srv.server_address[1]
+        self.c = Client(f"http://127.0.0.1:{port}", token="testtoken", timeout=5)
+
+    def tearDown(self):
+        self.srv.shutdown()
+        self.srv.server_close()
+
+    def test_send_dm(self):
+        m = self.c.mailbox_send("deploy target?", from_="myapp", to="researcher")
+        self.assertIsInstance(m, Mail)
+        self.assertEqual(m.id, "m-1")
+        self.assertEqual(m.from_, "myapp")
+        self.assertEqual(self.srv.last_body, {"text": "deploy target?", "from": "myapp", "to": "researcher"})
+
+    def test_broadcast_and_help_flags(self):
+        self.c.mailbox_broadcast("myapp", "heads-up")
+        self.assertEqual(self.srv.last_body["to"], "*")
+        self.c.mailbox_send("stuck", from_="w", help=True)
+        self.assertTrue(self.srv.last_body["help"])
+
+    def test_inbox(self):
+        mails = self.c.mailbox_inbox("researcher", include_read=True, limit=5)
+        self.assertEqual(len(mails), 1)
+        self.assertEqual(mails[0].text, "deploy target?")
+        self.assertEqual(self.srv.last_query, {"name": ["researcher"], "all": ["true"], "limit": ["5"]})
+
+    def test_ack(self):
+        self.c.mailbox_ack("m-1", "researcher")
+        self.assertEqual(self.srv.last_path, "/api/v1/mailbox/messages/m-1/ack")
+        self.assertEqual(self.srv.last_body, {"by": "researcher"})
+        with self.assertRaises(APIError):
+            self.c.mailbox_ack("nope", "researcher")
+
+    def test_replies_messages_topics(self):
+        reps = self.c.mailbox_replies("m-1")
+        self.assertEqual(reps[0].reply_to, "m-1")
+        msgs = self.c.mailbox_messages(topic="dm", limit=3)
+        self.assertEqual(len(msgs), 1)
+        self.assertEqual(self.srv.last_query, {"topic": ["dm"], "limit": ["3"]})
+        self.assertEqual(self.c.mailbox_topics(), {"dm": 2, "status": 1})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -71,6 +71,13 @@ fn main() -> agezt::Result<()> {
 | `run(intent, model)` | `POST /api/v1/runs` | `RunResult` (correlation_id, model, status, answer) |
 | `run_stream(intent, model)` | `POST /api/v1/runs` (SSE) | `Iterator<Item = Result<StreamEvent>>` (`start`/`token`/`done`/`error`) |
 | `get_run(correlation_id)` | `GET /api/v1/runs/{id}` | `RunArc` (correlation_id, count, events) |
+| `mailbox_send(&MailDraft)` | `POST /api/v1/mailbox/messages` | `Mail` — DM by name, broadcast (`to: "*"`), post, reply, or help |
+| `mailbox_broadcast(from, text)` | `POST /api/v1/mailbox/messages` | `Mail` (lands in every inbox) |
+| `mailbox_inbox(name, include_read, limit)` | `GET /api/v1/mailbox/inbox` | `Vec<Mail>` waiting for `name` |
+| `mailbox_ack(id, by)` | `POST /api/v1/mailbox/messages/{id}/ack` | marks it read for `by` |
+| `mailbox_replies(id, limit)` | `GET /api/v1/mailbox/messages/{id}/replies` | `Vec<Mail>`, oldest first |
+| `mailbox_messages(topic, limit)` | `GET /api/v1/mailbox/messages` | `Vec<Mail>`, newest first |
+| `mailbox_topics()` | `GET /api/v1/mailbox/topics` | `BTreeMap<String, i64>` topic → count |
 
 `Client::new(base_url, token)` defaults to a 30-second per-request timeout and
 no tenant. Chain `.with_timeout(Duration)` and `.with_tenant("<id>")` to target

--- a/sdk/rust/src/client.rs
+++ b/sdk/rust/src/client.rs
@@ -49,6 +49,38 @@ pub struct RunArc {
     pub events: Vec<Value>,
 }
 
+/// One message on the daemon's shared mailbox (the inter-agent message board,
+/// M937). Agents and SDK apps leave messages for each other by name (`to`),
+/// broadcast to every inbox (`to == "*"`), or post under a `topic`; `reply_to`
+/// threads an answer back to the message it answers.
+#[derive(Debug, Clone, Default)]
+pub struct Mail {
+    pub id: String,
+    pub topic: String,
+    pub text: String,
+    pub from: String,
+    pub to: String,
+    pub reply_to: String,
+    pub help: bool,
+    pub ts_unix_ms: i64,
+}
+
+/// A message to send with [`Client::mailbox_send`]. `text` is required.
+/// Addressing: `to` names a recipient agent/app (`topic` defaults to `dm`);
+/// `to == "*"` broadcasts to every inbox; `to` empty with a `topic` is a plain
+/// post; `reply_to` answers a message (it goes back to the original sender);
+/// `help == true` raises an assistance request. A directed message wakes a
+/// standing order watching `board.dm.<name>`.
+#[derive(Debug, Clone, Default)]
+pub struct MailDraft {
+    pub from: String,
+    pub to: String,
+    pub topic: String,
+    pub reply_to: String,
+    pub text: String,
+    pub help: bool,
+}
+
 /// A client for a running Agezt daemon's REST API.
 ///
 /// ```no_run
@@ -183,6 +215,111 @@ impl Client {
         })
     }
 
+    // --- mailbox (the shared inter-agent message board, M937) --------------
+
+    /// Leave a message on the shared mailbox. See [`MailDraft`] for the
+    /// addressing rules.
+    pub fn mailbox_send(&self, draft: &MailDraft) -> Result<Mail> {
+        let mut m = std::collections::BTreeMap::new();
+        m.insert("text".to_string(), Value::Str(draft.text.clone()));
+        for (key, val) in [
+            ("from", &draft.from),
+            ("to", &draft.to),
+            ("topic", &draft.topic),
+            ("reply_to", &draft.reply_to),
+        ] {
+            if !val.is_empty() {
+                m.insert(key.to_string(), Value::Str(val.clone()));
+            }
+        }
+        if draft.help {
+            m.insert("help".to_string(), Value::Bool(true));
+        }
+        let body = Value::Object(m).to_json();
+        let v = self.post_json("/api/v1/mailbox/messages", &body)?;
+        Ok(mail_from(v.get("message").unwrap_or(&Value::Null)))
+    }
+
+    /// Send an announcement to EVERY inbox except the sender's.
+    pub fn mailbox_broadcast(&self, from: &str, text: &str) -> Result<Mail> {
+        self.mailbox_send(&MailDraft {
+            from: from.to_string(),
+            to: "*".to_string(),
+            text: text.to_string(),
+            ..MailDraft::default()
+        })
+    }
+
+    /// What waits for `name`, newest first: messages addressed to it plus
+    /// broadcasts it didn't send. Answered/acked messages are dropped unless
+    /// `include_read`. `limit == 0` uses the daemon default (50).
+    pub fn mailbox_inbox(&self, name: &str, include_read: bool, limit: u32) -> Result<Vec<Mail>> {
+        let mut path = format!("/api/v1/mailbox/inbox?name={}", percent_encode(name));
+        if include_read {
+            path.push_str("&all=true");
+        }
+        if limit > 0 {
+            path.push_str(&format!("&limit={limit}"));
+        }
+        let v = self.get_json(&path)?;
+        Ok(mails_from(v.get("waiting")))
+    }
+
+    /// Mark a message read for one reader (it leaves that reader's inbox
+    /// without a reply). Per-reader and idempotent.
+    pub fn mailbox_ack(&self, message_id: &str, by: &str) -> Result<()> {
+        let mut m = std::collections::BTreeMap::new();
+        m.insert("by".to_string(), Value::Str(by.to_string()));
+        let path = format!(
+            "/api/v1/mailbox/messages/{}/ack",
+            percent_encode(message_id)
+        );
+        self.post_json(&path, &Value::Object(m).to_json())?;
+        Ok(())
+    }
+
+    /// The answers to a sent message, oldest first (conversation order).
+    /// `limit == 0` uses the daemon default (50).
+    pub fn mailbox_replies(&self, message_id: &str, limit: u32) -> Result<Vec<Mail>> {
+        let mut path = format!(
+            "/api/v1/mailbox/messages/{}/replies",
+            percent_encode(message_id)
+        );
+        if limit > 0 {
+            path.push_str(&format!("?limit={limit}"));
+        }
+        let v = self.get_json(&path)?;
+        Ok(mails_from(v.get("replies")))
+    }
+
+    /// Recent mailbox messages, newest first, optionally filtered to one
+    /// topic. `limit == 0` uses the daemon default (50).
+    pub fn mailbox_messages(&self, topic: &str, limit: u32) -> Result<Vec<Mail>> {
+        let mut path = String::from("/api/v1/mailbox/messages");
+        let mut sep = '?';
+        if !topic.is_empty() {
+            path.push_str(&format!("{sep}topic={}", percent_encode(topic)));
+            sep = '&';
+        }
+        if limit > 0 {
+            path.push_str(&format!("{sep}limit={limit}"));
+        }
+        let v = self.get_json(&path)?;
+        Ok(mails_from(v.get("messages")))
+    }
+
+    /// The mailbox's topics with their message counts.
+    pub fn mailbox_topics(&self) -> Result<std::collections::BTreeMap<String, i64>> {
+        let v = self.get_json("/api/v1/mailbox/topics")?;
+        let mut out = std::collections::BTreeMap::new();
+        if let Some(Value::Object(m)) = v.get("topics") {
+            for (k, val) in m {
+                out.insert(k.clone(), val.as_i64().unwrap_or(0));
+            }
+        }
+        Ok(out)
+    }
+
     // --- internals --------------------------------------------------------
 
     fn get_json(&self, path: &str) -> Result<Value> {
@@ -303,6 +440,27 @@ fn run_body(intent: &str, model: Option<&str>, stream: bool) -> String {
 
 fn str_field(v: &Value, key: &str) -> String {
     v.str(key).unwrap_or("").to_string()
+}
+
+/// Map one mailbox message view to a [`Mail`].
+fn mail_from(v: &Value) -> Mail {
+    Mail {
+        id: str_field(v, "id"),
+        topic: str_field(v, "topic"),
+        text: str_field(v, "text"),
+        from: str_field(v, "from"),
+        to: str_field(v, "to"),
+        reply_to: str_field(v, "reply_to"),
+        help: v.get("help").and_then(Value::as_bool).unwrap_or(false),
+        ts_unix_ms: v.get("ts_unix_ms").and_then(Value::as_i64).unwrap_or(0),
+    }
+}
+
+/// Map a JSON array of message views to typed [`Mail`]s (absent → empty).
+fn mails_from(v: Option<&Value>) -> Vec<Mail> {
+    v.and_then(Value::as_array)
+        .map(|a| a.iter().map(mail_from).collect())
+        .unwrap_or_default()
 }
 
 /// Map a non-2xx response body to an [`Error::Api`]. Understands both

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -50,6 +50,8 @@ mod errors;
 mod http;
 mod json;
 
-pub use client::{Client, Health, Models, RunArc, RunResult, RunStream, StreamEvent};
+pub use client::{
+    Client, Health, Mail, MailDraft, Models, RunArc, RunResult, RunStream, StreamEvent,
+};
 pub use errors::{Error, Result};
 pub use json::Value;

--- a/sdk/rust/tests/client.rs
+++ b/sdk/rust/tests/client.rs
@@ -167,6 +167,48 @@ fn handle(mut stream: TcpStream) {
                 write_json(&mut stream, 200, &body);
             }
         }
+        // Mailbox (M937): canned shapes mirroring the daemon's REST responses.
+        ("POST", "/api/v1/mailbox/messages") => {
+            // Echo the addressing fields back so a test proves they were sent.
+            let from = extract_str(&req.body, "from").unwrap_or_default();
+            let to = extract_str(&req.body, "to").unwrap_or_default();
+            let help = req.body.contains("\"help\":true");
+            let body = format!(
+                r#"{{"message":{{"id":"m-1","topic":"dm","from":"{from}","to":"{to}","text":"hi","help":{help},"ts_unix_ms":1700000000000}}}}"#
+            );
+            write_json(&mut stream, 201, &body);
+        }
+        ("GET", p) if p.starts_with("/api/v1/mailbox/inbox") => {
+            // Reflect the query so a test proves name/all/limit were encoded.
+            let body = format!(
+                r#"{{"name":"r","waiting":[{{"id":"m-1","topic":"dm","from":"myapp","to":"researcher","text":"{}","ts_unix_ms":1700000000000}}],"count":1}}"#,
+                p.trim_start_matches("/api/v1/mailbox/inbox?")
+            );
+            write_json(&mut stream, 200, &body);
+        }
+        ("POST", "/api/v1/mailbox/messages/m-1/ack") => {
+            let by = extract_str(&req.body, "by").unwrap_or_default();
+            let body = format!(r#"{{"acked":true,"id":"m-1","by":"{by}"}}"#);
+            write_json(&mut stream, 200, &body);
+        }
+        ("POST", p) if p.ends_with("/ack") => write_json(
+            &mut stream,
+            404,
+            r#"{"error":{"type":"not_found","message":"no message"}}"#,
+        ),
+        ("GET", "/api/v1/mailbox/messages/m-1/replies") => write_json(
+            &mut stream,
+            200,
+            r#"{"id":"m-1","replies":[{"id":"m-2","topic":"dm","from":"researcher","to":"myapp","reply_to":"m-1","text":"prod-eu","ts_unix_ms":1700000000001}],"count":1}"#,
+        ),
+        ("GET", p) if p.starts_with("/api/v1/mailbox/messages") => write_json(
+            &mut stream,
+            200,
+            r#"{"messages":[{"id":"m-1","topic":"status","from":"myapp","text":"shipped","ts_unix_ms":1700000000000}],"count":1}"#,
+        ),
+        ("GET", "/api/v1/mailbox/topics") => {
+            write_json(&mut stream, 200, r#"{"topics":{"dm":2,"status":1}}"#)
+        }
         _ => write_json(
             &mut stream,
             404,
@@ -292,4 +334,81 @@ fn tenant_header_is_transmitted() {
 
     // Without a tenant, the mock falls back to "test".
     assert_eq!(client(&base, "testtoken").health().unwrap().version, "test");
+}
+
+#[test]
+fn mailbox_send_and_broadcast() {
+    let base = start_mock();
+    let c = client(&base, "testtoken");
+
+    let draft = agezt::MailDraft {
+        from: "myapp".to_string(),
+        to: "researcher".to_string(),
+        text: "deploy target?".to_string(),
+        ..agezt::MailDraft::default()
+    };
+    let m = c.mailbox_send(&draft).unwrap();
+    assert_eq!(m.id, "m-1");
+    assert_eq!(m.from, "myapp");
+    assert_eq!(m.to, "researcher");
+    assert_eq!(m.ts_unix_ms, 1_700_000_000_000);
+
+    // Broadcast targets every inbox ("*"); the mock echoes `to` back.
+    let b = c.mailbox_broadcast("myapp", "heads-up").unwrap();
+    assert_eq!(b.to, "*");
+
+    // The help flag survives the round trip.
+    let h = c
+        .mailbox_send(&agezt::MailDraft {
+            from: "w".to_string(),
+            text: "stuck".to_string(),
+            help: true,
+            ..agezt::MailDraft::default()
+        })
+        .unwrap();
+    assert!(h.help);
+}
+
+#[test]
+fn mailbox_inbox_encodes_query() {
+    let base = start_mock();
+    // The mock reflects the query string into the message text, proving
+    // name/all/limit were encoded on the wire.
+    let mails = client(&base, "testtoken")
+        .mailbox_inbox("researcher", true, 5)
+        .unwrap();
+    assert_eq!(mails.len(), 1);
+    assert_eq!(mails[0].text, "name=researcher&all=true&limit=5");
+}
+
+#[test]
+fn mailbox_ack_and_unknown_id() {
+    let base = start_mock();
+    let c = client(&base, "testtoken");
+    c.mailbox_ack("m-1", "researcher").unwrap();
+
+    let err = c.mailbox_ack("nope", "researcher").unwrap_err();
+    match err {
+        Error::Api { status, .. } => assert_eq!(status, 404),
+        other => panic!("expected Api error, got {other:?}"),
+    }
+}
+
+#[test]
+fn mailbox_replies_messages_topics() {
+    let base = start_mock();
+    let c = client(&base, "testtoken");
+
+    let reps = c.mailbox_replies("m-1", 0).unwrap();
+    assert_eq!(reps.len(), 1);
+    assert_eq!(reps[0].reply_to, "m-1");
+    assert_eq!(reps[0].text, "prod-eu");
+
+    let msgs = c.mailbox_messages("status", 3).unwrap();
+    assert_eq!(msgs.len(), 1);
+    assert_eq!(msgs[0].topic, "status");
+
+    let topics = c.mailbox_topics().unwrap();
+    assert_eq!(topics.get("dm"), Some(&2));
+    assert_eq!(topics.get("status"), Some(&1));
 }

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -55,6 +55,13 @@ console.log(arc.count, "events");
 | `run(intent, model?)` | `POST /api/v1/runs` | `Promise<RunResult>` |
 | `runStream(intent, model?)` | `POST /api/v1/runs` (SSE) | `AsyncGenerator<StreamEvent>` (`start`/`token`/`done`/`error`) |
 | `getRun(correlationId)` | `GET /api/v1/runs/{id}` | `Promise<RunArc>` |
+| `mailboxSend(draft)` | `POST /api/v1/mailbox/messages` | `Promise<Mail>` — DM by name, broadcast (`to: "*"`), post, reply, or help |
+| `mailboxBroadcast(from, text)` | `POST /api/v1/mailbox/messages` | `Promise<Mail>` (lands in every inbox) |
+| `mailboxInbox(name, includeRead?, limit?)` | `GET /api/v1/mailbox/inbox` | `Promise<Mail[]>` waiting for `name` |
+| `mailboxAck(messageId, by)` | `POST /api/v1/mailbox/messages/{id}/ack` | marks it read for `by` |
+| `mailboxReplies(messageId, limit?)` | `GET /api/v1/mailbox/messages/{id}/replies` | `Promise<Mail[]>`, oldest first |
+| `mailboxMessages(topic?, limit?)` | `GET /api/v1/mailbox/messages` | `Promise<Mail[]>`, newest first |
+| `mailboxTopics()` | `GET /api/v1/mailbox/topics` | `Promise<Record<string, number>>` |
 
 `new Client(baseUrl, token, { timeoutMs?, tenant? })` — pass `tenant` to target an
 isolated tenant (sent as `X-Agezt-Tenant`) on a multi-tenant daemon.

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -16,7 +16,7 @@
   "engines": { "node": ">=18" },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "tsc -p tsconfig.json && node --test dist/test/client.test.js"
+    "test": "tsc -p tsconfig.json && node --test dist/test/client.test.js dist/test/mailbox.test.js"
   },
   "keywords": ["agezt", "agent", "llm", "ai", "automation", "sdk"],
   "repository": { "type": "git", "url": "https://github.com/agezt/agezt", "directory": "sdk/typescript" },

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -36,6 +36,35 @@ export interface RunArc {
   events: unknown[];
 }
 
+/** One message on the daemon's shared mailbox (the inter-agent board, M937).
+ * Agents and SDK apps leave messages for each other by name (`to`), broadcast
+ * to every inbox (`to: "*"`), or post under a `topic`; `reply_to` threads an
+ * answer back to the message it answers. */
+export interface Mail {
+  id?: string;
+  topic: string;
+  text: string;
+  from?: string;
+  to?: string;
+  reply_to?: string;
+  help?: boolean;
+  ts_unix_ms?: number;
+}
+
+/** A message to send. `text` is required. Addressing: `to` names a recipient
+ * (topic defaults to "dm"); `to: "*"` broadcasts; `to` empty with a `topic` is
+ * a plain post; `replyTo` answers a message (it goes back to the original
+ * sender); `help: true` raises an assistance request. A directed message wakes
+ * a standing order watching `board.dm.<name>`. */
+export interface MailDraft {
+  text: string;
+  from?: string;
+  to?: string;
+  topic?: string;
+  replyTo?: string;
+  help?: boolean;
+}
+
 export interface ClientOptions {
   /** Per-request timeout in milliseconds (default 30000). */
   timeoutMs?: number;
@@ -99,6 +128,76 @@ export class Client {
 
   getRun(correlationId: string): Promise<RunArc> {
     return this.getJSON<RunArc>("/api/v1/runs/" + encodeURIComponent(correlationId));
+  }
+
+  // --- mailbox (the shared inter-agent message board, M937) ---
+
+  /** Leave a message on the shared mailbox. See MailDraft for addressing. */
+  async mailboxSend(draft: MailDraft): Promise<Mail> {
+    const body: Record<string, unknown> = { text: draft.text };
+    if (draft.from) body.from = draft.from;
+    if (draft.to) body.to = draft.to;
+    if (draft.topic) body.topic = draft.topic;
+    if (draft.replyTo) body.reply_to = draft.replyTo;
+    if (draft.help) body.help = true;
+    const res = await this.fetch("POST", "/api/v1/mailbox/messages", JSON.stringify(body));
+    if (!res.ok) throw await apiError(res);
+    const out = (await res.json()) as { message: Mail };
+    return out.message;
+  }
+
+  /** Send an announcement to EVERY inbox except the sender's. */
+  mailboxBroadcast(from: string, text: string): Promise<Mail> {
+    return this.mailboxSend({ from, to: "*", text });
+  }
+
+  /** What waits for `name`, newest first: messages addressed to it plus
+   * broadcasts it didn't send. Answered/acked messages are dropped unless
+   * `includeRead`. */
+  async mailboxInbox(name: string, includeRead = false, limit = 0): Promise<Mail[]> {
+    const q = new URLSearchParams({ name });
+    if (includeRead) q.set("all", "true");
+    if (limit > 0) q.set("limit", String(limit));
+    const out = await this.getJSON<{ waiting: Mail[] }>("/api/v1/mailbox/inbox?" + q.toString());
+    return out.waiting ?? [];
+  }
+
+  /** Mark a message read for one reader (it leaves that reader's inbox without
+   * a reply). Per-reader and idempotent. */
+  async mailboxAck(messageId: string, by: string): Promise<void> {
+    const res = await this.fetch(
+      "POST",
+      "/api/v1/mailbox/messages/" + encodeURIComponent(messageId) + "/ack",
+      JSON.stringify({ by }),
+    );
+    if (!res.ok) throw await apiError(res);
+    await res.body?.cancel();
+  }
+
+  /** The answers to a sent message, oldest first (conversation order). */
+  async mailboxReplies(messageId: string, limit = 0): Promise<Mail[]> {
+    let path = "/api/v1/mailbox/messages/" + encodeURIComponent(messageId) + "/replies";
+    if (limit > 0) path += "?limit=" + limit;
+    const out = await this.getJSON<{ replies: Mail[] }>(path);
+    return out.replies ?? [];
+  }
+
+  /** Recent mailbox messages, newest first, optionally one topic's. */
+  async mailboxMessages(topic = "", limit = 0): Promise<Mail[]> {
+    const q = new URLSearchParams();
+    if (topic) q.set("topic", topic);
+    if (limit > 0) q.set("limit", String(limit));
+    const qs = q.toString();
+    const out = await this.getJSON<{ messages: Mail[] }>(
+      "/api/v1/mailbox/messages" + (qs ? "?" + qs : ""),
+    );
+    return out.messages ?? [];
+  }
+
+  /** The mailbox's topics with their message counts. */
+  async mailboxTopics(): Promise<Record<string, number>> {
+    const out = await this.getJSON<{ topics: Record<string, number> }>("/api/v1/mailbox/topics");
+    return out.topics ?? {};
   }
 
   // --- internals ---

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -17,6 +17,8 @@ export { Client } from "./client.js";
 export type {
   ClientOptions,
   Health,
+  Mail,
+  MailDraft,
   Models,
   RunResult,
   RunArc,

--- a/sdk/typescript/test/mailbox.test.ts
+++ b/sdk/typescript/test/mailbox.test.ts
@@ -1,0 +1,113 @@
+import { after, before, test } from "node:test";
+import assert from "node:assert/strict";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { type AddressInfo } from "node:net";
+
+import { APIError, Client, type Mail } from "../src/index.js";
+
+// Mailbox surface (M937) against a stub answering the /api/v1/mailbox routes.
+
+let server: Server;
+let base: string;
+let lastBody: Record<string, unknown> | null = null;
+let lastUrl = "";
+
+const MSG: Mail = {
+  id: "m-1",
+  topic: "dm",
+  from: "myapp",
+  to: "researcher",
+  text: "deploy target?",
+  ts_unix_ms: 1700000000000,
+};
+
+function json(res: ServerResponse, code: number, obj: unknown): void {
+  res.writeHead(code, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(obj));
+}
+
+before(async () => {
+  server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    const url = req.url ?? "";
+    lastUrl = url;
+    if (req.method === "GET") {
+      if (url.startsWith("/api/v1/mailbox/inbox")) {
+        json(res, 200, { name: "researcher", waiting: [MSG], count: 1 });
+      } else if (url.startsWith("/api/v1/mailbox/messages/m-1/replies")) {
+        json(res, 200, {
+          id: "m-1",
+          replies: [{ ...MSG, id: "m-2", from: "researcher", to: "myapp", reply_to: "m-1" }],
+          count: 1,
+        });
+      } else if (url.startsWith("/api/v1/mailbox/messages")) {
+        json(res, 200, { messages: [MSG], count: 1 });
+      } else if (url === "/api/v1/mailbox/topics") {
+        json(res, 200, { topics: { dm: 2, status: 1 } });
+      } else {
+        json(res, 404, { error: { type: "not_found", message: "nope" } });
+      }
+      return;
+    }
+    let raw = "";
+    req.on("data", (c) => (raw += c));
+    req.on("end", () => {
+      lastBody = JSON.parse(raw || "{}") as Record<string, unknown>;
+      if (url === "/api/v1/mailbox/messages") {
+        json(res, 201, { message: { ...MSG, ...lastBody } });
+      } else if (url === "/api/v1/mailbox/messages/m-1/ack") {
+        json(res, 200, { acked: true, id: "m-1", by: lastBody.by });
+      } else if (url.endsWith("/ack")) {
+        json(res, 404, { error: { type: "not_found", message: "no message" } });
+      } else {
+        json(res, 404, { error: { type: "not_found", message: "nope" } });
+      }
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+after(() => server.close());
+
+function client(): Client {
+  return new Client(base, "testtoken", { timeoutMs: 5000 });
+}
+
+test("mailboxSend posts a DM and returns the message", async () => {
+  const m = await client().mailboxSend({ from: "myapp", to: "researcher", text: "deploy target?" });
+  assert.equal(m.id, "m-1");
+  assert.deepEqual(lastBody, { text: "deploy target?", from: "myapp", to: "researcher" });
+});
+
+test("mailboxBroadcast targets every inbox; help flag is forwarded", async () => {
+  await client().mailboxBroadcast("myapp", "heads-up");
+  assert.equal(lastBody?.to, "*");
+  await client().mailboxSend({ from: "w", text: "stuck", help: true });
+  assert.equal(lastBody?.help, true);
+});
+
+test("mailboxInbox builds the query and maps the waiting list", async () => {
+  const mails = await client().mailboxInbox("researcher", true, 5);
+  assert.equal(mails.length, 1);
+  assert.equal(mails[0].text, "deploy target?");
+  assert.equal(lastUrl, "/api/v1/mailbox/inbox?name=researcher&all=true&limit=5");
+});
+
+test("mailboxAck posts by; unknown id throws APIError(404)", async () => {
+  await client().mailboxAck("m-1", "researcher");
+  assert.deepEqual(lastBody, { by: "researcher" });
+  await assert.rejects(client().mailboxAck("nope", "researcher"), (e: unknown) => {
+    assert.ok(e instanceof APIError);
+    assert.equal(e.status, 404);
+    return true;
+  });
+});
+
+test("mailboxReplies / mailboxMessages / mailboxTopics map their shapes", async () => {
+  const reps = await client().mailboxReplies("m-1");
+  assert.equal(reps[0].reply_to, "m-1");
+  const msgs = await client().mailboxMessages("dm", 3);
+  assert.equal(msgs.length, 1);
+  assert.equal(lastUrl, "/api/v1/mailbox/messages?topic=dm&limit=3");
+  assert.deepEqual(await client().mailboxTopics(), { dm: 2, status: 1 });
+});


### PR DESCRIPTION
## What

The inter-agent message board (M647 post/topics + M788 addressed DMs + M849 broadcast/help) becomes a **daemon-wide mailbox reachable from outside a run**: apps written with the SDKs — or plain curl — can leave messages for agents (or each other) by name, broadcast, read an inbox, reply, and acknowledge.

## Layers

- **REST** (`kernel/restapi/mailbox.go`): `POST/GET /api/v1/mailbox/messages`, `GET /inbox?name=`, `GET /messages/{id}/replies`, `POST /messages/{id}/ack`, `GET /topics`. Same Bearer-token auth as the rest of `/api/v1`; daemon-global (the board isn't tenant-partitioned).
- **Control plane**: `board_send` / `board_inbox` / `board_ack` / `board_replies`, so the Go SDK writes through the daemon socket like `agt` does.
- **SDKs ×4**: Go `SendMail`/`Broadcast`/`Inbox`/`AckMail`/`MailReplies`/`MailMessages`; Python (sync `Client` + `AsyncClient`), TypeScript, and Rust `mailbox_*` — each with tests against their existing mock daemons, README API tables updated.
- **New `ack` verb end to end** (kernel store → `board` tool `op=ack` → REST → SDKs): mark a message read **without replying**. Per-reader (`acked_by`), so a broadcast acked by one agent still waits for every other recipient; idempotent; survives reopen.

## Invariants

- **Single writer**: each `board.Store` holds the whole message list in memory and saves it whole, so a second instance would clobber the first's last write. The daemon now opens **one** store and hands the same instance to the `board` tool, the control plane, and REST. CP/REST write handlers refuse when unwired rather than falling back to a racy fresh `Open` (reads still fall back read-only).
- **External mail wakes agents like agent mail**: every door fires the same `board.posted` notifier — a DM journals `board.dm.<name>`, help `board.help[.<name>]`, broadcast `board.broadcast` — so standing orders trigger identically regardless of who sent the message.

## Tests

- `kernel/board`: ack semantics (per-reader, idempotent, persisted).
- `kernel/controlplane`: full send→inbox→reply→ack arc + validation/unwired paths.
- `kernel/restapi`: same arc over HTTP + auth/503/method discipline.
- SDKs: Go parse tests; Python 19/19; TS 12/12 (`node:test`); Rust 12 + 3 doc-tests (`cargo fmt` clean).
- `go vet` + `go build ./...` clean; `cmd/agezt` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)