### PR TITLE
Feat: mailbox watch — push instead of polling (M938)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ the hash-chained journal — `agt journal tail` / `agt why` (SPEC-08 §4.2).
   dump that buried the error. (M936)
 
 ### Added
+- **Mailbox watch — push instead of polling (M938).** `GET /api/v1/mailbox/watch?name=&topic=`
+  streams new board messages as SSE `mail` frames the moment they land: `name` watches one
+  agent/app's mail (DMs + foreign broadcasts, the live counterpart of the inbox), `topic` one
+  topic, neither tails everything. A leading `ready` frame marks the subscription attached (no
+  send/subscribe race) and 25s keepalives hold idle connections open. All four SDKs gain a watch
+  (`WatchMail` in Go over the control plane's pulse stream; `mailbox_watch` iterators in
+  Python/asyncio, TypeScript, Rust). New `board_get` control-plane command fetches one message by
+  id — the `board.posted` event carries metadata only, so watchers resolve the body through it.
 - **Mailbox for SDK apps — the shared board opens to the outside (M937).** The inter-agent message
   board (post/DM/broadcast/reply, M647/M788) is now reachable from OUTSIDE a run, so apps written
   with the SDKs can talk to agents (and each other) by name. New REST surface

--- a/kernel/controlplane/board.go
+++ b/kernel/controlplane/board.go
@@ -236,6 +236,28 @@ func (s *Server) handleBoardAck(conn net.Conn, req Request) {
 		Result: map[string]any{"acked": true, "id": id, "by": by}})
 }
 
+// handleBoardGet serves CmdBoardGet (M938): one message by id — how a watcher
+// that learned an id from a board.posted event (which carries no text) fetches
+// the body. Read-only.
+func (s *Server) handleBoardGet(conn net.Conn, req Request) {
+	st, err := s.boardReader()
+	if err != nil {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: err.Error()})
+		return
+	}
+	id := stringArg(req.Args, "id")
+	if id == "" {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "board_get requires id"})
+		return
+	}
+	m, found := st.Get(id)
+	if !found {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "no message with id " + id})
+		return
+	}
+	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{"message": boardMsgView(m)}})
+}
+
 // handleBoardReplies serves CmdBoardReplies (M937): the answers to a message,
 // oldest first — what the asker reads back. Read-only.
 func (s *Server) handleBoardReplies(conn net.Conn, req Request) {

--- a/kernel/controlplane/board_write_test.go
+++ b/kernel/controlplane/board_write_test.go
@@ -109,6 +109,23 @@ func TestBoardWrite_SendInboxAckReplies(t *testing.T) {
 	if len(notified) != 4 {
 		t.Fatalf("notifier fired %d times, want 4", len(notified))
 	}
+
+	// board_get fetches one message by id (M938) — the watcher's body lookup.
+	res, err = c.Call(ctx, controlplane.CmdBoardGet, map[string]any{"id": id})
+	if err != nil {
+		t.Fatalf("board_get: %v", err)
+	}
+	if got := res["message"].(map[string]any); got["id"] != id || got["text"] != "deploy target?" {
+		t.Fatalf("board_get view wrong: %+v", got)
+	}
+	if _, err := c.Call(ctx, controlplane.CmdBoardGet, map[string]any{}); err == nil ||
+		!strings.Contains(err.Error(), "id") {
+		t.Fatalf("board_get without id: err = %v", err)
+	}
+	if _, err := c.Call(ctx, controlplane.CmdBoardGet, map[string]any{"id": "nope"}); err == nil ||
+		!strings.Contains(err.Error(), "no message") {
+		t.Fatalf("board_get unknown id: err = %v", err)
+	}
 }
 
 // TestBoardWrite_Validation covers the error paths: writes without the shared

--- a/kernel/controlplane/protocol.go
+++ b/kernel/controlplane/protocol.go
@@ -1204,6 +1204,14 @@ const (
 	// Args: id (required); limit (optional; default 50, clamped 1..500).
 	// Returns: { id, replies: [msg…], count }
 	CmdBoardReplies = "board_replies"
+
+	// CmdBoardGet returns one board message by id (M938). The board.posted
+	// event carries only metadata (no text), so a watcher that learned an id
+	// from the event stream fetches the body here. Read-only.
+	// Args: id (required).
+	// Returns: { message: {id, topic, from?, to?, reply_to?, help?, text,
+	//            ts_unix_ms} }
+	CmdBoardGet = "board_get"
 )
 
 // Request is the wire shape sent by the client.

--- a/kernel/controlplane/server.go
+++ b/kernel/controlplane/server.go
@@ -898,6 +898,8 @@ func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
 		s.handleBoardAck(conn, req)
 	case CmdBoardReplies:
 		s.handleBoardReplies(conn, req)
+	case CmdBoardGet:
+		s.handleBoardGet(conn, req)
 	case CmdAutonomyFeed:
 		s.handleAutonomyFeed(conn, req)
 	default:

--- a/kernel/restapi/mailbox.go
+++ b/kernel/restapi/mailbox.go
@@ -19,6 +19,7 @@ package restapi
 //	                                             agent/app, newest first
 //	GET  /api/v1/mailbox/messages/{id}/replies — answers, oldest first
 //	POST /api/v1/mailbox/messages/{id}/ack     — mark read for one reader
+//	GET  /api/v1/mailbox/watch?name=&topic=    — SSE: new messages as they land
 //	GET  /api/v1/mailbox/topics                — topic → message count
 //
 // The mailbox is daemon-global (one board per daemon), so the X-Agezt-Tenant
@@ -33,6 +34,7 @@ import (
 	"time"
 
 	"github.com/agezt/agezt/kernel/board"
+	"github.com/agezt/agezt/kernel/event"
 )
 
 // mailboxDefaultLimit / mailboxMaxLimit bound the list endpoints (mirrors the
@@ -267,6 +269,129 @@ func (s *Server) handleMailboxMessageSub(w http.ResponseWriter, r *http.Request)
 
 	default:
 		writeErr(w, http.StatusNotFound, "not_found", "unknown action "+action+" (replies|ack)")
+	}
+}
+
+// --- GET /api/v1/mailbox/watch (SSE) ---
+
+// mailboxKeepalive is how often the watch stream emits an SSE comment frame so
+// idle connections survive proxies and dead peers are detected. The watch is
+// open-ended (unlike a run stream), so it can sit silent for hours otherwise.
+const mailboxKeepalive = 25 * time.Second
+
+// boardPostedPayload is the metadata a board.posted event carries (the daemon
+// journals no message text — watchers fetch the body from the store by id).
+type boardPostedPayload struct {
+	ID    string `json:"id"`
+	Topic string `json:"topic"`
+	From  string `json:"from"`
+	To    string `json:"to"`
+	Help  bool   `json:"help"`
+}
+
+// mailWatchMatch reports whether a posted message is for this watcher: with a
+// name, messages addressed to it (case-insensitive) plus broadcasts it didn't
+// send — the live counterpart of Inbox; with a topic, that topic's posts; with
+// neither, everything (a firehose tail).
+func mailWatchMatch(name, topic string, p boardPostedPayload) bool {
+	if name != "" {
+		to := strings.ToLower(strings.TrimSpace(p.To))
+		directed := to != "" && to == name
+		broadcast := p.To == board.Everyone && strings.ToLower(strings.TrimSpace(p.From)) != name
+		if !directed && !broadcast {
+			return false
+		}
+	}
+	if topic != "" && !strings.EqualFold(strings.TrimSpace(p.Topic), topic) {
+		return false
+	}
+	return true
+}
+
+// handleMailboxWatch streams new mailbox messages as SSE `mail` frames the
+// moment they land (M938) — the push counterpart of polling the inbox.
+// ?name= watches one agent/app's mail (DMs + broadcasts), ?topic= one topic,
+// neither tails everything. The mailbox is daemon-global, so this subscribes
+// the primary bus regardless of any tenant header.
+func (s *Server) handleMailboxWatch(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w, http.MethodGet)
+		return
+	}
+	st, ok := s.mailbox(w)
+	if !ok {
+		return
+	}
+	flusher, canFlush := w.(http.Flusher)
+	if !canFlush {
+		writeErr(w, http.StatusInternalServerError, "stream_unsupported", "streaming unsupported")
+		return
+	}
+	name := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("name")))
+	topic := strings.TrimSpace(r.URL.Query().Get("topic"))
+
+	// Subscribe BEFORE the ready frame so no message can slip between them.
+	sub, err := s.bus.Subscribe("board.>", 0)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "subscribe_error", err.Error())
+		return
+	}
+	defer sub.Cancel()
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+
+	send := func(eventName string, payload any) {
+		data, _ := json.Marshal(payload)
+		_, _ = w.Write([]byte("event: " + eventName + "\ndata: " + string(data) + "\n\n"))
+		flusher.Flush()
+	}
+	ready := map[string]any{}
+	if name != "" {
+		ready["name"] = name
+	}
+	if topic != "" {
+		ready["topic"] = topic
+	}
+	send("ready", ready)
+
+	keepalive := time.NewTicker(mailboxKeepalive)
+	defer keepalive.Stop()
+	ctx := r.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-keepalive.C:
+			_, _ = w.Write([]byte(": keepalive\n\n"))
+			flusher.Flush()
+		case ev, alive := <-sub.C:
+			if !alive {
+				return
+			}
+			if ev == nil || ev.Kind != event.KindBoardPosted || len(ev.Payload) == 0 {
+				continue
+			}
+			var p boardPostedPayload
+			if json.Unmarshal(ev.Payload, &p) != nil {
+				continue
+			}
+			if !mailWatchMatch(name, topic, p) {
+				continue
+			}
+			// The event carries metadata only; the body lives in the store. The
+			// write committed before the publish, so the lookup is reliable — but
+			// fall back to the metadata view if the message was already evicted.
+			if m, found := st.Get(p.ID); found {
+				send("mail", mailMsgView(m))
+				continue
+			}
+			send("mail", map[string]any{
+				"id": p.ID, "topic": p.Topic, "from": p.From, "to": p.To, "help": p.Help,
+			})
+		}
 	}
 }
 

--- a/kernel/restapi/mailbox_watch_test.go
+++ b/kernel/restapi/mailbox_watch_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MIT
+
+package restapi
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agezt/agezt/kernel/board"
+	"github.com/agezt/agezt/kernel/event"
+)
+
+// TestMailboxWatch_FiltersAndStreams drives the SSE watch end to end over a
+// real HTTP server: a watcher on one name receives its DM and a foreign
+// broadcast — with the full text resolved from the store — and nothing else.
+func TestMailboxWatch_FiltersAndStreams(t *testing.T) {
+	s := newServer(t, &fakeEngine{model: "m"}, "tok")
+	st, err := board.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("board.Open: %v", err)
+	}
+	// Wire the notifier the way the daemon does: publish board.posted with the
+	// metadata payload (no text) on the server's bus.
+	s.SetMailbox(st, func(m board.Message, corr string) {
+		_, _ = s.bus.Publish(event.Spec{
+			Subject:       "board.test",
+			Kind:          event.KindBoardPosted,
+			Actor:         "board",
+			CorrelationID: corr,
+			Payload: map[string]any{
+				"id": m.ID, "topic": m.Topic, "from": m.From, "to": m.To, "help": m.Help,
+			},
+		})
+	})
+	post := func(msg board.Message) {
+		t.Helper()
+		m, err := st.Send(msg, time.Now().UnixMilli())
+		if err != nil {
+			t.Fatalf("Send: %v", err)
+		}
+		s.boardNotify(m, "")
+	}
+
+	ts := httptest.NewServer(s.Handler())
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet,
+		ts.URL+"/api/v1/mailbox/watch?name=researcher", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("watch request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("watch status: %d", resp.StatusCode)
+	}
+
+	// frames yields (event, data) pairs parsed from the SSE stream.
+	scanner := bufio.NewScanner(resp.Body)
+	nextFrame := func() (string, map[string]any) {
+		t.Helper()
+		eventName := ""
+		for scanner.Scan() {
+			line := scanner.Text()
+			switch {
+			case strings.HasPrefix(line, "event: "):
+				eventName = strings.TrimPrefix(line, "event: ")
+			case strings.HasPrefix(line, "data: "):
+				var data map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &data); err != nil {
+					t.Fatalf("bad frame data: %v", err)
+				}
+				return eventName, data
+			}
+		}
+		t.Fatalf("stream ended early: %v", scanner.Err())
+		return "", nil
+	}
+
+	// The ready frame confirms the subscription is attached — only then is it
+	// safe to post (a message sent before it could race the subscribe).
+	if ev, data := nextFrame(); ev != "ready" || data["name"] != "researcher" {
+		t.Fatalf("expected ready frame, got %s %v", ev, data)
+	}
+
+	// One match (DM to the watcher), two non-matches (foreign DM; the
+	// watcher's own broadcast), one match (foreign broadcast).
+	post(board.Message{Topic: "dm", From: "myapp", To: "researcher", Text: "deploy target?"})
+	post(board.Message{Topic: "dm", From: "myapp", To: "writer", Text: "not yours"})
+	post(board.Message{Topic: "broadcast", From: "researcher", To: board.Everyone, Text: "my own"})
+	post(board.Message{Topic: "broadcast", From: "myapp", To: board.Everyone, Text: "heads-up"})
+
+	ev, data := nextFrame()
+	if ev != "mail" || data["text"] != "deploy target?" || data["to"] != "researcher" {
+		t.Fatalf("first mail wrong: %s %v", ev, data)
+	}
+	ev, data = nextFrame()
+	if ev != "mail" || data["text"] != "heads-up" {
+		t.Fatalf("second mail wrong (filtered frames leaked?): %s %v", ev, data)
+	}
+}
+
+// TestMailWatchMatch pins the filter table: name watching (directed,
+// broadcast, own-broadcast, foreign), topic watching, and the firehose.
+func TestMailWatchMatch(t *testing.T) {
+	cases := []struct {
+		name, topic string
+		p           boardPostedPayload
+		want        bool
+	}{
+		{"researcher", "", boardPostedPayload{To: "Researcher", From: "x"}, true},
+		{"researcher", "", boardPostedPayload{To: "writer", From: "x"}, false},
+		{"researcher", "", boardPostedPayload{To: "*", From: "myapp"}, true},
+		{"researcher", "", boardPostedPayload{To: "*", From: "researcher"}, false},
+		{"researcher", "", boardPostedPayload{To: "", Topic: "status"}, false},
+		{"", "status", boardPostedPayload{Topic: "Status"}, true},
+		{"", "status", boardPostedPayload{Topic: "dm"}, false},
+		{"researcher", "dm", boardPostedPayload{To: "researcher", Topic: "status"}, false},
+		{"", "", boardPostedPayload{Topic: "anything"}, true},
+	}
+	for i, c := range cases {
+		if got := mailWatchMatch(c.name, c.topic, c.p); got != c.want {
+			t.Errorf("case %d (%+v): got %v, want %v", i, c.p, got, c.want)
+		}
+	}
+}

--- a/kernel/restapi/restapi.go
+++ b/kernel/restapi/restapi.go
@@ -174,6 +174,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/api/v1/mailbox/messages", s.auth(s.handleMailboxMessages))
 	mux.HandleFunc("/api/v1/mailbox/messages/", s.auth(s.handleMailboxMessageSub))
 	mux.HandleFunc("/api/v1/mailbox/inbox", s.auth(s.handleMailboxInbox))
+	mux.HandleFunc("/api/v1/mailbox/watch", s.auth(s.handleMailboxWatch))
 	mux.HandleFunc("/api/v1/mailbox/topics", s.auth(s.handleMailboxTopics))
 	return mux
 }

--- a/sdk/mailbox.go
+++ b/sdk/mailbox.go
@@ -4,9 +4,12 @@ package sdk
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 	"time"
 
 	"github.com/agezt/agezt/kernel/controlplane"
+	"github.com/agezt/agezt/kernel/event"
 )
 
 // Mail is one message on the daemon's shared mailbox (the inter-agent message
@@ -122,6 +125,56 @@ func (c *Client) MailMessages(ctx context.Context, topic string, limit int) ([]M
 		return nil, err
 	}
 	return parseMails(res["messages"]), nil
+}
+
+// WatchMail streams new mail the moment it lands (M938) — the push
+// counterpart of polling Inbox. With a name it delivers that name's mail
+// (messages addressed to it plus broadcasts it didn't send); with an empty
+// name it delivers every board message (a firehose tail). fn is called from
+// the stream's read loop, so keep it quick (hand off to a channel for slow
+// work). Blocks until ctx is cancelled (returns nil) or the daemon connection
+// fails (returns the error).
+func (c *Client) WatchMail(ctx context.Context, name string, fn func(Mail)) error {
+	return c.cp.StreamUntilCancel(ctx, controlplane.CmdPulseSubscribe, map[string]any{
+		"pattern": "board.>",
+		"kinds":   []any{string(event.KindBoardPosted)},
+	}, func(ev *event.Event) {
+		if ev == nil || ev.Kind != event.KindBoardPosted || len(ev.Payload) == 0 {
+			return
+		}
+		var p struct {
+			ID    string `json:"id"`
+			Topic string `json:"topic"`
+			From  string `json:"from"`
+			To    string `json:"to"`
+			Help  bool   `json:"help"`
+		}
+		if json.Unmarshal(ev.Payload, &p) != nil || !mailForName(name, p.From, p.To) {
+			return
+		}
+		// The event carries metadata only; fetch the body by id. Fall back to
+		// the metadata view if the message was already evicted.
+		m := Mail{ID: p.ID, Topic: p.Topic, From: p.From, To: p.To, Help: p.Help}
+		if res, err := c.cp.Call(ctx, controlplane.CmdBoardGet, map[string]any{"id": p.ID}); err == nil {
+			if view, ok := res["message"].(map[string]any); ok {
+				m = parseMail(view)
+			}
+		}
+		fn(m)
+	})
+}
+
+// mailForName reports whether a posted message is for name: addressed to it
+// (case-insensitive), or a broadcast it didn't send. An empty name matches
+// everything.
+func mailForName(name, from, to string) bool {
+	if name == "" {
+		return true
+	}
+	name = strings.ToLower(strings.TrimSpace(name))
+	directed := strings.ToLower(strings.TrimSpace(to)) == name
+	broadcast := to == "*" && strings.ToLower(strings.TrimSpace(from)) != name
+	return directed || broadcast
 }
 
 // parseMails maps a []any of message views to typed Mail values.

--- a/sdk/mailbox_test.go
+++ b/sdk/mailbox_test.go
@@ -46,6 +46,25 @@ func TestParseMails(t *testing.T) {
 	}
 }
 
+func TestMailForName(t *testing.T) {
+	cases := []struct {
+		name, from, to string
+		want           bool
+	}{
+		{"researcher", "x", "Researcher", true},  // directed, case-insensitive
+		{"researcher", "x", "writer", false},     // someone else's DM
+		{"researcher", "myapp", "*", true},       // foreign broadcast
+		{"researcher", "Researcher", "*", false}, // own broadcast
+		{"researcher", "x", "", false},           // plain topic post
+		{"", "x", "writer", true},                // firehose matches everything
+	}
+	for i, c := range cases {
+		if got := mailForName(c.name, c.from, c.to); got != c.want {
+			t.Errorf("case %d (%q from=%q to=%q): got %v, want %v", i, c.name, c.from, c.to, got, c.want)
+		}
+	}
+}
+
 func TestParseMails_Empty(t *testing.T) {
 	if got := parseMails(nil); len(got) != 0 {
 		t.Fatalf("nil input: %d", len(got))

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -89,6 +89,7 @@ asyncio.run(main())
 | `mailbox_replies(message_id, limit=0)` | `GET /api/v1/mailbox/messages/{id}/replies` | `list[Mail]`, oldest first |
 | `mailbox_messages(topic="", limit=0)` | `GET /api/v1/mailbox/messages` | `list[Mail]`, newest first |
 | `mailbox_topics()` | `GET /api/v1/mailbox/topics` | `dict` topic → count |
+| `mailbox_watch(name="", topic="")` | `GET /api/v1/mailbox/watch` (SSE) | iterator of `Mail` as messages land (push, no polling) |
 
 `Client(base_url, token, timeout=30, tenant=None)` — pass `tenant` to target an
 isolated tenant (sent as the `X-Agezt-Tenant` header) on a multi-tenant daemon.

--- a/sdk/python/agezt/aio.py
+++ b/sdk/python/agezt/aio.py
@@ -185,6 +185,33 @@ class AsyncClient:
         """Return the mailbox's topics with their message counts."""
         return await self._in_thread(self._sync.mailbox_topics)
 
+    async def mailbox_watch(self, name: str = "", topic: str = "") -> AsyncIterator[Mail]:
+        """Stream new mail as it lands (see :meth:`Client.mailbox_watch`),
+        yielding to ``async for`` without blocking the event loop — the same
+        queue bridge as :meth:`run_stream`."""
+        loop = asyncio.get_running_loop()
+        queue: "asyncio.Queue[Any]" = asyncio.Queue()
+        done = object()
+
+        def produce() -> None:
+            try:
+                for mail in self._sync.mailbox_watch(name, topic):
+                    loop.call_soon_threadsafe(queue.put_nowait, mail)
+            except BaseException as exc:
+                loop.call_soon_threadsafe(queue.put_nowait, exc)
+            finally:
+                loop.call_soon_threadsafe(queue.put_nowait, done)
+
+        loop.run_in_executor(None, produce)
+
+        while True:
+            item = await queue.get()
+            if item is done:
+                return
+            if isinstance(item, BaseException):
+                raise item
+            yield item
+
     async def aclose(self) -> None:
         """No-op: the client holds no persistent resources. Provided for symmetry."""
         return None

--- a/sdk/python/agezt/client.py
+++ b/sdk/python/agezt/client.py
@@ -229,6 +229,34 @@ class Client:
         """Return the mailbox's topics with their message counts."""
         return self._get("/api/v1/mailbox/topics").get("topics", {})
 
+    def mailbox_watch(self, name: str = "", topic: str = "") -> Iterator[Mail]:
+        """Stream new mail the moment it lands — the push counterpart of
+        polling :meth:`mailbox_inbox`.
+
+        ``name`` watches one agent/app's mail (messages addressed to it plus
+        broadcasts it didn't send); ``topic`` watches one topic; neither tails
+        every board message. Blocks on the SSE stream until the server closes
+        it (or the caller abandons the iterator). The server's first frame is
+        a ``ready`` marker — messages sent after it are guaranteed delivered.
+        """
+        q: Dict[str, str] = {}
+        if name:
+            q["name"] = name
+        if topic:
+            q["topic"] = topic
+        path = "/api/v1/mailbox/watch"
+        if q:
+            path += "?" + urllib.parse.urlencode(q)
+        req = self._request("GET", path, accept="text/event-stream")
+        try:
+            resp = urllib.request.urlopen(req, timeout=self.timeout)
+        except urllib.error.HTTPError as e:
+            raise self._api_error(e) from None
+        with resp:
+            for ev in _parse_sse(resp):
+                if ev.event == "mail":
+                    yield Mail._from(ev.data)
+
     # --- internals --------------------------------------------------------
 
     def _request(

--- a/sdk/python/tests/test_mailbox.py
+++ b/sdk/python/tests/test_mailbox.py
@@ -43,6 +43,20 @@ class _Handler(BaseHTTPRequestHandler):
     def do_GET(self):
         u = urlparse(self.path)
         self.server.last_query = parse_qs(u.query)
+        if u.path == "/api/v1/mailbox/watch":
+            # A finite SSE stream: ready, one mail, then EOF (the iterator ends).
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.end_headers()
+            for frame in (
+                'event: ready\ndata: {"name": "researcher"}\n\n',
+                ": keepalive\n\n",
+                'event: mail\ndata: '
+                + json.dumps(_MSG)
+                + "\n\n",
+            ):
+                self.wfile.write(frame.encode())
+            return
         if u.path == "/api/v1/mailbox/inbox":
             self._json(200, {"name": "researcher", "waiting": [_MSG], "count": 1})
         elif u.path == "/api/v1/mailbox/messages/m-1/replies":
@@ -114,6 +128,13 @@ class MailboxTest(unittest.TestCase):
         self.assertEqual(self.srv.last_body, {"by": "researcher"})
         with self.assertRaises(APIError):
             self.c.mailbox_ack("nope", "researcher")
+
+    def test_watch_yields_mail_frames_only(self):
+        mails = list(self.c.mailbox_watch(name="researcher"))
+        self.assertEqual(len(mails), 1)  # ready + keepalive frames are skipped
+        self.assertEqual(mails[0].id, "m-1")
+        self.assertEqual(mails[0].text, "deploy target?")
+        self.assertEqual(self.srv.last_query, {"name": ["researcher"]})
 
     def test_replies_messages_topics(self):
         reps = self.c.mailbox_replies("m-1")

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -78,6 +78,7 @@ fn main() -> agezt::Result<()> {
 | `mailbox_replies(id, limit)` | `GET /api/v1/mailbox/messages/{id}/replies` | `Vec<Mail>`, oldest first |
 | `mailbox_messages(topic, limit)` | `GET /api/v1/mailbox/messages` | `Vec<Mail>`, newest first |
 | `mailbox_topics()` | `GET /api/v1/mailbox/topics` | `BTreeMap<String, i64>` topic → count |
+| `mailbox_watch(name, topic)` | `GET /api/v1/mailbox/watch` (SSE) | `Iterator<Item = Result<Mail>>` as messages land (push, no polling) |
 
 `Client::new(base_url, token)` defaults to a 30-second per-request timeout and
 no tenant. Chain `.with_timeout(Duration)` and `.with_tenant("<id>")` to target

--- a/sdk/rust/src/client.rs
+++ b/sdk/rust/src/client.rs
@@ -308,6 +308,35 @@ impl Client {
         Ok(mails_from(v.get("messages")))
     }
 
+    /// Stream new mail the moment it lands — the push counterpart of polling
+    /// [`Client::mailbox_inbox`]. `name` watches one agent/app's mail
+    /// (messages addressed to it plus broadcasts it didn't send); `topic`
+    /// watches one topic; both empty tails every board message. The server's
+    /// first frame is a `ready` marker (skipped here) — messages sent after
+    /// the iterator is obtained are guaranteed delivered. Iterates until the
+    /// connection closes; raise the client timeout for long quiet watches.
+    pub fn mailbox_watch(&self, name: &str, topic: &str) -> Result<MailWatch> {
+        let mut path = String::from("/api/v1/mailbox/watch");
+        let mut sep = '?';
+        if !name.is_empty() {
+            path.push_str(&format!("{sep}name={}", percent_encode(name)));
+            sep = '&';
+        }
+        if !topic.is_empty() {
+            path.push_str(&format!("{sep}topic={}", percent_encode(topic)));
+        }
+        let resp = self.send("GET", &path, None, "text/event-stream")?;
+        if !(200..300).contains(&resp.status) {
+            return Err(api_error(resp.status, &resp.read_text()?));
+        }
+        Ok(MailWatch {
+            inner: RunStream {
+                lines: resp.body.into_lines(),
+                done: false,
+            },
+        })
+    }
+
     /// The mailbox's topics with their message counts.
     pub fn mailbox_topics(&self) -> Result<std::collections::BTreeMap<String, i64>> {
         let v = self.get_json("/api/v1/mailbox/topics")?;
@@ -411,6 +440,27 @@ impl Iterator for RunStream {
                 event = rest.trim().to_string();
             } else if let Some(rest) = line.strip_prefix("data:") {
                 data_lines.push(rest.strip_prefix(' ').unwrap_or(rest).to_string());
+            }
+        }
+    }
+}
+
+/// The watch iterator returned by [`Client::mailbox_watch`]: each item is one
+/// newly-landed [`Mail`] (the SSE `mail` frames; `ready` and keepalives are
+/// skipped). Built on the same SSE reader as [`RunStream`].
+pub struct MailWatch {
+    inner: RunStream,
+}
+
+impl Iterator for MailWatch {
+    type Item = Result<Mail>;
+
+    fn next(&mut self) -> Option<Result<Mail>> {
+        loop {
+            match self.inner.next()? {
+                Err(e) => return Some(Err(e)),
+                Ok(ev) if ev.event == "mail" => return Some(Ok(mail_from(&ev.data))),
+                Ok(_) => {} // ready / unknown frames
             }
         }
     }

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -51,7 +51,7 @@ mod http;
 mod json;
 
 pub use client::{
-    Client, Health, Mail, MailDraft, Models, RunArc, RunResult, RunStream, StreamEvent,
+    Client, Health, Mail, MailDraft, MailWatch, Models, RunArc, RunResult, RunStream, StreamEvent,
 };
 pub use errors::{Error, Result};
 pub use json::Value;

--- a/sdk/rust/tests/client.rs
+++ b/sdk/rust/tests/client.rs
@@ -209,6 +209,25 @@ fn handle(mut stream: TcpStream) {
         ("GET", "/api/v1/mailbox/topics") => {
             write_json(&mut stream, 200, r#"{"topics":{"dm":2,"status":1}}"#)
         }
+        ("GET", p) if p.starts_with("/api/v1/mailbox/watch") => {
+            // A finite SSE stream: ready, keepalive, one mail, then EOF. The
+            // query is reflected into the mail text so a test can assert the
+            // name/topic were encoded on the wire.
+            let q = p
+                .trim_start_matches("/api/v1/mailbox/watch")
+                .trim_start_matches('?');
+            let mail = format!(
+                "event: mail\ndata: {{\"id\":\"m-9\",\"topic\":\"dm\",\"from\":\"myapp\",\"to\":\"researcher\",\"text\":\"{q}\",\"ts_unix_ms\":1700000000000}}\n\n"
+            );
+            write_sse(
+                &mut stream,
+                &[
+                    "event: ready\ndata: {\"name\":\"researcher\"}\n\n",
+                    ": keepalive\n\n",
+                    &mail,
+                ],
+            );
+        }
         _ => write_json(
             &mut stream,
             404,
@@ -411,4 +430,19 @@ fn mailbox_replies_messages_topics() {
     let topics = c.mailbox_topics().unwrap();
     assert_eq!(topics.get("dm"), Some(&2));
     assert_eq!(topics.get("status"), Some(&1));
+}
+
+#[test]
+fn mailbox_watch_yields_mail_frames_only() {
+    let base = start_mock();
+    let mails: Vec<_> = client(&base, "testtoken")
+        .mailbox_watch("researcher", "")
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    // ready + keepalive frames are skipped; the one mail frame arrives with
+    // the query (reflected by the mock) proving name= was encoded.
+    assert_eq!(mails.len(), 1);
+    assert_eq!(mails[0].id, "m-9");
+    assert_eq!(mails[0].text, "name=researcher");
 }

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -62,6 +62,7 @@ console.log(arc.count, "events");
 | `mailboxReplies(messageId, limit?)` | `GET /api/v1/mailbox/messages/{id}/replies` | `Promise<Mail[]>`, oldest first |
 | `mailboxMessages(topic?, limit?)` | `GET /api/v1/mailbox/messages` | `Promise<Mail[]>`, newest first |
 | `mailboxTopics()` | `GET /api/v1/mailbox/topics` | `Promise<Record<string, number>>` |
+| `mailboxWatch(name?, topic?)` | `GET /api/v1/mailbox/watch` (SSE) | `AsyncGenerator<Mail>` as messages land (push, no polling) |
 
 `new Client(baseUrl, token, { timeoutMs?, tenant? })` — pass `tenant` to target an
 isolated tenant (sent as `X-Agezt-Tenant`) on a multi-tenant daemon.

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -200,6 +200,33 @@ export class Client {
     return out.topics ?? {};
   }
 
+  /** Stream new mail the moment it lands — the push counterpart of polling
+   * `mailboxInbox`. `name` watches one agent/app's mail (messages addressed to
+   * it plus broadcasts it didn't send); `topic` watches one topic; neither
+   * tails every board message. The server's first frame is a `ready` marker —
+   * messages sent after it are guaranteed delivered. Iterates until the
+   * connection closes or the consumer breaks out.
+   *
+   * Note: pass `timeoutMs: 0`-like long timeouts via ClientOptions if the
+   * default 30s would cut a quiet watch short. */
+  async *mailboxWatch(name = "", topic = ""): AsyncGenerator<Mail> {
+    const q = new URLSearchParams();
+    if (name) q.set("name", name);
+    if (topic) q.set("topic", topic);
+    const qs = q.toString();
+    const res = await this.fetch(
+      "GET",
+      "/api/v1/mailbox/watch" + (qs ? "?" + qs : ""),
+      undefined,
+      "text/event-stream",
+    );
+    if (!res.ok) throw await apiError(res);
+    if (!res.body) return;
+    for await (const ev of parseSSE(res.body)) {
+      if (ev.event === "mail") yield ev.data as unknown as Mail;
+    }
+  }
+
   // --- internals ---
 
   private async getJSON<T>(path: string): Promise<T> {

--- a/sdk/typescript/test/mailbox.test.ts
+++ b/sdk/typescript/test/mailbox.test.ts
@@ -31,7 +31,14 @@ before(async () => {
     const url = req.url ?? "";
     lastUrl = url;
     if (req.method === "GET") {
-      if (url.startsWith("/api/v1/mailbox/inbox")) {
+      if (url.startsWith("/api/v1/mailbox/watch")) {
+        // A finite SSE stream: ready, keepalive, one mail, then EOF.
+        res.writeHead(200, { "Content-Type": "text/event-stream" });
+        res.write('event: ready\ndata: {"name":"researcher"}\n\n');
+        res.write(": keepalive\n\n");
+        res.write("event: mail\ndata: " + JSON.stringify(MSG) + "\n\n");
+        res.end();
+      } else if (url.startsWith("/api/v1/mailbox/inbox")) {
         json(res, 200, { name: "researcher", waiting: [MSG], count: 1 });
       } else if (url.startsWith("/api/v1/mailbox/messages/m-1/replies")) {
         json(res, 200, {
@@ -101,6 +108,14 @@ test("mailboxAck posts by; unknown id throws APIError(404)", async () => {
     assert.equal(e.status, 404);
     return true;
   });
+});
+
+test("mailboxWatch yields mail frames only (ready/keepalive skipped)", async () => {
+  const got: unknown[] = [];
+  for await (const m of client().mailboxWatch("researcher")) got.push(m);
+  assert.equal(got.length, 1);
+  assert.equal((got[0] as { id?: string }).id, "m-1");
+  assert.equal(lastUrl, "/api/v1/mailbox/watch?name=researcher");
 });
 
 test("mailboxReplies / mailboxMessages / mailboxTopics map their shapes", async () => {


### PR DESCRIPTION
Stacked on #364 (M937 mailbox).

## What

Apps no longer poll the inbox: `GET /api/v1/mailbox/watch?name=&topic=` streams new board messages as SSE `mail` frames the moment they land.

- `name=` → that agent/app's mail (DMs + broadcasts it didn't send) — the live counterpart of the inbox
- `topic=` → one topic's posts
- neither → firehose tail of the whole board

## Design

- **No send/subscribe race**: the server subscribes the bus (`board.>`) *before* emitting a leading `ready` frame; anything sent after `ready` is guaranteed delivered. 25s keepalive comments hold idle connections open (the watch is open-ended, unlike a run stream).
- **Body resolution**: `board.posted` events deliberately journal metadata only (no text). The REST watch resolves the body from the shared store by id; for the Go SDK a new read-only `board_get` control-plane command does the same.
- **SDKs ×4**: Go `WatchMail(ctx, name, fn)` rides the existing pulse event stream (`pattern: board.>`, `kinds: [board.posted]`) — no new streaming protocol; Python `mailbox_watch` (sync iterator + queue-bridged async iterator), TypeScript `mailboxWatch` async generator, Rust `MailWatch` iterator — all reuse their existing SSE parsers.

## Tests

- REST: end-to-end watch over a real `httptest` server — ready frame, filter table (directed / foreign-vs-own broadcast / topic / firehose), full text resolved from the store.
- CP: `board_get` round-trip + error paths.
- SDKs: Go filter-table test; Python 20/20; TS 13/13; Rust 13+13+3 (fmt clean) — mocks stream finite ready/keepalive/mail sequences and assert only `mail` frames surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Re-lands #365, whose squash went into the stacked base branch (feat/m937-mailbox) instead of main during the merge-train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)