### PR TITLE
fix(e2e): give Cockpit heading a 30s timeout

### DIFF
--- a/frontend/e2e/webui.spec.ts
+++ b/frontend/e2e/webui.spec.ts
@@ -68,9 +68,13 @@ test.describe("Agezt Web UI — embedded SPA against a real daemon", () => {
     // The seeded run shows up in the completed counter; the vitals strip and
     // widgets are real daemon state, not placeholders.
     await openView("System", "Overview");
+    // Generous timeout for the first post-nav heading: a click + React re-mount
+    // + initial data fetch under WSL runner load can exceed the default 10s.
+    // Same rationale as the data-connection-state live-or-stale tolerance in
+    // the connection-state assertion above.
     await expect(
       page.getByRole("heading", { level: 2, name: "Cockpit" }),
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 30_000 });
     await expect(page.getByText(/success rate/i)).toBeVisible();
     await expect(page.getByText(/active skills/i)).toBeVisible();
 


### PR DESCRIPTION
## What

Gives the first post-navigation heading assertion (`name: "Cockpit"`) a 30s timeout in `webui-e2e` (frontend/e2e/webui.spec.ts), so it passes under WSL runner load where a click + React re-mount + initial data fetch can exceed the default 10s.

## Why

The webui-e2e Playwright spec has 8 distinct navigation sections, each with a `getByRole("heading", { level: 2, ... })` assertion immediately after an `openView(...)` click. The first one — `name: "Cockpit"` after `openView("System", "Overview")` — fails on the contended WSL runner because:

- two-level nav click → React re-mount → initial data fetch > 10s default

This is the same class of timing issue that PR #494 fixed for the data-connection-state assertion (relaxed the value, not the window). The Cockpit one is a pure navigation-timeout, so the fix is the timeout option.

## Change

```ts
// before
await expect(
  page.getByRole("heading", { level: 2, name: "Cockpit" }),
).toBeVisible();

// after
await expect(
  page.getByRole("heading", { level: 2, name: "Cockpit" }),
).toBeVisible({ timeout: 30_000 });
```

The follow-on assertions in the same section (success rate, active skills) keep the default 10s — they should be fast once the route is mounted; bumping them too would hide real regressions.

## Scope

Surgical: only the Cockpit heading assertion. If other navigation headings start timing out in future runs, apply the same pattern (and consider raising the global `expect` timeout if it becomes widespread).

## Verification

- `tsc --noEmit`: clean
- The full `webui-e2e` Playwright suite will run in CI on this PR (on the now-stable WSL runners under the persistent session holder)

## Out of scope

- The `AnimatedNumber` `setTimeout` leak in `frontend/src/components/AnimatedNumber.tsx` causing the viper `window is not defined` error in `frontend-test` is a separate, pre-existing test-suite bug — needs its own follow-up.
- The WSL poweroff root cause + persistent-session-holder fix are tracked as ops on host WHITE.
