### PR TITLE
fix(agentgw): data race in AuditLogger flush (slice backing-array aliasing)

### DIFF
--- a/kernel/agentgw/audit.go
+++ b/kernel/agentgw/audit.go
@@ -46,7 +46,10 @@ func (a *AuditLogger) LogSync(entry AuditEntry) {
 	a.mu.Lock()
 	a.buf = append(a.buf, entry)
 	entries := a.buf
-	a.buf = a.buf[:0]
+	// Hand the backing array off to writeEntries and start a fresh buffer.
+	// Reusing it via a.buf[:0] would let a concurrent Log append into the same
+	// array elements that writeEntries is reading unlocked — a data race.
+	a.buf = make([]AuditEntry, 0, 64)
 	a.mu.Unlock()
 
 	a.writeEntries(entries)
@@ -60,7 +63,9 @@ func (a *AuditLogger) Flush() {
 		return
 	}
 	entries := a.buf
-	a.buf = a.buf[:0]
+	// Fresh backing array, not a.buf[:0]: entries is read unlocked by
+	// writeEntries, so it must not share storage with future appends.
+	a.buf = make([]AuditEntry, 0, 64)
 	a.mu.Unlock()
 
 	a.writeEntries(entries)


### PR DESCRIPTION
## Problem

`go test -race` fails `TestAuditLogger_Concurrent` (revealed once CI checkout was unbroken in #454):

```
WARNING: DATA RACE
Write at 0x… by goroutine N:   ... kernel/agentgw/audit.go (Log → append)
Previous read at 0x… by goroutine M: ... kernel/agentgw/audit.go (writeEntries)
--- FAIL: TestAuditLogger_Concurrent
```

`Flush`/`LogSync` did `entries := a.buf; a.buf = a.buf[:0]` — **reusing the same backing array**. After the lock was released, `writeEntries(entries)` read those elements unlocked while a concurrent `Log` did `a.buf = append(a.buf, entry)`, writing into the **same array element** → write/read race.

## Fix

Hand the backing array off and allocate a fresh one:

```go
entries := a.buf
a.buf = make([]AuditEntry, 0, 64)   // was: a.buf = a.buf[:0]
```

Now the flushed slice never shares storage with future appends. `journal.Append` is already mutex-guarded, so concurrent `writeEntries` is safe. Pre-existing bug, not caused by recent work.

## Verification
- Logic: flushed `entries` is exclusively owned by `writeEntries`; new appends go to a fresh array.
- `go test ./kernel/agentgw/` green; `go vet` clean; gofmt clean. (`-race` needs gcc, unavailable on the Windows dev box — the CI `race (linux, cgo)` job is the authoritative check.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)