### PR TITLE
fix(overseer): accept flat profile fields in create/edit, not just nested

### DIFF
--- a/plugins/tools/overseertool/overseer_test.go
+++ b/plugins/tools/overseertool/overseer_test.go
@@ -304,6 +304,55 @@ func TestCreateNeedsSlug(t *testing.T) {
 	}
 }
 
+// TestCreateFlatProfile asserts the tolerant parser accepts a flattened profile
+// — fields placed at the top level instead of nested under "profile" — which is
+// how some models shape the args. Without this they'd hit "a profile object is
+// required".
+func TestCreateFlatProfile(t *testing.T) {
+	f := &fakeSource{}
+	out, isErr := invoke(t, newTool(f), map[string]any{
+		"op": "create", "slug": "atlas", "name": "Atlas", "soul": "Be sharp.", "model": "deepseek-chat",
+	})
+	if isErr {
+		t.Fatalf("flat create errored: %v", out)
+	}
+	if f.created.Slug != "atlas" || f.created.Name != "Atlas" || f.created.Model != "deepseek-chat" {
+		t.Errorf("flat create fields not applied: %+v", f.created)
+	}
+	if out["action"] != "created" {
+		t.Errorf("action = %v, want created", out["action"])
+	}
+}
+
+// TestEditFlatProfile is the op=edit twin: "agent" is the control ref, the rest
+// of the top-level keys are read as the profile.
+func TestEditFlatProfile(t *testing.T) {
+	f := &fakeSource{}
+	out, isErr := invoke(t, newTool(f), map[string]any{
+		"op": "edit", "agent": "scout", "model": "deepseek-chat", "soul": "Be terse.",
+	})
+	if isErr {
+		t.Fatalf("flat edit errored: %v", out)
+	}
+	if f.edited != "scout" {
+		t.Errorf("edited target = %q, want scout", f.edited)
+	}
+	if f.editFields.Model != "deepseek-chat" || f.editFields.Soul != "Be terse." {
+		t.Errorf("flat edit fields not applied: %+v", f.editFields)
+	}
+}
+
+// TestCreateEmptyStillErrors: a payload with neither a profile object nor any
+// flat fields must still be rejected — a guardian can't silently no-op.
+func TestCreateEmptyStillErrors(t *testing.T) {
+	if _, isErr := invoke(t, newTool(&fakeSource{}), map[string]any{"op": "create"}); !isErr {
+		t.Error("op=create with no profile and no flat fields should error")
+	}
+	if _, isErr := invoke(t, newTool(&fakeSource{}), map[string]any{"op": "create", "profile": map[string]any{}}); !isErr {
+		t.Error("op=create with empty profile object should error")
+	}
+}
+
 func TestRepairAgent(t *testing.T) {
 	f := &fakeSource{repairRes: RepairResult{Agent: "builder", Correlation: "corr-1", Applied: []string{"model"}, Answer: "patched"}}
 	out, isErr := invoke(t, newTool(f), map[string]any{"op": "repair", "agent": "builder", "reason": "invalid runtime override"})

--- a/plugins/tools/overseertool/tool.go
+++ b/plugins/tools/overseertool/tool.go
@@ -180,7 +180,7 @@ func (t *Tool) Invoke(_ context.Context, raw json.RawMessage) (agent.Result, err
 		if ref == "" {
 			return errResult(`op=edit needs "agent" (the target slug) and a "profile" object`), nil
 		}
-		prof, perr := parseProfile(in.Profile)
+		prof, perr := parseProfile(in.Profile, raw)
 		if perr != nil {
 			return errResult(perr.Error()), nil
 		}
@@ -191,7 +191,7 @@ func (t *Tool) Invoke(_ context.Context, raw json.RawMessage) (agent.Result, err
 		return okJSON(map[string]any{"agent": p.Slug, "action": "edited", "profile": agentView(p)}), nil
 
 	case "create":
-		prof, perr := parseProfile(in.Profile)
+		prof, perr := parseProfile(in.Profile, raw)
 		if perr != nil {
 			return errResult(perr.Error()), nil
 		}
@@ -231,17 +231,57 @@ func (t *Tool) Invoke(_ context.Context, raw json.RawMessage) (agent.Result, err
 	}
 }
 
-// parseProfile decodes the op=edit/create "profile" object into a roster.Profile.
-// A missing/empty object is an error so a guardian can't silently no-op an edit.
-func parseProfile(raw json.RawMessage) (roster.Profile, error) {
-	if len(raw) == 0 || string(raw) == "null" || string(raw) == "{}" {
-		return roster.Profile{}, fmt.Errorf(`a "profile" object is required`)
+// overseerControlKeys are the top-level input keys that are NOT profile fields,
+// so they're ignored when a model flattens the profile onto the tool input.
+var overseerControlKeys = map[string]bool{
+	"op": true, "agent": true, "run": true, "reason": true, "limit": true, "profile": true,
+}
+
+// parseProfile decodes the op=edit/create profile into a roster.Profile. The
+// canonical shape is a nested "profile" object, but some models flatten the
+// fields straight onto the tool input (e.g. {"op":"create","slug":"x",...})
+// instead of nesting them — so when "profile" is missing/empty we fall back to
+// reading the profile fields off the top-level input. Either shape works; only
+// a genuinely empty payload (no profile object AND no flat fields) is an error,
+// so a guardian still can't silently no-op an edit.
+func parseProfile(profileRaw, fullRaw json.RawMessage) (roster.Profile, error) {
+	if hasProfileObject(profileRaw) {
+		var p roster.Profile
+		if err := json.Unmarshal(profileRaw, &p); err != nil {
+			return roster.Profile{}, fmt.Errorf("profile: %w", err)
+		}
+		return p, nil
 	}
-	var p roster.Profile
-	if err := json.Unmarshal(raw, &p); err != nil {
-		return roster.Profile{}, fmt.Errorf("profile: %w", err)
+	if hasFlatProfileFields(fullRaw) {
+		var p roster.Profile
+		if err := json.Unmarshal(fullRaw, &p); err != nil {
+			return roster.Profile{}, fmt.Errorf("profile: %w", err)
+		}
+		return p, nil
 	}
-	return p, nil
+	return roster.Profile{}, fmt.Errorf(`a "profile" object is required (nest the agent fields under "profile", or pass them as top-level keys like "slug"/"name"/"soul"/"model")`)
+}
+
+// hasProfileObject reports whether raw is a populated "profile" object (not
+// absent, null, or empty).
+func hasProfileObject(raw json.RawMessage) bool {
+	s := strings.TrimSpace(string(raw))
+	return s != "" && s != "null" && s != "{}"
+}
+
+// hasFlatProfileFields reports whether the top-level input carries any key that
+// isn't a control key — i.e. the model flattened profile fields onto the input.
+func hasFlatProfileFields(fullRaw json.RawMessage) bool {
+	var m map[string]json.RawMessage
+	if json.Unmarshal(fullRaw, &m) != nil {
+		return false
+	}
+	for k := range m {
+		if !overseerControlKeys[k] {
+			return true
+		}
+	}
+	return false
 }
 
 func cancelNote(ok bool) string {


### PR DESCRIPTION
## Problem
Agent-driven `overseer` `create`/`edit` failed repeatedly with **`a "profile" object is required`**. The tool only accepted the agent fields nested under a `profile` object, but some models flatten them straight onto the tool input (e.g. `{"op":"create","slug":"atlas",...}`). Every such call hit the guard in `parseProfile`, making it effectively impossible for the brain/overseer agent to create or retune agents.

## Fix
`parseProfile` is now tolerant of both shapes:
- **Canonical**: a populated nested `profile` object (unchanged, preferred).
- **Flat fallback**: when `profile` is absent/`null`/`{}`, read profile fields from the top-level input, ignoring the control keys (`op`, `agent`, `run`, `reason`, `limit`, `profile`).
- Only a **genuinely empty** payload (no profile object *and* no flat fields) still errors — so a guardian still cannot silently no-op an edit. The error message now points the caller at both accepted shapes.

## Tests
- `TestCreateFlatProfile` — flat-form create applies fields.
- `TestEditFlatProfile` — flat-form edit (with `agent` as the control ref) applies fields.
- `TestCreateEmptyStillErrors` — empty payload and empty `profile: {}` still rejected.

`go test ./plugins/tools/overseertool/` ✅ · `go vet` ✅ · `gofmt` clean.

> Note: lives in the embedded daemon — requires an `agezt` rebuild + restart for a running brain agent to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)