### PR TITLE
fix(agezt): don't crash boot when AGEZT_MODEL lives on another provider

### DIFF
--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -6757,6 +6757,24 @@ func buildFromCatalog(entry *catalog.Provider, modelOverride string, lookup func
 	if constructModel == "" {
 		return nil, "", "", "", fmt.Errorf("provider %q in catalog has no models; set %sMODEL", entry.ID, brand.EnvPrefix)
 	}
+	// Auto-repair a cross-provider default model (don't hard-fail the boot):
+	// AGEZT_MODEL may name a model this provider's catalog doesn't serve because
+	// it is resolved per-run through routing / a fallback chain on a DIFFERENT
+	// provider (e.g. AGEZT_PROVIDER=minimax-coding-plan + AGEZT_MODEL=gpt-5.4,
+	// where gpt-5.4 rides @new-chain). compat.Build only needs a concrete,
+	// catalog-valid id to construct the wire, so fall back to the inert
+	// placeholder for CONSTRUCTION while keeping runModel as the override — the
+	// governor still resolves the real model per run (or fails that one run with
+	// an actionable error), instead of the whole daemon refusing to start.
+	if modelOverride != "" {
+		if _, ok := entry.Models[modelOverride]; !ok {
+			placeholder := compat.FirstModelID(entry)
+			fmt.Fprintf(os.Stderr,
+				"%s: %sMODEL %q is not in provider %q's catalog — treating it as a routing/fallback-chain model and constructing %q with placeholder %q (set %sMODEL to one of this provider's models to silence)\n",
+				brand.Binary, brand.EnvPrefix, modelOverride, entry.ID, entry.ID, placeholder, brand.EnvPrefix)
+			constructModel = placeholder
+		}
+	}
 	prov, _, err := compat.Build(entry, constructModel, lookup)
 	if err != nil {
 		return nil, "", "", "", err

--- a/cmd/agezt/main_test.go
+++ b/cmd/agezt/main_test.go
@@ -317,6 +317,48 @@ func TestModelAdvisory(t *testing.T) {
 	}
 }
 
+// TestBuildFromCatalog_CrossProviderModelDoesNotFailBoot: AGEZT_MODEL may name a
+// model the chosen provider's catalog doesn't serve because it is resolved per-run
+// through a fallback chain on a DIFFERENT provider (e.g. provider=minimax-coding-plan
+// + model=gpt-5.4 via @new-chain). buildFromCatalog must auto-repair this — construct
+// the wire with an inert catalog-valid placeholder while preserving the override as
+// the run model — instead of hard-failing the daemon boot (the user-reported
+// "compat: ... has no model" startup crash).
+func TestBuildFromCatalog_CrossProviderModelDoesNotFailBoot(t *testing.T) {
+	entry := &catalog.Provider{
+		ID: "minimax-coding-plan", NPM: "@ai-sdk/openai-compatible",
+		API: "http://localhost:9/v1", // local-family (no Env) → no creds needed to construct
+		Models: map[string]*catalog.Model{
+			"minimax-m2": {ID: "minimax-m2", ToolCall: true, Limit: catalog.Limit{Context: 200000}},
+		},
+	}
+	lookup := func(string) string { return "" }
+
+	// Model NOT in this provider's catalog → must NOT error; run model preserved
+	// for routing, provider still constructed.
+	prov, _, runModel, _, err := buildFromCatalog(entry, "gpt-5.4", lookup)
+	if err != nil {
+		t.Fatalf("cross-provider model must not fail boot, got error: %v", err)
+	}
+	if prov == nil {
+		t.Fatal("provider should still be constructed with the placeholder model")
+	}
+	if runModel != "gpt-5.4" {
+		t.Errorf("run model should stay the override %q for routing, got %q", "gpt-5.4", runModel)
+	}
+
+	// A catalog-valid override still works unchanged.
+	if _, _, rm, _, err := buildFromCatalog(entry, "minimax-m2", lookup); err != nil || rm != "minimax-m2" {
+		t.Errorf("valid model: got (%q, %v), want (minimax-m2, nil)", rm, err)
+	}
+
+	// A provider with no models at all is still a hard error (nothing to construct).
+	empty := &catalog.Provider{ID: "empty", NPM: "@ai-sdk/openai-compatible", API: "http://localhost:9/v1"}
+	if _, _, _, _, err := buildFromCatalog(empty, "gpt-5.4", lookup); err == nil {
+		t.Error("a provider with zero catalog models should still error")
+	}
+}
+
 // TestBuildGovernor_UnconfiguredWhenNoProvider: with no AGEZT_PROVIDER and no
 // credentialed catalog, the daemon must boot the "unconfigured" sentinel — NOT a
 // mock and NOT an auto-picked provider — and must surface no default run model.


### PR DESCRIPTION
## Problem
A valid cross-provider config crashes the daemon at startup:

```
AGEZT_PROVIDER=minimax-coding-plan
AGEZT_MODEL=gpt-5.4          # served per-run via a fallback chain on another provider
AGEZT_FALLBACK_CHAINS=new-chain=gpt-5-codex,k2p7,...
```
```
agezt: compat: model not in this provider's catalog entry: "minimax-coding-plan" has no model "gpt-5.4"
```

`buildFromCatalog` was forcing `compat.Build` to construct the primary provider's wire with `gpt-5.4`, which that provider's catalog doesn't list — so the whole daemon refused to start, even though `gpt-5.4` is meant to be resolved per-run by routing / the `@new-chain` fallback on a different provider.

## Fix (auto-repair, no hard boot failure)
`compat.Build` only needs *a* concrete, catalog-valid id to build the wire (the run model is resolved per request). So when `AGEZT_MODEL` isn't in the chosen provider's catalog, `buildFromCatalog` now constructs with the inert `FirstModelID` placeholder (exactly as it already does when `AGEZT_MODEL` is empty) and **keeps the override as the run model**, printing a one-line warning instead of crashing:

```
agezt: AGEZT_MODEL "gpt-5.4" is not in provider "minimax-coding-plan"'s catalog — treating it as a routing/fallback-chain model and constructing "minimax-coding-plan" with placeholder "..." (set AGEZT_MODEL to one of this provider's models to silence)
```

Unchanged: a catalog-valid `AGEZT_MODEL` works as before; a provider with **zero** catalog models is still a hard error; an unknown `AGEZT_PROVIDER` id is still a loud error.

## Tests
Adds `TestBuildFromCatalog_CrossProviderModelDoesNotFailBoot` covering the cross-provider model, the valid-model control, and the empty-catalog hard error. `go build/vet`, `staticcheck ./cmd/agezt/...` clean.

> Note: CI self-hosted runners are currently offline; verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)