### PR TITLE
feat(agt): `agt pulse asks` — CLI parity for the M1001 ask-approval bridge

### DIFF
--- a/cmd/agt/help.go
+++ b/cmd/agt/help.go
@@ -214,6 +214,7 @@ func helpGroups() []helpGroup {
 			{"pulse", "live tail of the event bus + the proactive heartbeat", []string{
 				"pulse [--subject PATTERN] [--kind K] [--json]   live tail (Ctrl+C to exit)",
 				"pulse status [--json] | pulse pause | pulse resume",
+				"pulse asks [--json] | pulse asks {approve|reject} <issue_key>   ask-mode verdicts",
 			}},
 			{"changelog", "system-level changes folded from the journal", []string{
 				"changelog [N] [--since <dur>] [--json]",

--- a/cmd/agt/pulse.go
+++ b/cmd/agt/pulse.go
@@ -42,6 +42,8 @@ func cmdPulse(args []string, stdout, stderr io.Writer) int {
 		switch args[0] {
 		case "status", "pause", "resume":
 			return cmdPulseControl(args[0], args[1:], stdout, stderr)
+		case "asks":
+			return cmdPulseAsks(args[1:], stdout, stderr)
 		}
 	}
 

--- a/cmd/agt/pulse_control.go
+++ b/cmd/agt/pulse_control.go
@@ -12,6 +12,96 @@ import (
 	"github.com/agezt/agezt/kernel/controlplane"
 )
 
+// cmdPulseAsks implements `agt pulse asks [--json]` (list) and
+// `agt pulse asks {approve|reject} <issue_key>` (M1001) — the CLI half of the
+// operator-approval bridge the Jarvis presence pillar drives. Approval re-emits the
+// signal onto pulse.initiative.act (the act path); reject drops it.
+func cmdPulseAsks(args []string, stdout, stderr io.Writer) int {
+	asJSON := false
+	var verb, key string
+	for _, a := range args {
+		switch a {
+		case "--json":
+			asJSON = true
+		case "-h", "--help":
+			fmt.Fprintf(stdout, "usage: %s pulse asks [--json]\n       %s pulse asks {approve|reject} <issue_key>\n", brand.CLI, brand.CLI)
+			return 0
+		case "approve", "reject":
+			verb = a
+		default:
+			if verb != "" && key == "" {
+				key = a
+			} else {
+				fmt.Fprintf(stderr, "%s pulse asks: unexpected arg %q\n", brand.CLI, a)
+				return 2
+			}
+		}
+	}
+	if verb != "" && key == "" {
+		fmt.Fprintf(stderr, "%s pulse asks %s: an <issue_key> is required\n", brand.CLI, verb)
+		return 2
+	}
+
+	c := dial(stderr)
+	if c == nil {
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Resolve verb: approve/reject one ask.
+	if verb != "" {
+		res, err := c.Call(ctx, controlplane.CmdPulseAskResolve, map[string]any{"issue_key": key, "approve": verb == "approve"})
+		if err != nil {
+			fmt.Fprintf(stderr, "%s pulse asks %s: %v\n", brand.CLI, verb, err)
+			return 1
+		}
+		if asJSON {
+			return encodeJSON(stdout, res)
+		}
+		if verb == "reject" {
+			fmt.Fprintf(stdout, "dismissed %s\n", key)
+			return 0
+		}
+		if acted, _ := res["acted"].(bool); acted {
+			fmt.Fprintf(stdout, "approved %s — handed to the initiative responder\n", key)
+		} else {
+			fmt.Fprintf(stdout, "approved %s — enable the Initiative responder (agt standing) to act on it\n", key)
+		}
+		return 0
+	}
+
+	// List verb: show pending asks.
+	res, err := c.Call(ctx, controlplane.CmdPulseAsks, nil)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s pulse asks: %v\n", brand.CLI, err)
+		return 1
+	}
+	if asJSON {
+		return encodeJSON(stdout, res)
+	}
+	asks, _ := res["asks"].([]any)
+	if len(asks) == 0 {
+		fmt.Fprintln(stdout, "no pending asks — the heartbeat hasn't raised anything for your verdict")
+		return 0
+	}
+	fmt.Fprintf(stdout, "%d pending ask(s) — approve/reject with `%s pulse asks {approve|reject} <issue_key>`:\n", len(asks), brand.CLI)
+	for _, a := range asks {
+		m, ok := a.(map[string]any)
+		if !ok {
+			continue
+		}
+		key, _ := m["issue_key"].(string)
+		summary, _ := m["summary"].(string)
+		source, _ := m["source"].(string)
+		if summary == "" {
+			summary = source
+		}
+		fmt.Fprintf(stdout, "  %-28s %s\n", key, summary)
+	}
+	return 0
+}
+
 // cmdPulseControl implements `agt pulse {status|pause|resume} [--json]`,
 // driving the resident proactive engine (SPEC-03 §2).
 func cmdPulseControl(sub string, args []string, stdout, stderr io.Writer) int {

--- a/cmd/agt/pulse_control_test.go
+++ b/cmd/agt/pulse_control_test.go
@@ -30,6 +30,40 @@ func TestCmdPulseControl_RejectsUnexpectedArg(t *testing.T) {
 	}
 }
 
+func TestCmdPulseAsks_Help(t *testing.T) {
+	var out, errOut bytes.Buffer
+	if code := cmdPulseAsks([]string{"--help"}, &out, &errOut); code != 0 {
+		t.Fatalf("asks --help exit=%d", code)
+	}
+	if !strings.Contains(out.String(), "pulse asks") {
+		t.Errorf("asks help missing usage; got %q", out.String())
+	}
+}
+
+func TestCmdPulseAsks_ArgValidation(t *testing.T) {
+	// approve/reject without an issue_key is a usage error (exit 2), no dial.
+	for _, verb := range []string{"approve", "reject"} {
+		var out, errOut bytes.Buffer
+		if code := cmdPulseAsks([]string{verb}, &out, &errOut); code != 2 {
+			t.Errorf("%s without key should be exit 2, got %d", verb, code)
+		}
+	}
+	// An unexpected bare arg (no verb) is a usage error too.
+	var out, errOut bytes.Buffer
+	if code := cmdPulseAsks([]string{"bogus"}, &out, &errOut); code != 2 {
+		t.Errorf("unexpected arg should be exit 2, got %d", code)
+	}
+}
+
+func TestCmdPulse_RoutesAsksSubcommand(t *testing.T) {
+	// `pulse asks approve` (missing key) must hit the asks arg-validation (exit 2),
+	// proving the router dispatches "asks" rather than falling through to the tail.
+	var out, errOut bytes.Buffer
+	if code := cmdPulse([]string{"asks", "approve"}, &out, &errOut); code != 2 {
+		t.Errorf("pulse asks approve (no key) should route to asks validation (exit 2), got %d", code)
+	}
+}
+
 // TestCmdPulse_TailUnaffected — bare `agt pulse --help`-style parsing must NOT
 // be intercepted by the new subcommand router. We assert routing only triggers
 // for the three control verbs by checking that a flag-only invocation still


### PR DESCRIPTION
The M1001 operator-approval bridge shipped with a web UI (the Jarvis presence pillar) and control-plane commands, but **no CLI** — operators who live in the terminal couldn't see or resolve pending asks. This adds the missing surface:

- `agt pulse asks [--json]` — list actionable observations awaiting a verdict under `initiative=ask`.
- `agt pulse asks approve <issue_key>` — re-emit onto `pulse.initiative.act` (the act path).
- `agt pulse asks reject <issue_key>` — drop it.

Mirrors the existing `CmdPulseAsks` / `CmdPulseAskResolve` control-plane commands — **no new daemon surface**. Approve reports whether the initiative responder is enabled to act on it.

## Verification
- Help text + daemon-free arg-validation tests (`--help`, missing-key → exit 2, subcommand routing).
- **Live-verified** against an isolated daemon: `agt pulse asks` → empty-list message, `approve <bogus>` → graceful "no pending ask" error, `--help` → usage.
- `go build ./cmd/agt` clean; targeted `cmd/agt` tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)