### PR TITLE
ci: systemd WSL keepalive service to prevent VM suspension

### DIFF
--- a/ops/wsl-runners/README.md
+++ b/ops/wsl-runners/README.md
@@ -1,0 +1,92 @@
+# WSL Runner Operations
+
+Infrastructure for the 3 self-hosted GitHub Actions runners (`wsl-runner-1/2/3`)
+running in a WSL2 Ubuntu VM on host `WHITE`.
+
+## Current setup
+
+| Component | Location | Status |
+|---|---|---|
+| GitHub Actions runners | `/home/ersinkoc/actions-runner-{1,2,3}` | Registered as `wsl-runner-{1,2,3}-new` (IDs 25/26/27) |
+| systemd unit files | `/etc/systemd/system/actions.runner.agezt-agezt.wsl-runner-{1,2,3}.service` | `Restart=always`, `RestartSec=10` |
+| WSL VM config | `C:\Users\ersin\.wslconfig` | `vmIdleTimeout=-1`, `autoMemoryReclaim=disabled` |
+| Keepalive | `/etc/systemd/system/wsl-keepalive.service` | Continuous `sleep` process, `Restart=always` |
+| Go toolchain staging | `setup-go-safe` composite action | GOROOT/GOCACHE/GOTMPDIR on `/dev/shm` tmpfs |
+
+## Keepalive service
+
+The WSL2 VM suspends when no user-space process holds it open, killing
+long-running CI jobs (e.g. the race detector's stressed depth pass). The
+keepalive service runs a perpetual `sleep` process that makes the VM
+ineligible for idle suspension.
+
+### Install
+
+From inside WSL Ubuntu (one-time):
+
+```bash
+bash ops/wsl-runners/install-keepalive.sh
+```
+
+### Verify
+
+```bash
+systemctl is-active wsl-keepalive.service
+# → active
+```
+
+### How it works
+
+- `ExecStart=/bin/sleep 3600` — a long sleep that costs 0 CPU and ~0 memory.
+- `Restart=always` with `RestartSec=5` — systemd restarts the sleep when it
+  exits (after 1h), creating a perpetual process inside the VM.
+- Combined with `.wslconfig`'s `vmIdleTimeout=-1`, the VM stays alive between
+  CI jobs, during idle periods, and through runner service restarts.
+
+## Runner systemd units
+
+Each runner's unit file (`actions.runner.agezt-agezt.wsl-runner-N.service`)
+has:
+
+```ini
+[Service]
+Restart=always
+RestartSec=10
+```
+
+If the runner listener exits (clean exit, crash, or GitHub disconnect),
+systemd restarts it within 10 seconds instead of leaving it offline.
+
+### Modifying runner units
+
+The unit files live at:
+```
+/etc/systemd/system/actions.runner.agezt-agezt.wsl-runner-{1,2,3}.service
+```
+
+After editing:
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart actions.runner.agezt-agezt.wsl-runner-{1,2,3}.service
+```
+
+## Re-registering runners
+
+If GitHub shows stale sessions ("A session for this runner already exists"):
+
+1. Stop all runner services:
+   ```bash
+   sudo systemctl stop actions.runner.agezt-agezt.wsl-runner-*.service
+   ```
+2. Get a fresh registration token:
+   ```bash
+   gh api --method POST repos/agezt/agezt/actions/runners/registration-token --jq .token
+   ```
+3. Remove old config and re-register each runner:
+   ```bash
+   cd /home/ersinkoc/actions-runner-N
+   rm -f .runner .credentials .credentials_rsaparams .runner_migrated .service .path
+   ./config.sh --url https://github.com/agezt/agezt --token <TOKEN> \
+     --name wsl-runner-N-new --labels wsl-runner --unattended --replace
+   ```
+4. Delete old runner registrations on GitHub and restart services.

--- a/ops/wsl-runners/install-keepalive.sh
+++ b/ops/wsl-runners/install-keepalive.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Install the WSL keepalive service on the self-hosted runner VM.
+# Run inside WSL Ubuntu:
+#   bash ops/wsl-runners/install-keepalive.sh
+set -euo pipefail
+
+UNIT="wsl-keepalive.service"
+SRC_DIR="$(cd "$(dirname "$0")" && pwd)"
+DST="/etc/systemd/system/${UNIT}"
+
+echo "Installing ${UNIT}..."
+
+sudo cp "${SRC_DIR}/${UNIT}" "${DST}"
+sudo chown root:root "${DST}"
+sudo chmod 644 "${DST}"
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now "${UNIT}"
+
+echo
+echo "Status:"
+systemctl status "${UNIT}" --no-pager -l || true
+echo
+echo "Done. The WSL VM will now stay alive even between CI jobs."

--- a/ops/wsl-runners/wsl-keepalive.service
+++ b/ops/wsl-runners/wsl-keepalive.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=WSL VM keepalive — holds a process so Windows doesn't suspend the VM
+# The WSL2 VM on host WHITE suspends when no user session holds it open,
+# killing long-running CI jobs (e.g. race detector stressed depth pass).
+# This service runs a lightweight sleep loop that keeps the VM alive
+# even when all CI jobs are between steps.
+After=network-online.target
+
+[Service]
+Type=simple
+# A perpetually-running process makes the VM ineligible for idle suspension.
+# The sleep duration is long (1h) and looped by systemd's Restart=always.
+ExecStart=/bin/sleep 3600
+Restart=always
+RestartSec=5
+# No resource cost — sleep is 0% CPU, ~0 memory.
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Closes #480.

## Problem

The WSL2 VM on host `WHITE` suspends when no user-space process holds it open, killing long-running CI jobs mid-execution. The race detector's stressed depth pass (5-8 min) was consistently killed this way across 4+ consecutive runs, with no log retained.

The `.wslconfig` already sets `vmIdleTimeout=-1`, but the VM still cycles when all foreground WSL sessions exit between CI steps.

## Fix

A perpetual systemd process inside the VM makes it ineligible for idle suspension:

- **`ops/wsl-runners/wsl-keepalive.service`** — systemd unit running `/bin/sleep 3600` with `Restart=always`. Zero cost: 0% CPU, 220KB memory. Systemd restarts the sleep every hour, creating an unbroken process chain.

- **`ops/wsl-runners/install-keepalive.sh`** — one-time install script.

- **`ops/wsl-runners/README.md`** — documents the full runner infrastructure (runners, systemd units, `.wslconfig`, keepalive, re-registration procedure).

## Installed on live VM

The service is already installed, enabled, and running on the live VM:

```
● wsl-keepalive.service - WSL VM keepalive
     Active: active (running)
   Main PID: 533 (sleep)
     Memory: 220.0K
        CPU: 1ms
```

## Verification

This is a docs + ops change (no Go or TS code). The keepalive service is verified running. The next long CI job (race detector) will confirm whether the VM stays alive through the stressed depth pass.