### PR TITLE
docs: fix dependency count + flag agent-SDK spec as partly aspirational

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,4 +426,5 @@ dependency, a CGO requirement, or a substantial design phase:
 
 MIT. See [`LICENSE`](LICENSE). Dependency policy: every external
 dep requires a written justification in
-[`DEPENDENCIES.md`](DEPENDENCIES.md). Current count: 1 + 1 transitive.
+[`DEPENDENCIES.md`](DEPENDENCIES.md). Current count: 4 direct (plus their
+transitive graph) — see the table for the full resolved module list.

--- a/docs/AGENT-SDK-ARCHITECTURE.md
+++ b/docs/AGENT-SDK-ARCHITECTURE.md
@@ -130,6 +130,25 @@ This architecture bridges that gap: agents issue **scoped, temporary tokens** to
 
 ## REST API Specification
 
+> **Accuracy note.** The endpoint catalogue below is the *intended full design*.
+> The agent gateway as currently implemented (`kernel/agentgw`) exposes a
+> **subset** of these, and under a different prefix — **`/v1/...`**, not
+> `/api/v1/agent/...`. The handler registrations in `kernel/agentgw/gateway.go`
+> are the source of truth. The routes live today are:
+>
+> ```
+> POST   /v1/eventbus/publish      GET    /v1/eventbus/subscribe
+> POST   /v1/memory/write          GET    /v1/memory/search    DELETE /v1/memory/delete
+> POST   /v1/log/write             GET    /v1/log/read
+> GET    /v1/config                POST   /v1/config           GET /v1/config/audit  GET /v1/config/search
+> GET    /v1/agent/list            GET    /v1/agent/query
+> POST   /v1/token/create
+> ```
+>
+> Channels, the data lake, run management, and the richer discovery/token
+> verbs below are roadmap, not yet served. Treat the rest of this section as
+> the design target until a route appears in `gateway.go`.
+
 ### Base URL
 ```
 /api/v1/agent


### PR DESCRIPTION
Two factual-accuracy fixes from the audit (docs only, no code change):

**README dependency count.** The policy line claimed `Current count: 1 + 1 transitive`. `go.mod` actually declares **4 direct** dependencies (`btcec`, `coder/websocket`, `go-imap`, `blake3`) plus their transitive graph. Corrected to point at the `DEPENDENCIES.md` table rather than a stale number.

**Agent-SDK API spec drift.** `docs/AGENT-SDK-ARCHITECTURE.md` documents a large REST surface under `/api/v1/agent/...` — but the implemented gateway (`kernel/agentgw/gateway.go`) serves a **15-route subset under `/v1/...`**, and channels / data-lake / run-management / the richer discovery+token verbs are **not served at all**. Rather than unilaterally rewrite a design doc (its aspirational vision may be intentional), I added an **accuracy banner** at the top of the REST spec that:
- corrects the prefix (`/v1/` not `/api/v1/agent/`),
- lists the routes that actually exist today (source of truth: `gateway.go`),
- marks the remainder as roadmap.

So nobody codes against a fictional endpoint, and the design intent is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)