### PR TITLE
ci: add Windows-side WSL keepalive to prevent VM cycling

### DIFF
--- a/ops/wsl-runners/README.md
+++ b/ops/wsl-runners/README.md
@@ -10,7 +10,8 @@ running in a WSL2 Ubuntu VM on host `WHITE`.
 | GitHub Actions runners | `/home/ersinkoc/actions-runner-{1,2,3}` | Registered as `wsl-runner-{1,2,3}-new` (IDs 25/26/27) |
 | systemd unit files | `/etc/systemd/system/actions.runner.agezt-agezt.wsl-runner-{1,2,3}.service` | `Restart=always`, `RestartSec=10` |
 | WSL VM config | `C:\Users\ersin\.wslconfig` | `vmIdleTimeout=-1`, `autoMemoryReclaim=disabled` |
-| Keepalive | `/etc/systemd/system/wsl-keepalive.service` | Continuous `sleep` process, `Restart=always` |
+| Keepalive (in-VM) | `/etc/systemd/system/wsl-keepalive.service` | Continuous `sleep` process, `Restart=always` |
+| Keepalive (Windows) | Scheduled task `WSLKeepAlive` → `wsl-keepalive.cmd` | Persistent `wsl.exe` session at logon (required) |
 | Go toolchain staging | `setup-go-safe` composite action | GOROOT/GOCACHE/GOTMPDIR on `/dev/shm` tmpfs |
 
 ## Keepalive service
@@ -42,6 +43,51 @@ systemctl is-active wsl-keepalive.service
   exits (after 1h), creating a perpetual process inside the VM.
 - Combined with `.wslconfig`'s `vmIdleTimeout=-1`, the VM stays alive between
   CI jobs, during idle periods, and through runner service restarts.
+
+**Important:** the in-VM systemd keepalive alone is **not sufficient**. Windows
+terminates the WSL2 VM process from outside regardless of in-VM activity. A
+Windows-side scheduled task (below) is also required.
+
+## Windows-side keepalive (required)
+
+The WSL2 VM is a Windows process (`wslservice`). Windows kills it every
+~15-50s when no foreground `wsl.exe` invocation holds a session open — even
+with `vmIdleTimeout=-1` in `.wslconfig` and the in-VM systemd keepalive
+running. The fix is a Windows scheduled task that holds a persistent WSL
+session from the Windows side.
+
+### Install
+
+Run in PowerShell (one-time, per host):
+
+```powershell
+# 1. Create the launcher script
+@'
+@echo off
+wsl.exe -d Ubuntu bash -c "while true; do sleep 3600; done"
+'@ | Set-Content "$env:USERPROFILE\wsl-keepalive.cmd"
+
+# 2. Register the scheduled task (starts at logon, runs indefinitely)
+Register-ScheduledTask -TaskName 'WSLKeepAlive' `
+  -Trigger (New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME) `
+  -Action (New-ScheduledTaskAction -Execute "$env:USERPROFILE\wsl-keepalive.cmd") `
+  -Settings (New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -ExecutionTimeLimit ([TimeSpan]::Zero)) `
+  -Force
+
+# 3. Start it now
+Start-ScheduledTask -TaskName 'WSLKeepAlive'
+```
+
+### Verify
+
+Check that the VM stops cycling (the in-VM keepalive journal should show
+no restarts after the task is running):
+
+```bash
+# Inside WSL:
+journalctl -u wsl-keepalive.service --since -5min --no-pager
+# Should show: "-- No entries --" (VM hasn't been killed)
+```
 
 ## Runner systemd units
 


### PR DESCRIPTION
## Problem

The in-VM systemd keepalive service (PR #485) was **not sufficient**. The WSL2 VM journal showed it being killed and restarted every ~15-50 seconds:

```
Jul 05 23:05:55 Started wsl-keepalive.service
Jul 05 23:06:12 Stopping wsl-keepalive.service
Jul 05 23:06:16 Started wsl-keepalive.service
Jul 05 23:06:42 Stopping wsl-keepalive.service
... (repeats every 15-50s for 2 hours)
```

Windows terminates the WSL2 VM process from outside regardless of in-VM activity, even with `vmIdleTimeout=-1` in `.wslconfig`.

## Root cause

Windows kills the WSL2 VM when no foreground `wsl.exe` process holds a session open. Each CI job's shell exits between steps, creating a brief window where no Windows-side WSL session exists. The in-VM systemd process can't prevent this — Windows tears down the entire VM.

## Fix

A **Windows scheduled task** (`WSLKeepAlive`) that runs a persistent `wsl.exe` session at logon. The task holds the VM open indefinitely.

Installed on host WHITE via PowerShell. Verified: the in-VM keepalive journal shows **no restarts** after the task started (vs. restarting every 15-50s before).

## Changes

Docs-only (1 file): updated `ops/wsl-runners/README.md` with:
- Windows-side keepalive section with PowerShell install instructions
- Clarification that the in-VM keepalive alone is not sufficient
- Updated setup table showing both keepalive layers