### PR TITLE
fix(webui): block symlink escape in file raw/delete handlers (os.Stat → os.Lstat)

### DIFF
--- a/kernel/webui/files_route.go
+++ b/kernel/webui/files_route.go
@@ -224,7 +224,7 @@ func (s *Server) handleFileTree(w http.ResponseWriter, r *http.Request) {
 		_ = full
 	}
 	resp := fileTreeResponse{
-		Root: rel,
+		Root:  rel,
 		Nodes: nodes,
 	}
 	writeJSON(w, http.StatusOK, resp)
@@ -240,7 +240,10 @@ func (s *Server) handleFileRaw(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	info, err := os.Stat(targetAbs)
+	// Lstat, not Stat: Stat follows the symlink and loses the ModeSymlink bit,
+	// which would let an in-root link to an out-of-root file sail past the
+	// symlink guard below and stream bytes from outside the workspace.
+	info, err := os.Lstat(targetAbs)
 	if err != nil {
 		if os.IsNotExist(err) {
 			http.Error(w, "not found", http.StatusNotFound)
@@ -374,7 +377,10 @@ func (s *Server) handleFileDelete(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	info, err := os.Stat(targetAbs)
+	// Lstat, not Stat: Stat resolves the link, hiding the ModeSymlink bit and
+	// defeating the symlink guard below — an in-root link could then let
+	// os.Remove/os.RemoveAll chase a target outside the workspace.
+	info, err := os.Lstat(targetAbs)
 	if err != nil {
 		if os.IsNotExist(err) {
 			http.Error(w, "not found", http.StatusNotFound)
@@ -426,4 +432,3 @@ func readJSONBody(w http.ResponseWriter, r *http.Request, maxBytes int64) (map[s
 	}
 	return out, true
 }
-

--- a/kernel/webui/files_route_test.go
+++ b/kernel/webui/files_route_test.go
@@ -159,10 +159,10 @@ func TestFiles_PathTraversalRefused(t *testing.T) {
 	}
 
 	cases := []string{
-		"../secret.txt",       // plain traversal
+		"../secret.txt",        // plain traversal
 		"foo/../../secret.txt", // nested traversal
-		"/etc/passwd",         // absolute
-		`C:\\Windows`,         // windows drive-prefix
+		"/etc/passwd",          // absolute
+		`C:\\Windows`,          // windows drive-prefix
 	}
 	for _, p := range cases {
 		rec := httpJSON(t, s.Handler(), http.MethodGet, "/api/files/raw?path="+p+"&token=secret", "")
@@ -209,6 +209,38 @@ func TestFiles_SymlinkRefused(t *testing.T) {
 	rec = httpJSON(t, s.Handler(), http.MethodGet, "/api/files/raw?path=link.txt&token=secret", "")
 	if rec.Code == http.StatusOK {
 		t.Fatalf("symlink raw read returned 200; body=%s", rec.Body.String())
+	}
+}
+
+// TestFiles_SymlinkDeleteRefused locks in the same defence for the delete
+// handler: os.Stat used to follow the link there too, hiding the ModeSymlink
+// bit and letting os.Remove/os.RemoveAll chase a target outside the root.
+func TestFiles_SymlinkDeleteRefused(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics on Windows vary; covered by the resolver tests")
+	}
+	root := t.TempDir()
+	withFileRoot(t, root)
+	outsideDir := t.TempDir()
+	target := filepath.Join(outsideDir, "secret.txt")
+	if err := os.Symlink(target, filepath.Join(root, "link.txt")); err != nil {
+		t.Skipf("symlink: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("OWNED\n"), 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	s, _ := newServer(t, &fakeCaller{}, "secret")
+
+	// Deleting the in-root symlink must be refused, never chase the target.
+	rec := httpJSON(t, s.Handler(), http.MethodPost, "/api/files/delete?token=secret",
+		`{"path":"link.txt"}`)
+	if rec.Code == http.StatusOK {
+		t.Fatalf("symlink delete returned 200; body=%s", rec.Body.String())
+	}
+	// The out-of-root target must be untouched.
+	if _, err := os.Stat(target); err != nil {
+		t.Fatalf("out-of-root target was removed via symlink: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes a symlink-escape vulnerability in the webui file manager's `handleFileRaw` and `handleFileDelete` handlers.

Both handlers called `os.Stat` on the resolved path before checking `info.Mode()&os.ModeSymlink`. `os.Stat` **follows** symlinks, so the returned `FileInfo` describes the link *target* and never carries `ModeSymlink` — making the symlink-rejection guard dead code. A symlink created inside the workspace root pointing at a file outside the root was:
- **served in full** via `/api/files/raw` (bytes streamed from outside the workspace), or
- **deleted** (the link, and via `os.RemoveAll` potentially the target subtree) via `/api/files/delete`.

`handleFileTree` was already safe — its `ReadDir` loop uses `DirEntry.Info()`, which is lstat-style, so symlinks are skipped there.

## Root cause

```go
// before — guard never fires:
info, err := os.Stat(targetAbs)   // Stat follows the link; ModeSymlink is gone
if info.Mode()&os.ModeSymlink != 0 { ... }
```

## Fix

One-line change at each site: `os.Stat` → `os.Lstat`. `Lstat` does not follow the link, so `ModeSymlink` is reported and the existing 403 guard fires correctly.

```go
info, err := os.Lstat(targetAbs)
if info.Mode()&os.ModeSymlink != 0 {
    http.Error(w, "symlinks are not served", http.StatusForbidden)
    return
}
```

## Test coverage

- `TestFiles_SymlinkRefused` (raw read) already existed and **surfaced this bug on CI** once the WSL runners could finally finish a full `go test -race ./...` sweep — it was previously masked by the runners cycling every ~16s.
- Adds `TestFiles_SymlinkDeleteRefused` to lock in the same defence for the delete handler (no delete-symlink coverage existed before).

Both symlink tests skip on Windows (`runtime.GOOS == "windows"`); they run on Linux CI.

## Scope

- `kernel/webui/files_route.go` — 2× `os.Stat` → `os.Lstat` with explanatory comments. gofmt also corrected a pre-existing struct-field alignment and trailing newline in the same file.
- `kernel/webui/files_route_test.go` — new `TestFiles_SymlinkDeleteRefused`; gofmt realigned a neighbouring comment block.

No other handlers, routes, or packages touched.

## Provenance

Pre-existing bug on `main` (introduced in `5986b6a5 feat(webui+kernel): file manager + Monaco editor`). Discovered while investigating PR #476 CI failures — **unrelated** to the frontend language-rename work in that PR. Filed as a separate follow-up to keep #476 focused.

## Checklist

- [x] `go vet ./kernel/webui/` clean
- [x] `go test ./kernel/webui/` green (symlink tests skip on Windows; verified they compile + the non-symlink file tests pass)
- [x] `gofmt` clean on both changed files
- [x] No new dependencies, no API changes