### PR TITLE
fix(shell): run commands with a scrubbed host env, not an empty one (M957)

### DIFF
--- a/plugins/tools/shell/env.go
+++ b/plugins/tools/shell/env.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+
+package shell
+
+import (
+	"os"
+	"strings"
+)
+
+// scrubEnv builds the child environment for a shell command (M957): an allowlist
+// of harmless OS variables a shell needs — PATH (so external programs resolve),
+// the Windows system vars cmd.exe relies on (SystemRoot/COMSPEC/… — without them
+// even built-ins fail with "The filename, directory name, or volume label syntax
+// is incorrect"), and locale — with HOME/TMP pointed at the work dir. Every
+// secret-shaped variable and the entire AGEZT_* namespace (API keys, provider
+// creds, tokens) is dropped, so a model-issued command can never read the
+// daemon's secrets.
+//
+// This mirrors codeexec.scrubEnv (the load-bearing safety property of code_exec):
+// warden defaults a nil Spec.Env to an EMPTY environment to avoid leaking the
+// daemon's secrets, but an empty env breaks cmd.exe entirely (no PATH/SystemRoot)
+// — the cause of the shell tool's ~66% Windows error rate. A scrubbed host env
+// is the documented "caller wants inheritance, explicitly" path, secret-safe per
+// the non-negotiable secret-scrub posture.
+func scrubEnv(dir string) []string {
+	if dir == "" {
+		dir = os.TempDir()
+	}
+	allow := map[string]bool{
+		"PATH": true, "PATHEXT": true, "COMSPEC": true,
+		"SYSTEMROOT": true, "SYSTEMDRIVE": true, "WINDIR": true,
+		"NUMBER_OF_PROCESSORS": true, "PROCESSOR_ARCHITECTURE": true,
+		// User/identity vars many tools need to locate config (git, ssh, npm…)
+		// — none secret-bearing; secret-shaped names are still dropped below.
+		"USERPROFILE": true, "USERNAME": true, "HOMEDRIVE": true, "HOMEPATH": true,
+		"LANG": true,
+	}
+	var out []string
+	for _, kv := range os.Environ() {
+		name, _, ok := strings.Cut(kv, "=")
+		if !ok {
+			continue
+		}
+		up := strings.ToUpper(name)
+		if isSecretName(up) {
+			continue
+		}
+		if allow[up] || strings.HasPrefix(up, "LC_") {
+			out = append(out, kv)
+		}
+	}
+	// Point HOME / temp at the work dir so scratch files land in the workspace
+	// rather than the daemon user's real home.
+	out = append(out,
+		"HOME="+dir,
+		"TMPDIR="+dir,
+		"TEMP="+dir,
+		"TMP="+dir,
+	)
+	return out
+}
+
+// isSecretName reports whether an env var name looks secret-bearing and must
+// never be forwarded into a model-issued command. Mirrors codeexec.isSecretName.
+func isSecretName(up string) bool {
+	for _, frag := range []string{"KEY", "TOKEN", "SECRET", "PASSWORD", "PASSWD", "CRED", "AWS_", "AGEZT_"} {
+		if strings.Contains(up, frag) {
+			return true
+		}
+	}
+	return false
+}

--- a/plugins/tools/shell/env_test.go
+++ b/plugins/tools/shell/env_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+
+package shell
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsSecretName(t *testing.T) {
+	secret := []string{"OPENAI_API_KEY", "GITHUB_TOKEN", "DB_PASSWORD", "MY_SECRET", "AWS_ACCESS_KEY_ID", "AGEZT_WEB_PASSWORD", "SOME_CRED"}
+	for _, n := range secret {
+		if !isSecretName(strings.ToUpper(n)) {
+			t.Errorf("%s should be flagged secret", n)
+		}
+	}
+	safe := []string{"PATH", "SYSTEMROOT", "COMSPEC", "LANG", "USERPROFILE", "NUMBER_OF_PROCESSORS"}
+	for _, n := range safe {
+		if isSecretName(strings.ToUpper(n)) {
+			t.Errorf("%s should NOT be flagged secret", n)
+		}
+	}
+}
+
+func TestScrubEnv_KeepsPathDropsSecrets(t *testing.T) {
+	// A real PATH must already exist in the test process env.
+	t.Setenv("PATH", t.TempDir())
+	// Plant secret-shaped vars that must NOT survive into the child env.
+	t.Setenv("OPENAI_API_KEY", "sk-should-not-leak")
+	t.Setenv("AGEZT_VAULT_PASSPHRASE", "nope")
+	t.Setenv("MY_TOKEN", "leak-me-not")
+
+	env := scrubEnv("C:\\work")
+	joined := strings.Join(env, "\n")
+
+	// PATH survives (so external programs resolve — the whole point of the fix).
+	hasPath := false
+	for _, kv := range env {
+		if strings.HasPrefix(strings.ToUpper(kv), "PATH=") {
+			hasPath = true
+		}
+	}
+	if !hasPath {
+		t.Error("scrubEnv must keep PATH")
+	}
+	// Secrets are gone.
+	for _, leak := range []string{"OPENAI_API_KEY", "AGEZT_VAULT_PASSPHRASE", "MY_TOKEN", "sk-should-not-leak", "nope", "leak-me-not"} {
+		if strings.Contains(joined, leak) {
+			t.Errorf("scrubbed env leaked %q", leak)
+		}
+	}
+	// HOME/TMP point at the work dir.
+	for _, want := range []string{"HOME=C:\\work", "TEMP=C:\\work", "TMP=C:\\work", "TMPDIR=C:\\work"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("scrubEnv missing %q", want)
+		}
+	}
+}
+
+func TestScrubEnv_EmptyDirFallsBackToTemp(t *testing.T) {
+	env := scrubEnv("")
+	var home string
+	for _, kv := range env {
+		if v, ok := strings.CutPrefix(kv, "HOME="); ok {
+			home = v
+		}
+	}
+	if home == "" {
+		t.Error("empty dir should fall back to a temp dir for HOME, got empty")
+	}
+}

--- a/plugins/tools/shell/shell.go
+++ b/plugins/tools/shell/shell.go
@@ -151,6 +151,11 @@ func (t *Tool) Invoke(ctx context.Context, raw json.RawMessage) (agent.Result, e
 	res, err := w.Run(ctx, warden.Spec{
 		Profile: profile,
 		Argv:    []string{shellBin, shellArg, in.Command},
+		// A scrubbed host environment (M957): PATH + the OS vars a shell needs,
+		// secrets dropped. Warden defaults a nil Env to EMPTY (anti-leak), but an
+		// empty env breaks cmd.exe on Windows (no PATH/SystemRoot → "not
+		// recognized" / "syntax is incorrect"), which was crippling the shell tool.
+		Env:     scrubEnv(workDir),
 		WorkDir: workDir, // M609 workspace coherence + M792 per-agent subdir
 		Limits: warden.Limits{
 			Timeout:        timeout,

--- a/plugins/tools/shell/shell_path_test.go
+++ b/plugins/tools/shell/shell_path_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+
+package shell
+
+import (
+	"context"
+	"encoding/json"
+	"runtime"
+	"testing"
+)
+
+// TestShell_ResolvesExternalProgram is the regression guard for M957: the shell
+// tool must run with a working PATH so external programs resolve. Before the fix
+// the tool passed no Env → warden gave the child an EMPTY environment → on
+// Windows cmd.exe could find nothing ("'where' is not recognized") and even
+// built-ins failed ("syntax is incorrect"). This runs a PATH-dependent command
+// on the real host and asserts it succeeds.
+func TestShell_ResolvesExternalProgram(t *testing.T) {
+	// A command that requires resolving an EXTERNAL program via PATH.
+	cmd := "ls /" // unix: ls lives on PATH
+	if runtime.GOOS == "windows" {
+		cmd = "where where" // where.exe lives in System32, found via PATH
+	}
+
+	tool := New()
+	in, _ := json.Marshal(shellInput{Command: cmd})
+	res, err := tool.Invoke(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Invoke returned a transport error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("PATH-dependent command %q failed — shell env has no PATH?\n%s", cmd, res.Output)
+	}
+	if res.Output == "" {
+		t.Errorf("expected output from %q, got empty", cmd)
+	}
+}


### PR DESCRIPTION
## Why

Diagnosed live from the dev daemon's `tool stats`: the **shell tool had a 66% error rate (586/893 calls)** — the single biggest source of the fleet's ~37% tool-error rate. The errors:
- `'python' / 'powershell' / 'where' / 'findstr' / 'certutil' is not recognized as an internal or external command`
- `The filename, directory name, or volume label syntax is incorrect` (209×)
- commands mangled to a single quoted token (`'"dir … /b"' is not recognized`)

**Root cause:** the shell tool passed no `Spec.Env`, and warden deliberately maps a nil `Env` to an **EMPTY environment** (M186, to avoid leaking the daemon's secrets). With no `PATH`/`SystemRoot`/`COMSPEC`, Windows `cmd.exe` can resolve no external program and even built-ins fail. `code_exec` already avoids this with `scrubEnv()`; the shell tool didn't — so it was crippled on Windows.

## Fix

The shell tool now runs with a **scrubbed host environment** (`plugins/tools/shell/env.go`, mirroring `codeexec.scrubEnv`):
- **Allowlist** of harmless OS vars: `PATH`, `PATHEXT`, `COMSPEC`, `SYSTEMROOT`/`SYSTEMDRIVE`, `WINDIR`, `USERPROFILE`/`USERNAME`/`HOMEDRIVE`/`HOMEPATH`, `NUMBER_OF_PROCESSORS`, `PROCESSOR_ARCHITECTURE`, `LANG`/`LC_*`.
- `HOME`/`TMP`/`TEMP`/`TMPDIR` pointed at the work dir.
- **Dropped:** every secret-shaped name (`*KEY`/`*TOKEN`/`*SECRET`/`*PASSWORD`/`*CRED`/`AWS_*`/`AGEZT_*`).

External programs resolve again; daemon secrets never reach a model-issued command — honouring the non-negotiable secret-scrub posture and warden's anti-leak intent (this is the documented "caller wants inheritance, explicitly" path).

## Tests

- `scrubEnv` keeps `PATH`, drops planted secrets (`OPENAI_API_KEY`, `AGEZT_VAULT_PASSPHRASE`, `MY_TOKEN`), points `HOME` at the workdir; empty-dir fallback; `isSecretName` classification.
- **`TestShell_ResolvesExternalProgram`** — a host integration guard that runs a real PATH-dependent command (`where where` / `ls /`) through the shell tool and asserts success. This is the regression that would have caught the original bug (it had none).
- `go test ./plugins/tools/shell/` green on this Windows host; `go build`/`go vet ./...` clean; gofmt-clean.

## Impact

The shell tool is usable again on Windows — expect the fleet's tool-error rate to fall sharply once the daemon is redeployed with this build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)