### PR TITLE
chore(dev): warn when dev.ps1 builds a stale checkout (M972)

### DIFF
--- a/dev.ps1
+++ b/dev.ps1
@@ -16,6 +16,7 @@
 param(
     [switch]$Fresh,
     [switch]$SkipBuild,
+    [switch]$Pull,
     [string]$WebAddr = "127.0.0.1:8899"
 )
 
@@ -65,6 +66,26 @@ $env:AGEZT_HOME = $DevHome
 # pass-through env the daemon reads; everything else stays out of the process env
 foreach ($k in @("AGEZT_PROVIDER", "AGEZT_MODEL", "AGEZT_ALLOW_ALL", "AGEZT_VAULT_PASSPHRASE")) {
     if ($DotEnv.ContainsKey($k)) { Set-Item -Path "env:$k" -Value $DotEnv[$k] }
+}
+
+# --- build freshness (M972): the daemon embeds the web UI at build time, so a
+# stale checkout silently ships an OLD console (e.g. no Fallback Chains page,
+# old agent edit form). Print the revision we're building and shout when the
+# branch is behind its upstream, so a redeploy that "changed nothing" is
+# obvious. Pass -Pull to fast-forward to the latest before building.
+if (-not $SkipBuild) {
+    $branch = (git -C $Root rev-parse --abbrev-ref HEAD 2>$null)
+    if ($Pull) {
+        Step "git pull --ff-only ($branch)"
+        git -C $Root pull --ff-only
+    }
+    $head = (git -C $Root rev-parse --short HEAD 2>$null)
+    if ($head) { Step "building $branch @ $head" }
+    git -C $Root fetch -q 2>$null
+    $behind = (git -C $Root rev-list --count "HEAD..@{upstream}" 2>$null)
+    if ($behind -and ([int]$behind) -gt 0) {
+        Write-Host ("    WARNING: this checkout is {0} commit(s) BEHIND its upstream - the build and its embedded console will be OLD. Run:  git pull   (or .\dev.ps1 -Pull)" -f $behind) -ForegroundColor Yellow
+    }
 }
 
 # --- build


### PR DESCRIPTION
## Why

The daemon embeds the web UI at build time, so `dev.ps1` building from a checkout that's behind `origin/main` silently ships an **old console** — the recurring cause of "I redeployed but the Fallback Chains page / agent detail editing isn't there." `dev.ps1` never pulled and never showed which revision it was compiling.

## What

- Prints `building <branch> @ <short-sha>` before compiling.
- Best-effort `git fetch` + a loud **WARNING** when the checkout is behind its upstream ("N commits behind — the build and its embedded console will be OLD. Run: git pull").
- New **`-Pull`** switch to fast-forward before building.

Pairs with M971 (build revision in the sidebar footer): the footer shows what's *running*, this shows what you're *building*.

## Verification
- PowerShell parse-check passes. Script-only; no Go/frontend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)