### PR TITLE
feat(controlplane): cursor pagination for 6 unregistered log endpoints (A2 Phase 2)

### DIFF
--- a/docs/REFACTOR-A2-LOG-PAGINATION-PLAN.md
+++ b/docs/REFACTOR-A2-LOG-PAGINATION-PLAN.md
@@ -77,3 +77,40 @@ Lowest-risk, most-mechanical of the refactoring plans. P1 = 6 × (3-line Go + 1 
 test). P2 = 6 × (same + route-map move). P3 = 11 tiny frontend wrappers + footers. No new cursor
 design. Per-endpoint gate: `go build ./... && go test ./kernel/{controlplane,webui,journal}/...`;
 frontend phase adds `tsc + vitest + npm run build`.
+
+## Status — DONE (locally verified; awaiting CI to merge)
+
+Branch `feat/log-cursor-pagination-phase2` (PR #475), stacked on PR #474 (P1) and merged PR #473
+(journal cursor helper). All work verified locally (`go build`/`go test` green; frontend `tsc`
+clean + `vitest` 1461/1461) — the only blocker is the self-hosted WSL runners flapping so CI never
+completes.
+
+- **P0/P1 (6 registered endpoints — cursor):** ✅ `17c136c9`.
+- **P2 (6 unregistered endpoints — register + cursor):** ✅ `3c03709a`.
+- **P3 backend (`seq` row-id on 10 log handlers) + 12 frontend `use*LogPager` wrappers + tests:**
+  ✅ `1148ad2d`.
+- **P4 shared footer + per-view wiring:**
+  - ✅ `29300ee9` — shared `components/ui/load-more-footer.tsx` (`LoadMoreFooter`) + 6 tests;
+    `Runs.tsx` refactored to consume it (drops the duplicated inline footer).
+  - ✅ `b55bf845` — **Providers** routing log → `useProviderLogPager` + footer.
+  - ✅ `032fe2d4` — **Approvals** decision history → `useApprovalsLogPager` + footer.
+  - ✅ `31f8df40` — **Tools** invocation log → `useToolLogPager` + footer.
+
+### Key finding — the view surface is smaller than "12 endpoints"
+
+Categorizing the 12 log endpoints against their consuming views: **only 6 are rendered by any view.**
+The other 6 — `ratelimit_log`, `webhook_log`, `warden_log`, `netguard_log`, `world_log`,
+`memory_log` (and `schedule_fires`) — have **no UI consumer**; their pager hooks exist for API
+completeness / future use. Of the 6 rendered:
+
+- **Providers, Approvals, Tools** — always-visible growing log streams → converted to pager + footer (done).
+- **FlowStudio** (`plan_history`) — **deliberately left as-is:** a mutation-driven "latest 8" recency
+  panel (re-fetched on `plan.completed`/`plan.failed`), not a growing log; pagination would fight its
+  design.
+- **Policy** (`policy_log`) — uses the collapsible `LogDetail` drill-down (lazy one-shot fetch on
+  expand); a load-more footer adds little → low priority, left as-is.
+- **AgentDetail** — aggregates **per-agent** `/agents/{ref}/*` routes, a different endpoint surface
+  from the top-level log routes; out of scope for this plan.
+
+**P4 is therefore functionally complete.** Remaining action is operational, not code: unblock/replace
+the WSL runners so PRs #473 → #474 → #475 can merge in order.

--- a/frontend/src/components/ui/load-more-footer.test.tsx
+++ b/frontend/src/components/ui/load-more-footer.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { LoadMoreFooter } from "./load-more-footer";
+
+afterEach(cleanup);
+
+describe("LoadMoreFooter", () => {
+  it("renders a load-more button with the page size when hasMore is true", () => {
+    render(
+      <LoadMoreFooter hasMore loadingMore={false} onLoadMore={() => {}} pageSize={50} label="tool log" />,
+    );
+    const btn = screen.getByRole("button", { name: /load 50 more/i });
+    expect(btn).toBeTruthy();
+    expect(btn.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("fires onLoadMore when the button is clicked", () => {
+    const onLoadMore = vi.fn();
+    render(<LoadMoreFooter hasMore loadingMore={false} onLoadMore={onLoadMore} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the button and sets aria-busy while loadingMore", () => {
+    render(<LoadMoreFooter hasMore loadingMore onLoadMore={() => {}} />);
+    const btn = screen.getByRole("button");
+    expect(btn.hasAttribute("disabled")).toBe(true);
+    expect(btn.getAttribute("aria-busy")).toBe("true");
+    expect(screen.getByText(/loading/i)).toBeTruthy();
+  });
+
+  it("surfaces a moreError via role=alert without hiding the button", () => {
+    render(
+      <LoadMoreFooter hasMore loadingMore={false} moreError="boom" onLoadMore={() => {}} />,
+    );
+    const alert = screen.getByRole("alert");
+    expect(alert.textContent).toContain("boom");
+    expect(screen.getByRole("button")).toBeTruthy();
+  });
+
+  it("shows a terminal marker (no button) once the list is drained", () => {
+    render(<LoadMoreFooter hasMore={false} loadingMore={false} onLoadMore={() => {}} label="tool log" />);
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.getByText(/end of tool log/i)).toBeTruthy();
+  });
+
+  it("defaults the terminal label to \"list\" when none is given", () => {
+    render(<LoadMoreFooter hasMore={false} loadingMore={false} onLoadMore={() => {}} />);
+    expect(screen.getByText(/end of list/i)).toBeTruthy();
+  });
+});

--- a/frontend/src/components/ui/load-more-footer.tsx
+++ b/frontend/src/components/ui/load-more-footer.tsx
@@ -1,0 +1,79 @@
+import { Loader2 } from "lucide-react";
+
+/**
+ * LoadMoreFooter — the shared "Load N more / end of list" footer used by
+ * every cursor-paginated view (Runs, and the 12 log views wired to the
+ * use*LogPager hooks in lib/cursorPager). It renders:
+ *
+ *   • a "Load N more" button while the pager reports `hasMore`,
+ *   • an inline spinner + "loading…" label while a page is in flight,
+ *   • a non-blocking error line if the last loadMore() rejected,
+ *   • a stable "— end of <label> —" terminal marker once drained.
+ *
+ * The props mirror the tail of `useCursorPager`'s return value, so a view
+ * can spread the hook result straight in:
+ *
+ *   const { paged, hasMore, loadingMore, moreError, loadMore } = useToolLogPager();
+ *   …
+ *   <LoadMoreFooter
+ *     hasMore={hasMore}
+ *     loadingMore={loadingMore}
+ *     moreError={moreError}
+ *     onLoadMore={loadMore}
+ *     pageSize={50}
+ *     label="tool log"
+ *   />
+ *
+ * Keeping this in one place means the footer's markup, a11y attributes
+ * (aria-busy / role="alert"), and copy stay consistent across all views.
+ */
+export interface LoadMoreFooterProps {
+  hasMore: boolean;
+  loadingMore: boolean;
+  moreError?: string | null;
+  onLoadMore: () => void;
+  /** Page size shown in the button copy ("Load 50 more"). Defaults to 50. */
+  pageSize?: number;
+  /** Noun shown in the terminal marker ("— end of tool log —"). */
+  label?: string;
+}
+
+export function LoadMoreFooter({
+  hasMore,
+  loadingMore,
+  moreError,
+  onLoadMore,
+  pageSize = 50,
+  label = "list",
+}: LoadMoreFooterProps) {
+  return (
+    <div className="flex flex-col items-center gap-1 border-t border-border/50 px-3 py-3">
+      {hasMore ? (
+        <>
+          <button
+            type="button"
+            onClick={onLoadMore}
+            disabled={loadingMore}
+            aria-busy={loadingMore || undefined}
+            className="inline-flex items-center gap-2 rounded-md border border-border bg-card px-3 py-1.5 text-xs text-foreground hover:border-accent disabled:opacity-50"
+          >
+            {loadingMore ? (
+              <>
+                <Loader2 className="size-3 animate-spin" /> loading…
+              </>
+            ) : (
+              <>Load {pageSize} more</>
+            )}
+          </button>
+          {moreError && (
+            <p className="text-[11px] text-bad" role="alert">
+              couldn't load more: {moreError}
+            </p>
+          )}
+        </>
+      ) : (
+        <p className="text-xs text-muted">— end of {label} —</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/lib/cursorPager.test.ts
+++ b/frontend/src/lib/cursorPager.test.ts
@@ -50,6 +50,8 @@ import {
   useMemoryPager,
   useAgentActivityPager,
   useAgentEscalationsPager,
+  useToolLogPager,
+  usePlanHistoryPager,
 } from "@/lib/cursorPager";
 
 function row(id: string): Row {
@@ -274,5 +276,44 @@ describe("useAgentEscalationsPager", () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(messages[0]).toContain("ref=audited");
     expect(result.current.paged.map((e) => e.message_id)).toEqual(["esc-1"]);
+  });
+});
+
+// Log endpoints (A2 Phase 1 + 2): representative seq-keyed and correlation_id-keyed wrappers.
+
+describe("useToolLogPager", () => {
+  it("hits /api/tool_log with the invocations envelope and seq-dedup", async () => {
+    const chain = ["50:2", null];
+    nextResponse = (cursor) => {
+      const i = ["", ...chain].indexOf(cursor ?? "");
+      return {
+        invocations: i === 0 ? [{ seq: 3 }, { seq: 2 }] : [{ seq: 1 }],
+        next_cursor: chain[Math.min(i, chain.length - 1)],
+      } as unknown as Record<string, unknown>;
+    };
+    const { result } = renderHook(() => useToolLogPager());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(messages[0]).toMatch(/^\/api\/tool_log\?/);
+    expect(result.current.paged.map((r) => String(r.seq))).toEqual(["3", "2"]);
+    expect(result.current.hasMore).toBe(true);
+    await act(async () => {
+      await result.current.loadMore();
+    });
+    expect(result.current.paged.map((r) => String(r.seq))).toEqual(["3", "2", "1"]);
+    expect(result.current.hasMore).toBe(false);
+  });
+});
+
+describe("usePlanHistoryPager", () => {
+  it("hits /api/plan_history with the plans envelope and correlation_id-dedup", async () => {
+    nextResponse = () => ({
+      plans: [{ correlation_id: "plan-a" }, { correlation_id: "plan-b" }],
+      next_cursor: null,
+    } as unknown as Record<string, unknown>);
+    const { result } = renderHook(() => usePlanHistoryPager());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(messages[0]).toMatch(/^\/api\/plan_history\?/);
+    expect(result.current.paged.map((r) => r.correlation_id)).toEqual(["plan-a", "plan-b"]);
+    expect(result.current.hasMore).toBe(false);
   });
 });

--- a/frontend/src/lib/cursorPager.ts
+++ b/frontend/src/lib/cursorPager.ts
@@ -239,3 +239,81 @@ export function useAgentEscalationsPager(ref: string, limit: number = 50) {
     { ref },
   );
 }
+
+// ─────────────────────── log endpoints (A2 Phase 1 + 2) ───────────────────────
+//
+// The 12 journal-backed log endpoints all page on the shared ms:seq cursor and
+// expose a `seq` field on every row as the dedup id (plan/schedule use their
+// natural correlation_id). itemsKey matches each handler's response envelope.
+
+export interface LogRow extends Record<string, unknown> {
+  seq: number;
+}
+
+/** useToolLogPager — /api/tool_log (tool-invocation audit). */
+export function useToolLogPager(limit: number = 50) {
+  return useCursorPager<LogRow>("/api/tool_log", "invocations", "seq", limit);
+}
+
+/** useProviderLogPager — /api/provider_log (routing + fallbacks). */
+export function useProviderLogPager(limit: number = 50) {
+  return useCursorPager<LogRow>("/api/provider_log", "events", "seq", limit);
+}
+
+/** usePolicyLogPager — /api/policy_log (edict gating decisions). */
+export function usePolicyLogPager(limit: number = 50) {
+  return useCursorPager<LogRow>("/api/policy_log", "decisions", "seq", limit);
+}
+
+/** useApprovalsLogPager — /api/approvals_log (resolved HITL approvals). */
+export function useApprovalsLogPager(limit: number = 50) {
+  return useCursorPager<LogRow>("/api/approvals_log", "approvals", "seq", limit);
+}
+
+/** useRateLimitLogPager — /api/ratelimit_log (throttle events). */
+export function useRateLimitLogPager(limit: number = 50) {
+  return useCursorPager<LogRow>("/api/ratelimit_log", "throttles", "seq", limit);
+}
+
+/** useWebhookLogPager — /api/webhook_log (delivery attempts). */
+export function useWebhookLogPager(limit: number = 50) {
+  return useCursorPager<LogRow>("/api/webhook_log", "deliveries", "seq", limit);
+}
+
+/** useWardenLogPager — /api/warden_log (sandboxed executions). */
+export function useWardenLogPager(limit: number = 50) {
+  return useCursorPager<LogRow>("/api/warden_log", "executions", "seq", limit);
+}
+
+/** useNetguardLogPager — /api/netguard_log (blocked egress). */
+export function useNetguardLogPager(limit: number = 50) {
+  return useCursorPager<LogRow>("/api/netguard_log", "blocks", "seq", limit);
+}
+
+/** useWorldLogPager — /api/world_log (world-model ops). */
+export function useWorldLogPager(limit: number = 50) {
+  return useCursorPager<LogRow>("/api/world_log", "ops", "seq", limit);
+}
+
+/** useMemoryLogPager — /api/memory_log (memory write/forget ops). */
+export function useMemoryLogPager(limit: number = 50) {
+  return useCursorPager<LogRow>("/api/memory_log", "ops", "seq", limit);
+}
+
+export interface PlanHistoryRow extends Record<string, unknown> {
+  correlation_id: string;
+}
+
+/** usePlanHistoryPager — /api/plan_history (past plan runs; id = correlation_id). */
+export function usePlanHistoryPager(limit: number = 50) {
+  return useCursorPager<PlanHistoryRow>("/api/plan_history", "plans", "correlation_id", limit);
+}
+
+export interface ScheduleFiresRow extends Record<string, unknown> {
+  correlation_id: string;
+}
+
+/** useScheduleFiresPager — /api/schedule/fires (cronjob firings; id = correlation_id). */
+export function useScheduleFiresPager(limit: number = 50) {
+  return useCursorPager<ScheduleFiresRow>("/api/schedule/fires", "fires", "correlation_id", limit);
+}

--- a/frontend/src/views/Approvals.tsx
+++ b/frontend/src/views/Approvals.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { ShieldCheck, History, Check, X, Clock, RefreshCw } from "lucide-react";
 import { Row, Count } from "@/components/Panel";
 import { Badge } from "@/components/ui/badge";
@@ -9,7 +8,8 @@ import { EmptyState } from "@/components/ui/empty";
 import { SkeletonList } from "@/components/ui/skeleton";
 import { ActionButton } from "@/components/ActionButton";
 import { usePanel } from "@/lib/usePanel";
-import { getJSON } from "@/lib/api";
+import { useApprovalsLogPager } from "@/lib/cursorPager";
+import { LoadMoreFooter } from "@/components/ui/load-more-footer";
 import { cn, fmtTime } from "@/lib/utils";
 import { ErrorText, Muted } from "@/components/JsonView";
 
@@ -88,49 +88,50 @@ interface ResolvedApproval {
 // to-do; this is the record — the audit trail of the trust boundary, so you can review
 // what was allowed, what was refused, and who/what resolved it. Read-only.
 export function ApprovalsHistory() {
-  const [rows, setRows] = useState<ResolvedApproval[]>([]);
-  const [loaded, setLoaded] = useState(false);
-
-  async function load() {
-    try {
-      const d = await getJSON<{ approvals?: ResolvedApproval[] }>("/api/approvals_log", { limit: "50" });
-      // The log includes still-pending rows; those live in the panel above, so the
-      // history shows only resolved decisions.
-      setRows((d.approvals || []).filter((a) => a.status && a.status !== "pending"));
-    } catch {
-      setRows([]);
-    } finally {
-      setLoaded(true);
-    }
-  }
-  useEffect(() => {
-    load();
-    const id = setInterval(load, 8000);
-    return () => clearInterval(id);
-  }, []);
+  // The resolved-decision history is cursor-paginated via useApprovalsLogPager
+  // (the hook owns polling + live-event reload). The log envelope includes
+  // still-pending rows; those live in the panel above, so we filter to resolved
+  // decisions only for display. loadMore pulls the next raw page, then the same
+  // filter re-applies.
+  const { paged, loading, loadMore, loadingMore, moreError, hasMore } = useApprovalsLogPager(50);
+  const rows = (paged as unknown as ResolvedApproval[]).filter((a) => a.status && a.status !== "pending");
 
   return (
     <div className="glass rounded-xl p-3">
       <div className="mb-2 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-normal text-muted">
         <History className="size-3.5" /> Decision history
-        {loaded && <span className="ml-1 normal-case text-muted/70">({rows.length})</span>}
+        {!loading && <span className="ml-1 normal-case text-muted/70">({rows.length})</span>}
       </div>
-      {!loaded ? (
+      {loading && paged.length === 0 ? (
         <Muted>loading…</Muted>
-      ) : rows.length === 0 ? (
+      ) : rows.length === 0 && !hasMore ? (
         <Muted>no resolved approvals yet — decisions you make above will be recorded here</Muted>
       ) : (
-        <ul className="space-y-1">
-          {rows.map((a, i) => (
-            <li key={a.approval_id || i} className="flex items-center gap-2 border-b border-border/40 py-1 text-xs last:border-0">
-              <StatusBadge status={a.status} />
-              <span className="shrink-0 font-mono text-[11px] text-foreground">{a.capability || a.tool || "?"}</span>
-              <span className="min-w-0 flex-1 truncate text-muted">{a.reason || a.tool || ""}</span>
-              {a.resolved_by && <span className="shrink-0 text-xs text-muted/80">by {a.resolved_by}</span>}
-              <span className="w-14 shrink-0 text-right tabular-nums text-muted">{fmtTime(a.ts_unix_ms)}</span>
-            </li>
-          ))}
-        </ul>
+        <>
+          {rows.length > 0 && (
+            <ul className="space-y-1">
+              {rows.map((a, i) => (
+                <li key={a.approval_id || i} className="flex items-center gap-2 border-b border-border/40 py-1 text-xs last:border-0">
+                  <StatusBadge status={a.status} />
+                  <span className="shrink-0 font-mono text-[11px] text-foreground">{a.capability || a.tool || "?"}</span>
+                  <span className="min-w-0 flex-1 truncate text-muted">{a.reason || a.tool || ""}</span>
+                  {a.resolved_by && <span className="shrink-0 text-xs text-muted/80">by {a.resolved_by}</span>}
+                  <span className="w-14 shrink-0 text-right tabular-nums text-muted">{fmtTime(a.ts_unix_ms)}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+          {/* Footer stays reachable even when the current page filtered to
+              zero resolved rows, so loadMore can pull more history. */}
+          <LoadMoreFooter
+            hasMore={hasMore}
+            loadingMore={loadingMore}
+            moreError={moreError}
+            onLoadMore={loadMore}
+            pageSize={50}
+            label="decision history"
+          />
+        </>
       )}
     </div>
   );

--- a/frontend/src/views/Providers.tsx
+++ b/frontend/src/views/Providers.tsx
@@ -10,6 +10,8 @@ import { SkeletonList } from "@/components/ui/skeleton";
 import { PageHeader } from "@/components/ui/page-header";
 import { BarList } from "@/components/Charts";
 import { MetricWidget, MetricGrid } from "@/components/ui/metric-widget";
+import { useProviderLogPager } from "@/lib/cursorPager";
+import { LoadMoreFooter } from "@/components/ui/load-more-footer";
 
 interface Stats {
   routed?: number;
@@ -35,10 +37,22 @@ export function Providers() {
   const { events } = useEvents();
   const ui = useUI();
   const [stats, setStats] = useState<Stats | null>(null);
-  const [log, setLog] = useState<LogEvent[]>([]);
   const [err, setErr] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [reloading, setReloading] = useState(false);
+
+  // The routing log is cursor-paginated via useProviderLogPager: the hook owns
+  // its own polling + live-event reload (see lib/usePanel), so the stats
+  // reload() below no longer fetches /api/provider_log. Rows arrive as the
+  // generic LogRow shape; we read them back as LogEvent for rendering.
+  const {
+    paged: logRows,
+    loadMore,
+    loadingMore,
+    moreError,
+    hasMore,
+  } = useProviderLogPager(50);
+  const log = logRows as unknown as LogEvent[];
 
   // Re-read credentials + catalog on the daemon, in place (M745) — apply a key or
   // provider change without restarting. Distinct from Refresh, which only re-fetches
@@ -66,15 +80,15 @@ export function Providers() {
 
   async function reload() {
     setLoading(true);
-    const [s, l] = await Promise.allSettled([
-      getJSON<Stats>("/api/providers"),
-      getJSON<{ events?: LogEvent[] }>("/api/provider_log", { limit: "50" }),
-    ]);
-    if (s.status === "fulfilled") {
-      setStats(s.value);
+    // Only the routing stats are fetched here now — the routing log is owned
+    // by useProviderLogPager (which polls and reloads on live events itself).
+    try {
+      const s = await getJSON<Stats>("/api/providers");
+      setStats(s);
       setErr(null);
-    } else setErr((s.reason as Error).message);
-    if (l.status === "fulfilled") setLog(l.value.events || []);
+    } catch (e) {
+      setErr((e as Error).message);
+    }
     setLoading(false);
   }
   useEffect(() => {
@@ -155,24 +169,37 @@ export function Providers() {
             {log.length === 0 ? (
               <Muted>no routing events</Muted>
             ) : (
-              <ul className="max-h-80 overflow-auto font-mono text-xs">
-                {log.map((ev, i) => (
-                  <li key={i} className="flex items-center gap-2 border-b border-border/40 py-1 last:border-0">
-                    <span className="w-14 shrink-0 tabular-nums text-muted">{fmtTime(ev.ts_unix_ms)}</span>
-                    {ev.kind === "fallback" ? (
-                      <span className="text-bad">
-                        ↻ fallback {ev.failed || "?"} → {ev.next || "?"}
-                        {ev.reason ? <span className="text-muted"> · {ev.reason.slice(0, 80)}</span> : null}
-                      </span>
-                    ) : (
-                      <span className="text-accent">
-                        → route {ev.primary || "?"}
-                        {ev.task_type ? <span className="text-muted"> · {ev.task_type}</span> : null}
-                      </span>
-                    )}
-                  </li>
-                ))}
-              </ul>
+              <>
+                <ul className="max-h-80 overflow-auto font-mono text-xs">
+                  {log.map((ev, i) => (
+                    <li
+                      key={(ev as { seq?: number }).seq ?? i}
+                      className="flex items-center gap-2 border-b border-border/40 py-1 last:border-0"
+                    >
+                      <span className="w-14 shrink-0 tabular-nums text-muted">{fmtTime(ev.ts_unix_ms)}</span>
+                      {ev.kind === "fallback" ? (
+                        <span className="text-bad">
+                          ↻ fallback {ev.failed || "?"} → {ev.next || "?"}
+                          {ev.reason ? <span className="text-muted"> · {ev.reason.slice(0, 80)}</span> : null}
+                        </span>
+                      ) : (
+                        <span className="text-accent">
+                          → route {ev.primary || "?"}
+                          {ev.task_type ? <span className="text-muted"> · {ev.task_type}</span> : null}
+                        </span>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+                <LoadMoreFooter
+                  hasMore={hasMore}
+                  loadingMore={loadingMore}
+                  moreError={moreError}
+                  onLoadMore={loadMore}
+                  pageSize={50}
+                  label="routing log"
+                />
+              </>
             )}
           </ProviderPanel>
         </>

--- a/frontend/src/views/Runs.tsx
+++ b/frontend/src/views/Runs.tsx
@@ -10,7 +10,6 @@ import {
   Clock,
   CircleDot,
   CircleStop,
-  Loader2,
 } from "lucide-react";
 import { postAction } from "@/lib/api";
 import { useUI } from "@/components/ui/feedback";
@@ -27,6 +26,7 @@ import { useRunFocus, clearRunFocus } from "@/lib/runfocus";
 import { TabNav } from "@/components/ui/tab-nav";
 import { MetricWidget, MetricGrid } from "@/components/ui/metric-widget";
 import { useCursorPager } from "@/lib/cursorPager";
+import { LoadMoreFooter } from "@/components/ui/load-more-footer";
 
 interface Run {
   correlation_id?: string;
@@ -442,33 +442,14 @@ function RunList({
           — a stable terminal page hides it. The `pager` prop is optional so the
           test suite can render RunList without a real hook. */}
       {pager && (
-        <div className="flex flex-col items-center gap-1 border-t border-border/50 px-3 py-3">
-          {pager.hasMore ? (
-            <>
-              <button
-                onClick={pager.onLoadMore}
-                disabled={pager.loadingMore}
-                aria-busy={pager.loadingMore || undefined}
-                className="inline-flex items-center gap-2 rounded-md border border-border bg-card px-3 py-1.5 text-xs text-foreground hover:border-accent disabled:opacity-50"
-              >
-                {pager.loadingMore ? (
-                  <>
-                    <Loader2 className="size-3 animate-spin" /> loading…
-                  </>
-                ) : (
-                  <>Load 50 more</>
-                )}
-              </button>
-              {pager.moreError && (
-                <p className="text-[11px] text-bad" role="alert">
-                  couldn't load more: {pager.moreError}
-                </p>
-              )}
-            </>
-          ) : (
-            <p className="text-xs text-muted">— end of run history —</p>
-          )}
-        </div>
+        <LoadMoreFooter
+          hasMore={pager.hasMore}
+          loadingMore={pager.loadingMore}
+          moreError={pager.moreError}
+          onLoadMore={pager.onLoadMore}
+          pageSize={RUN_PAGE_SIZE}
+          label="run history"
+        />
       )}
     </section>
   );

--- a/frontend/src/views/Tools.tsx
+++ b/frontend/src/views/Tools.tsx
@@ -8,6 +8,8 @@ import { Muted, ErrorText } from "@/components/JsonView";
 import { SkeletonList } from "@/components/ui/skeleton";
 import { PageHeader } from "@/components/ui/page-header";
 import { Ring } from "@/components/Widgets";
+import { useToolLogPager } from "@/lib/cursorPager";
+import { LoadMoreFooter } from "@/components/ui/load-more-footer";
 
 interface ToolStat {
   calls?: number;
@@ -161,25 +163,34 @@ function rollbackBadge(v: ToolView): { label: string; tone: "good" | "warn" | "b
 export function Tools() {
   const { events } = useEvents();
   const [stats, setStats] = useState<Stats | null>(null);
-  const [log, setLog] = useState<Invocation[]>([]);
   const [catalog, setCatalog] = useState<ToolDef[]>([]);
   const [err, setErr] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [query, setQuery] = useState("");
   const [capFilter, setCapFilter] = useState("");
 
+  // The invocation log is cursor-paginated via useToolLogPager (which owns its
+  // own polling + live-event reload); reload() below fetches only the stats and
+  // catalog. Rows arrive as the generic LogRow shape; read back as Invocation.
+  const {
+    paged: logRows,
+    loadMore,
+    loadingMore,
+    moreError,
+    hasMore,
+  } = useToolLogPager(50);
+  const log = logRows as unknown as Invocation[];
+
   async function reload() {
     setLoading(true);
-    const [s, l, c] = await Promise.allSettled([
+    const [s, c] = await Promise.allSettled([
       getJSON<Stats>("/api/tools"),
-      getJSON<{ invocations?: Invocation[] }>("/api/tool_log", { limit: "50" }),
       getJSON<{ tools?: ToolDef[] }>("/api/tools_catalog"),
     ]);
     if (s.status === "fulfilled") {
       setStats(s.value);
       setErr(null);
     } else setErr((s.reason as Error).message);
-    if (l.status === "fulfilled") setLog(l.value.invocations || []);
     if (c.status === "fulfilled") setCatalog(c.value.tools || []);
     setLoading(false);
   }
@@ -369,24 +380,34 @@ export function Tools() {
             {log.length === 0 ? (
               <Muted>no invocations</Muted>
             ) : (
-              <ul className="max-h-80 overflow-auto font-mono text-xs">
-                {log.map((ev, i) => (
-                  <li
-                    key={i}
-                    className={cn("flex items-center gap-2 border-b border-border/40 py-1 last:border-0", ev.error && "bg-bad/5")}
-                  >
-                    <span className="w-14 shrink-0 tabular-nums text-muted">{fmtTime(ev.ts_unix_ms)}</span>
-                    <span className={cn("w-28 shrink-0 truncate font-medium", ev.error ? "text-bad" : "text-accent")}>
-                      {ev.error ? "✗" : "✓"} {ev.tool || "?"}
-                    </span>
-                    {ev.duration_ms != null && <span className="w-12 shrink-0 tabular-nums text-muted">{ms(ev.duration_ms)}</span>}
-                    <ObservationBadge ev={ev} />
-                    <span className="min-w-0 flex-1 truncate text-muted">
-                      {[ev.input, ev.output].filter(Boolean).map((s) => clip(String(s), 60)).join(" → ")}
-                    </span>
-                  </li>
-                ))}
-              </ul>
+              <>
+                <ul className="max-h-80 overflow-auto font-mono text-xs">
+                  {log.map((ev, i) => (
+                    <li
+                      key={(ev as { seq?: number }).seq ?? i}
+                      className={cn("flex items-center gap-2 border-b border-border/40 py-1 last:border-0", ev.error && "bg-bad/5")}
+                    >
+                      <span className="w-14 shrink-0 tabular-nums text-muted">{fmtTime(ev.ts_unix_ms)}</span>
+                      <span className={cn("w-28 shrink-0 truncate font-medium", ev.error ? "text-bad" : "text-accent")}>
+                        {ev.error ? "✗" : "✓"} {ev.tool || "?"}
+                      </span>
+                      {ev.duration_ms != null && <span className="w-12 shrink-0 tabular-nums text-muted">{ms(ev.duration_ms)}</span>}
+                      <ObservationBadge ev={ev} />
+                      <span className="min-w-0 flex-1 truncate text-muted">
+                        {[ev.input, ev.output].filter(Boolean).map((s) => clip(String(s), 60)).join(" → ")}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+                <LoadMoreFooter
+                  hasMore={hasMore}
+                  loadingMore={loadingMore}
+                  moreError={moreError}
+                  onLoadMore={loadMore}
+                  pageSize={50}
+                  label="invocation log"
+                />
+              </>
             )}
           </Card>
         </>

--- a/kernel/controlplane/approvals_log.go
+++ b/kernel/controlplane/approvals_log.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 
 	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/journal"
 )
 
 // handleApprovalsStats aggregates HITL approvals (M88) — total / granted /
@@ -158,6 +159,7 @@ func (s *Server) handleApprovalsLog(conn net.Conn, req Request) {
 	if limit > maxRunsLimit {
 		limit = maxRunsLimit
 	}
+	cursorMS, cursorSeq, cursorOK := journal.DecodeCursor(req.Args["cursor"]) // A2 cursor pagination
 	deniedOnly, _ := req.Args["denied"].(bool)
 	cutoff := sinceCutoff(req.Args["since_ms"]) // M65 helper
 
@@ -252,6 +254,15 @@ func (s *Server) handleApprovalsLog(conn net.Conn, req Request) {
 		}
 		return rows[i].seq > rows[j].seq
 	})
+	if cursorOK { // A2: keep rows strictly older than the cursor, before the limit
+		kept := rows[:0]
+		for _, r := range rows {
+			if journal.KeepBeforeCursor(r.ts, r.seq, cursorMS, cursorSeq) {
+				kept = append(kept, r)
+			}
+		}
+		rows = kept
+	}
 	if len(rows) > limit {
 		rows = rows[:limit]
 	}
@@ -270,9 +281,13 @@ func (s *Server) handleApprovalsLog(conn net.Conn, req Request) {
 			"resolved_by":    a.resolvedBy,
 		})
 	}
+	var nextCursor string // A2: page past the last (oldest) emitted row when the page is full
+	if n := len(rows); n > 0 {
+		nextCursor = journal.NextCursor(rows[n-1].ts, rows[n-1].seq, n, limit)
+	}
 	s.writeResp(conn, Response{
 		ID:     req.ID,
 		Type:   RespResult,
-		Result: map[string]any{"approvals": out, "count": len(out)},
+		Result: map[string]any{"approvals": out, "count": len(out), "next_cursor": nextCursor},
 	})
 }

--- a/kernel/controlplane/approvals_log.go
+++ b/kernel/controlplane/approvals_log.go
@@ -271,6 +271,7 @@ func (s *Server) handleApprovalsLog(conn net.Conn, req Request) {
 	for _, a := range rows {
 		out = append(out, map[string]any{
 			"ts_unix_ms":     a.ts,
+			"seq":            a.seq, // A2: stable per-row id for the frontend cursor pager
 			"approval_id":    a.id,
 			"capability":     a.capability,
 			"tool":           a.tool,

--- a/kernel/controlplane/memory_log.go
+++ b/kernel/controlplane/memory_log.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 
 	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/journal"
 )
 
 func (s *Server) handleMemoryLog(conn net.Conn, req Request) {
@@ -35,8 +36,9 @@ func (s *Server) handleMemoryLog(conn net.Conn, req Request) {
 	if limit > maxRunsLimit {
 		limit = maxRunsLimit
 	}
-	opFilter, _ := req.Args["op"].(string)      // written|forgotten|superseded
-	cutoff := sinceCutoff(req.Args["since_ms"]) // M65 helper: optional window
+	opFilter, _ := req.Args["op"].(string)                            // written|forgotten|superseded
+	cursorMS, cursorSeq, cursorOK := journal.DecodeCursor(req.Args["cursor"]) // A2 cursor pagination
+	cutoff := sinceCutoff(req.Args["since_ms"])                       // M65 helper: optional window
 
 	k, err := s.kernelFor(tenantOf(req))
 	if err != nil {
@@ -107,6 +109,15 @@ func (s *Server) handleMemoryLog(conn net.Conn, req Request) {
 		}
 		return ops[i].seq > ops[j].seq
 	})
+	if cursorOK { // A2: keep rows strictly older than the cursor, before the limit
+		kept := ops[:0]
+		for _, m := range ops {
+			if journal.KeepBeforeCursor(m.ts, m.seq, cursorMS, cursorSeq) {
+				kept = append(kept, m)
+			}
+		}
+		ops = kept
+	}
 	if len(ops) > limit {
 		ops = ops[:limit]
 	}
@@ -121,10 +132,14 @@ func (s *Server) handleMemoryLog(conn net.Conn, req Request) {
 			"subject":    m.subject,
 		})
 	}
+	var nextCursor string // A2: page past the last (oldest) emitted row when the page is full
+	if n := len(ops); n > 0 {
+		nextCursor = journal.NextCursor(ops[n-1].ts, ops[n-1].seq, n, limit)
+	}
 	s.writeResp(conn, Response{
 		ID:     req.ID,
 		Type:   RespResult,
-		Result: map[string]any{"ops": out, "count": len(out)},
+		Result: map[string]any{"ops": out, "count": len(out), "next_cursor": nextCursor},
 	})
 }
 

--- a/kernel/controlplane/memory_log.go
+++ b/kernel/controlplane/memory_log.go
@@ -126,6 +126,7 @@ func (s *Server) handleMemoryLog(conn net.Conn, req Request) {
 	for _, m := range ops {
 		out = append(out, map[string]any{
 			"ts_unix_ms": m.ts,
+			"seq":        m.seq, // A2: stable per-row id for the frontend cursor pager
 			"op":         m.op,
 			"id":         m.id,
 			"type":       m.mtyp,

--- a/kernel/controlplane/netguard_log.go
+++ b/kernel/controlplane/netguard_log.go
@@ -92,6 +92,7 @@ func (s *Server) handleNetguardLog(conn net.Conn, req Request) {
 	for _, r := range rows {
 		out = append(out, map[string]any{
 			"ts_unix_ms": r.ts,
+			"seq":        r.seq, // A2: stable per-row id for the frontend cursor pager
 			"ip":         r.ip,
 			"reason":     r.reason,
 			"tool":       r.tool,

--- a/kernel/controlplane/netguard_log.go
+++ b/kernel/controlplane/netguard_log.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 
 	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/journal"
 )
 
 func (s *Server) handleNetguardLog(conn net.Conn, req Request) {
@@ -35,6 +36,7 @@ func (s *Server) handleNetguardLog(conn net.Conn, req Request) {
 	if limit > maxRunsLimit {
 		limit = maxRunsLimit
 	}
+	cursorMS, cursorSeq, cursorOK := journal.DecodeCursor(req.Args["cursor"]) // A2 cursor pagination
 	cutoff := sinceCutoff(req.Args["since_ms"])
 
 	k, err := s.kernelFor(tenantOf(req))
@@ -74,6 +76,15 @@ func (s *Server) handleNetguardLog(conn net.Conn, req Request) {
 		}
 		return rows[i].seq > rows[j].seq
 	})
+	if cursorOK { // A2: keep rows strictly older than the cursor, before the limit
+		kept := rows[:0]
+		for _, r := range rows {
+			if journal.KeepBeforeCursor(r.ts, r.seq, cursorMS, cursorSeq) {
+				kept = append(kept, r)
+			}
+		}
+		rows = kept
+	}
 	if len(rows) > limit {
 		rows = rows[:limit]
 	}
@@ -86,9 +97,13 @@ func (s *Server) handleNetguardLog(conn net.Conn, req Request) {
 			"tool":       r.tool,
 		})
 	}
+	var nextCursor string // A2: page past the last (oldest) emitted row when the page is full
+	if n := len(rows); n > 0 {
+		nextCursor = journal.NextCursor(rows[n-1].ts, rows[n-1].seq, n, limit)
+	}
 	s.writeResp(conn, Response{
 		ID:     req.ID,
 		Type:   RespResult,
-		Result: map[string]any{"blocks": out, "count": len(out)},
+		Result: map[string]any{"blocks": out, "count": len(out), "next_cursor": nextCursor},
 	})
 }

--- a/kernel/controlplane/plan_history.go
+++ b/kernel/controlplane/plan_history.go
@@ -17,6 +17,7 @@ import (
 	"sort"
 
 	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/journal"
 )
 
 func (s *Server) handlePlanHistory(conn net.Conn, req Request) {
@@ -37,7 +38,8 @@ func (s *Server) handlePlanHistory(conn net.Conn, req Request) {
 	if limit > maxRunsLimit {
 		limit = maxRunsLimit
 	}
-	statusFilter, _ := req.Args["status"].(string) // completed|failed|running
+	cursorMS, cursorSeq, cursorOK := journal.DecodeCursor(req.Args["cursor"]) // A2 cursor pagination
+	statusFilter, _ := req.Args["status"].(string)                           // completed|failed|running
 
 	k, err := s.kernelFor(tenantOf(req))
 	if err != nil {
@@ -107,6 +109,15 @@ func (s *Server) handlePlanHistory(conn net.Conn, req Request) {
 		}
 		return rows[i].startSeq > rows[j].startSeq
 	})
+	if cursorOK { // A2: keep rows strictly older than the cursor, before the limit
+		kept := rows[:0]
+		for _, p := range rows {
+			if journal.KeepBeforeCursor(p.startedMS, p.startSeq, cursorMS, cursorSeq) {
+				kept = append(kept, p)
+			}
+		}
+		rows = kept
+	}
 	if len(rows) > limit {
 		rows = rows[:limit]
 	}
@@ -126,10 +137,14 @@ func (s *Server) handlePlanHistory(conn net.Conn, req Request) {
 			"duration_ms":     duration,
 		})
 	}
+	var nextCursor string // A2: page past the last (oldest) emitted row when the page is full
+	if n := len(rows); n > 0 {
+		nextCursor = journal.NextCursor(rows[n-1].startedMS, rows[n-1].startSeq, n, limit)
+	}
 	s.writeResp(conn, Response{
 		ID:     req.ID,
 		Type:   RespResult,
-		Result: map[string]any{"plans": out, "count": len(out)},
+		Result: map[string]any{"plans": out, "count": len(out), "next_cursor": nextCursor},
 	})
 }
 

--- a/kernel/controlplane/policy_log.go
+++ b/kernel/controlplane/policy_log.go
@@ -108,6 +108,7 @@ func (s *Server) handleEdictLog(conn net.Conn, req Request) {
 	for _, d := range decisions {
 		out = append(out, map[string]any{
 			"ts_unix_ms":     d.ts,
+			"seq":            d.seq, // A2: stable per-row id for the frontend cursor pager
 			"actor":          d.actor,
 			"correlation_id": d.corr,
 			"tool":           d.tool,

--- a/kernel/controlplane/policy_log.go
+++ b/kernel/controlplane/policy_log.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/journal"
 )
 
 func (s *Server) handleEdictLog(conn net.Conn, req Request) {
@@ -35,6 +36,7 @@ func (s *Server) handleEdictLog(conn net.Conn, req Request) {
 	if limit > maxRunsLimit {
 		limit = maxRunsLimit
 	}
+	cursorMS, cursorSeq, cursorOK := journal.DecodeCursor(req.Args["cursor"]) // A2 cursor pagination
 	deniedOnly, _ := req.Args["denied"].(bool)
 	toolFilter, _ := req.Args["tool"].(string)      // M74: scope to one tool
 	capFilter, _ := req.Args["capability"].(string) // M74: scope to one capability
@@ -89,6 +91,15 @@ func (s *Server) handleEdictLog(conn net.Conn, req Request) {
 		}
 		return decisions[i].seq > decisions[j].seq
 	})
+	if cursorOK { // A2: keep rows strictly older than the cursor, before the limit
+		kept := decisions[:0]
+		for _, d := range decisions {
+			if journal.KeepBeforeCursor(d.ts, d.seq, cursorMS, cursorSeq) {
+				kept = append(kept, d)
+			}
+		}
+		decisions = kept
+	}
 	if len(decisions) > limit {
 		decisions = decisions[:limit]
 	}
@@ -106,10 +117,14 @@ func (s *Server) handleEdictLog(conn net.Conn, req Request) {
 			"hard_denied":    d.hardDenied,
 		})
 	}
+	var nextCursor string // A2: page past the last (oldest) emitted row when the page is full
+	if n := len(decisions); n > 0 {
+		nextCursor = journal.NextCursor(decisions[n-1].ts, decisions[n-1].seq, n, limit)
+	}
 	s.writeResp(conn, Response{
 		ID:     req.ID,
 		Type:   RespResult,
-		Result: map[string]any{"decisions": out, "count": len(out)},
+		Result: map[string]any{"decisions": out, "count": len(out), "next_cursor": nextCursor},
 	})
 }
 

--- a/kernel/controlplane/provider_log.go
+++ b/kernel/controlplane/provider_log.go
@@ -302,7 +302,7 @@ func (s *Server) handleProviderLog(conn net.Conn, req Request) {
 
 	out := make([]map[string]any, 0, len(events))
 	for _, e := range events {
-		row := map[string]any{"ts_unix_ms": e.ts, "kind": e.kind}
+		row := map[string]any{"ts_unix_ms": e.ts, "seq": e.seq, "kind": e.kind}
 		if e.kind == "route" {
 			row["primary"] = e.primary
 			row["chain"] = e.chain

--- a/kernel/controlplane/provider_log.go
+++ b/kernel/controlplane/provider_log.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/journal"
 )
 
 // handleProviderStats aggregates provider routing (M90) — total routed calls,
@@ -216,6 +217,7 @@ func (s *Server) handleProviderLog(conn net.Conn, req Request) {
 	if limit > maxRunsLimit {
 		limit = maxRunsLimit
 	}
+	cursorMS, cursorSeq, cursorOK := journal.DecodeCursor(req.Args["cursor"]) // A2 cursor pagination
 	fallbacksOnly, _ := req.Args["fallbacks"].(bool)
 	cutoff := sinceCutoff(req.Args["since_ms"]) // M65 helper
 
@@ -285,6 +287,15 @@ func (s *Server) handleProviderLog(conn net.Conn, req Request) {
 		}
 		return events[i].seq > events[j].seq
 	})
+	if cursorOK { // A2: keep rows strictly older than the cursor, before the limit
+		kept := events[:0]
+		for _, e := range events {
+			if journal.KeepBeforeCursor(e.ts, e.seq, cursorMS, cursorSeq) {
+				kept = append(kept, e)
+			}
+		}
+		events = kept
+	}
 	if len(events) > limit {
 		events = events[:limit]
 	}
@@ -309,9 +320,13 @@ func (s *Server) handleProviderLog(conn net.Conn, req Request) {
 		}
 		out = append(out, row)
 	}
+	var nextCursor string // A2: page past the last (oldest) emitted row when the page is full
+	if n := len(events); n > 0 {
+		nextCursor = journal.NextCursor(events[n-1].ts, events[n-1].seq, n, limit)
+	}
 	s.writeResp(conn, Response{
 		ID:     req.ID,
 		Type:   RespResult,
-		Result: map[string]any{"events": out, "count": len(out)},
+		Result: map[string]any{"events": out, "count": len(out), "next_cursor": nextCursor},
 	})
 }

--- a/kernel/controlplane/ratelimit_log.go
+++ b/kernel/controlplane/ratelimit_log.go
@@ -92,6 +92,7 @@ func (s *Server) handleRateLimitLog(conn net.Conn, req Request) {
 	for _, r := range rows {
 		out = append(out, map[string]any{
 			"ts_unix_ms":    r.ts,
+			"seq":           r.seq, // A2: stable per-row id for the frontend cursor pager's dedup
 			"used":          r.used,
 			"limit_per_min": r.limitN,
 		})

--- a/kernel/controlplane/ratelimit_log.go
+++ b/kernel/controlplane/ratelimit_log.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 
 	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/journal"
 )
 
 func (s *Server) handleRateLimitLog(conn net.Conn, req Request) {
@@ -36,6 +37,7 @@ func (s *Server) handleRateLimitLog(conn net.Conn, req Request) {
 	if limit > maxRunsLimit {
 		limit = maxRunsLimit
 	}
+	cursorMS, cursorSeq, cursorOK := journal.DecodeCursor(req.Args["cursor"]) // A2 cursor pagination
 	cutoff := sinceCutoff(req.Args["since_ms"])
 
 	k, err := s.kernelFor(tenantOf(req))
@@ -74,6 +76,15 @@ func (s *Server) handleRateLimitLog(conn net.Conn, req Request) {
 		}
 		return rows[i].seq > rows[j].seq
 	})
+	if cursorOK { // A2: keep rows strictly older than the cursor, before the limit
+		kept := rows[:0]
+		for _, r := range rows {
+			if journal.KeepBeforeCursor(r.ts, r.seq, cursorMS, cursorSeq) {
+				kept = append(kept, r)
+			}
+		}
+		rows = kept
+	}
 	if len(rows) > limit {
 		rows = rows[:limit]
 	}
@@ -85,10 +96,14 @@ func (s *Server) handleRateLimitLog(conn net.Conn, req Request) {
 			"limit_per_min": r.limitN,
 		})
 	}
+	var nextCursor string // A2: page past the last (oldest) emitted row when the page is full
+	if n := len(rows); n > 0 {
+		nextCursor = journal.NextCursor(rows[n-1].ts, rows[n-1].seq, n, limit)
+	}
 	s.writeResp(conn, Response{
 		ID:     req.ID,
 		Type:   RespResult,
-		Result: map[string]any{"throttles": out, "count": len(out)},
+		Result: map[string]any{"throttles": out, "count": len(out), "next_cursor": nextCursor},
 	})
 }
 

--- a/kernel/controlplane/ratelimit_log_cursor_test.go
+++ b/kernel/controlplane/ratelimit_log_cursor_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+
+package controlplane_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/agezt/agezt/kernel/controlplane"
+)
+
+// TestRateLimitLog_CursorPagination proves that the route registered in
+// webui.go (A2 Phase 2) is reachable, accepts a cursor query arg, and that
+// the journal.Cursor filter + NextCursor emit work for the rate_limit_log
+// source. Sends 3 stream calls through a 1-per-min governor to seed ≥2
+// throttle events, then paginates with limit 1 to assert a multi-page walk.
+func TestRateLimitLog_CursorPagination(t *testing.T) {
+	gov := rateLimitedGovernor(t, 1) // 1 admit/min; throttles every subsequent call
+	k, _, c, _ := startPair(t, gov)
+	gov.SetBus(k.Bus())
+
+	// Three stream calls → at least two "rate.limited" events land in the journal.
+	for i := 0; i < 3; i++ {
+		_, _ = c.Stream(context.Background(), controlplane.CmdRun, map[string]any{"intent": "x"}, nil)
+	}
+
+	// Page 1 (limit 1) → exactly one row + a non-empty next_cursor.
+	p1, err := c.Call(context.Background(), controlplane.CmdRateLimitLog,
+		map[string]any{"limit": float64(1)})
+	if err != nil {
+		t.Fatalf("page 1 Call: %v", err)
+	}
+	rows, _ := p1["throttles"].([]any)
+	if len(rows) != 1 {
+		t.Fatalf("page 1 rows = %d want 1", len(rows))
+	}
+	cursor, _ := p1["next_cursor"].(string)
+	if cursor == "" {
+		t.Fatalf("page 1 next_cursor empty; want a token because the page is full")
+	}
+
+	// Page 2 → page 1's same row must NOT reappear (cursor filter works).
+	p2, err := c.Call(context.Background(), controlplane.CmdRateLimitLog,
+		map[string]any{"limit": float64(1), "cursor": cursor})
+	if err != nil {
+		t.Fatalf("page 2 Call: %v", err)
+	}
+	rows2, _ := p2["throttles"].([]any)
+	if len(rows2) != 1 {
+		t.Fatalf("page 2 rows = %d want 1", len(rows2))
+	}
+	// Page 2 must be a *different* row from page 1 (cursor filter advanced).
+	// Re-emitting the same row means the cursor filter didn't advance. Compare
+	// the row map directly: at minimum, ts_unix_ms or some other field must
+	// differ; here we require the entire map to differ.
+	fa, _ := rows[0].(map[string]any)
+	fb, _ := rows2[0].(map[string]any)
+	if fmt.Sprint(fa) == fmt.Sprint(fb) {
+		t.Fatalf("page 2 re-emitted the exact same row as page 1 (cursor filter failed); %v", fa)
+	}
+}
+
+// TestRateLimitLog_MalformedCursorFallsBack — a bad cursor must not error;
+// the handler should ignore it and return the newest page (journal.DecodeCursor
+// returns ok=false on parse error).
+func TestRateLimitLog_MalformedCursorFallsBack(t *testing.T) {
+	gov := rateLimitedGovernor(t, 1)
+	k, _, c, _ := startPair(t, gov)
+	gov.SetBus(k.Bus())
+	for i := 0; i < 2; i++ {
+		_, _ = c.Stream(context.Background(), controlplane.CmdRun, map[string]any{"intent": "x"}, nil)
+	}
+
+	res, err := c.Call(context.Background(), controlplane.CmdRateLimitLog,
+		map[string]any{"cursor": "definitely-not-valid", "limit": float64(10)})
+	if err != nil {
+		t.Fatalf("Call with bad cursor errored: %v", err)
+	}
+	rows, _ := res["throttles"].([]any)
+	if len(rows) < 1 {
+		t.Fatalf("bad cursor rows = %d, want at least 1 (fallback to newest page)", len(rows))
+	}
+}

--- a/kernel/controlplane/schedule_fires.go
+++ b/kernel/controlplane/schedule_fires.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/agezt/agezt/kernel/cadence"
 	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/journal"
 	"github.com/agezt/agezt/kernel/runtime"
 )
 
@@ -92,6 +93,7 @@ func (s *Server) handleScheduleFires(conn net.Conn, req Request) {
 	if limit > maxRunsLimit {
 		limit = maxRunsLimit
 	}
+	cursorMS, cursorSeq, cursorOK := journal.DecodeCursor(req.Args["cursor"]) // A2 cursor pagination
 	// Optional filter (M55): only firings of this schedule id.
 	idFilter, _ := req.Args["id"].(string)
 	// Optional status filter (M61): completed|failed|running|abandoned.
@@ -185,6 +187,15 @@ func (s *Server) handleScheduleFires(conn net.Conn, req Request) {
 		}
 		return fires[i].seq > fires[j].seq
 	})
+	if cursorOK { // A2: keep rows strictly older than the cursor, before the limit
+		kept := fires[:0]
+		for _, f := range fires {
+			if journal.KeepBeforeCursor(f.firedMS, f.seq, cursorMS, cursorSeq) {
+				kept = append(kept, f)
+			}
+		}
+		fires = kept
+	}
 	if len(fires) > limit {
 		fires = fires[:limit]
 	}
@@ -244,10 +255,14 @@ func (s *Server) handleScheduleFires(conn net.Conn, req Request) {
 		out = append(out, row)
 	}
 
+	var nextCursor string // A2: page past the last (oldest) emitted row when the page is full
+	if n := len(fires); n > 0 {
+		nextCursor = journal.NextCursor(fires[n-1].firedMS, fires[n-1].seq, n, limit)
+	}
 	s.writeResp(conn, Response{
 		ID:     req.ID,
 		Type:   RespResult,
-		Result: map[string]any{"fires": out, "count": len(out)},
+		Result: map[string]any{"fires": out, "count": len(out), "next_cursor": nextCursor},
 	})
 }
 

--- a/kernel/controlplane/tool_log.go
+++ b/kernel/controlplane/tool_log.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/journal"
 )
 
 // toolOutputPreviewRunes bounds the one-line output/input excerpt folded into a
@@ -43,6 +44,10 @@ func (s *Server) handleToolLog(conn net.Conn, req Request) {
 	if limit > maxRunsLimit {
 		limit = maxRunsLimit
 	}
+	// Cursor pagination (A2): opaque ts:seq token from the previous page; we
+	// return rows strictly older than it. Absent/unparseable falls back to the
+	// newest page. Shares journal.Cursor with /api/runs and the other logs.
+	cursorMS, cursorSeq, cursorOK := journal.DecodeCursor(req.Args["cursor"])
 	errorsOnly, _ := req.Args["errors"].(bool)
 	toolFilter, _ := req.Args["tool"].(string)
 	cutoff := sinceCutoff(req.Args["since_ms"]) // M65 helper: optional time window
@@ -137,6 +142,17 @@ func (s *Server) handleToolLog(conn net.Conn, req Request) {
 		}
 		return results[i].seq > results[j].seq
 	})
+	// Cursor filter (A2): keep only rows strictly older than the cursor, in the
+	// same descending (ts, seq) order, before applying the page limit.
+	if cursorOK {
+		kept := results[:0]
+		for _, r := range results {
+			if journal.KeepBeforeCursor(r.ts, r.seq, cursorMS, cursorSeq) {
+				kept = append(kept, r)
+			}
+		}
+		results = kept
+	}
 	if len(results) > limit {
 		results = results[:limit]
 	}
@@ -161,10 +177,17 @@ func (s *Server) handleToolLog(conn net.Conn, req Request) {
 			"directive_matches":  r.directiveMatches,
 		})
 	}
+	// next_cursor (A2): the (ts, seq) of the last (oldest) emitted row, so the
+	// client's next request pages past it. Only when the page is full.
+	var nextCursor string
+	if n := len(results); n > 0 {
+		last := results[n-1]
+		nextCursor = journal.NextCursor(last.ts, last.seq, n, limit)
+	}
 	s.writeResp(conn, Response{
 		ID:     req.ID,
 		Type:   RespResult,
-		Result: map[string]any{"invocations": out, "count": len(out)},
+		Result: map[string]any{"invocations": out, "count": len(out), "next_cursor": nextCursor},
 	})
 }
 

--- a/kernel/controlplane/tool_log.go
+++ b/kernel/controlplane/tool_log.go
@@ -161,6 +161,7 @@ func (s *Server) handleToolLog(conn net.Conn, req Request) {
 	for _, r := range results {
 		out = append(out, map[string]any{
 			"ts_unix_ms":     r.ts,
+			"seq":            r.seq, // A2: stable per-row id for the frontend cursor pager
 			"actor":          r.actor,
 			"correlation_id": r.corr,
 			"tool":           r.tool,

--- a/kernel/controlplane/tool_log_cursor_test.go
+++ b/kernel/controlplane/tool_log_cursor_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+
+package controlplane_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/agezt/agezt/kernel/controlplane"
+	"github.com/agezt/agezt/plugins/providers/mock"
+)
+
+// TestToolLog_CursorPagination walks /api/tool_log across two pages using the
+// shared journal cursor (A2). It seeds more tool calls than one page holds,
+// pulls page 1 with a small limit, feeds the returned next_cursor into page 2,
+// and asserts the pages are contiguous and non-overlapping — the exact
+// contract journal.KeepBeforeCursor / NextCursor provide. The cursor codec
+// itself is unit-tested in kernel/journal/cursor_test.go; this is the
+// endpoint-level integration proof.
+func TestToolLog_CursorPagination(t *testing.T) {
+	k, _, c, _ := startPair(t, mock.New(mock.FinalText("ok")))
+
+	// Seed 5 tool.result events (newest last). Each call_id is unique so we can
+	// track which rows a page returned by their tool name.
+	const total = 5
+	for i := 0; i < total; i++ {
+		id := "call-" + string(rune('a'+i))
+		toolResult(k, id, "tool-"+string(rune('a'+i)), "out", false)
+	}
+
+	// Page 1: limit 2 → newest 2, plus a next_cursor because the page is full.
+	p1, err := c.Call(context.Background(), controlplane.CmdToolLog, map[string]any{"limit": float64(2)})
+	if err != nil {
+		t.Fatalf("page 1 Call: %v", err)
+	}
+	p1rows, _ := p1["invocations"].([]any)
+	if len(p1rows) != 2 {
+		t.Fatalf("page 1 rows = %d want 2", len(p1rows))
+	}
+	cursor, _ := p1["next_cursor"].(string)
+	if cursor == "" {
+		t.Fatalf("page 1 next_cursor empty; want a token because the page was full")
+	}
+
+	// Page 2: same limit, carrying the cursor → the next 2 older rows.
+	p2, err := c.Call(context.Background(), controlplane.CmdToolLog, map[string]any{"limit": float64(2), "cursor": cursor})
+	if err != nil {
+		t.Fatalf("page 2 Call: %v", err)
+	}
+	p2rows, _ := p2["invocations"].([]any)
+	if len(p2rows) != 2 {
+		t.Fatalf("page 2 rows = %d want 2", len(p2rows))
+	}
+
+	// No overlap: the cursor must exclude every row already emitted on page 1.
+	seen := map[string]bool{}
+	for _, r := range p1rows {
+		m, _ := r.(map[string]any)
+		seen[toolName(m)] = true
+	}
+	for _, r := range p2rows {
+		m, _ := r.(map[string]any)
+		if seen[toolName(m)] {
+			t.Fatalf("page 2 re-emitted a page-1 row: %q (cursor filter failed)", toolName(m))
+		}
+	}
+
+	// Page 3: the last (5th) row, then a terminal page with no next_cursor.
+	c2, _ := p2["next_cursor"].(string)
+	if c2 == "" {
+		t.Fatalf("page 2 next_cursor empty; 1 row remains, want a token")
+	}
+	p3, err := c.Call(context.Background(), controlplane.CmdToolLog, map[string]any{"limit": float64(2), "cursor": c2})
+	if err != nil {
+		t.Fatalf("page 3 Call: %v", err)
+	}
+	p3rows, _ := p3["invocations"].([]any)
+	if len(p3rows) != 1 {
+		t.Fatalf("page 3 rows = %d want 1 (the last remaining row)", len(p3rows))
+	}
+	// A short page is terminal: no next_cursor.
+	if tok, _ := p3["next_cursor"].(string); tok != "" {
+		t.Fatalf("page 3 next_cursor = %q, want empty (short page is terminal)", tok)
+	}
+}
+
+// TestToolLog_MalformedCursorFallsBack — a bad cursor must not error; it falls
+// back to the newest page (journal.DecodeCursor returns ok=false).
+func TestToolLog_MalformedCursorFallsBack(t *testing.T) {
+	k, _, c, _ := startPair(t, mock.New(mock.FinalText("ok")))
+	toolResult(k, "call-1", "shell", "ok", false)
+	toolResult(k, "call-2", "http", "ok", false)
+
+	res, err := c.Call(context.Background(), controlplane.CmdToolLog, map[string]any{"cursor": "not-a-valid-cursor"})
+	if err != nil {
+		t.Fatalf("Call with bad cursor errored: %v", err)
+	}
+	rows, _ := res["invocations"].([]any)
+	if len(rows) != 2 {
+		t.Fatalf("bad cursor rows = %d want 2 (should fall back to newest page)", len(rows))
+	}
+}
+
+func toolName(m map[string]any) string {
+	s, _ := m["tool"].(string)
+	return s
+}

--- a/kernel/controlplane/warden_log.go
+++ b/kernel/controlplane/warden_log.go
@@ -213,7 +213,7 @@ func (s *Server) handleWardenLog(conn net.Conn, req Request) {
 
 	out := make([]map[string]any, 0, len(rows))
 	for _, r := range rows {
-		m := map[string]any{"ts_unix_ms": r.ts, "kind": r.kind, "profile": r.profile}
+		m := map[string]any{"ts_unix_ms": r.ts, "seq": r.seq, "kind": r.kind, "profile": r.profile}
 		switch r.kind {
 		case "exec":
 			m["argv0"] = r.argv0

--- a/kernel/controlplane/warden_log.go
+++ b/kernel/controlplane/warden_log.go
@@ -17,6 +17,7 @@ import (
 	"sort"
 
 	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/journal"
 )
 
 // handleWardenStats aggregates sandboxed executions (M97) — total execs,
@@ -119,7 +120,8 @@ func (s *Server) handleWardenLog(conn net.Conn, req Request) {
 	}
 	// --downgrades keeps only the noteworthy events (downgrades + limit breaches).
 	issuesOnly, _ := req.Args["issues"].(bool)
-	cutoff := sinceCutoff(req.Args["since_ms"]) // M65 helper
+	cursorMS, cursorSeq, cursorOK := journal.DecodeCursor(req.Args["cursor"]) // A2 cursor pagination
+	cutoff := sinceCutoff(req.Args["since_ms"])                                // M65 helper
 
 	k, err := s.kernelFor(tenantOf(req))
 	if err != nil {
@@ -196,6 +198,15 @@ func (s *Server) handleWardenLog(conn net.Conn, req Request) {
 		}
 		return rows[i].seq > rows[j].seq
 	})
+	if cursorOK { // A2: keep rows strictly older than the cursor, before the limit
+		kept := rows[:0]
+		for _, r := range rows {
+			if journal.KeepBeforeCursor(r.ts, r.seq, cursorMS, cursorSeq) {
+				kept = append(kept, r)
+			}
+		}
+		rows = kept
+	}
 	if len(rows) > limit {
 		rows = rows[:limit]
 	}
@@ -219,9 +230,13 @@ func (s *Server) handleWardenLog(conn net.Conn, req Request) {
 		}
 		out = append(out, m)
 	}
+	var nextCursor string // A2: page past the last (oldest) emitted row when the page is full
+	if n := len(rows); n > 0 {
+		nextCursor = journal.NextCursor(rows[n-1].ts, rows[n-1].seq, n, limit)
+	}
 	s.writeResp(conn, Response{
 		ID:     req.ID,
 		Type:   RespResult,
-		Result: map[string]any{"executions": out, "count": len(out)},
+		Result: map[string]any{"executions": out, "count": len(out), "next_cursor": nextCursor},
 	})
 }

--- a/kernel/controlplane/webhook_log.go
+++ b/kernel/controlplane/webhook_log.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 
 	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/journal"
 )
 
 func (s *Server) handleWebhookLog(conn net.Conn, req Request) {
@@ -37,6 +38,7 @@ func (s *Server) handleWebhookLog(conn net.Conn, req Request) {
 		limit = maxRunsLimit
 	}
 	failedOnly, _ := req.Args["failed"].(bool)
+	cursorMS, cursorSeq, cursorOK := journal.DecodeCursor(req.Args["cursor"]) // A2 cursor pagination
 	cutoff := sinceCutoff(req.Args["since_ms"])
 
 	k, err := s.kernelFor(tenantOf(req))
@@ -88,6 +90,15 @@ func (s *Server) handleWebhookLog(conn net.Conn, req Request) {
 		}
 		return rows[i].seq > rows[j].seq
 	})
+	if cursorOK { // A2: keep rows strictly older than the cursor, before the limit
+		kept := rows[:0]
+		for _, r := range rows {
+			if journal.KeepBeforeCursor(r.ts, r.seq, cursorMS, cursorSeq) {
+				kept = append(kept, r)
+			}
+		}
+		rows = kept
+	}
 	if len(rows) > limit {
 		rows = rows[:limit]
 	}
@@ -107,10 +118,14 @@ func (s *Server) handleWebhookLog(conn net.Conn, req Request) {
 		}
 		out = append(out, m)
 	}
+	var nextCursor string // A2: page past the last (oldest) emitted row when the page is full
+	if n := len(rows); n > 0 {
+		nextCursor = journal.NextCursor(rows[n-1].ts, rows[n-1].seq, n, limit)
+	}
 	s.writeResp(conn, Response{
 		ID:     req.ID,
 		Type:   RespResult,
-		Result: map[string]any{"deliveries": out, "count": len(out)},
+		Result: map[string]any{"deliveries": out, "count": len(out), "next_cursor": nextCursor},
 	})
 }
 

--- a/kernel/controlplane/webhook_log.go
+++ b/kernel/controlplane/webhook_log.go
@@ -106,6 +106,7 @@ func (s *Server) handleWebhookLog(conn net.Conn, req Request) {
 	for _, r := range rows {
 		m := map[string]any{
 			"ts_unix_ms": r.ts,
+			"seq":        r.seq, // A2: stable per-row id for the frontend cursor pager
 			"ok":         r.ok,
 			"url":        r.url,
 			"event_kind": r.kind,

--- a/kernel/controlplane/world_log.go
+++ b/kernel/controlplane/world_log.go
@@ -121,6 +121,7 @@ func (s *Server) handleWorldLog(conn net.Conn, req Request) {
 	for _, o := range ops {
 		out = append(out, map[string]any{
 			"ts_unix_ms": o.ts,
+			"seq":        o.seq, // A2: stable per-row id for the frontend cursor pager
 			"op":         o.op,
 			"what":       o.what,
 			"label":      o.label,

--- a/kernel/controlplane/world_log.go
+++ b/kernel/controlplane/world_log.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 
 	"github.com/agezt/agezt/kernel/event"
+	"github.com/agezt/agezt/kernel/journal"
 )
 
 func (s *Server) handleWorldLog(conn net.Conn, req Request) {
@@ -35,8 +36,9 @@ func (s *Server) handleWorldLog(conn net.Conn, req Request) {
 	if limit > maxRunsLimit {
 		limit = maxRunsLimit
 	}
-	kindFilter, _ := req.Args["kind"].(string)  // entity|relation
-	cutoff := sinceCutoff(req.Args["since_ms"]) // M65 helper
+	kindFilter, _ := req.Args["kind"].(string)                          // entity|relation
+	cursorMS, cursorSeq, cursorOK := journal.DecodeCursor(req.Args["cursor"]) // A2 cursor pagination
+	cutoff := sinceCutoff(req.Args["since_ms"])                             // M65 helper
 
 	k, err := s.kernelFor(tenantOf(req))
 	if err != nil {
@@ -102,6 +104,15 @@ func (s *Server) handleWorldLog(conn net.Conn, req Request) {
 		}
 		return ops[i].seq > ops[j].seq
 	})
+	if cursorOK { // A2: keep rows strictly older than the cursor, before the limit
+		kept := ops[:0]
+		for _, o := range ops {
+			if journal.KeepBeforeCursor(o.ts, o.seq, cursorMS, cursorSeq) {
+				kept = append(kept, o)
+			}
+		}
+		ops = kept
+	}
 	if len(ops) > limit {
 		ops = ops[:limit]
 	}
@@ -115,9 +126,13 @@ func (s *Server) handleWorldLog(conn net.Conn, req Request) {
 			"label":      o.label,
 		})
 	}
+	var nextCursor string // A2: page past the last (oldest) emitted row when the page is full
+	if n := len(ops); n > 0 {
+		nextCursor = journal.NextCursor(ops[n-1].ts, ops[n-1].seq, n, limit)
+	}
 	s.writeResp(conn, Response{
 		ID:     req.ID,
 		Type:   RespResult,
-		Result: map[string]any{"ops": out, "count": len(out)},
+		Result: map[string]any{"ops": out, "count": len(out), "next_cursor": nextCursor},
 	})
 }

--- a/kernel/webui/webui.go
+++ b/kernel/webui/webui.go
@@ -297,8 +297,8 @@ var readArgsRoutes = map[string]writeRoute{
 	// free-text pattern plus kind/subject/actor/correlation — over all history,
 	// powering the Search view. Read-only, like every readArgsRoute.
 	"/api/journal_search": {controlplane.CmdJournalGrep, []string{"pattern", "kind", "subject", "actor", "correlation_id", "limit"}},
-	"/api/provider_log":   {controlplane.CmdProviderLog, []string{"limit", "fallbacks"}},
-	"/api/tool_log":       {controlplane.CmdToolLog, []string{"limit", "tool", "errors"}},
+	"/api/provider_log":   {controlplane.CmdProviderLog, []string{"limit", "cursor", "fallbacks"}},
+	"/api/tool_log":       {controlplane.CmdToolLog, []string{"limit", "cursor", "tool", "errors"}},
 	"/api/execution_profile": {controlplane.CmdExecutionProfileShow, []string{
 		"id",
 	}},
@@ -353,15 +353,15 @@ var readArgsRoutes = map[string]writeRoute{
 	"/api/market":         {controlplane.CmdMarketList, []string{"query"}},
 	"/api/market/show":    {controlplane.CmdMarketShow, []string{"name", "marketplace"}},
 	"/api/market/sources": {controlplane.CmdMarketSources, nil},
-	"/api/policy_log":     {controlplane.CmdEdictLog, []string{"limit", "denied"}},
+	"/api/policy_log":     {controlplane.CmdEdictLog, []string{"limit", "cursor", "denied"}},
 	// Chat suggested-prompts (memory-derived + tool-context). Read-only: blends
 	// the agent's active memory into starter/next-step chips for the chat surface.
 	// tools is a comma-joined list of recently-used tool names.
 	"/api/suggestions": {controlplane.CmdChatSuggestions, []string{"session_id", "tools"}},
 	// Resolved HITL approval history (M773): a timeline of past approval requests
 	// joined with their granted/denied/timeout outcome. Read-only.
-	"/api/approvals_log": {controlplane.CmdApprovalsLog, []string{"limit", "denied"}},
-	"/api/plan_history":  {controlplane.CmdPlanHistory, []string{"limit", "status"}},
+	"/api/approvals_log": {controlplane.CmdApprovalsLog, []string{"limit", "cursor", "denied"}},
+	"/api/plan_history":  {controlplane.CmdPlanHistory, []string{"limit", "cursor", "status"}},
 	// Provider keyring list (M700): labels + active + last-4 for one provider/env.
 	// Read-only — values never leave the daemon.
 	"/api/provider/keys": {controlplane.CmdProviderKeyList, []string{"provider", "env"}},
@@ -369,7 +369,7 @@ var readArgsRoutes = map[string]writeRoute{
 	"/api/schedule/test": {controlplane.CmdScheduleTest, []string{"id", "count"}},
 	// Schedule firing history (M976): cronjob executions as structured actions,
 	// not prompt text. Read-only and filterable for the dashboard.
-	"/api/schedule/fires": {controlplane.CmdScheduleFires, []string{"limit", "id", "status", "since_ms", "intent"}},
+	"/api/schedule/fires": {controlplane.CmdScheduleFires, []string{"limit", "cursor", "id", "status", "since_ms", "intent"}},
 	// A standing order's life story (M746): every standing.* journal event for it —
 	// created, paused/resumed, each firing, removed. Read-only provenance.
 	"/api/standing/why": {controlplane.CmdStandingWhy, []string{"id"}},

--- a/kernel/webui/webui.go
+++ b/kernel/webui/webui.go
@@ -370,6 +370,14 @@ var readArgsRoutes = map[string]writeRoute{
 	// Schedule firing history (M976): cronjob executions as structured actions,
 	// not prompt text. Read-only and filterable for the dashboard.
 	"/api/schedule/fires": {controlplane.CmdScheduleFires, []string{"limit", "cursor", "id", "status", "since_ms", "intent"}},
+	// A2 Phase 2: register the six log endpoints that previously streamed full
+	// slices via apiRoutes (no-args proxy). They now expose cursor pagination.
+	"/api/ratelimit_log":  {controlplane.CmdRateLimitLog, []string{"limit", "cursor", "since_ms"}},
+	"/api/webhook_log":    {controlplane.CmdWebhookLog, []string{"limit", "cursor", "since_ms"}},
+	"/api/warden_log":     {controlplane.CmdWardenLog, []string{"limit", "cursor", "since_ms"}},
+	"/api/netguard_log":   {controlplane.CmdNetguardLog, []string{"limit", "cursor", "since_ms"}},
+	"/api/world_log":      {controlplane.CmdWorldLog, []string{"limit", "cursor", "since_ms"}},
+	"/api/memory_log":     {controlplane.CmdMemoryLog, []string{"limit", "cursor", "since_ms"}},
 	// A standing order's life story (M746): every standing.* journal event for it —
 	// created, paused/resumed, each firing, removed. Read-only provenance.
 	"/api/standing/why": {controlplane.CmdStandingWhy, []string{"id"}},


### PR DESCRIPTION
## Summary

**A2 Phase 2** (`docs/REFACTOR-A2-LOG-PAGINATION-PLAN.md`): routes and paginates the six log list endpoints that were previously streaming full slices via the `apiRoutes` no-args proxy. Same `journal.C​ursor` helper and identical parse/filter/emit pattern as Phase 1 (#474).

## Endpoints

| Endpoint | Handler | c​ursor key | Response key |
|---|---|---|---|
| `/api/ratelimit_log` | `handleRateLimitLog` | `ts, seq` | `throttles` |
| `/api/webhook_log` | `handleWebhookLog` | `ts, seq` | `deliveries` |
| `/api/warden_log` | `handleWardenLog` | `ts, seq` | `executions` |
| `/api/netguard_log` | `handleNetguardLog` | `ts, seq` | `blocks` |
| `/api/world_log` | `handleWorldLog` | `ts, seq` (`ops`) | `ops` |
| `/api/memory_log` | `handleMemoryLog` | `ts, seq` (`ops`) | `ops` |

## Mechanism (identical per endpoint)

1. Parse `cursor` → `journal.DecodeC​ursor` (absent/malformed → newest page, never an error).
2. After the existing descending `(ts, seq)` sort, before the page limit: drop rows at/above the cursor via `journal.KeepBeforeC​ursor`.
3. Emit `next_c​ursor` via `journal.NextC​ursor` (only when the page is full — a short page is terminal).
4. `webui.go`: register the endpoint on `readArgsRoutes` with the `{"limit","cursor","since_ms"}` allowlist.

The anchor lines per file vary (`failedOnly`/`issuesOnly`/`cutoff`/...) — each was read individually before editing; `warden_log` has two `cutoff` lines (one for `handleWardenStats`, one for `handleWardenLog`) and only the paginated handler was touched.

## Tests

New `kernel/controlplane/ratelimit_log_cursor_test.go`:

- `TestRateLimitLog_C​ursorPagination` — 2-page walk with `limit=1`, asserts non-overlap and non-empty `next_c​ursor`. Proves the new route is registered, the cursor query arg reaches the handler, and the filter/emitter wiring works end-to-end against the rate_limit_log source.
- `TestRateLimitLog_MalformedC​ursorFallsBack` — graceful fallback (journal contract).

Existing `TestRateLimitLogAndStats` continues to pass (no regression).

The remaining 5 endpoints share the identical handler shape and use the same `journal.C​ursor` plumbing that `TestRateLimitLog_C​ursorPagination` exercises; one representative test was chosen to keep the diff focused. The cursor codec itself is unit-tested in `kernel/journal/cursor_test.go`.

## Verification

- `go build ./...` — clean
- `go vet ./kernel/controlplane/... ./kernel/webui/...` — clean
- `go test ./kernel/controlplane/` — green (full package, 28 s)

## Depends on

#474 (shared `journal.C​ursor` helper + Phase 1 endpoints).
