### PR TITLE
fix(warden): pass cmd /C commands to cmd.exe verbatim on Windows (M958)

### DIFF
--- a/kernel/warden/cmdline_other.go
+++ b/kernel/warden/cmdline_other.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package warden
+
+import "os/exec"
+
+// fixupWindowsCmd is a no-op off Windows: sh -c on Unix passes the command as a
+// single arg that the standard escaping handles correctly. (M958)
+func fixupWindowsCmd(_ *exec.Cmd) {}

--- a/kernel/warden/cmdline_windows.go
+++ b/kernel/warden/cmdline_windows.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+
+//go:build windows
+
+package warden
+
+import (
+	"os/exec"
+	"strings"
+	"syscall"
+)
+
+// fixupWindowsCmd makes a `cmd /C <command>` invocation pass the command to
+// cmd.exe VERBATIM (M958). Go's os/exec escapes each arg for the MSVC C-runtime
+// rules, but cmd.exe does NOT follow those rules: it has its own /C quote
+// handling, so a command containing double-quotes (e.g. `dir "C:\a b" /b`) comes
+// out mangled — "The filename, directory name, or volume label syntax is
+// incorrect" or the whole command read as one quoted program name. This was the
+// shell tool's dominant residual Windows error after the env fix (M957).
+//
+// The robust form is `cmd /S /C "<command>"`: with /S, cmd strips exactly the
+// first and last quote of the string after /C and runs the remainder as-is —
+// so embedded quotes survive intact. We set SysProcAttr.CmdLine directly, which
+// tells os/exec to use this raw command line instead of re-escaping Args. The
+// child binary is still cmd.Path (resolved from Args[0]).
+func fixupWindowsCmd(cmd *exec.Cmd) {
+	if cmd == nil || len(cmd.Args) < 3 {
+		return
+	}
+	base := strings.ToLower(cmd.Args[0])
+	isCmd := base == "cmd" || base == "cmd.exe" ||
+		strings.HasSuffix(base, `\cmd.exe`) || strings.HasSuffix(base, `/cmd.exe`)
+	if !isCmd {
+		return
+	}
+	if strings.ToLower(cmd.Args[1]) != "/c" {
+		return
+	}
+	command := strings.Join(cmd.Args[2:], " ")
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CmdLine = `cmd /S /C "` + command + `"`
+}

--- a/kernel/warden/cmdline_windows_test.go
+++ b/kernel/warden/cmdline_windows_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+
+//go:build windows
+
+package warden
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestFixupWindowsCmd_RawCmdLineForCmdC(t *testing.T) {
+	c := exec.Command("cmd", "/C", `dir "C:\a b" /b`)
+	fixupWindowsCmd(c)
+	if c.SysProcAttr == nil || c.SysProcAttr.CmdLine == "" {
+		t.Fatal("expected a raw CmdLine to be set for cmd /C")
+	}
+	want := `cmd /S /C "dir "C:\a b" /b"`
+	if c.SysProcAttr.CmdLine != want {
+		t.Errorf("CmdLine =\n  %q\nwant\n  %q", c.SysProcAttr.CmdLine, want)
+	}
+}
+
+func TestFixupWindowsCmd_IgnoresNonCmd(t *testing.T) {
+	// A direct interpreter invocation (code_exec path) must be left untouched.
+	c := exec.Command("python", "-c", `print("hi")`)
+	fixupWindowsCmd(c)
+	if c.SysProcAttr != nil && c.SysProcAttr.CmdLine != "" {
+		t.Errorf("non-cmd invocation must not get a raw CmdLine, got %q", c.SysProcAttr.CmdLine)
+	}
+	// Too few args is also a no-op.
+	c2 := exec.Command("cmd")
+	fixupWindowsCmd(c2)
+	if c2.SysProcAttr != nil && c2.SysProcAttr.CmdLine != "" {
+		t.Error("bare cmd must not get a raw CmdLine")
+	}
+}

--- a/kernel/warden/warden.go
+++ b/kernel/warden/warden.go
@@ -299,6 +299,10 @@ func (e *engine) Run(ctx context.Context, spec Spec) (*Result, error) {
 	// Linux for Setpgid so kill-on-timeout sweeps grandchildren;
 	// no-op on non-Linux).
 	configurePlatformAttrs(cmd, effective)
+	// M958: on Windows, hand `cmd /C <command>` to cmd.exe verbatim (cmd /S /C
+	// "<command>") so a quoted command isn't mangled by os/exec's MSVC-style
+	// escaping. No-op off Windows and for non-cmd invocations.
+	fixupWindowsCmd(cmd)
 
 	stdoutBuf := newCapBuffer(maxOut)
 	stderrBuf := newCapBuffer(maxOut)

--- a/plugins/tools/shell/shell_quote_windows_test.go
+++ b/plugins/tools/shell/shell_quote_windows_test.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+
+//go:build windows
+
+package shell
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestShell_QuotedCommandRunsVerbatim is the M958 regression guard: a perfectly
+// valid Windows command that contains double-quotes (e.g. a quoted path) must
+// run, not fail with "The filename, directory name, or volume label syntax is
+// incorrect". Before the fix, os/exec's MSVC-style escaping of `cmd /C
+// <command>` mangled any quoted command. Runs on the real host.
+func TestShell_QuotedCommandRunsVerbatim(t *testing.T) {
+	tool := New()
+	for _, cmd := range []string{
+		`dir "."`,            // quoted path argument
+		`echo "hello world"`, // quoted literal with a space
+	} {
+		in, _ := json.Marshal(shellInput{Command: cmd})
+		res, err := tool.Invoke(context.Background(), in)
+		if err != nil {
+			t.Fatalf("%q: transport error: %v", cmd, err)
+		}
+		if res.IsError {
+			t.Errorf("quoted command %q failed (cmd /C quoting bug?):\n%s", cmd, res.Output)
+		}
+	}
+	// Sanity: the quoted echo's text actually came through.
+	in, _ := json.Marshal(shellInput{Command: `echo "hello world"`})
+	res, _ := tool.Invoke(context.Background(), in)
+	if !strings.Contains(res.Output, "hello world") {
+		t.Errorf("quoted echo output missing the text: %q", res.Output)
+	}
+}


### PR DESCRIPTION
## Why

Follow-up to #387 (M957, shell empty-env fix). Live measurement after redeploy confirmed the PATH class of errors was gone (PowerShell/`Get-ChildItem` run now), but a **second, distinct bug** remained — and is now the dominant shell error:

| command (from the live journal) | result |
|---|---|
| `dir D:\…\pending /b` (no quotes) | ✅ ok |
| `dir "D:\…\pending" /b` (quoted path) | ❌ "The filename, directory name, or volume label syntax is incorrect" |
| `if not exist "D:\…" …` | ❌ same |
| `powershell -Command "Get-ChildItem …"` | ✅ ok (M957) |

These are valid Windows commands — the tool was mangling any command containing double-quotes.

**Root cause:** warden runs `exec.CommandContext("cmd", "/C", command)`. Go escapes each arg for the MSVC C-runtime rules, but `cmd.exe` does **not** follow those rules — its own `/C` quote handling then garbles a quoted command.

## Fix

On Windows, build the raw command line **`cmd /S /C "<command>"`** via `SysProcAttr.CmdLine`, so cmd.exe receives the command **verbatim**. `/S` makes cmd strip exactly the outer quote pair and run the rest as-is, so embedded quotes survive.

- Scoped to `cmd /C` invocations (the shell tool). `code_exec` calls interpreters directly (`python`/`node`/`deno`) → untouched. No-op off Windows (`sh -c` handles a single arg correctly).
- New build-tagged `kernel/warden/cmdline_windows.go` + `cmdline_other.go`; one call added in `warden.go`.

## Tests

- Unit: `fixupWindowsCmd` sets `cmd /S /C "…"` for `cmd /C`, leaves `python -c …` and bare `cmd` alone.
- **Host integration guard** `TestShell_QuotedCommandRunsVerbatim`: runs `dir "."` and `echo "hello world"` through the shell tool and asserts success (the regression this class never had).
- `go test ./kernel/warden/ ./plugins/tools/shell/` green on Windows; **linux cross-build + vet clean** (build tags verified for CI).

## Together with M957

M957 (env) + M958 (quoting) restore the shell tool on Windows end-to-end: external programs resolve **and** quoted commands run. Expect the fleet's shell error rate to drop from ~66% to near-baseline once redeployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)