### PR TITLE
fix(governor): skip definitively-unservable models in the fallback chain (M955)

### DIFF
--- a/kernel/governor/governor.go
+++ b/kernel/governor/governor.go
@@ -366,6 +366,14 @@ var ErrRateLimited = errors.New("governor: rate limit exceeded")
 // advertise tool-use. A pre-flight error — no provider is called.
 var ErrModelLacksToolUse = errors.New("governor: model does not support tool-use")
 
+// ErrModelUnservable is returned when a model fallback chain entry is skipped
+// because no registered provider serves it and every provider declares a
+// (non-empty) catalog model list — so dispatching it would only hit a provider
+// that 400s on an unrecognised id (M955: the glm-5.1→deepseek misroute). The
+// chain walk advances to the next model; this is the last error only when EVERY
+// model in the chain was unservable.
+var ErrModelUnservable = errors.New("governor: no registered provider serves model")
+
 // ErrNoProviders is returned when no provider in the chain succeeded.
 type ErrNoProviders struct {
 	Tried []string
@@ -842,6 +850,36 @@ func (g *Governor) completeChained(req agent.CompletionRequest, runOne func(agen
 	}
 	var lastErr error
 	for i, m := range models {
+		// Skip a chain model that NO registered provider can serve (M955).
+		// Without this, applyModelRoute leaves the default chain in place and
+		// the model id is dispatched to the primary provider, which 400s on an
+		// id it doesn't recognise — one failed call PER provider in the chain,
+		// a fallback storm — before the walk finally reaches the next model.
+		// Skipping straight to the next model produces a real answer with zero
+		// doomed calls. Guarded to "definitively unservable" (every provider
+		// declares a model list and none include m) so an unknown-coverage
+		// provider (empty Models, e.g. the mock/echo fallback) still gets the
+		// benefit of the doubt — its presence preserves the legacy fall-through.
+		if g.modelKnownUnservable(m) {
+			lastErr = fmt.Errorf("%w: %q", ErrModelUnservable, m)
+			if i+1 < len(models) {
+				g.publish(event.Spec{
+					Subject:       "governor.fallback",
+					Kind:          event.KindProviderFallback,
+					Actor:         "governor",
+					CorrelationID: req.CorrelationID,
+					Payload: map[string]any{
+						"failed_model": m,
+						"next_model":   models[i+1],
+						"reason":       "no registered provider serves this model",
+						"scope":        scope,
+						"task_type":    req.TaskType,
+						"skipped":      true,
+					},
+				})
+			}
+			continue
+		}
 		attempt := req
 		attempt.Model = m
 		resp, err := runOne(attempt)
@@ -884,6 +922,37 @@ func (g *Governor) modelChainFor(taskType string) []string {
 		return nil
 	}
 	return slices.Clone(src)
+}
+
+// modelKnownUnservable reports whether the registered providers DEFINITIVELY
+// cannot serve model: no registered provider lists it AND every registered
+// provider declares a non-empty catalog model list. An empty Models list means
+// "unknown coverage" (the comment on ProviderInfo.Models) — such a provider may
+// accept an unlisted id, so its presence makes the verdict false (don't skip).
+// Mirrors the routeChain snapshot discipline: read the chain slices under
+// chainMu so a concurrent Replace (hot reload) can't race the scan.
+func (g *Governor) modelKnownUnservable(model string) bool {
+	if model == "" {
+		return false
+	}
+	g.chainMu.RLock()
+	defer g.chainMu.RUnlock()
+	for _, p := range g.sortedPrimary {
+		if p.Serves(model) || len(p.Models) == 0 {
+			return false
+		}
+	}
+	for _, p := range g.fallback {
+		if p.Serves(model) || len(p.Models) == 0 {
+			return false
+		}
+	}
+	// Guard: with no providers at all (impossible post-New, but cheap) treat as
+	// servable so we never skip every model on an empty registry.
+	if len(g.sortedPrimary) == 0 && len(g.fallback) == 0 {
+		return false
+	}
+	return true
 }
 
 // SetTaskModelChains atomically replaces the per-task-type model fallback chains

--- a/kernel/governor/modelchain_skip_test.go
+++ b/kernel/governor/modelchain_skip_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+
+package governor_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/governor"
+)
+
+// M955: a model fallback chain entry that NO registered provider serves (and
+// that every provider's catalog model list rules out) must be SKIPPED — the
+// walk advances to the next model without dispatching a doomed request to the
+// primary. This is the fix for the glm-5.1→deepseek fallback storm: glm-5.1 was
+// served only by an (unregistered) zhipu provider, so it fell through to the
+// deepseek primary and 400'd once per provider in the chain.
+func TestModelChain_SkipsUnservableModel(t *testing.T) {
+	b, _ := newBus(t)
+	r := governor.NewRegistry()
+	// trap is the primary (registered first) and 400s on anything — it stands in
+	// for deepseek receiving "glm-5.1". It declares its own model list, so the
+	// guard knows it cannot serve the mystery model.
+	trap := &fakeProvider{name: "trap", err: errors.New("HTTP 400 invalid_request_error")}
+	echo := &fakeProvider{name: "echo", resp: okResp("model-a", 1, 1)}
+	mustRegister(t, r,
+		&governor.ProviderInfo{Name: "trap", Provider: trap, AuthMode: governor.AuthAPIKey, Models: []string{"model-trap"}},
+		&governor.ProviderInfo{Name: "echo", Provider: echo, AuthMode: governor.AuthAPIKey, Models: []string{"model-a"}},
+	)
+	g, err := governor.New(governor.Config{
+		Registry:        r,
+		Bus:             b,
+		TaskModelChains: governor.TaskModelChains{"chat": {"mystery", "model-a"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := g.Complete(context.Background(), agent.CompletionRequest{TaskType: "chat"})
+	if err != nil {
+		t.Fatalf("chain should succeed on model-a after skipping mystery: %v", err)
+	}
+	if resp == nil || resp.Usage.Model != "model-a" {
+		t.Fatalf("want answer from model-a, got %+v", resp)
+	}
+	if trap.calls.Load() != 0 {
+		t.Errorf("trap (the 400 primary) must NOT be called for the unservable model, got %d calls", trap.calls.Load())
+	}
+	if echo.calls.Load() != 1 {
+		t.Errorf("echo (serves model-a) should be called once, got %d", echo.calls.Load())
+	}
+}
+
+// When EVERY model in the chain is unservable, Complete fails clean with
+// ErrModelUnservable instead of misrouting to a provider that 400s.
+func TestModelChain_AllUnservableErrorsClean(t *testing.T) {
+	b, _ := newBus(t)
+	r := governor.NewRegistry()
+	trap := &fakeProvider{name: "trap", err: errors.New("HTTP 400")}
+	echo := &fakeProvider{name: "echo", resp: okResp("model-a", 1, 1)}
+	mustRegister(t, r,
+		&governor.ProviderInfo{Name: "trap", Provider: trap, AuthMode: governor.AuthAPIKey, Models: []string{"model-trap"}},
+		&governor.ProviderInfo{Name: "echo", Provider: echo, AuthMode: governor.AuthAPIKey, Models: []string{"model-a"}},
+	)
+	g, _ := governor.New(governor.Config{
+		Registry:        r,
+		Bus:             b,
+		TaskModelChains: governor.TaskModelChains{"chat": {"mystery-1", "mystery-2"}},
+	})
+
+	_, err := g.Complete(context.Background(), agent.CompletionRequest{TaskType: "chat"})
+	if !errors.Is(err, governor.ErrModelUnservable) {
+		t.Fatalf("want ErrModelUnservable, got %v", err)
+	}
+	if trap.calls.Load() != 0 || echo.calls.Load() != 0 {
+		t.Errorf("no provider should be dispatched for all-unservable chain: trap=%d echo=%d", trap.calls.Load(), echo.calls.Load())
+	}
+}
+
+// An unknown-coverage provider (empty Models — e.g. the mock/echo fallback in
+// keyless mode) preserves the legacy fall-through: an unlisted model is NOT
+// skipped, because that provider might accept it.
+func TestModelChain_UnknownCoverageNotSkipped(t *testing.T) {
+	b, _ := newBus(t)
+	r := governor.NewRegistry()
+	mock := &fakeProvider{name: "mock", resp: okResp("mystery", 1, 1)}
+	mustRegister(t, r,
+		// Empty Models = unknown coverage.
+		&governor.ProviderInfo{Name: "mock", Provider: mock, AuthMode: governor.AuthLocal},
+	)
+	g, _ := governor.New(governor.Config{
+		Registry:        r,
+		Bus:             b,
+		TaskModelChains: governor.TaskModelChains{"chat": {"mystery"}},
+	})
+
+	if _, err := g.Complete(context.Background(), agent.CompletionRequest{TaskType: "chat"}); err != nil {
+		t.Fatalf("unknown-coverage provider should still be tried: %v", err)
+	}
+	if mock.calls.Load() != 1 {
+		t.Errorf("mock (empty Models) should be called once, got %d", mock.calls.Load())
+	}
+}


### PR DESCRIPTION
## Why

A live health-sentinel agent flagged `provider_fallbacks=367` (threshold >100). Root cause traced: the per-task model fallback chains reference `glm-5.1`, which in the catalog is served only by `zhipuai-coding-plan` (open.bigmodel.cn). When that provider isn't in the governor's registry, `applyModelRoute` finds no serving provider and **leaves the default chain unchanged** — so `glm-5.1` is dispatched to the **primary** provider (`deepseek`), which rejects it with HTTP 400 `invalid_request_error`. That happens **once per provider in the chain** before `completeChained` finally advances to the next model — a fallback storm.

## What

`completeChained` now **skips** a chain model when `modelKnownUnservable(m)` is true and advances straight to the next model — zero doomed provider calls.

`modelKnownUnservable(m)` is true only when:
- no registered provider lists `m` in its catalog `Models`, **and**
- every registered provider declares a **non-empty** `Models` list.

An empty `Models` list means "unknown coverage" (per the `ProviderInfo.Models` doc) — such a provider (the mock/echo fallback in keyless mode) might accept an unlisted id, so its presence keeps the **legacy fall-through**. This also means **direct, non-chain requests are unchanged** (the existing `TestModelRoute_UnknownModelKeepsDefaultOrder` contract holds — the change is localized to the model-chain walk).

## Effect

- glm-5.1 with no registered zhipu provider → **skipped**, chain proceeds to `deepseek-v4-pro` (a real answer), no 400s.
- glm-5.1 *with* a registered zhipu provider → served normally (not skipped).
- Defense-in-depth: the storm cannot recur even if a provider is mis/under-registered.

## How

- `kernel/governor/governor.go`: add `ErrModelUnservable`, `modelKnownUnservable` (chainMu-guarded registry scan), and the skip + `{skipped:true}` fallback event in `completeChained`.
- New `kernel/governor/modelchain_skip_test.go`: skip-to-next, all-unservable clean error, unknown-coverage passthrough.

## Verification

- `go test ./kernel/governor/` (full package) green; targeted skip/route/serves tests green.
- `go build ./...` + `go vet ./...` clean. New lines gofmt-clean (pre-existing CRLF-masked alignment in this file is unrelated and untouched).

## Operational note (live system)

This stops the **storm**. To make glm-5.1 actually *run*, the operator should redeploy current binaries and **fully restart** the daemon so `zhipuai-coding-plan` (already keyed: `ZHIPU_API_KEY`) registers at boot and serves glm-5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)