### PR TITLE
fix(agezt): correct the user-profile boot hint to the real command

### DIFF
--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -1697,7 +1697,7 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// Operator profile (M1000): inject what we've learned about the operator into
 	// every run, and synthesize it on a daily timer. Off with AGEZT_USER_PROFILE=off.
 	if pdDesc := startProfileDistillTicker(ctx, k, profileOn, stdout); pdDesc != "" {
-		fmt.Fprintf(stdout, "  user profile     : on, auto-synthesis %s (agt profile rebuild)\n", pdDesc)
+		fmt.Fprintf(stdout, "  user profile     : on, auto-synthesis %s (agt memory profile)\n", pdDesc)
 	} else {
 		fmt.Fprintf(stdout, "  user profile     : off\n")
 	}
@@ -4218,7 +4218,7 @@ func startBrainDistillTicker(ctx context.Context, k *kernelruntime.Kernel, stdou
 // cadence (M1000) when the profile feature is on, so AGEZT learns who the
 // operator is without being asked. Default 24h; AGEZT_USER_PROFILE_EVERY overrides
 // (operators can also schedule the profile_distill system task at a custom cadence
-// or run `agt profile rebuild`). Returns a banner description, or "" when off.
+// or run `agt memory profile`). Returns a banner description, or "" when off.
 func startProfileDistillTicker(ctx context.Context, k *kernelruntime.Kernel, on bool, stdout io.Writer) string {
 	if !on {
 		return ""


### PR DESCRIPTION
The daemon boot summary advertised `agt profile rebuild`:

```
user profile     : on, auto-synthesis every 24h0m0s (agt profile rebuild)
```

…but that command does not exist — `agt: unknown command "profile"`. The real trigger is **`agt memory profile`** (verified: it runs and returns the empty-store no-op). Fixes the banner line (`main.go:1700`) + the matching doc comment.

**Found by live verification** — booted a fresh binary against an isolated `AGEZT_HOME` and followed the hint the daemon prints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)