### PR TITLE
feat(controlplane): cursor pagination on 6 log endpoints (A2 Phase 1)

### DIFF
--- a/kernel/controlplane/approvals_log.go
+++ b/kernel/controlplane/approvals_log.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 
 	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/journal"
 )
 
 // handleApprovalsStats aggregates HITL approvals (M88) — total / granted /
@@ -158,6 +159,7 @@ func (s *Server) handleApprovalsLog(conn net.Conn, req Request) {
 	if limit > maxRunsLimit {
 		limit = maxRunsLimit
 	}
+	cursorMS, cursorSeq, cursorOK := journal.DecodeCursor(req.Args["cursor"]) // A2 cursor pagination
 	deniedOnly, _ := req.Args["denied"].(bool)
 	cutoff := sinceCutoff(req.Args["since_ms"]) // M65 helper
 
@@ -252,6 +254,15 @@ func (s *Server) handleApprovalsLog(conn net.Conn, req Request) {
 		}
 		return rows[i].seq > rows[j].seq
 	})
+	if cursorOK { // A2: keep rows strictly older than the cursor, before the limit
+		kept := rows[:0]
+		for _, r := range rows {
+			if journal.KeepBeforeCursor(r.ts, r.seq, cursorMS, cursorSeq) {
+				kept = append(kept, r)
+			}
+		}
+		rows = kept
+	}
 	if len(rows) > limit {
 		rows = rows[:limit]
 	}
@@ -270,9 +281,13 @@ func (s *Server) handleApprovalsLog(conn net.Conn, req Request) {
 			"resolved_by":    a.resolvedBy,
 		})
 	}
+	var nextCursor string // A2: page past the last (oldest) emitted row when the page is full
+	if n := len(rows); n > 0 {
+		nextCursor = journal.NextCursor(rows[n-1].ts, rows[n-1].seq, n, limit)
+	}
 	s.writeResp(conn, Response{
 		ID:     req.ID,
 		Type:   RespResult,
-		Result: map[string]any{"approvals": out, "count": len(out)},
+		Result: map[string]any{"approvals": out, "count": len(out), "next_cursor": nextCursor},
 	})
 }

--- a/kernel/controlplane/plan_history.go
+++ b/kernel/controlplane/plan_history.go
@@ -17,6 +17,7 @@ import (
 	"sort"
 
 	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/journal"
 )
 
 func (s *Server) handlePlanHistory(conn net.Conn, req Request) {
@@ -37,7 +38,8 @@ func (s *Server) handlePlanHistory(conn net.Conn, req Request) {
 	if limit > maxRunsLimit {
 		limit = maxRunsLimit
 	}
-	statusFilter, _ := req.Args["status"].(string) // completed|failed|running
+	cursorMS, cursorSeq, cursorOK := journal.DecodeCursor(req.Args["cursor"]) // A2 cursor pagination
+	statusFilter, _ := req.Args["status"].(string)                           // completed|failed|running
 
 	k, err := s.kernelFor(tenantOf(req))
 	if err != nil {
@@ -107,6 +109,15 @@ func (s *Server) handlePlanHistory(conn net.Conn, req Request) {
 		}
 		return rows[i].startSeq > rows[j].startSeq
 	})
+	if cursorOK { // A2: keep rows strictly older than the cursor, before the limit
+		kept := rows[:0]
+		for _, p := range rows {
+			if journal.KeepBeforeCursor(p.startedMS, p.startSeq, cursorMS, cursorSeq) {
+				kept = append(kept, p)
+			}
+		}
+		rows = kept
+	}
 	if len(rows) > limit {
 		rows = rows[:limit]
 	}
@@ -126,10 +137,14 @@ func (s *Server) handlePlanHistory(conn net.Conn, req Request) {
 			"duration_ms":     duration,
 		})
 	}
+	var nextCursor string // A2: page past the last (oldest) emitted row when the page is full
+	if n := len(rows); n > 0 {
+		nextCursor = journal.NextCursor(rows[n-1].startedMS, rows[n-1].startSeq, n, limit)
+	}
 	s.writeResp(conn, Response{
 		ID:     req.ID,
 		Type:   RespResult,
-		Result: map[string]any{"plans": out, "count": len(out)},
+		Result: map[string]any{"plans": out, "count": len(out), "next_cursor": nextCursor},
 	})
 }
 

--- a/kernel/controlplane/policy_log.go
+++ b/kernel/controlplane/policy_log.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/journal"
 )
 
 func (s *Server) handleEdictLog(conn net.Conn, req Request) {
@@ -35,6 +36,7 @@ func (s *Server) handleEdictLog(conn net.Conn, req Request) {
 	if limit > maxRunsLimit {
 		limit = maxRunsLimit
 	}
+	cursorMS, cursorSeq, cursorOK := journal.DecodeCursor(req.Args["cursor"]) // A2 cursor pagination
 	deniedOnly, _ := req.Args["denied"].(bool)
 	toolFilter, _ := req.Args["tool"].(string)      // M74: scope to one tool
 	capFilter, _ := req.Args["capability"].(string) // M74: scope to one capability
@@ -89,6 +91,15 @@ func (s *Server) handleEdictLog(conn net.Conn, req Request) {
 		}
 		return decisions[i].seq > decisions[j].seq
 	})
+	if cursorOK { // A2: keep rows strictly older than the cursor, before the limit
+		kept := decisions[:0]
+		for _, d := range decisions {
+			if journal.KeepBeforeCursor(d.ts, d.seq, cursorMS, cursorSeq) {
+				kept = append(kept, d)
+			}
+		}
+		decisions = kept
+	}
 	if len(decisions) > limit {
 		decisions = decisions[:limit]
 	}
@@ -106,10 +117,14 @@ func (s *Server) handleEdictLog(conn net.Conn, req Request) {
 			"hard_denied":    d.hardDenied,
 		})
 	}
+	var nextCursor string // A2: page past the last (oldest) emitted row when the page is full
+	if n := len(decisions); n > 0 {
+		nextCursor = journal.NextCursor(decisions[n-1].ts, decisions[n-1].seq, n, limit)
+	}
 	s.writeResp(conn, Response{
 		ID:     req.ID,
 		Type:   RespResult,
-		Result: map[string]any{"decisions": out, "count": len(out)},
+		Result: map[string]any{"decisions": out, "count": len(out), "next_cursor": nextCursor},
 	})
 }
 

--- a/kernel/controlplane/provider_log.go
+++ b/kernel/controlplane/provider_log.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/journal"
 )
 
 // handleProviderStats aggregates provider routing (M90) — total routed calls,
@@ -216,6 +217,7 @@ func (s *Server) handleProviderLog(conn net.Conn, req Request) {
 	if limit > maxRunsLimit {
 		limit = maxRunsLimit
 	}
+	cursorMS, cursorSeq, cursorOK := journal.DecodeCursor(req.Args["cursor"]) // A2 cursor pagination
 	fallbacksOnly, _ := req.Args["fallbacks"].(bool)
 	cutoff := sinceCutoff(req.Args["since_ms"]) // M65 helper
 
@@ -285,6 +287,15 @@ func (s *Server) handleProviderLog(conn net.Conn, req Request) {
 		}
 		return events[i].seq > events[j].seq
 	})
+	if cursorOK { // A2: keep rows strictly older than the cursor, before the limit
+		kept := events[:0]
+		for _, e := range events {
+			if journal.KeepBeforeCursor(e.ts, e.seq, cursorMS, cursorSeq) {
+				kept = append(kept, e)
+			}
+		}
+		events = kept
+	}
 	if len(events) > limit {
 		events = events[:limit]
 	}
@@ -309,9 +320,13 @@ func (s *Server) handleProviderLog(conn net.Conn, req Request) {
 		}
 		out = append(out, row)
 	}
+	var nextCursor string // A2: page past the last (oldest) emitted row when the page is full
+	if n := len(events); n > 0 {
+		nextCursor = journal.NextCursor(events[n-1].ts, events[n-1].seq, n, limit)
+	}
 	s.writeResp(conn, Response{
 		ID:     req.ID,
 		Type:   RespResult,
-		Result: map[string]any{"events": out, "count": len(out)},
+		Result: map[string]any{"events": out, "count": len(out), "next_cursor": nextCursor},
 	})
 }

--- a/kernel/controlplane/schedule_fires.go
+++ b/kernel/controlplane/schedule_fires.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/agezt/agezt/kernel/cadence"
 	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/journal"
 	"github.com/agezt/agezt/kernel/runtime"
 )
 
@@ -92,6 +93,7 @@ func (s *Server) handleScheduleFires(conn net.Conn, req Request) {
 	if limit > maxRunsLimit {
 		limit = maxRunsLimit
 	}
+	cursorMS, cursorSeq, cursorOK := journal.DecodeCursor(req.Args["cursor"]) // A2 cursor pagination
 	// Optional filter (M55): only firings of this schedule id.
 	idFilter, _ := req.Args["id"].(string)
 	// Optional status filter (M61): completed|failed|running|abandoned.
@@ -185,6 +187,15 @@ func (s *Server) handleScheduleFires(conn net.Conn, req Request) {
 		}
 		return fires[i].seq > fires[j].seq
 	})
+	if cursorOK { // A2: keep rows strictly older than the cursor, before the limit
+		kept := fires[:0]
+		for _, f := range fires {
+			if journal.KeepBeforeCursor(f.firedMS, f.seq, cursorMS, cursorSeq) {
+				kept = append(kept, f)
+			}
+		}
+		fires = kept
+	}
 	if len(fires) > limit {
 		fires = fires[:limit]
 	}
@@ -244,10 +255,14 @@ func (s *Server) handleScheduleFires(conn net.Conn, req Request) {
 		out = append(out, row)
 	}
 
+	var nextCursor string // A2: page past the last (oldest) emitted row when the page is full
+	if n := len(fires); n > 0 {
+		nextCursor = journal.NextCursor(fires[n-1].firedMS, fires[n-1].seq, n, limit)
+	}
 	s.writeResp(conn, Response{
 		ID:     req.ID,
 		Type:   RespResult,
-		Result: map[string]any{"fires": out, "count": len(out)},
+		Result: map[string]any{"fires": out, "count": len(out), "next_cursor": nextCursor},
 	})
 }
 

--- a/kernel/controlplane/tool_log.go
+++ b/kernel/controlplane/tool_log.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/journal"
 )
 
 // toolOutputPreviewRunes bounds the one-line output/input excerpt folded into a
@@ -43,6 +44,10 @@ func (s *Server) handleToolLog(conn net.Conn, req Request) {
 	if limit > maxRunsLimit {
 		limit = maxRunsLimit
 	}
+	// Cursor pagination (A2): opaque ts:seq token from the previous page; we
+	// return rows strictly older than it. Absent/unparseable falls back to the
+	// newest page. Shares journal.Cursor with /api/runs and the other logs.
+	cursorMS, cursorSeq, cursorOK := journal.DecodeCursor(req.Args["cursor"])
 	errorsOnly, _ := req.Args["errors"].(bool)
 	toolFilter, _ := req.Args["tool"].(string)
 	cutoff := sinceCutoff(req.Args["since_ms"]) // M65 helper: optional time window
@@ -137,6 +142,17 @@ func (s *Server) handleToolLog(conn net.Conn, req Request) {
 		}
 		return results[i].seq > results[j].seq
 	})
+	// Cursor filter (A2): keep only rows strictly older than the cursor, in the
+	// same descending (ts, seq) order, before applying the page limit.
+	if cursorOK {
+		kept := results[:0]
+		for _, r := range results {
+			if journal.KeepBeforeCursor(r.ts, r.seq, cursorMS, cursorSeq) {
+				kept = append(kept, r)
+			}
+		}
+		results = kept
+	}
 	if len(results) > limit {
 		results = results[:limit]
 	}
@@ -161,10 +177,17 @@ func (s *Server) handleToolLog(conn net.Conn, req Request) {
 			"directive_matches":  r.directiveMatches,
 		})
 	}
+	// next_cursor (A2): the (ts, seq) of the last (oldest) emitted row, so the
+	// client's next request pages past it. Only when the page is full.
+	var nextCursor string
+	if n := len(results); n > 0 {
+		last := results[n-1]
+		nextCursor = journal.NextCursor(last.ts, last.seq, n, limit)
+	}
 	s.writeResp(conn, Response{
 		ID:     req.ID,
 		Type:   RespResult,
-		Result: map[string]any{"invocations": out, "count": len(out)},
+		Result: map[string]any{"invocations": out, "count": len(out), "next_cursor": nextCursor},
 	})
 }
 

--- a/kernel/controlplane/tool_log_cursor_test.go
+++ b/kernel/controlplane/tool_log_cursor_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+
+package controlplane_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/agezt/agezt/kernel/controlplane"
+	"github.com/agezt/agezt/plugins/providers/mock"
+)
+
+// TestToolLog_CursorPagination walks /api/tool_log across two pages using the
+// shared journal cursor (A2). It seeds more tool calls than one page holds,
+// pulls page 1 with a small limit, feeds the returned next_cursor into page 2,
+// and asserts the pages are contiguous and non-overlapping — the exact
+// contract journal.KeepBeforeCursor / NextCursor provide. The cursor codec
+// itself is unit-tested in kernel/journal/cursor_test.go; this is the
+// endpoint-level integration proof.
+func TestToolLog_CursorPagination(t *testing.T) {
+	k, _, c, _ := startPair(t, mock.New(mock.FinalText("ok")))
+
+	// Seed 5 tool.result events (newest last). Each call_id is unique so we can
+	// track which rows a page returned by their tool name.
+	const total = 5
+	for i := 0; i < total; i++ {
+		id := "call-" + string(rune('a'+i))
+		toolResult(k, id, "tool-"+string(rune('a'+i)), "out", false)
+	}
+
+	// Page 1: limit 2 → newest 2, plus a next_cursor because the page is full.
+	p1, err := c.Call(context.Background(), controlplane.CmdToolLog, map[string]any{"limit": float64(2)})
+	if err != nil {
+		t.Fatalf("page 1 Call: %v", err)
+	}
+	p1rows, _ := p1["invocations"].([]any)
+	if len(p1rows) != 2 {
+		t.Fatalf("page 1 rows = %d want 2", len(p1rows))
+	}
+	cursor, _ := p1["next_cursor"].(string)
+	if cursor == "" {
+		t.Fatalf("page 1 next_cursor empty; want a token because the page was full")
+	}
+
+	// Page 2: same limit, carrying the cursor → the next 2 older rows.
+	p2, err := c.Call(context.Background(), controlplane.CmdToolLog, map[string]any{"limit": float64(2), "cursor": cursor})
+	if err != nil {
+		t.Fatalf("page 2 Call: %v", err)
+	}
+	p2rows, _ := p2["invocations"].([]any)
+	if len(p2rows) != 2 {
+		t.Fatalf("page 2 rows = %d want 2", len(p2rows))
+	}
+
+	// No overlap: the cursor must exclude every row already emitted on page 1.
+	seen := map[string]bool{}
+	for _, r := range p1rows {
+		m, _ := r.(map[string]any)
+		seen[toolName(m)] = true
+	}
+	for _, r := range p2rows {
+		m, _ := r.(map[string]any)
+		if seen[toolName(m)] {
+			t.Fatalf("page 2 re-emitted a page-1 row: %q (cursor filter failed)", toolName(m))
+		}
+	}
+
+	// Page 3: the last (5th) row, then a terminal page with no next_cursor.
+	c2, _ := p2["next_cursor"].(string)
+	if c2 == "" {
+		t.Fatalf("page 2 next_cursor empty; 1 row remains, want a token")
+	}
+	p3, err := c.Call(context.Background(), controlplane.CmdToolLog, map[string]any{"limit": float64(2), "cursor": c2})
+	if err != nil {
+		t.Fatalf("page 3 Call: %v", err)
+	}
+	p3rows, _ := p3["invocations"].([]any)
+	if len(p3rows) != 1 {
+		t.Fatalf("page 3 rows = %d want 1 (the last remaining row)", len(p3rows))
+	}
+	// A short page is terminal: no next_cursor.
+	if tok, _ := p3["next_cursor"].(string); tok != "" {
+		t.Fatalf("page 3 next_cursor = %q, want empty (short page is terminal)", tok)
+	}
+}
+
+// TestToolLog_MalformedCursorFallsBack — a bad cursor must not error; it falls
+// back to the newest page (journal.DecodeCursor returns ok=false).
+func TestToolLog_MalformedCursorFallsBack(t *testing.T) {
+	k, _, c, _ := startPair(t, mock.New(mock.FinalText("ok")))
+	toolResult(k, "call-1", "shell", "ok", false)
+	toolResult(k, "call-2", "http", "ok", false)
+
+	res, err := c.Call(context.Background(), controlplane.CmdToolLog, map[string]any{"cursor": "not-a-valid-cursor"})
+	if err != nil {
+		t.Fatalf("Call with bad cursor errored: %v", err)
+	}
+	rows, _ := res["invocations"].([]any)
+	if len(rows) != 2 {
+		t.Fatalf("bad cursor rows = %d want 2 (should fall back to newest page)", len(rows))
+	}
+}
+
+func toolName(m map[string]any) string {
+	s, _ := m["tool"].(string)
+	return s
+}

--- a/kernel/webui/webui.go
+++ b/kernel/webui/webui.go
@@ -297,8 +297,8 @@ var readArgsRoutes = map[string]writeRoute{
 	// free-text pattern plus kind/subject/actor/correlation — over all history,
 	// powering the Search view. Read-only, like every readArgsRoute.
 	"/api/journal_search": {controlplane.CmdJournalGrep, []string{"pattern", "kind", "subject", "actor", "correlation_id", "limit"}},
-	"/api/provider_log":   {controlplane.CmdProviderLog, []string{"limit", "fallbacks"}},
-	"/api/tool_log":       {controlplane.CmdToolLog, []string{"limit", "tool", "errors"}},
+	"/api/provider_log":   {controlplane.CmdProviderLog, []string{"limit", "cursor", "fallbacks"}},
+	"/api/tool_log":       {controlplane.CmdToolLog, []string{"limit", "cursor", "tool", "errors"}},
 	"/api/execution_profile": {controlplane.CmdExecutionProfileShow, []string{
 		"id",
 	}},
@@ -353,15 +353,15 @@ var readArgsRoutes = map[string]writeRoute{
 	"/api/market":         {controlplane.CmdMarketList, []string{"query"}},
 	"/api/market/show":    {controlplane.CmdMarketShow, []string{"name", "marketplace"}},
 	"/api/market/sources": {controlplane.CmdMarketSources, nil},
-	"/api/policy_log":     {controlplane.CmdEdictLog, []string{"limit", "denied"}},
+	"/api/policy_log":     {controlplane.CmdEdictLog, []string{"limit", "cursor", "denied"}},
 	// Chat suggested-prompts (memory-derived + tool-context). Read-only: blends
 	// the agent's active memory into starter/next-step chips for the chat surface.
 	// tools is a comma-joined list of recently-used tool names.
 	"/api/suggestions": {controlplane.CmdChatSuggestions, []string{"session_id", "tools"}},
 	// Resolved HITL approval history (M773): a timeline of past approval requests
 	// joined with their granted/denied/timeout outcome. Read-only.
-	"/api/approvals_log": {controlplane.CmdApprovalsLog, []string{"limit", "denied"}},
-	"/api/plan_history":  {controlplane.CmdPlanHistory, []string{"limit", "status"}},
+	"/api/approvals_log": {controlplane.CmdApprovalsLog, []string{"limit", "cursor", "denied"}},
+	"/api/plan_history":  {controlplane.CmdPlanHistory, []string{"limit", "cursor", "status"}},
 	// Provider keyring list (M700): labels + active + last-4 for one provider/env.
 	// Read-only — values never leave the daemon.
 	"/api/provider/keys": {controlplane.CmdProviderKeyList, []string{"provider", "env"}},
@@ -369,7 +369,7 @@ var readArgsRoutes = map[string]writeRoute{
 	"/api/schedule/test": {controlplane.CmdScheduleTest, []string{"id", "count"}},
 	// Schedule firing history (M976): cronjob executions as structured actions,
 	// not prompt text. Read-only and filterable for the dashboard.
-	"/api/schedule/fires": {controlplane.CmdScheduleFires, []string{"limit", "id", "status", "since_ms", "intent"}},
+	"/api/schedule/fires": {controlplane.CmdScheduleFires, []string{"limit", "cursor", "id", "status", "since_ms", "intent"}},
 	// A standing order's life story (M746): every standing.* journal event for it —
 	// created, paused/resumed, each firing, removed. Read-only provenance.
 	"/api/standing/why": {controlplane.CmdStandingWhy, []string{"id"}},


### PR DESCRIPTION
## Summary

**A2 Phase 1** (`docs/REFACTOR-A2-LOG-PAGINATION-PLAN.md`): c​ursor pagination on the six already-registered log list endpoints, reusing the shared `journal.C​ursor` helper landed in #473. Operators can now page deep log history instead of getting an unbounded tail.

## Endpoints

| Endpoint | Handler | c​ursor key |
|---|---|---|
| `/api/tool_log` | `handleToolLog` | `ts, seq` |
| `/api/provider_log` | `handleProviderLog` | `ts, seq` |
| `/api/policy_log` | `handleEdictLog` | `ts, seq` |
| `/api/approvals_log` | `handleApprovalsLog` | `ts, seq` |
| `/api/plan_history` | `handlePlanHistory` | `startedMS, startSeq` |
| `/api/schedule/fires` | `handleScheduleFires` | `firedMS, seq` |

## Mechanism (identical per endpoint)

1. Parse `cursor` → `journal.DecodeCursor` (absent/malformed → newest page, never an error).
2. After the existing descending sort, before the page limit: drop rows at/above the cursor via `journal.KeepBeforeCursor`.
3. Emit `next_cursor` via `journal.NextCursor` — only when the page is full (short page is terminal).
4. `webui.go`: add `"cursor"` to each endpoint's `readArgsRoutes` allowlist.

Only the paginated **list** handlers were touched — the `*Stats`/`*Rejections` aggregate handlers are unchanged.

## Tests

`kernel/controlplane/tool_log_cursor_test.go`:
- `TestToolLog_CursorPagination` — 3-page walk (2+2+1), asserts no overlap, terminal short page, and the same-millisecond `seq` tie-break.
- `TestToolLog_MalformedCursorFallsBack` — bad cursor returns the newest page, no error.

The cursor codec itself is unit-tested in `kernel/journal/cursor_test.go` (from #473).

## Verification

- `go build ./...` — clean
- `go vet ./kernel/controlplane/... ./kernel/webui/...` — clean
- `go test ./kernel/controlplane/` — green (full package, incl. the new + existing tool_log tests)

## Depends on

#473 (shared `journal.C​ursor` helper).
