### PR TITLE
feat(webui): wire 6 remaining cursor-pager log hooks into views

### DIFF
--- a/frontend/src/components/LogHistoryPanel.tsx
+++ b/frontend/src/components/LogHistoryPanel.tsx
@@ -1,0 +1,75 @@
+import { type LucideIcon } from "lucide-react";
+import { LoadMoreFooter } from "@/components/ui/load-more-footer";
+import { Muted } from "@/components/JsonView";
+import { fmtDateTime } from "@/lib/utils";
+
+interface LogHistoryPanelProps<T extends Record<string, unknown>> {
+  icon: LucideIcon;
+  title: string;
+  rows: T[];
+  loading: boolean;
+  loadMore: () => Promise<void>;
+  loadingMore: boolean;
+  moreError: string | null;
+  hasMore: boolean;
+  pageSize: number;
+  renderRow: (row: T, index: number) => React.ReactNode;
+}
+
+/**
+ * LogHistoryPanel renders a cursor-paginated log list with a LoadMoreFooter.
+ * It standardises the layout (header, list, footer) so each consuming view
+ * only needs to provide a row renderer. Used by the 6 log-endpoint views.
+ */
+export function LogHistoryPanel<T extends Record<string, unknown> & { seq: number }>({
+  icon: Icon,
+  title,
+  rows,
+  loading,
+  loadMore,
+  loadingMore,
+  moreError,
+  hasMore,
+  pageSize,
+  renderRow,
+}: LogHistoryPanelProps<T>) {
+  return (
+    <div className="glass rounded-xl p-3">
+      <div className="mb-2 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-normal text-muted">
+        <Icon className="size-3.5" /> {title}
+        {!loading && <span className="ml-1 normal-case text-muted/70">({rows.length})</span>}
+      </div>
+      {loading && rows.length === 0 ? (
+        <Muted>loading…</Muted>
+      ) : rows.length === 0 && !hasMore ? (
+        <Muted>no entries yet</Muted>
+      ) : (
+        <>
+          {rows.length > 0 && (
+            <ul className="space-y-1">
+              {rows.map((row, i) => (
+                <li
+                  key={row.seq ?? i}
+                  className="flex items-center gap-2 border-b border-border/40 py-1 text-xs last:border-0"
+                >
+                  {renderRow(row, i)}
+                  {row.ts_unix_ms != null && (
+                    <span className="ml-auto shrink-0 text-muted">{fmtDateTime(row.ts_unix_ms as number)}</span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+          <LoadMoreFooter
+            hasMore={hasMore}
+            loadingMore={loadingMore}
+            moreError={moreError}
+            onLoadMore={loadMore}
+            pageSize={pageSize}
+            label={title.toLowerCase()}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/lib/cursorPager.ts
+++ b/frontend/src/lib/cursorPager.ts
@@ -276,50 +276,32 @@ export function useApprovalsLogPager(limit: number = 50) {
   return useCursorPager<LogRow>("/api/approvals_log", "approvals", "seq", limit);
 }
 
-/**
- * useRateLimitLogPager — /api/ratelimit_log (throttle events).
- * @public Pre-wired for the RateLimit view; view integration lands in a follow-up.
- */
+/** useRateLimitLogPager — /api/ratelimit_log (throttle events). */
 export function useRateLimitLogPager(limit: number = 50) {
   return useCursorPager<LogRow>("/api/ratelimit_log", "throttles", "seq", limit);
 }
 
-/**
- * useWebhookLogPager — /api/webhook_log (delivery attempts).
- * @public Pre-wired for the Webhook view; view integration lands in a follow-up.
- */
+/** useWebhookLogPager — /api/webhook_log (delivery attempts). */
 export function useWebhookLogPager(limit: number = 50) {
   return useCursorPager<LogRow>("/api/webhook_log", "deliveries", "seq", limit);
 }
 
-/**
- * useWardenLogPager — /api/warden_log (sandboxed executions).
- * @public Pre-wired for the Warden view; view integration lands in a follow-up.
- */
+/** useWardenLogPager — /api/warden_log (sandboxed executions). */
 export function useWardenLogPager(limit: number = 50) {
   return useCursorPager<LogRow>("/api/warden_log", "executions", "seq", limit);
 }
 
-/**
- * useNetguardLogPager — /api/netguard_log (blocked egress).
- * @public Pre-wired for the Netguard view; view integration lands in a follow-up.
- */
+/** useNetguardLogPager — /api/netguard_log (blocked egress). */
 export function useNetguardLogPager(limit: number = 50) {
   return useCursorPager<LogRow>("/api/netguard_log", "blocks", "seq", limit);
 }
 
-/**
- * useWorldLogPager — /api/world_log (world-model ops).
- * @public Pre-wired for the World view; view integration lands in a follow-up.
- */
+/** useWorldLogPager — /api/world_log (world-model ops). */
 export function useWorldLogPager(limit: number = 50) {
   return useCursorPager<LogRow>("/api/world_log", "ops", "seq", limit);
 }
 
-/**
- * useMemoryLogPager — /api/memory_log (memory write/forget ops).
- * @public Pre-wired for the Memory view; view integration lands in a follow-up.
- */
+/** useMemoryLogPager — /api/memory_log (memory write/forget ops). */
 export function useMemoryLogPager(limit: number = 50) {
   return useCursorPager<LogRow>("/api/memory_log", "ops", "seq", limit);
 }

--- a/frontend/src/views/Budget.tsx
+++ b/frontend/src/views/Budget.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactNode } from "react";
-import { RefreshCw, Wallet, Check, Infinity as InfinityIcon, SlidersHorizontal, X } from "lucide-react";
+import { RefreshCw, Wallet, Check, Infinity as InfinityIcon, SlidersHorizontal, X, Gauge } from "lucide-react";
 import { usePanel } from "@/lib/usePanel";
 import { postAction } from "@/lib/api";
 import { money } from "@/lib/format";
@@ -9,6 +9,8 @@ import { ErrorText } from "@/components/JsonView";
 import { SkeletonList } from "@/components/ui/skeleton";
 import { PageHeader } from "@/components/ui/page-header";
 import { Ring, BarRow } from "@/components/Widgets";
+import { useRateLimitLogPager } from "@/lib/cursorPager";
+import { LogHistoryPanel } from "@/components/LogHistoryPanel";
 
 interface BudgetData {
   utc_date?: string;
@@ -41,6 +43,16 @@ export function Budget() {
   const [note, setNote] = useState<string | null>(null);
   const [noteBad, setNoteBad] = useState(false);
   const [adjustOpen, setAdjustOpen] = useState(false);
+
+  // Cursor-paginated rate-limit events (the journal-backed /api/ratelimit_log).
+  const {
+    paged: rateLimitRows,
+    loading: rateLimitLoading,
+    loadMore: loadMoreRateLimit,
+    loadingMore: loadingMoreRateLimit,
+    moreError: rateLimitError,
+    hasMore: hasMoreRateLimit,
+  } = useRateLimitLogPager(50);
 
   const spent = data?.spent_mc ?? 0;
   const ceiling = data?.ceiling_mc ?? 0;
@@ -243,6 +255,25 @@ export function Budget() {
           <SkeletonList count={3} lines={2} />
         )}
       </div>
+
+      <LogHistoryPanel
+        icon={Gauge}
+        title="Rate limit events"
+        rows={rateLimitRows}
+        loading={rateLimitLoading}
+        loadMore={loadMoreRateLimit}
+        loadingMore={loadingMoreRateLimit}
+        moreError={rateLimitError}
+        hasMore={hasMoreRateLimit}
+        pageSize={50}
+        renderRow={(r) => (
+          <>
+            <span className="font-mono text-foreground">{String(r.agent || "")}</span>
+            <span className="shrink-0 text-muted">{String(r.model || "")}</span>
+            <span className="min-w-0 flex-1 truncate text-muted">{String(r.reason || "")}</span>
+          </>
+        )}
+      />
     </div>
   );
 }

--- a/frontend/src/views/Channels.tsx
+++ b/frontend/src/views/Channels.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import {
   Radio, RefreshCw, Check, ExternalLink, Save, SendHorizontal, QrCode,
   Image as ImageIcon, Mic, ArrowDown, ArrowUp, ArrowLeftRight, ArrowRight,
-  Plus, Pencil, Trash2, X, ListChecks, KeyRound,
+  Plus, Pencil, Trash2, X, ListChecks, KeyRound, Send,
 } from "lucide-react";
 import { getJSON, postJSON } from "@/lib/api";
 import { cn } from "@/lib/utils";
@@ -14,6 +14,8 @@ import { Badge } from "@/components/ui/badge";
 import { SkeletonList } from "@/components/ui/skeleton";
 import { useUI } from "@/components/ui/feedback";
 import { MetricGrid, MetricWidget } from "@/components/ui/metric-widget";
+import { useWebhookLogPager } from "@/lib/cursorPager";
+import { LogHistoryPanel } from "@/components/LogHistoryPanel";
 
 // One account field of a channel (mirrors kernel/settings.Field + set-state).
 interface ChannelField {
@@ -597,6 +599,16 @@ export function Channels() {
   const [err, setErr] = useState("");
   const [openKind, setOpenKind] = useState<string>("");
 
+  // Cursor-paginated webhook delivery log (the journal-backed /api/webhook_log).
+  const {
+    paged: deliveryRows,
+    loading: deliveryLoading,
+    loadMore: loadMoreDelivery,
+    loadingMore: loadingMoreDelivery,
+    moreError: deliveryError,
+    hasMore: hasMoreDelivery,
+  } = useWebhookLogPager(50);
+
   async function load() {
     try {
       const res = await getJSON<{ channels: ChannelRow[] }>("/api/channels");
@@ -722,6 +734,29 @@ export function Channels() {
           })}
         </div>
       )}
+
+      <LogHistoryPanel
+        icon={Send}
+        title="Delivery log"
+        rows={deliveryRows}
+        loading={deliveryLoading}
+        loadMore={loadMoreDelivery}
+        loadingMore={loadingMoreDelivery}
+        moreError={deliveryError}
+        hasMore={hasMoreDelivery}
+        pageSize={50}
+        renderRow={(r) => {
+          const sc = typeof r.status_code === "number" ? r.status_code : Number(r.status_code);
+          const ok = !Number.isNaN(sc) && sc >= 200 && sc < 300;
+          return (
+            <>
+              <span className="font-mono text-foreground">{String(r.channel || "")}</span>
+              <span className="shrink-0 text-muted">{String(r.event || "")}</span>
+              <Badge variant={ok ? "good" : "bad"}>{String(r.status_code ?? "")}</Badge>
+            </>
+          );
+        }}
+      />
     </div>
   );
 }

--- a/frontend/src/views/Memory.tsx
+++ b/frontend/src/views/Memory.tsx
@@ -13,6 +13,8 @@ import { Page } from "@/components/ui/page";
 import { MetricWidget, MetricGrid } from "@/components/ui/metric-widget";
 import { Badge } from "@/components/ui/badge";
 import { Disclosure } from "@/components/ui/disclosure";
+import { useMemoryLogPager } from "@/lib/cursorPager";
+import { LogHistoryPanel } from "@/components/LogHistoryPanel";
 
 interface MemRecord {
   id?: string;
@@ -93,6 +95,16 @@ export function Memory() {
   // owner browse them side by side.
   const [scopeFilter, setScopeFilter] = useState<string | null>(null);
   const fileRef = useRef<HTMLInputElement>(null);
+
+  // Cursor-paginated write/forget history (the journal-backed /api/memory_log).
+  const {
+    paged: writeLogRows,
+    loading: writeLogLoading,
+    loadMore: loadMoreWriteLog,
+    loadingMore: loadingMoreWriteLog,
+    moreError: writeLogError,
+    hasMore: hasMoreWriteLog,
+  } = useMemoryLogPager(50);
 
   function exportMemory() {
     downloadText("agezt-memory.json", JSON.stringify({ version: 1, memory: records ?? [] }, null, 2), "application/json");
@@ -580,6 +592,26 @@ export function Memory() {
           />
         </MemoryModal>
       )}
+
+      <LogHistoryPanel
+        icon={History}
+        title="Write history"
+        rows={writeLogRows}
+        loading={writeLogLoading}
+        loadMore={loadMoreWriteLog}
+        loadingMore={loadingMoreWriteLog}
+        moreError={writeLogError}
+        hasMore={hasMoreWriteLog}
+        pageSize={50}
+        renderRow={(r) => (
+          <>
+            <Badge variant="default">{String(r.op || "")}</Badge>
+            <span className="font-mono text-foreground">{String(r.record_id || "")}</span>
+            <span className="shrink-0 text-muted">{String(r.agent || "")}</span>
+            <span className="min-w-0 flex-1 truncate text-muted">{String(r.summary || "")}</span>
+          </>
+        )}
+      />
     </Page>
   );
 }

--- a/frontend/src/views/Sandbox.test.tsx
+++ b/frontend/src/views/Sandbox.test.tsx
@@ -27,7 +27,15 @@ beforeEach(() => {
 
 describe("Sandbox view", () => {
   it("shows the empty state when no projects exist", async () => {
-    getJSON.mockResolvedValueOnce({ projects: [] });
+    // The view now also paginates /api/warden_log + /api/netguard_log via the
+    // cursor pager (usePanel-backed); answer them with empty envelopes so the
+    // panels render their "no entries yet" state without throwing.
+    getJSON.mockImplementation((path: string) => {
+      if (path === "/api/sandbox") return Promise.resolve({ projects: [] });
+      if (path === "/api/warden_log") return Promise.resolve({ executions: [], next_cursor: null });
+      if (path === "/api/netguard_log") return Promise.resolve({ blocks: [], next_cursor: null });
+      return Promise.resolve({});
+    });
     render(withUI(<Sandbox />));
     await waitFor(() => expect(screen.getByText("No sandbox projects yet")).toBeTruthy());
   });

--- a/frontend/src/views/Sandbox.tsx
+++ b/frontend/src/views/Sandbox.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { FlaskConical, RefreshCw, ChevronRight, ChevronDown, FileCode, FileText, Download, Trash2 } from "lucide-react";
+import { FlaskConical, RefreshCw, ChevronRight, ChevronDown, FileCode, FileText, Download, Trash2, ShieldAlert } from "lucide-react";
 import { getJSON, postAction } from "@/lib/api";
 import { cn, fmtDateTime } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -10,6 +10,8 @@ import { ErrorText } from "@/components/JsonView";
 import { MetricWidget, MetricGrid } from "@/components/ui/metric-widget";
 import { Badge } from "@/components/ui/badge";
 import { Page } from "@/components/ui/page";
+import { useWardenLogPager, useNetguardLogPager } from "@/lib/cursorPager";
+import { LogHistoryPanel } from "@/components/LogHistoryPanel";
 
 // downloadText saves text content to a file via a transient object URL — lets the
 // operator grab an artifact an agent built without leaving the browser.
@@ -53,6 +55,26 @@ export function Sandbox() {
   const [projects, setProjects] = useState<Project[] | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+
+  // Cursor-paginated sandbox-execution log (the journal-backed /api/warden_log).
+  const {
+    paged: wardenRows,
+    loading: wardenLoading,
+    loadMore: loadMoreWarden,
+    loadingMore: loadingMoreWarden,
+    moreError: wardenError,
+    hasMore: hasMoreWarden,
+  } = useWardenLogPager(50);
+
+  // Cursor-paginated blocked-egress log (the journal-backed /api/netguard_log).
+  const {
+    paged: netguardRows,
+    loading: netguardLoading,
+    loadMore: loadMoreNetguard,
+    loadingMore: loadingMoreNetguard,
+    moreError: netguardError,
+    hasMore: hasMoreNetguard,
+  } = useNetguardLogPager(50);
 
   async function reload() {
     setLoading(true);
@@ -111,6 +133,52 @@ export function Sandbox() {
           ))}
         </MetricGrid>
       )}
+
+      <LogHistoryPanel
+        icon={FlaskConical}
+        title="Sandbox executions"
+        rows={wardenRows}
+        loading={wardenLoading}
+        loadMore={loadMoreWarden}
+        loadingMore={loadingMoreWarden}
+        moreError={wardenError}
+        hasMore={hasMoreWarden}
+        pageSize={50}
+        renderRow={(r) => {
+          const code = typeof r.exit_code === "number" ? r.exit_code : Number(r.exit_code);
+          const ok = !Number.isNaN(code) && code === 0;
+          return (
+            <>
+              <span className="font-mono text-foreground">{String(r.agent || "")}</span>
+              <span className="shrink-0 text-muted">{String(r.tool || "")}</span>
+              <Badge variant="default">{String(r.lang || "")}</Badge>
+              <Badge variant={ok ? "good" : "bad"}>exit {String(r.exit_code ?? "")}</Badge>
+            </>
+          );
+        }}
+      />
+
+      <LogHistoryPanel
+        icon={ShieldAlert}
+        title="Blocked egress"
+        rows={netguardRows}
+        loading={netguardLoading}
+        loadMore={loadMoreNetguard}
+        loadingMore={loadingMoreNetguard}
+        moreError={netguardError}
+        hasMore={hasMoreNetguard}
+        pageSize={50}
+        renderRow={(r) => (
+          <>
+            <span className="font-mono text-foreground">{String(r.agent || "")}</span>
+            <span className="shrink-0 text-muted">
+              {String(r.dest_host || "")}:{String(r.dest_port || "")}
+            </span>
+            <Badge variant="default">{String(r.protocol || "")}</Badge>
+            <Badge variant="bad">{String(r.action || "")}</Badge>
+          </>
+        )}
+      />
     </Page>
   );
 }

--- a/frontend/src/views/World.tsx
+++ b/frontend/src/views/World.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState, type ReactNode } from "react";
-import { Globe, Plus, RefreshCw, Pencil, Save, X, Download, Upload, Search, Tags, SlidersHorizontal, type LucideIcon } from "lucide-react";
+import { Globe, Plus, RefreshCw, Pencil, Save, X, Download, Upload, Search, Tags, SlidersHorizontal, History, type LucideIcon } from "lucide-react";
 import { Row, Count } from "@/components/Panel";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -17,6 +17,8 @@ import { downloadText } from "@/lib/export";
 import { cn } from "@/lib/utils";
 import { useUI } from "@/components/ui/feedback";
 import { Disclosure } from "@/components/ui/disclosure";
+import { useWorldLogPager } from "@/lib/cursorPager";
+import { LogHistoryPanel } from "@/components/LogHistoryPanel";
 
 // The entity kinds the world model recognises — offered when teaching it one.
 const WORLD_KINDS = ["person", "project", "repo", "org", "account", "device", "channel", "topic", "task"];
@@ -135,6 +137,16 @@ export function World() {
   const [addOpen, setAddOpen] = useState(false);
   const [relateOpen, setRelateOpen] = useState(false);
   const { data, error, loading, reload } = usePanel<Record<string, any>>("/api/world");
+
+  // Cursor-paginated world-model ops log (the journal-backed /api/world_log).
+  const {
+    paged: opsRows,
+    loading: opsLoading,
+    loadMore: loadMoreOps,
+    loadingMore: loadingMoreOps,
+    moreError: opsError,
+    hasMore: hasMoreOps,
+  } = useWorldLogPager(50);
   return (
     <Page
       icon={Globe}
@@ -354,6 +366,26 @@ export function World() {
         );
             })()
           )}
+          <LogHistoryPanel
+            icon={History}
+            title="Operations log"
+            rows={opsRows}
+            loading={opsLoading}
+            loadMore={loadMoreOps}
+            loadingMore={loadingMoreOps}
+            moreError={opsError}
+            hasMore={hasMoreOps}
+            pageSize={50}
+            renderRow={(r) => (
+              <>
+                <Badge variant="default">{String(r.op || "")}</Badge>
+                <span className="font-mono text-foreground">
+                  {String(r.entity_type || "")}:{String(r.entity_id || "")}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-muted">{String(r.field || "")}</span>
+              </>
+            )}
+          />
         </CardBody>
       </Card>
     </Page>


### PR DESCRIPTION
Closes #483.

## Summary

Wires all 6 remaining pre-wired cursor-pager log hooks into their target views, completing the A2 cursor-pagination feature.

## Changes

### New component: `LogHistoryPanel.tsx`
A reusable panel that standardises cursor-paginated log lists — icon, title, count, rows with auto-timestamp, and a `LoadMoreFooter`. Each consuming view only provides a row renderer.

### 6 view integrations

| Hook | View | Panel title | Row content |
|---|---|---|---|
| `useMemoryLogPager` | Memory.tsx | "Write history" | op badge, record_id (mono), agent, summary |
| `useWorldLogPager` | World.tsx | "Operations log" | op badge, entity_type/id (mono), field |
| `useWardenLogPager` | Sandbox.tsx | "Sandbox executions" | agent (mono), tool, lang badge, exit_code badge |
| `useNetguardLogPager` | Sandbox.tsx | "Blocked egress" | agent (mono), dest_host:port, protocol/action badges |
| `useWebhookLogPager` | Channels.tsx | "Delivery log" | channel (mono), event, status_code badge |
| `useRateLimitLogPager` | Budget.tsx | "Rate limit events" | agent (mono), model, reason |

### cursorPager.ts cleanup
Removed `@public` knip tags from all 6 hooks — they now have consuming views.

## Verification

- `tsc --noEmit`: clean
- `vitest run`: 177 files / 1461 tests, all pass
- `knip`: 0 issues