### PR TITLE
feat(agt): skill export --all --agent <slug> — export one agent's skills (M943)

### DIFF
--- a/cmd/agt/skill.go
+++ b/cmd/agt/skill.go
@@ -61,7 +61,7 @@ func cmdSkill(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stdout, "  reassign <id> [--agent S]     change a skill's owning agent (omit --agent to share)\n")
 		fmt.Fprintf(stdout, "  diff <id> [<id2>]             diff a skill's body vs its parent (or vs id2)\n")
 		fmt.Fprintf(stdout, "  export <id> [--out <file>]    write a portable, verifiable skill bundle\n")
-		fmt.Fprintf(stdout, "  export --all [--dir <dir>]    export every skill into a directory registry\n")
+		fmt.Fprintf(stdout, "  export --all [--dir <dir>] [--agent <slug>]   export every skill (or one agent's) into a registry dir\n")
 		fmt.Fprintf(stdout, "  import <bundle|dir> [--json]  install a bundle/SKILL.md/skill directory as a draft\n")
 		fmt.Fprintf(stdout, "  files <id> [--json]           list a skill's bundle resources + their directory\n")
 		fmt.Fprintf(stdout, "  cat <id> <path>               print one bundle resource (reference file or script)\n")

--- a/cmd/agt/skill_export.go
+++ b/cmd/agt/skill_export.go
@@ -114,7 +114,11 @@ func safeSkillFilename(name, id string) string {
 // CmdSkillList call supplies the full records, bodies included). It is the
 // publisher side of the skill registry: a node exports its whole skill library
 // as a directory another node can browse with `agt skill registry`.
-func exportAllSkills(dir string, stdout, stderr io.Writer) int {
+// exportAllSkills writes one bundle per skill into dir plus a registry index.
+// When agentFilter is non-empty, only skills owned by that roster agent (M932)
+// are exported — `skill export --all --agent <slug>` lifts one agent's private
+// skill set out as a portable bundle directory (M943).
+func exportAllSkills(dir, agentFilter string, stdout, stderr io.Writer) int {
 	c := dial(stderr)
 	if c == nil {
 		return 1
@@ -127,6 +131,21 @@ func exportAllSkills(dir string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	rawSkills, _ := res["skills"].([]any)
+	if agentFilter != "" {
+		filtered := rawSkills[:0:0]
+		for _, raw := range rawSkills {
+			if m, ok := raw.(map[string]any); ok {
+				if owner, _ := m["agent"].(string); owner == agentFilter {
+					filtered = append(filtered, raw)
+				}
+			}
+		}
+		rawSkills = filtered
+		if len(rawSkills) == 0 {
+			fmt.Fprintf(stdout, "no skills owned by agent %q to export\n", agentFilter)
+			return 0
+		}
+	}
 	if len(rawSkills) == 0 {
 		fmt.Fprintf(stdout, "no skills to export\n")
 		return 0
@@ -204,9 +223,19 @@ func cmdSkillExport(args []string, stdout, stderr io.Writer) int {
 	outPath := ""
 	all := false
 	dir := "."
+	agent := ""
 	for i := 0; i < len(args); i++ {
 		a := args[i]
 		switch {
+		case a == "--agent":
+			if i+1 >= len(args) {
+				fmt.Fprintf(stderr, "%s skill export: --agent needs a slug\n", brand.CLI)
+				return 2
+			}
+			i++
+			agent = args[i]
+		case strings.HasPrefix(a, "--agent="):
+			agent = strings.TrimPrefix(a, "--agent=")
 		case a == "--out":
 			if i+1 >= len(args) {
 				fmt.Fprintf(stderr, "%s skill export: --out needs a file path\n", brand.CLI)
@@ -229,11 +258,12 @@ func cmdSkillExport(args []string, stdout, stderr io.Writer) int {
 			dir = strings.TrimPrefix(a, "--dir=")
 		case a == "-h" || a == "--help":
 			fmt.Fprintf(stdout, "usage: %s skill export <id> [--out <file>]\n", brand.CLI)
-			fmt.Fprintf(stdout, "       %s skill export --all [--dir <dir>]\n", brand.CLI)
+			fmt.Fprintf(stdout, "       %s skill export --all [--dir <dir>] [--agent <slug>]\n", brand.CLI)
 			fmt.Fprintf(stdout, "write a portable, verifiable skill bundle (default: to stdout)\n")
-			fmt.Fprintf(stdout, "  --out <file>  write the bundle to a file instead of stdout\n")
-			fmt.Fprintf(stdout, "  --all         export every skill, one file per skill, into --dir\n")
-			fmt.Fprintf(stdout, "  --dir <dir>   target directory for --all (default: .)\n")
+			fmt.Fprintf(stdout, "  --out <file>    write the bundle to a file instead of stdout\n")
+			fmt.Fprintf(stdout, "  --all           export every skill, one file per skill, into --dir\n")
+			fmt.Fprintf(stdout, "  --dir <dir>     target directory for --all (default: .)\n")
+			fmt.Fprintf(stdout, "  --agent <slug>  with --all: export only skills owned by that agent\n")
 			return 0
 		case strings.HasPrefix(a, "-"):
 			fmt.Fprintf(stderr, "%s skill export: unexpected flag %q\n", brand.CLI, a)
@@ -251,7 +281,11 @@ func cmdSkillExport(args []string, stdout, stderr io.Writer) int {
 			fmt.Fprintf(stderr, "%s skill export: --all takes no id (it exports every skill)\n", brand.CLI)
 			return 2
 		}
-		return exportAllSkills(dir, stdout, stderr)
+		return exportAllSkills(dir, agent, stdout, stderr)
+	}
+	if agent != "" {
+		fmt.Fprintf(stderr, "%s skill export: --agent only applies to --all\n", brand.CLI)
+		return 2
 	}
 	if id == "" {
 		fmt.Fprintf(stderr, "%s skill export: id required (or --all)\n", brand.CLI)

--- a/cmd/agt/skill_export_test.go
+++ b/cmd/agt/skill_export_test.go
@@ -118,6 +118,18 @@ func TestCmdSkillExport_AllRejectsID(t *testing.T) {
 	}
 }
 
+// --agent scopes the bulk export to one roster agent (M943); on its own (no
+// --all, single-skill export) it is meaningless and rejected before any dial.
+func TestCmdSkillExport_AgentRequiresAll(t *testing.T) {
+	var out, errb bytes.Buffer
+	if code := cmdSkillExport([]string{"someid", "--agent", "alice"}, &out, &errb); code != 2 {
+		t.Errorf("exit = %d, want 2 for --agent without --all", code)
+	}
+	if !strings.Contains(errb.String(), "--agent only applies to --all") {
+		t.Errorf("stderr = %q, want an --agent/--all message", errb.String())
+	}
+}
+
 func mustJSON(t *testing.T, v any) string {
 	t.Helper()
 	data, err := json.MarshalIndent(v, "", "  ")


### PR DESCRIPTION
## What

`agt skill export --all` exported **every** skill into a bundle registry directory, but there was no way to lift just **one agent's** private skill set (M932) out as a portable bundle. This adds an `--agent <slug>` filter to the bulk export.

- `agt skill export --all --agent <slug> [--dir <dir>]` — writes only the skills owned by that agent, using the same content-addressed/verified bundles + registry index.
- `--agent` without `--all` is rejected (meaningless for single-skill export).

## Why

Completes the last open item from the Storage/Artifacts/Army arc ("physically exporting an agent's skills as a bundle dir"), pairing with the M942 ownership valve and M932 per-agent skills.

## Scope

CLI-only — reuses the existing bundle/verify/registry-index machinery. No backend, no frontend.

## Verification

- `go build ./cmd/agt/...`, `go vet` clean
- New test `TestCmdSkillExport_AgentRequiresAll` + existing export tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)