### PR TITLE
ci(race): split into breadth + depth jobs (next.md #7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,23 +42,16 @@ jobs:
       - run: bash scripts/ci-go-retry.sh go test ./...
       - run: bash scripts/ci-go-retry.sh go build ./...
 
-  race:
-    # Race detector needs cgo, so it can't run in the default CGO_ENABLED=0
-    # build matrix. We run it on Linux (the self-hosted WSL-Ubuntu runners,
-    # which have native gcc) with cgo enabled to surface concurrent-code
-    # regressions in kernel/bus, kernel/journal, etc.
+  race-breadth:
+    # Race detector (BREADTH pass) needs cgo, so it can't run in the default
+    # CGO_ENABLED=0 build matrix. We run it on Linux (the self-hosted
+    # WSL-Ubuntu runners, which have native gcc) with cgo enabled to surface
+    # concurrent-code regressions across the whole tree.
     #
-    # Two passes, because the threat is two-fold:
-    #   1. BREADTH — one `-race ./...` run catches any obviously-racy access
-    #      across the whole tree.
-    #   2. DEPTH — a single pass is unreliable for SCHEDULE-DEPENDENT races
-    #      (the data race only manifests on an unlucky goroutine interleaving).
-    #      The concurrency fixes this gate exists to protect are exactly that
-    #      kind: the channel-registry boot-window race (VULN-002) and the
-    #      pulse / OAuth context-cancellation paths. So we additionally
-    #      stress-run just those packages with -count, multiplying the number
-    #      of interleavings sampled per push at negligible extra cost.
-    name: race (linux, cgo)
+    # This is the critical gate — a single `-race ./...` run catches any
+    # obviously-racy access. The DEPTH pass (race-depth below) is a separate
+    # job so its failure doesn't mask a breadth-pass green (next.md #7).
+    name: race-breadth (linux, cgo)
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, Linux, X64]
     env:
@@ -70,19 +63,40 @@ jobs:
       - uses: ./.github/actions/setup-go-safe
       - name: Race detector — full tree (breadth)
         run: bash scripts/ci-go-retry.sh go test -race ./...
+
+  race-depth:
+    # Race detector (DEPTH pass). A single breadth pass is unreliable for
+    # SCHEDULE-DEPENDENT races (a data race only manifests on an unlucky
+    # goroutine interleaving). The concurrency fixes this gate exists to
+    # protect are exactly that kind: the channel-registry boot-window race
+    # (VULN-002), the pulse / OAuth context-cancellation paths, etc. So we
+    # stress-run just those packages with -count, multiplying the number of
+    # interleavings sampled per push at negligible extra cost.
+    #
+    # Separate job from race-breadth so a depth-pass kill (often flaky on
+    # contended WSL runners) doesn't mask a breadth-pass green — next.md #7.
+    # Keep this list in sync with the concurrency/context fixes:
+    #   kernel/channel        — VULN-002 registry RWMutex (boot-window race)
+    #   kernel/controlplane   — pulse read-timeout + ctx-aware sleep + oauth ctx
+    #   kernel/chatgptauth    — ExchangeCode ctx cancellation
+    #   kernel/runtime        — WithTrustCeiling clamp / delegation ctx
+    #   kernel/pulse          — engine fan-out / subscription lifecycle
+    #   kernel/governor       — soft budget caps (concurrent recordUsage)
+    #   kernel/bus            — historically race-prone event fan-out
+    #   kernel/journal        — historically race-prone append/read
+    name: race-depth (linux, cgo)
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, Linux, X64]
+    env:
+      CGO_ENABLED: '1'
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-go-safe
       - name: Race detector — concurrency-critical packages (depth, stressed)
-        # Re-run the packages touched by the concurrency/context fixes many
-        # times so a schedule-dependent race has many chances to surface.
         # -count forces real re-execution (not the test cache); these packages
-        # are small, so 20x is cheap. Keep this list in sync with the fixes:
-        #   kernel/channel        — VULN-002 registry RWMutex (boot-window race)
-        #   kernel/controlplane   — pulse read-timeout + ctx-aware sleep + oauth ctx
-        #   kernel/chatgptauth    — ExchangeCode ctx cancellation
-        #   kernel/runtime        — WithTrustCeiling clamp / delegation ctx
-        #   kernel/pulse          — engine fan-out / subscription lifecycle
-        #   kernel/governor       — soft budget caps (concurrent recordUsage)
-        #   kernel/bus            — historically race-prone event fan-out
-        #   kernel/journal        — historically race-prone append/read
+        # are small, so 20x is cheap.
         env:
           RACE_STRESS_COUNT: '20'
         run: |


### PR DESCRIPTION
## What

Splits the single `race (linux, cgo)` job into two independent jobs:

- `race-breadth (linux, cgo)` — the critical gate, runs `go test -race ./...` across the full tree.
- `race-depth (linux, cgo)` — the depth/stress pass: `go test -race -count=20` over the 8 concurrency-critical packages tied to recent context-fix changes (kernel/channel, kernel/controlplane, kernel/chatgptauth, kernel/runtime, kernel/pulse, kernel/governor, kernel/bus, kernel/journal).

## Why

The old single job ran both passes sequentially, so a depth-pass failure (usually transient/flaky on the contended WSL runner) was indistinguishable from a real race in the PR checks view — and could block merges even when the breadth pass was green. With the split, a depth-pass failure now shows red while the breadth-pass green is visible, instead of the whole `race` job being red. Maintainers can merge with a depth fix as a follow-up.

Resolves `next.md` #7.

## Scope

Both jobs still run on `push` to any branch + same-repo PRs, preserving current regression-protection coverage. The benefit is purely a visibility split — no behavior change for green PRs.

## Verification

- YAML parses cleanly (16 total jobs, +1 net)
- `race-breadth` and `race-depth` both have correct `name`, `if`-condition, `runs-on`, and the right single step
- The depth package list is unchanged from the old combined job (kept in sync comment block)

## Out of scope

- The 21-job CI run (run `28759345187`) is still finishing the old `race` job in the background; it'll complete soon and won't affect this PR's CI run (the new PR will dispatch the new split jobs).
- The WSL infra fix + the two webui-e2e timing-tolerance PRs (#494, #495) are independent.
