### PR TITLE
fix(e2e): assert connection chip state, not removed "● live" text

### DIFF
--- a/frontend/e2e/webui.spec.ts
+++ b/frontend/e2e/webui.spec.ts
@@ -36,9 +36,14 @@ test.describe("Agezt Web UI — embedded SPA against a real daemon", () => {
     const title = page.locator("h1", { hasText: "· console" });
     await expect(title).toBeVisible();
     await expect(title).toContainText(/agezt/i);
-    // "● live" renders in the header AND in the Cockpit panel — either proves
-    // the SSE stream connected.
-    await expect(page.getByText("● live").first()).toBeVisible();
+    // The header ConnectionChip (commit 8fca29fa) is a dot+icon indicator:
+    // its visible label is screen-reader-only, so we assert on its
+    // data-connection-state attribute instead of literal "● live" text.
+    // The state flips to "live" once /events connects AND delivers an event,
+    // which proves the live SSE stream is wired end to end.
+    const conn = page.locator("[data-connection-state]").first();
+    await expect(conn).toBeVisible();
+    await expect(conn).toHaveAttribute("data-connection-state", "live");
 
     const nav = page.getByRole("navigation");
     // exact: true so a substring nav label can't hijack the match — e.g. the


### PR DESCRIPTION
## What

Fixes the `webui-e2e` Playwright failure that's been red on `main` since 2026-07-03 (commit `8fca29fa`).

## Root cause

`webui.spec.ts:41` asserted visible text `● live`:
```ts
await expect(page.getByText("● live").first()).toBeVisible();
```

Commit `8fca29fa` (SSE three-state connection chip) **removed** that text from the header, replacing it with `<ConnectionChip />` — a dot+icon indicator whose word label is **screen-reader-only** (`sr-only`). Playwright's `toBeVisible()` correctly reports `sr-only` text as not visible, so `getByText("● live")` could never match → 10s timeout, 3 retries, all failed.

## Why it wasn't caught for 3 days

The WSL runner outage (the missing `WSLKeepAlive` scheduled task, fixed today) meant the `webui-e2e` job **never actually completed** — it sat `queued` or died mid-setup. The failure was only exposed once the runners came back online.

## Fix

Replace the stale literal-text assertion with a semantic one against the chip's `data-connection-state` attribute, which flips to `"live"` once `/events` connects **and** delivers an event:

```ts
const conn = page.locator("[data-connection-state]").first();
await expect(conn).toBeVisible();
await expect(conn).toHaveAttribute("data-connection-state", "live");
```

Same "the live SSE stream is wired" intent, expressed resiliently against the chip's actual DOM contract rather than removed display text.

## Verification

- `tsc --noEmit`: clean
- `ConnectionChip.test.tsx`: 5/5 pass
- `events.test.ts` (connectionState logic): 7/7 pass

The full e2e suite will run in CI once this PR opens (on the now-healthy runners).

## Out of scope

The unrelated `race (linux, cgo)` CI failure is tracked separately in `next.md` #3 — different root cause.
