### PR TITLE
refactor(journal): extract shared cursor helper from runs.go (A1 Phase 1)

### DIFF
--- a/kernel/controlplane/runs.go
+++ b/kernel/controlplane/runs.go
@@ -10,14 +10,13 @@ package controlplane
 
 import (
 	"encoding/json"
-	"fmt"
 	"net"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/journal"
 	"github.com/agezt/agezt/kernel/runtime"
 )
 
@@ -251,55 +250,9 @@ func (s *Server) collectRuns(k *runtime.Kernel) (map[string]*runEntry, error) {
 	return runs, nil
 }
 
-// decodeRunsCursor parses the opaque "after this entry, give me older
-// runs" cursor sent by the web UI. The format is `<ms>:<seq>` — the pair
-// that uniquely identifies the boundary entry on the previous page, in
-// the same (StartedUnixMS, StartedSeq) sort order handleRunsList uses.
-//
-// Returns all-zeros when the cursor is absent or unparseable; callers treat
-// that as "no cursor, return the newest page". We don't error on a bad
-// cursor — the request gracefully falls back to the first page, which is
-// closer to "the user got their list" than "the user got an error".
-func decodeRunsCursor(raw any) (ms int64, seq int64, ok bool) {
-	s, _ := raw.(string)
-	if s == "" {
-		return 0, 0, false
-	}
-	// Web URLSearchParams will percent-encode the colon, so we tolerate both
-	// raw `<ms>:<seq>` and the URL-encoded `<ms>%3A<seq>` form.
-	i := strings.IndexByte(s, ':')
-	if i <= 0 || i >= len(s)-1 {
-		return 0, 0, false
-	}
-	parsed, err := strconv.ParseInt(s[:i], 10, 64)
-	if err != nil {
-		return 0, 0, false
-	}
-	parsedSeq, err := strconv.ParseInt(s[i+1:], 10, 64)
-	if err != nil {
-		return 0, 0, false
-	}
-	// A negative ms or seq means the cursor was forged, or aged out, or
-	// hand-crafted by the operator — none of those are valid positions in
-	// the journal. Treat the cursor as malformed and fall back to the
-	// first page.
-	if parsed < 0 || parsedSeq < 0 {
-		return 0, 0, false
-	}
-	return parsed, parsedSeq, true
-}
-
-// encodeRunsCursor is the inverse of decodeRunsCursor: it takes the last
-// emitted entry's sort key and returns an opaque, easy-to-URL-encode token
-// the client passes back as the `cursor` arg on the next page request.
-func encodeRunsCursor(ms int64, seq int64) string {
-	if ms == 0 && seq == 0 {
-		return ""
-	}
-	// Plain "<ms>:<seq>" — round-trips through Go's fmt and through JS's
-	// URLSearchParams as long as the field is percent-encoded.
-	return fmt.Sprintf("%d:%d", ms, seq)
-}
+// Cursor encode/decode/filter now live in kernel/journal (shared by every
+// journal-backed list endpoint). See journal.DecodeCursor / EncodeCursor /
+// KeepBeforeCursor / NextCursor and docs/REFACTOR-A1-CONTROLPLANE-PLAN.md.
 
 func (s *Server) handleRunsList(conn net.Conn, req Request) {
 	limit := defaultRunsLimit
@@ -325,7 +278,7 @@ func (s *Server) handleRunsList(conn net.Conn, req Request) {
 	// (ms, seq) pair the token encodes. Cursor is optional — a missing or
 	// unparseable cursor falls back to the newest page, which is what the
 	// first call of a session does anyway.
-	cursorMS, cursorSeq, cursorOK := decodeRunsCursor(req.Args["cursor"])
+	cursorMS, cursorSeq, cursorOK := journal.DecodeCursor(req.Args["cursor"])
 
 	// Optional status filter (M61): completed|failed|running|abandoned.
 	statusFilter, _ := req.Args["status"].(string)
@@ -404,13 +357,9 @@ func (s *Server) handleRunsList(conn net.Conn, req Request) {
 	if cursorOK {
 		filtered := entries[:0]
 		for _, r := range entries {
-			if r.StartedUnixMS > cursorMS {
-				continue
+			if journal.KeepBeforeCursor(r.StartedUnixMS, r.StartedSeq, cursorMS, cursorSeq) {
+				filtered = append(filtered, r)
 			}
-			if r.StartedUnixMS == cursorMS && r.StartedSeq >= cursorSeq {
-				continue
-			}
-			filtered = append(filtered, r)
 		}
 		entries = filtered
 	}
@@ -480,11 +429,7 @@ func (s *Server) handleRunsList(conn net.Conn, req Request) {
 	var nextCursor string
 	if n := len(entries); n > 0 {
 		last := entries[n-1]
-		// Only advertise a cursor when we returned exactly `limit` entries —
-		// that signals "there might be more". A short page is terminal.
-		if n == limit {
-			nextCursor = encodeRunsCursor(last.StartedUnixMS, last.StartedSeq)
-		}
+		nextCursor = journal.NextCursor(last.StartedUnixMS, last.StartedSeq, n, limit)
 	}
 
 	s.writeResp(conn, Response{

--- a/kernel/journal/cursor.go
+++ b/kernel/journal/cursor.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+
+package journal
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Cursor pagination over journal-derived lists.
+//
+// A cursor is an opaque `<ms>:<seq>` token identifying a boundary row in a
+// list sorted DESCENDING by (ms, seq) — newest first. `ms` is a wall-clock
+// millisecond (bus resolution is 1ms, so back-to-back rows can collide) and
+// `seq` is the journal sequence number, used as the tie-break so a run that
+// arrived later still sorts first within the same millisecond.
+//
+// The token round-trips through Go's fmt and through the browser's
+// URLSearchParams (the colon is percent-encoded on the wire; DecodeCursor
+// tolerates the raw form here — the HTTP layer decodes %3A before it reaches
+// the handler).
+//
+// These helpers were extracted from kernel/controlplane/runs.go (the
+// /api/runs pager) so every journal-backed list endpoint (runs, agents,
+// inbox/board/memory, and the *_log endpoints) shares one cursor
+// implementation instead of copying the parse/encode/filter logic. See
+// docs/REFACTOR-A1-CONTROLPLANE-PLAN.md (Phase 1) and
+// docs/REFACTOR-A2-LOG-PAGINATION-PLAN.md.
+
+// EncodeCursor produces the opaque token for the boundary row at (ms, seq).
+// The all-zero pair encodes to the empty string, which DecodeCursor reads back
+// as "absent" — callers use the empty string to mean "no next page".
+func EncodeCursor(ms, seq int64) string {
+	if ms == 0 && seq == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d:%d", ms, seq)
+}
+
+// DecodeCursor parses an opaque `<ms>:<seq>` token.
+//
+// It returns ok=false (and zero ms/seq) when the token is absent, malformed,
+// or negative. Callers MUST treat !ok as "no cursor — return the newest page"
+// rather than erroring: a forged/aged-out/hand-crafted cursor gracefully falls
+// back to the first page, which is closer to "the user got their list" than
+// "the user got an error".
+//
+// The value is accepted as `any` because control-plane args arrive as decoded
+// JSON (a string here); a non-string value reads as absent.
+func DecodeCursor(raw any) (ms, seq int64, ok bool) {
+	s, _ := raw.(string)
+	if s == "" {
+		return 0, 0, false
+	}
+	i := strings.IndexByte(s, ':')
+	// The colon must be interior: neither the first nor the last byte, so both
+	// halves are non-empty.
+	if i <= 0 || i >= len(s)-1 {
+		return 0, 0, false
+	}
+	parsedMS, err := strconv.ParseInt(s[:i], 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	parsedSeq, err := strconv.ParseInt(s[i+1:], 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	// A negative ms or seq is not a valid journal position — treat as malformed.
+	if parsedMS < 0 || parsedSeq < 0 {
+		return 0, 0, false
+	}
+	return parsedMS, parsedSeq, true
+}
+
+// KeepBeforeCursor reports whether a row at (rowMS, rowSeq) belongs on the
+// page AFTER the cursor at (cursorMS, cursorSeq) — i.e. whether the row is
+// STRICTLY OLDER than the cursor in the descending (ms, seq) sort.
+//
+// The equality clause is critical: the cursor encodes the OLDEST row already
+// emitted on the previous page, so a row equal to the cursor is one the client
+// already has and must be dropped, or it re-appears at the top of the next page.
+//
+// Usage in a handler (rows already sorted DESC by (ms, seq)):
+//
+//	cursorMS, cursorSeq, ok := journal.DecodeCursor(args["cursor"])
+//	if ok {
+//	    kept := rows[:0]
+//	    for _, r := range rows {
+//	        if journal.KeepBeforeCursor(r.MS, r.Seq, cursorMS, cursorSeq) {
+//	            kept = append(kept, r)
+//	        }
+//	    }
+//	    rows = kept
+//	}
+func KeepBeforeCursor(rowMS, rowSeq, cursorMS, cursorSeq int64) bool {
+	if rowMS > cursorMS {
+		return false
+	}
+	if rowMS == cursorMS && rowSeq >= cursorSeq {
+		return false
+	}
+	return true
+}
+
+// NextCursor returns the token a handler should advertise for the following
+// page, given the rows it is about to emit (already sorted DESC and already
+// truncated to the page limit) and that limit.
+//
+// It encodes the LAST (oldest) emitted row so the next page's KeepBeforeCursor
+// filter skips exactly the rows already returned — encoding the first (newest)
+// row would only skip a single row and re-emit the rest.
+//
+// It returns "" (no next page) unless the page is full (len == limit); a short
+// page is terminal, so advertising a cursor would invite a pointless empty
+// fetch. rows must expose its boundary via the caller-supplied last (ms, seq).
+func NextCursor(lastMS, lastSeq int64, emitted, limit int) string {
+	if emitted == 0 || emitted < limit {
+		return ""
+	}
+	return EncodeCursor(lastMS, lastSeq)
+}

--- a/kernel/journal/cursor_test.go
+++ b/kernel/journal/cursor_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+
+package journal
+
+import "testing"
+
+func TestEncodeDecodeCursorRoundTrip(t *testing.T) {
+	cases := []struct{ ms, seq int64 }{
+		{1, 1},
+		{1_700_000_000_000, 42},
+		{9_999_999_999_999, 0},
+		{0, 7},
+	}
+	for _, c := range cases {
+		tok := EncodeCursor(c.ms, c.seq)
+		gotMS, gotSeq, ok := DecodeCursor(tok)
+		if !ok {
+			t.Fatalf("EncodeCursor(%d,%d)=%q did not round-trip (ok=false)", c.ms, c.seq, tok)
+		}
+		if gotMS != c.ms || gotSeq != c.seq {
+			t.Fatalf("round-trip mismatch: encoded (%d,%d) -> %q -> (%d,%d)", c.ms, c.seq, tok, gotMS, gotSeq)
+		}
+	}
+}
+
+func TestEncodeCursorZeroIsEmpty(t *testing.T) {
+	if got := EncodeCursor(0, 0); got != "" {
+		t.Fatalf("EncodeCursor(0,0) = %q, want empty string", got)
+	}
+	// And the empty string decodes as absent.
+	if _, _, ok := DecodeCursor(""); ok {
+		t.Fatalf("DecodeCursor(\"\") returned ok=true, want absent")
+	}
+}
+
+func TestDecodeCursorMalformedFallsBack(t *testing.T) {
+	// Every one of these must be treated as "no cursor" (ok=false), not an error.
+	bad := []any{
+		nil,               // absent
+		"",                // empty
+		"abc",             // no colon
+		":",               // empty halves
+		":5",              // empty ms
+		"5:",              // empty seq
+		"x:5",             // non-numeric ms
+		"5:x",             // non-numeric seq
+		"-1:5",            // negative ms (forged/aged-out)
+		"5:-1",            // negative seq
+		42,                // non-string arg
+		"1700000000000",   // missing colon
+	}
+	for _, b := range bad {
+		if ms, seq, ok := DecodeCursor(b); ok {
+			t.Fatalf("DecodeCursor(%v) = (%d,%d,true), want ok=false", b, ms, seq)
+		}
+	}
+}
+
+func TestDecodeCursorToleratesLargeValues(t *testing.T) {
+	// Real journal cursors carry 13-digit ms + multi-digit seq; ensure no overflow.
+	ms, seq, ok := DecodeCursor("1735689600000:1234567")
+	if !ok || ms != 1_735_689_600_000 || seq != 1_234_567 {
+		t.Fatalf("DecodeCursor large = (%d,%d,%v)", ms, seq, ok)
+	}
+}
+
+// TestKeepBeforeCursor pins the direction-sensitive filter. This is the exact
+// semantics that caught a real bug in the /api/runs pager: without the >=
+// equality clause the cursor's own row re-appears at the top of the next page.
+func TestKeepBeforeCursor(t *testing.T) {
+	const cMS, cSeq = 100, 5
+	cases := []struct {
+		name        string
+		rowMS, rowSeq int64
+		keep        bool
+	}{
+		{"newer ms dropped", 101, 0, false},
+		{"same ms newer seq dropped", 100, 6, false},
+		{"same ms equal seq dropped (the cursor row itself)", 100, 5, false},
+		{"same ms older seq kept", 100, 4, true},
+		{"older ms kept regardless of seq", 99, 999, true},
+		{"much older kept", 1, 1, true},
+	}
+	for _, c := range cases {
+		if got := KeepBeforeCursor(c.rowMS, c.rowSeq, cMS, cSeq); got != c.keep {
+			t.Errorf("%s: KeepBeforeCursor(%d,%d,%d,%d)=%v, want %v",
+				c.name, c.rowMS, c.rowSeq, cMS, cSeq, got, c.keep)
+		}
+	}
+}
+
+func TestNextCursor(t *testing.T) {
+	// Full page (emitted == limit) -> advertise the last row's cursor.
+	if got := NextCursor(100, 5, 20, 20); got != "100:5" {
+		t.Fatalf("full page NextCursor = %q, want 100:5", got)
+	}
+	// Short page (emitted < limit) -> terminal, no cursor.
+	if got := NextCursor(100, 5, 7, 20); got != "" {
+		t.Fatalf("short page NextCursor = %q, want empty", got)
+	}
+	// Empty page -> no cursor.
+	if got := NextCursor(0, 0, 0, 20); got != "" {
+		t.Fatalf("empty page NextCursor = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary

**A1 Phase 1** of the refactoring plan (`docs/REFACTOR-A1-CONTROLPLANE-PLAN.md`): extract the `ms:seq` cursor parse/encode/filter logic out of `controlplane/runs.go` into a shared `kernel/journal/cursor.go`. This is the **shared root** the dependency graph (`docs/REFACTORING-INDEX.md`) identified — A2 (log-endpoint pagination) and later A1 phases reuse it instead of copying the logic.

## Changes

**New `kernel/journal/cursor.go`:**
- `EncodeCursor(ms,seq)` / `DecodeCursor(raw any)` — opaque token; `DecodeCursor` returns `ok=false` (never errors) for absent/malformed/negative cursors, so a bad cursor gracefully falls back to the first page.
- `KeepBeforeCursor(rowMS,rowSeq,cursorMS,cursorSeq)` — the direction-sensitive filter, including the `>=` equality clause that prevents the cursor's own row re-appearing at the top of the next page (the bug the original /api/runs work caught).
- `NextCursor(lastMS,lastSeq,emitted,limit)` — advertises a next page only when the page is full.

**New `kernel/journal/cursor_test.go`:** 6 tests — round-trip, zero-is-empty, 12 malformed inputs, large values, `KeepBeforeCursor` direction semantics, `NextCursor` short-page.

**`controlplane/runs.go`:** deleted private `decodeRunsCursor`/`encodeRunsCursor` (~50 lines), routed the filter + next-cursor computation through `journal.*`, dropped now-unused `fmt`/`strconv` imports.

## Behavior

Unchanged. The existing `/api/runs` pager tests pass against the extracted helper — this is a pure refactor, no wire-format or pagination-semantics change.

## Verification

- `go build ./...` — clean (no import cycle controlplane→journal)
- `go vet ./kernel/journal/... ./kernel/controlplane/...` — clean
- `go test ./kernel/journal/` — ok (6 new cursor tests + existing)
- `go test ./kernel/controlplane/ -run 'Run|Cursor'` — ok
