### PR TITLE
fix(ci): remove orphan .worktrees/rebased-main gitlink breaking actions/checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ bin/
 # npm is the source of truth for frontend (VULN-010); keep a stray pnpm lock out.
 frontend/pnpm-lock.yaml
 pnpm-lock.yaml
+
+# Local git worktrees must never be committed (an orphan gitlink breaks actions/checkout).
+.worktrees/

--- a/kernel/controlplane/chatsuggestions.go
+++ b/kernel/controlplane/chatsuggestions.go
@@ -33,7 +33,9 @@ type ChatSuggestion struct {
 // based on the recent conversation turns and tool activity. The session_id
 // arg is optional (used for future per-session suggestion memory).
 // Args: session_id (string, optional), turns ([{role,text}], optional),
-//       tools ([string], optional — recently used tool names).
+//
+//	tools ([string], optional — recently used tool names).
+//
 // Returns: { suggestions: [ChatSuggestion] }.
 func (s *Server) handleChatSuggestions(conn net.Conn, req Request) {
 	var sessionID string

--- a/kernel/standing/standing_test.go
+++ b/kernel/standing/standing_test.go
@@ -18,7 +18,7 @@ func TestInitiativeModeMaxAutonomyTrust(t *testing.T) {
 		{InitiativeInformOnly, "L0", true},
 		{InitiativeAsk, "L1", true},
 		{InitiativeActOrAsk, "", false},
-		{"", "", false},        // unset → unchanged (backward compatible)
+		{"", "", false},         // unset → unchanged (backward compatible)
 		{"nonsense", "", false}, // unknown → no extra cap, never panics
 	}
 	for _, c := range cases {


### PR DESCRIPTION
## Problem

**All of main's CI has been fully red** — every job (Go, SDKs, gitleaks, lint, everything) dies at the `actions/checkout` step:

```
fatal: No url found for submodule path '.worktrees/rebased-main' in .gitmodules
The process '/usr/bin/git' failed with exit code 128
```

A **live local git worktree** was accidentally committed as a submodule **gitlink** (mode `160000`) at `.worktrees/rebased-main` in commit `1d0a80f6`, with **no `.gitmodules`** entry. `actions/checkout` runs `git submodule foreach` during its auth-cleanup, which fails on the orphan gitlink and aborts checkout — so every job fails at startup, independent of the change under test. (This is why #452 and later main runs were all red.)

## Fix

- `git rm --cached .worktrees/rebased-main` — untrack the gitlink. The live worktree on disk (branch `update/rebased-main`) is **untouched**.
- gitignore `.worktrees/` so a stray `git add -A` can't recommit it.

Once merged, `actions/checkout` succeeds and CI can actually run. This PR's own branch already has the gitlink removed, so its checkout is clean — it should be the first green run in a while.

🤖 Generated with [Claude Code](https://claude.com/claude-code)