### PR TITLE
docs(wsl-runners): reproduce the Windows-side keepalive fix

### DIFF
--- a/ops/wsl-runners/README.md
+++ b/ops/wsl-runners/README.md
@@ -9,9 +9,9 @@ running in a WSL2 Ubuntu VM on host `WHITE`.
 |---|---|---|
 | GitHub Actions runners | `/home/ersinkoc/actions-runner-{1,2,3}` | Registered as `wsl-runner-{1,2,3}-new` (IDs 25/26/27) |
 | systemd unit files | `/etc/systemd/system/actions.runner.agezt-agezt.wsl-runner-{1,2,3}.service` | `Restart=always`, `RestartSec=10` |
-| WSL VM config | `C:\Users\ersin\.wslconfig` | `vmIdleTimeout=-1`, `autoMemoryReclaim=disabled` |
+| WSL VM config | `C:\Users\ersin\.wslconfig` | `vmIdleTimeout=999999999`, `autoMemoryReclaim=disabled` |
 | Keepalive (in-VM) | `/etc/systemd/system/wsl-keepalive.service` | Continuous `sleep` process, `Restart=always` |
-| Keepalive (Windows) | Scheduled task `WSLKeepAlive` → `wsl-keepalive.cmd` | Persistent `wsl.exe` session at logon (required) |
+| Keepalive (Windows) | Scheduled task `WSLKeepAlive` → `wsl-keepalive.cmd` | Persistent WSL session (nohup+disown inside, foreground wsl.exe outside), at logon |
 | Go toolchain staging | `setup-go-safe` composite action | GOROOT/GOCACHE/GOTMPDIR on `/dev/shm` tmpfs |
 
 ## Keepalive service
@@ -58,25 +58,33 @@ session from the Windows side.
 
 ### Install
 
-Run in PowerShell (one-time, per host):
+Run in PowerShell (one-time, per host). The script is idempotent and safe
+to re-run; it copies the canonical launcher from `ops\wsl-runners\wsl-keepalive.cmd`
+into `%USERPROFILE%`, re-registers the scheduled task with durable settings
+(RestartCount 999 / RestartInterval 1 min), starts it immediately, and
+verifies:
 
 ```powershell
-# 1. Create the launcher script
-@'
-@echo off
-wsl.exe -d Ubuntu bash -c "while true; do sleep 3600; done"
-'@ | Set-Content "$env:USERPROFILE\wsl-keepalive.cmd"
-
-# 2. Register the scheduled task (starts at logon, runs indefinitely)
-Register-ScheduledTask -TaskName 'WSLKeepAlive' `
-  -Trigger (New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME) `
-  -Action (New-ScheduledTaskAction -Execute "$env:USERPROFILE\wsl-keepalive.cmd") `
-  -Settings (New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -ExecutionTimeLimit ([TimeSpan]::Zero)) `
-  -Force
-
-# 3. Start it now
-Start-ScheduledTask -TaskName 'WSLKeepAlive'
+# From the repo root:
+powershell -NoProfile -ExecutionPolicy Bypass -File ops\wsl-runners\install-keepalive.ps1
 ```
+
+### Why the naive `while true; do sleep 3600; done` version dies
+
+A simpler one-liner
+(`wsl.exe -d Ubuntu bash -c "while true; do sleep 3600; done"`) was
+insufficient on the WSL2 build used here: when WSL terminates the instance
+(after the last `wsl.exe` session ends, which `systemd-logind` treats as
+"idle"), the `wsl.exe` process is signalled (exit code `0xC000013A` /
+`STATUS_CONTROL_C_EXIT`), the bash loop dies, and the holder is gone. The
+VM then boots fresh with no holder; the last transient `wsl.exe` session
+ends; `systemd-logind` poweroffs again; the cycle repeats every ~1 min.
+
+The robust launcher in `wsl-keepalive.cmd` uses `nohup ... & disown` to
+**detach a persistent sleep inside the Ubuntu instance** (so it survives
+the `wsl.exe` process being signalled) and then keeps a **foreground
+`wsl.exe` sleep** alive too (so logind always sees ≥1 active session).
+Together they hold the VM continuously across WSL poweroff/reboot cycles.
 
 ### Verify
 
@@ -88,6 +96,35 @@ no restarts after the task is running):
 journalctl -u wsl-keepalive.service --since -5min --no-pager
 # Should show: "-- No entries --" (VM hasn't been killed)
 ```
+
+```bash
+# Also confirm the holder session is alive (≥1 wsl.exe process and a logind
+# session for the Ubuntu user):
+wsl -d Ubuntu -- bash -c "loginctl list-sessions && ps -ef | grep '[s]leep 3600'"
+```
+
+### Troubleshooting
+
+If the VM is poweroff-ing (CI jobs killed mid-run with
+"The runner has received a shutdown signal"), check these in order:
+
+1. **Holder not running** (most common cause): the Windows-side task died
+   or was never installed. Re-run `install-keepalive.ps1`. Verify
+   `Get-ScheduledTask -TaskName 'WSLKeepAlive'` shows `State=Running` and
+   `Get-Process -Name wsl` shows ≥1 process.
+2. **systemd-logind poweroff signal** (the actual WSL2 mechanism): check
+   the in-VM journal for `systemd-logind: The system will power off now!`
+   followed by `Reached target poweroff.target`. If you see this, logind is
+   seeing "no active sessions" and powering off. The holder above (nohup
+   + foreground wsl.exe) is the fix; if you modified `wsl-keepalive.cmd`,
+   re-run `install-keepalive.ps1` to restore the canonical version.
+3. **dmesg poweroff attempts** (the WSL fallback when the in-VM shutdown
+   stalls): `dmesg -T | grep InitTerminateInstanceInternal`. If events appear
+   more often than every ~5 min, the holder is failing to hold — see #1.
+4. **`vmIdleTimeout`** in `.wslconfig`: this is set to a large positive int
+   (`999999999`) because this WSL build does not honor `-1`. If you see
+   `vmIdleTimeout=-1` in the file, change it and run `wsl --shutdown` to
+   force the re-read.
 
 ## Runner systemd units
 

--- a/ops/wsl-runners/install-keepalive.ps1
+++ b/ops/wsl-runners/install-keepalive.ps1
@@ -1,0 +1,109 @@
+<#
+.SYNOPSIS
+    Installs (or reinstalls) the Windows-side WSLKeepAlive scheduled task on
+    host WHITE. Persistent WSL session holder that prevents the
+    systemd-logind poweroff cycle that kills long-running CI jobs.
+
+.DESCRIPTION
+    1. Writes (or overwrites) the launcher .cmd to %USERPROFILE%
+       using the robust version from ops\wsl-runners\wsl-keepalive.cmd
+       (nohup + disown so the inner sleep survives the wsl.exe process
+       being signalled when WSL terminates the instance).
+    2. Removes any existing WSLKeepAlive task (idempotent).
+    3. Registers the WSLKeepAlive scheduled task: AtLogOn trigger,
+       AllowStartIfOnBatteries + DontStopIfGoingOnBatteries + zero
+       execution-time-limit, RestartCount 999 with RestartInterval 1m
+       (the holder will respawn itself if anything ever does kill it).
+    4. Starts the task immediately so the fix takes effect right now.
+    5. Verifies: task is Running, ≥1 wsl.exe process is alive.
+
+.PARAMETER CmdPath
+    Override the launcher .cmd path (default: %USERPROFILE%\wsl-keepalive.cmd).
+
+.PARAMETER RepoRoot
+    Path to the repo root (default: auto-resolved via $PSScriptRoot or PWD).
+    The script copies ops\wsl-runners\wsl-keepalive.cmd from here.
+
+.EXAMPLE
+    # Standard install (run as the user who owns the WSL Ubuntu install):
+    powershell -NoProfile -ExecutionPolicy Bypass -File ops\wsl-runners\install-keepalive.ps1
+
+.EXAMPLE
+    # Verify it stays running:
+    Get-ScheduledTask -TaskName 'WSLKeepAlive'
+    Get-Process -Name wsl
+    # (inside WSL)
+    loginctl list-sessions
+    ps -ef | grep '[s]leep 3600'
+#>
+[CmdletBinding()]
+param(
+    [string]$CmdPath = (Join-Path $env:USERPROFILE 'wsl-keepalive.cmd'),
+    [string]$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Resolve the source cmd from the repo (always copy the canonical version
+# from ops/wsl-runners/, so updates to the repo are reflected on reinstall).
+$Src = Join-Path $RepoRoot 'ops' 'wsl-runners' 'wsl-keepalive.cmd'
+if (-not (Test-Path $Src)) {
+    throw "Source launcher not found: $Src (run this from the repo root or pass -RepoRoot)"
+}
+
+Write-Host "===1. Installing launcher to $CmdPath==="
+Copy-Item -Path $Src -Destination $CmdPath -Force
+Write-Host "Done."
+
+Write-Host "===2. Removing any pre-existing WSLKeepAlive task (idempotent)==="
+$existing = Get-ScheduledTask -TaskName 'WSLKeepAlive' -ErrorAction SilentlyContinue
+if ($existing) {
+    Write-Host "Existing task (State=$($existing.State)) — removing for clean re-register."
+    Unregister-ScheduledTask -TaskName 'WSLKeepAlive' -Confirm:$false
+}
+
+Write-Host "===3. Registering WSLKeepAlive task (AtLogOn, durable, auto-restart)==="
+$trigger  = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
+$action   = New-ScheduledTaskAction -Execute $CmdPath
+$settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries `
+    -ExecutionTimeLimit ([TimeSpan]::Zero) `
+    -RestartCount 999 `
+    -RestartInterval (New-TimeSpan -Minutes 1)
+
+Register-ScheduledTask `
+    -TaskName 'WSLKeepAlive' `
+    -Trigger $trigger `
+    -Action $action `
+    -Settings $settings `
+    -Description 'Holds a persistent WSL2 session so systemd-logind never poweroffs the VM (reproducible fix from ops/wsl-runners/).' `
+    -Force | Out-Null
+
+Write-Host "Done."
+
+Write-Host "===4. Starting the task now==="
+Start-ScheduledTask -TaskName 'WSLKeepAlive'
+Start-Sleep -Seconds 3
+
+Write-Host "===5. Verifying==="
+$t = Get-ScheduledTask -TaskName 'WSLKeepAlive'
+$i = $t | Get-ScheduledTaskInfo
+Write-Host ("TaskName : " + $t.TaskName)
+Write-Host ("State    : " + $t.State)
+Write-Host ("Action   : " + $t.Actions[0].Execute)
+Write-Host ("Trigger  : " + $t.Triggers[0].CimClass.CimClassName)
+Write-Host ("LastRC   : " + $i.LastTaskResult)
+
+$wslProcs = @(Get-Process -Name 'wsl' -ErrorAction SilentlyContinue)
+Write-Host ("wsl.exe process count: " + $wslProcs.Count)
+if ($wslProcs.Count -lt 1) {
+    Write-Warning "No wsl.exe processes running — the holder is not holding. Check the task LastRC above."
+}
+
+Write-Host ""
+Write-Host "===Next: verify from inside WSL that the VM stops poweroff-ing==="
+Write-Host "  wsl -d Ubuntu -- bash -lc 'journalctl --since -2min | grep -c InitTerminateInstanceInternal'"
+Write-Host "  (expected: 0 — the in-VM keepalive journal should show no restarts after the task is running)"
+Write-Host ""
+Write-Host "Install complete."

--- a/ops/wsl-runners/wsl-keepalive.cmd
+++ b/ops/wsl-runners/wsl-keepalive.cmd
@@ -1,0 +1,18 @@
+@echo off
+REM WSL2 persistent session holder.
+REM
+REM The naive "wsl.exe -d Ubuntu bash -c 'while true; do sleep 3600; done'"
+REM version is fragile: when WSL terminates the instance (e.g. after the
+REM last wsl.exe session ends, which systemd-logind treats as "idle" and
+REM poweroffs), the wsl.exe process is signalled (STATUS_CONTROL_C_EXIT /
+REM 0xC000013A) and the holder dies. The VM then boots fresh with no
+REM holder, the last transient wsl.exe session ends, and the cycle
+REM repeats every ~1 minute.
+REM
+REM This launcher detaches a nohup sleep INSIDE the Ubuntu instance so it
+REM survives the wsl.exe process exiting, then keeps a foreground wsl.exe
+REM sleep alive too. The detached sleep keeps the VM running; the
+REM foreground sleep keeps a logind session open. Together they hold
+REM the VM continuously even across WSL poweroff/reboot cycles.
+wsl.exe -d Ubuntu -- bash -lc "nohup bash -c 'while true; do sleep 3600; done' >/dev/null 2>&1 & disown; echo keepalive-session-launched"
+wsl.exe -d Ubuntu -- bash -c "while true; do sleep 3600; done"


### PR DESCRIPTION
## What

Commits the files and instructions needed to reproduce the persistent WSL session holder that ended the "WSL runner flake" affecting CI for weeks.

## Files

| File | Status | Purpose |
|---|---|---|
| `ops/wsl-runners/wsl-keepalive.cmd` | modified | Replaces the naive single-line launcher with a robust variant (nohup+disown inside the VM, foreground wsl.exe outside) |
| `ops/wsl-runners/install-keepalive.ps1` | new | Reusable install script — copies the canonical launcher from the repo, registers the task with durable settings, starts + verifies |
| `ops/wsl-runners/README.md` | modified | New install command, "Why the naive version dies" explainer, expanded verify + a Troubleshooting section |

## Why the naive version was insufficient

The previous documented launcher was:
```cmd
wsl.exe -d Ubuntu bash -c "while true; do sleep 3600; done"
```

This is **fragile** on the WSL2 build used here. When WSL terminates the instance (after the last `wsl.exe` session ends, which `systemd-logind` treats as "idle"), the `wsl.exe` process receives `STATUS_CONTROL_C_EXIT` (`0xC000013A`), the bash loop dies, the holder is gone, the VM boots fresh with no holder, the last transient session ends, `systemd-logind` poweroffs again, and the cycle repeats every ~1 minute.

The robust launcher uses `nohup ... & disown` to **detach a persistent sleep inside the Ubuntu instance** (survives the `wsl.exe` process being signalled) and then keeps a **foreground `wsl.exe` sleep** alive too (so `logind` always sees ≥1 active session). Together they hold the VM continuously across WSL poweroff/reboot cycles — verified stable for 30+ min in the original debugging session (was cycling every ~1 min before).

## Reproducing the fix on a fresh host

```powershell
# From the repo root:
powershell -NoProfile -ExecutionPolicy Bypass -File ops\wsl-runners\install-keepalive.ps1
```

The script is idempotent and safe to re-run; it copies the canonical launcher from the repo into `%USERPROFILE%`, re-registers the scheduled task (with `AtLogOn` trigger, zero execution-time-limit, `RestartCount 999` / `RestartInterval 1min`), starts it, and verifies.

## Verification

- The install script verifies: task `State=Running`, `≥1` `wsl.exe` process alive
- The README's verify section now also checks `loginctl list-sessions` + a `sleep 3600` process inside WSL
- The troubleshooting section names the actual signals to look for:
  - `systemd-logind: The system will power off now!` (the WSL2 poweroff trigger)
  - `dmesg` `InitTerminateInstanceInternal` events (WSL fallback when the in-VM shutdown stalls)
  - `vmIdleTimeout=-1` not being honored (use `999999999` instead)

## Out of scope

- No code changes; this is a docs + ops-script only PR.
- Resolves the last `next.md` #3 follow-up.
