### PR TITLE
feat/coverage tool plugins

### DIFF
--- a/kernel/configcenter/coverage_supp_test.go
+++ b/kernel/configcenter/coverage_supp_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MIT
+
+package configcenter
+
+import (
+	"testing"
+)
+
+// --- ConfigEntry chaining helpers (AllowAgent / DenyAgent dedup paths) ---
+
+func TestAllowAgent_Dedup(t *testing.T) {
+	e := NewConfigEntry("k", "v").AllowAgent("a1").AllowAgent("a2").AllowAgent("a1")
+	if len(e.AllowedAgents) != 2 {
+		t.Fatalf("AllowAgent should dedup: got %v", e.AllowedAgents)
+	}
+	if e.AllowedAgents[0] != "a1" || e.AllowedAgents[1] != "a2" {
+		t.Fatalf("AllowAgent order wrong: %v", e.AllowedAgents)
+	}
+}
+
+func TestDenyAgent_Dedup(t *testing.T) {
+	e := NewConfigEntry("k", "v").DenyAgent("a1").DenyAgent("a2").DenyAgent("a1")
+	if len(e.ExcludedAgents) != 2 {
+		t.Fatalf("DenyAgent should dedup: got %v", e.ExcludedAgents)
+	}
+	if e.ExcludedAgents[0] != "a1" || e.ExcludedAgents[1] != "a2" {
+		t.Fatalf("DenyAgent order wrong: %v", e.ExcludedAgents)
+	}
+}
+
+// --- Store basic operations ---
+
+func TestStore_Delete(t *testing.T) {
+	s := NewStore()
+	if err := s.Set(NewConfigEntry("k", "v")); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Delete("k"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Get("k"); err == nil {
+		t.Error("Get after Delete should error")
+	}
+	// Delete non-existent key.
+	if err := s.Delete("missing"); err == nil {
+		t.Error("Delete missing should error")
+	}
+}
+
+func TestStore_ListByRating(t *testing.T) {
+	s := NewStore()
+	pub := NewConfigEntry("pub", "x").SetRating(RatingPublic)
+	internal := NewConfigEntry("int", "y").SetRating(RatingInternal)
+	secret := NewConfigEntry("sec", "z").SetRating(RatingSecret)
+	for _, e := range []*ConfigEntry{pub, internal, secret} {
+		if err := s.Set(e); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := s.ListByRating(RatingPublic); len(got) != 1 || got[0].Key != "pub" {
+		t.Fatalf("ListByRating(public) = %d entries, want 1", len(got))
+	}
+	if got := s.ListByRating(RatingSecret); len(got) != 1 || got[0].Key != "sec" {
+		t.Fatalf("ListByRating(secret) = %d entries, want 1", len(got))
+	}
+	// Empty result for unmatched rating.
+	if got := s.ListByRating(RatingRestricted); len(got) != 0 {
+		t.Fatalf("ListByRating(confidential) should be empty, got %d", len(got))
+	}
+}
+
+func TestStore_Search(t *testing.T) {
+	s := NewStore()
+	for _, e := range []*ConfigEntry{
+		NewConfigEntry("api.key", "123").SetRating(RatingInternal).SetTags("api"),
+		NewConfigEntry("db.url", "pg://").SetRating(RatingInternal).SetTags("db"),
+		NewConfigEntry("secret.token", "ghp_xxx").SetRating(RatingSecret).SetTags("auth"),
+	} {
+		if err := s.Set(e); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Search by key prefix — secrets are excluded.
+	if got := s.Search("api", 0); len(got) != 1 || got[0].Key != "api.key" {
+		t.Fatalf("Search('api') = %d entries, want 1", len(got))
+	}
+	// Search with limit.
+	if got := s.Search("", 2); len(got) > 2 {
+		t.Fatalf("Search('', limit=2) returned %d entries", len(got))
+	}
+	// Search by tag.
+	if got := s.Search("db", 0); len(got) != 1 || got[0].Key != "db.url" {
+		t.Fatalf("Search('db') = %d entries, want 1", len(got))
+	}
+}
+
+func TestStore_AuditLog(t *testing.T) {
+	s := NewStore()
+	if got := s.GetAuditLog(0); len(got) != 0 {
+		t.Fatalf("audit log on empty store should be empty, got %d", len(got))
+	}
+	s.AddAuditEntry(&AuditEntry{Key: "k1"})
+	s.AddAuditEntry(&AuditEntry{Key: "k2"})
+	s.AddAuditEntry(&AuditEntry{Key: "k3"})
+	if got := s.GetAuditLog(0); len(got) != 3 {
+		t.Fatalf("GetAuditLog(0) = %d, want 3", len(got))
+	}
+	if got := s.GetAuditLog(2); len(got) != 2 || got[0].Key != "k2" || got[1].Key != "k3" {
+		t.Fatalf("GetAuditLog(2) = %#v, want last 2", got)
+	}
+}

--- a/plugins/channels/chatwebhook/chatwebhook_cov_test.go
+++ b/plugins/channels/chatwebhook/chatwebhook_cov_test.go
@@ -1,0 +1,333 @@
+// SPDX-License-Identifier: MIT
+
+package chatwebhook
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agezt/agezt/kernel/bus"
+	"github.com/agezt/agezt/kernel/channel"
+	"github.com/agezt/agezt/kernel/journal"
+)
+
+func newBus(t *testing.T) *bus.Bus {
+	t.Helper()
+	j, err := journal.Open(t.TempDir(), journal.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := bus.New(j)
+	t.Cleanup(func() { b.Close(); j.Close() })
+	return b
+}
+
+func TestName(t *testing.T) {
+	if got := New(Config{Kind: "Mattermost"}).Name(); got != "mattermost" {
+		t.Fatalf("Name = %q", got)
+	}
+}
+
+func TestNewDefaults(t *testing.T) {
+	c := New(Config{Kind: "mattermost"})
+	if c.path != "/mattermost" || c.client == nil {
+		t.Fatalf("defaults not applied: %+v", c)
+	}
+	c2 := New(Config{Kind: "googlechat", Path: "/gc", HTTPClient: &http.Client{}})
+	if c2.path != "/gc" {
+		t.Fatalf("path override = %q", c2.path)
+	}
+}
+
+func TestStartNoAddrBlocksUntilCancel(t *testing.T) {
+	c := New(Config{Kind: "mattermost"})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- c.Start(ctx) }()
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return")
+	}
+}
+
+func TestStartServesThenShutsDown(t *testing.T) {
+	c := New(Config{Kind: "mattermost", Addr: "127.0.0.1:39501"})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- c.Start(ctx) }()
+	time.Sleep(150 * time.Millisecond)
+	resp, err := http.Post("http://127.0.0.1:39501/mattermost", "application/x-www-form-urlencoded", strings.NewReader("text=hi"))
+	if err == nil {
+		resp.Body.Close()
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Start did not return after cancel")
+	}
+}
+
+func TestHandleInboundMethodNotAllowed(t *testing.T) {
+	c := New(Config{Kind: "mattermost"})
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + "/mattermost")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+}
+
+func TestHandleInboundMattermostTokenMismatch(t *testing.T) {
+	c := New(Config{Kind: "mattermost", Token: "sek"})
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+	form := url.Values{"token": {"wrong"}, "user_name": {"bob"}, "text": {"hi"}}
+	resp, err := http.Post(srv.URL+"/mattermost", "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+}
+
+func TestHandleInboundGoogleChatTokenMismatch(t *testing.T) {
+	c := New(Config{Kind: "googlechat", Token: "sek"})
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+	resp, err := http.Post(srv.URL+"/googlechat?token=wrong", "application/json", strings.NewReader(`{"type":"MESSAGE"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+}
+
+func TestHandleInboundMattermostDispatches(t *testing.T) {
+	var apiSrv *httptest.Server
+	var replyHit bool
+	apiSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		replyHit = true
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer apiSrv.Close()
+
+	done := make(chan struct{}, 1)
+	c := New(Config{
+		Kind:       "mattermost",
+		Token:      "sek",
+		WebhookURL: apiSrv.URL,
+		Allowlist:  channel.NewAllowlist([]string{"bob"}),
+		HTTPClient: apiSrv.Client(),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			done <- struct{}{}
+			return channel.Reply{Text: "pong"}, nil
+		},
+	})
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+	form := url.Values{"token": {"sek"}, "user_name": {"bob"}, "channel_name": {"town-square"}, "text": {"!ping hi"}, "trigger_word": {"!ping"}, "post_id": {"P1"}}
+	resp, err := http.Post(srv.URL+"/mattermost", "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler not invoked")
+	}
+	time.Sleep(150 * time.Millisecond)
+	if !replyHit {
+		t.Fatal("reply not posted to webhook")
+	}
+}
+
+func TestDispatchGuards(t *testing.T) {
+	c := New(Config{Kind: "mattermost"})
+	c.dispatch(context.Background(), inbound{sender: ""})
+	c.dispatch(context.Background(), inbound{sender: "bob", text: "  "})
+	c.seenBefore("dup")
+	c.dispatch(context.Background(), inbound{sender: "bob", text: "hi", id: "dup"})
+}
+
+func TestDispatchNotAllowed(t *testing.T) {
+	var called bool
+	c := New(Config{
+		Kind:      "mattermost",
+		Allowlist: channel.NewAllowlist([]string{"other"}),
+		Bus:       newBus(t),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			called = true
+			return channel.Reply{Text: "x"}, nil
+		},
+	})
+	c.dispatch(context.Background(), inbound{sender: "bob", text: "hi", id: "e1"})
+	if called {
+		t.Fatal("handler must not run for non-allowlisted sender")
+	}
+}
+
+func TestDispatchHandlerErrorSendsApology(t *testing.T) {
+	var sent string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		sent = string(b)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+	c := New(Config{
+		Kind:       "mattermost",
+		WebhookURL: srv.URL,
+		Allowlist:  channel.NewAllowlist([]string{"bob"}),
+		HTTPClient: srv.Client(),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			return channel.Reply{}, io.EOF
+		},
+	})
+	c.dispatch(context.Background(), inbound{sender: "bob", target: "ch", text: "hi", id: "e2"})
+	time.Sleep(100 * time.Millisecond)
+	if !strings.Contains(sent, "sorry") {
+		t.Fatalf("expected apology, got %q", sent)
+	}
+}
+
+func TestDispatchEmptyReplyNoSend(t *testing.T) {
+	c := New(Config{
+		Kind:      "mattermost",
+		Allowlist: channel.NewAllowlist([]string{"bob"}),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			return channel.Reply{Text: ""}, nil
+		},
+	})
+	c.dispatch(context.Background(), inbound{sender: "bob", text: "hi", id: "e3"})
+}
+
+func TestSendEmptyNoop(t *testing.T) {
+	if err := New(Config{Kind: "mattermost"}).Send(context.Background(), channel.Outbound{Text: "  "}); err != nil {
+		t.Fatalf("empty send should no-op, got %v", err)
+	}
+}
+
+func TestSendRequiresWebhook(t *testing.T) {
+	if err := New(Config{Kind: "mattermost"}).Send(context.Background(), channel.Outbound{Text: "hi"}); err == nil {
+		t.Fatal("expected error without webhook URL")
+	}
+}
+
+func TestSendChunksAndPublishes(t *testing.T) {
+	var hits int
+	var lastPayload string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		b, _ := io.ReadAll(r.Body)
+		lastPayload = string(b)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+	long := strings.Repeat("a", chatMaxChars+50)
+	c := New(Config{Kind: "mattermost", WebhookURL: srv.URL, HTTPClient: srv.Client(), Bus: newBus(t)})
+	if err := c.Send(context.Background(), channel.Outbound{ChannelID: "town-square", Text: long}); err != nil {
+		t.Fatal(err)
+	}
+	if hits < 2 {
+		t.Fatalf("expected >=2 chunk posts, got %d", hits)
+	}
+	if !strings.Contains(lastPayload, "town-square") {
+		t.Fatalf("mattermost channel override missing: %q", lastPayload)
+	}
+}
+
+func TestSendNon2xxError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+	c := New(Config{Kind: "googlechat", WebhookURL: srv.URL, HTTPClient: srv.Client()})
+	if err := c.Send(context.Background(), channel.Outbound{Text: "hi"}); err == nil {
+		t.Fatal("expected non-2xx error")
+	}
+}
+
+func TestSendTransportError(t *testing.T) {
+	c := New(Config{Kind: "mattermost", WebhookURL: "http://127.0.0.1:0", HTTPClient: &http.Client{Timeout: 200 * time.Millisecond}})
+	if err := c.Send(context.Background(), channel.Outbound{Text: "hi"}); err == nil {
+		t.Fatal("expected transport error")
+	}
+}
+
+func TestEmitInboundNilBus(t *testing.T) {
+	New(Config{Kind: "mattermost"}).emitInbound(channel.UnifiedMessage{}, "corr", true)
+}
+
+func TestEmitInboundWithBus(t *testing.T) {
+	c := New(Config{Kind: "mattermost", Bus: newBus(t)})
+	c.emitInbound(channel.UnifiedMessage{ChannelID: "ch", Sender: "bob", Text: "hi"}, "corr", true)
+}
+
+func TestSeenBeforeRingEviction(t *testing.T) {
+	c := New(Config{Kind: "mattermost"})
+	for i := 0; i < dedupCapacity+5; i++ {
+		if c.seenBefore("id" + itoa(i)) {
+			t.Fatalf("fresh id%d seen", i)
+		}
+	}
+	if !c.seenBefore("id" + itoa(dedupCapacity+4)) {
+		t.Fatal("recent id should be seen")
+	}
+	if c.seenBefore("id0") {
+		t.Fatal("first id should be evicted")
+	}
+}
+
+func TestParseInboundBothDialects(t *testing.T) {
+	// Mattermost form.
+	m, ok := parseInbound(KindMattermost, []byte("user_name=bob&channel_name=ch&text=hi&post_id=P1"))
+	if !ok || m.sender != "bob" || m.target != "ch" || m.text != "hi" || m.id != "P1" {
+		t.Fatalf("mattermost = %+v ok=%v", m, ok)
+	}
+	// Google Chat MESSAGE event.
+	g, ok := parseInbound(KindGoogleChat, []byte(`{"type":"MESSAGE","message":{"name":"m1","text":"hello","sender":{"displayName":"Al","email":"al@x.com"}},"space":{"name":"spaces/AAA"}}`))
+	if !ok || g.text != "hello" {
+		t.Fatalf("googlechat = %+v ok=%v", g, ok)
+	}
+	// Non-MESSAGE google chat event dropped.
+	if _, ok := parseInbound(KindGoogleChat, []byte(`{"type":"ADDED_TO_SPACE"}`)); ok {
+		t.Fatal("non-MESSAGE event should be dropped")
+	}
+	// Invalid google chat JSON.
+	if _, ok := parseInbound(KindGoogleChat, []byte("not json")); ok {
+		t.Fatal("invalid JSON should be dropped")
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}

--- a/plugins/channels/dingtalk/dingtalk_cov_test.go
+++ b/plugins/channels/dingtalk/dingtalk_cov_test.go
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: MIT
+
+package dingtalk
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agezt/agezt/kernel/bus"
+	"github.com/agezt/agezt/kernel/channel"
+	"github.com/agezt/agezt/kernel/journal"
+)
+
+func newBus(t *testing.T) *bus.Bus {
+	t.Helper()
+	j, err := journal.Open(t.TempDir(), journal.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := bus.New(j)
+	t.Cleanup(func() { b.Close(); j.Close() })
+	return b
+}
+
+func signNow(secret string) (ts, sign string) {
+	ts = strconv.FormatInt(time.Now().UnixMilli(), 10)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(ts + "\n" + secret))
+	sign = base64.StdEncoding.EncodeToString(mac.Sum(nil))
+	return
+}
+
+func TestName(t *testing.T) {
+	if got := New(Config{}).Name(); got != "dingtalk" {
+		t.Fatalf("Name = %q", got)
+	}
+}
+
+func TestNewDefaults(t *testing.T) {
+	c := New(Config{})
+	if c.path != DefaultPath || c.client == nil {
+		t.Fatalf("defaults not applied: %+v", c)
+	}
+	c2 := New(Config{Path: "/dt", HTTPClient: &http.Client{}})
+	if c2.path != "/dt" {
+		t.Fatalf("path override = %q", c2.path)
+	}
+}
+
+func TestStartNoAddrBlocksUntilCancel(t *testing.T) {
+	c := New(Config{})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- c.Start(ctx) }()
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return")
+	}
+}
+
+func TestStartServesThenShutsDown(t *testing.T) {
+	c := New(Config{Addr: "127.0.0.1:39481"})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- c.Start(ctx) }()
+	time.Sleep(150 * time.Millisecond)
+	resp, err := http.Post("http://127.0.0.1:39481"+DefaultPath, "application/json", strings.NewReader(`{}`))
+	if err == nil {
+		resp.Body.Close()
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Start did not return after cancel")
+	}
+}
+
+func TestHandleInboundMethodNotAllowed(t *testing.T) {
+	c := New(Config{})
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + DefaultPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+}
+
+func TestHandleInboundBadSign(t *testing.T) {
+	c := New(Config{Secret: "sek"})
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+DefaultPath, strings.NewReader(`{}`))
+	req.Header.Set("timestamp", strconv.FormatInt(time.Now().UnixMilli(), 10))
+	req.Header.Set("sign", "wrong")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+}
+
+func TestHandleInboundDispatchesAndRepliesViaSessionWebhook(t *testing.T) {
+	secret := "sek"
+	var replyHit bool
+	// The reply session webhook (must be a *.dingtalk.com host to be trusted,
+	// so we can't point it at httptest). Instead assert the handler runs and
+	// the reply is attempted to the configured (trusted) robot webhook.
+	var robotSrv *httptest.Server
+	robotSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		replyHit = true
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer robotSrv.Close()
+
+	done := make(chan struct{}, 1)
+	c := New(Config{
+		Secret:     secret,
+		WebhookURL: robotSrv.URL,
+		Allowlist:  channel.NewAllowlist([]string{"S1"}),
+		HTTPClient: robotSrv.Client(),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			done <- struct{}{}
+			return channel.Reply{Text: "pong"}, nil
+		},
+	})
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+	ts, sign := signNow(secret)
+	// replyURL points to a non-dingtalk host => safeReplyURL rejects it =>
+	// reply falls back to the configured robot webhook.
+	body := `{"msgtype":"text","text":{"content":"hi"},"senderStaffId":"S1","msgId":"M1","sessionWebhook":"https://evil.example/x"}`
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+DefaultPath, strings.NewReader(body))
+	req.Header.Set("timestamp", ts)
+	req.Header.Set("sign", sign)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler not invoked")
+	}
+	time.Sleep(150 * time.Millisecond)
+	if !replyHit {
+		t.Fatal("reply not sent to configured robot webhook fallback")
+	}
+}
+
+func TestDispatchGuards(t *testing.T) {
+	c := New(Config{})
+	c.dispatch(context.Background(), inbound{sender: ""})
+	c.dispatch(context.Background(), inbound{sender: "S1", text: "  "})
+	c.seenBefore("dup")
+	c.dispatch(context.Background(), inbound{sender: "S1", text: "hi", id: "dup"})
+}
+
+func TestDispatchNotAllowed(t *testing.T) {
+	var called bool
+	c := New(Config{
+		Allowlist: channel.NewAllowlist([]string{"other"}),
+		Bus:       newBus(t),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			called = true
+			return channel.Reply{Text: "x"}, nil
+		},
+	})
+	c.dispatch(context.Background(), inbound{sender: "S1", text: "hi", id: "e1"})
+	if called {
+		t.Fatal("handler must not run for non-allowlisted sender")
+	}
+}
+
+func TestDispatchHandlerErrorSendsApology(t *testing.T) {
+	var sent string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		sent = string(b)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+	c := New(Config{
+		WebhookURL: srv.URL,
+		Allowlist:  channel.NewAllowlist([]string{"S1"}),
+		HTTPClient: srv.Client(),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			return channel.Reply{}, io.EOF
+		},
+	})
+	c.dispatch(context.Background(), inbound{sender: "S1", text: "hi", id: "e2"})
+	time.Sleep(100 * time.Millisecond)
+	if !strings.Contains(sent, "sorry") {
+		t.Fatalf("expected apology, got %q", sent)
+	}
+}
+
+func TestDispatchEmptyReplyNoSend(t *testing.T) {
+	c := New(Config{
+		Allowlist: channel.NewAllowlist([]string{"S1"}),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			return channel.Reply{Text: ""}, nil
+		},
+	})
+	c.dispatch(context.Background(), inbound{sender: "S1", text: "hi", id: "e3"})
+}
+
+func TestSendEmptyTextNoop(t *testing.T) {
+	if err := New(Config{}).Send(context.Background(), channel.Outbound{Text: "  "}); err != nil {
+		t.Fatalf("empty text should no-op, got %v", err)
+	}
+}
+
+func TestSendRequiresWebhook(t *testing.T) {
+	if err := New(Config{}).Send(context.Background(), channel.Outbound{Text: "hi"}); err == nil {
+		t.Fatal("expected error without webhook URL")
+	}
+}
+
+func TestSendChunksAndPublishes(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+	long := strings.Repeat("a", dtMaxChars+50)
+	c := New(Config{WebhookURL: srv.URL, HTTPClient: srv.Client(), Bus: newBus(t)})
+	if err := c.Send(context.Background(), channel.Outbound{ChannelID: "S1", Text: long}); err != nil {
+		t.Fatal(err)
+	}
+	if hits < 2 {
+		t.Fatalf("expected >=2 chunk posts, got %d", hits)
+	}
+}
+
+func TestSendNon2xxError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+	c := New(Config{WebhookURL: srv.URL, HTTPClient: srv.Client()})
+	if err := c.Send(context.Background(), channel.Outbound{Text: "hi"}); err == nil {
+		t.Fatal("expected non-2xx error")
+	}
+}
+
+func TestPostEmptyURLError(t *testing.T) {
+	c := New(Config{})
+	if err := c.post(context.Background(), "", "hi"); err == nil {
+		t.Fatal("expected error for empty URL")
+	}
+}
+
+func TestPostTransportError(t *testing.T) {
+	c := New(Config{HTTPClient: &http.Client{Timeout: 200 * time.Millisecond}})
+	if err := c.post(context.Background(), "http://127.0.0.1:0/x", "hi"); err == nil {
+		t.Fatal("expected transport error")
+	}
+}
+
+func TestEmitInboundNilBus(t *testing.T) {
+	New(Config{}).emitInbound(channel.UnifiedMessage{}, "corr", true)
+}
+
+func TestEmitInboundWithBus(t *testing.T) {
+	c := New(Config{Bus: newBus(t)})
+	c.emitInbound(channel.UnifiedMessage{ChannelID: "S1", Sender: "S1", Text: "hi"}, "corr", true)
+}
+
+func TestSeenBeforeRingEviction(t *testing.T) {
+	c := New(Config{})
+	for i := 0; i < dedupCapacity+5; i++ {
+		if c.seenBefore("id" + itoa(i)) {
+			t.Fatalf("fresh id%d seen", i)
+		}
+	}
+	if !c.seenBefore("id" + itoa(dedupCapacity+4)) {
+		t.Fatal("recent id should be seen")
+	}
+	if c.seenBefore("id0") {
+		t.Fatal("first id should be evicted")
+	}
+}
+
+func TestValidSignEmptyFields(t *testing.T) {
+	if validSign("s", "", "sign") {
+		t.Fatal("empty timestamp accepted")
+	}
+	if validSign("s", "123", "") {
+		t.Fatal("empty sign accepted")
+	}
+	if validSign("s", "not-a-number", "sign") {
+		t.Fatal("non-numeric timestamp accepted")
+	}
+}
+
+func TestParseInboundDrops(t *testing.T) {
+	// Non-text message type is dropped.
+	if _, ok := parseInbound([]byte(`{"msgtype":"image"}`)); ok {
+		t.Fatal("image msgtype should be dropped")
+	}
+	// Invalid JSON.
+	if _, ok := parseInbound([]byte("not json")); ok {
+		t.Fatal("invalid JSON should return ok=false")
+	}
+	// Fallback to senderNick when staff id is empty.
+	m, ok := parseInbound([]byte(`{"text":{"content":"hi"},"senderNick":"Bob","msgId":"M"}`))
+	if !ok || m.sender != "Bob" {
+		t.Fatalf("nick fallback = %+v ok=%v", m, ok)
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}

--- a/plugins/channels/email/inbound_cov_test.go
+++ b/plugins/channels/email/inbound_cov_test.go
@@ -1,0 +1,329 @@
+// SPDX-License-Identifier: MIT
+
+package email
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"net/smtp"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/agezt/agezt/kernel/bus"
+	"github.com/agezt/agezt/kernel/channel"
+	"github.com/agezt/agezt/kernel/journal"
+)
+
+func newBus(t *testing.T) *bus.Bus {
+	t.Helper()
+	j, err := journal.Open(t.TempDir(), journal.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := bus.New(j)
+	t.Cleanup(func() { b.Close(); j.Close() })
+	return b
+}
+
+// pop3Server is a tiny fake POP3 server: greeting, USER/PASS, UIDL, RETR.
+type pop3Server struct {
+	ln       net.Listener
+	mu       sync.Mutex
+	messages map[string]string // uidl -> raw RFC5322 message
+	order    []string          // uidl order (msgnum = index+1)
+}
+
+func newPOP3(t *testing.T, messages map[string]string, order []string) *pop3Server {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := &pop3Server{ln: ln, messages: messages, order: order}
+	t.Cleanup(func() { ln.Close() })
+	go s.acceptLoop()
+	return s
+}
+
+func (s *pop3Server) addr() string { return s.ln.Addr().String() }
+
+func (s *pop3Server) acceptLoop() {
+	for {
+		conn, err := s.ln.Accept()
+		if err != nil {
+			return
+		}
+		go s.handle(conn)
+	}
+}
+
+func (s *pop3Server) handle(conn net.Conn) {
+	defer conn.Close()
+	r := bufio.NewReader(conn)
+	w := bufio.NewWriter(conn)
+	writeLine := func(str string) { w.WriteString(str + "\r\n"); w.Flush() }
+	writeLine("+OK POP3 ready")
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			return
+		}
+		cmd := strings.TrimRight(line, "\r\n")
+		switch {
+		case strings.HasPrefix(cmd, "USER"), strings.HasPrefix(cmd, "PASS"):
+			writeLine("+OK")
+		case cmd == "UIDL":
+			writeLine("+OK")
+			s.mu.Lock()
+			for i, uidl := range s.order {
+				writeLine(itoa(i+1) + " " + uidl)
+			}
+			s.mu.Unlock()
+			writeLine(".")
+		case strings.HasPrefix(cmd, "RETR "):
+			numStr := strings.TrimSpace(strings.TrimPrefix(cmd, "RETR "))
+			idx := atoiSafe(numStr) - 1
+			s.mu.Lock()
+			var raw string
+			if idx >= 0 && idx < len(s.order) {
+				raw = s.messages[s.order[idx]]
+			}
+			s.mu.Unlock()
+			writeLine("+OK")
+			// Dot-stuff and dot-terminate.
+			for _, ln := range strings.Split(raw, "\n") {
+				ln = strings.TrimRight(ln, "\r")
+				if strings.HasPrefix(ln, ".") {
+					ln = "." + ln
+				}
+				writeLine(ln)
+			}
+			writeLine(".")
+		case cmd == "QUIT":
+			writeLine("+OK bye")
+			return
+		default:
+			writeLine("+OK")
+		}
+	}
+}
+
+func atoiSafe(s string) int { return atoi(s) }
+
+func atoi(s string) int {
+	n := 0
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return -1
+		}
+		n = n*10 + int(r-'0')
+	}
+	return n
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+const sampleMail = "From: alice@example.com\r\n" +
+	"Subject: Hello\r\n" +
+	"Message-ID: <m1@example.com>\r\n" +
+	"Content-Type: text/plain; charset=UTF-8\r\n" +
+	"\r\n" +
+	"this is the body\r\n"
+
+func TestName(t *testing.T) {
+	if got := New(Config{}).Name(); got != "email" {
+		t.Fatalf("Name = %q", got)
+	}
+}
+
+func TestStartOutboundOnlyBlocks(t *testing.T) {
+	// No inbox configured => Start blocks until ctx cancel.
+	c := New(Config{Addr: "smtp.test:25", From: "a@b.com"})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- c.Start(ctx) }()
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return")
+	}
+}
+
+func TestStartInboundPOP3PollsAndDispatches(t *testing.T) {
+	// Prime the mailbox with a message that arrives *after* priming: prime()
+	// records existing UIDLs so only new mail is delivered. We add a fresh
+	// message keyed by a UIDL not present at prime time by starting empty then
+	// injecting. Simpler: start with one message and assert the FIRST poll
+	// after prime does NOT deliver it (it's backlog), then add a new one.
+	srv := newPOP3(t, map[string]string{"U1": sampleMail}, []string{"U1"})
+
+	got := make(chan channel.UnifiedMessage, 4)
+	var sendMu sync.Mutex
+	var sends int
+	c := New(Config{
+		Addr:          "smtp.test:25",
+		From:          "bot@example.com",
+		Allowlist:     channel.NewAllowlist([]string{"alice@example.com"}),
+		InboxAddr:     srv.addr(),
+		InboxProtocol: "pop3",
+		InboxTLS:      "none",
+		InboxUsername: "u",
+		InboxPassword: "p",
+		PollSecs:      1,
+		Send: func(addr string, _ smtp.Auth, from string, to []string, msg []byte) error {
+			sendMu.Lock()
+			sends++
+			sendMu.Unlock()
+			return nil
+		},
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			got <- m
+			return channel.Reply{Text: "reply"}, nil
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { _ = c.Start(ctx) }()
+	// Give prime() a moment, then add a NEW message that should be delivered.
+	time.Sleep(300 * time.Millisecond)
+	srv.mu.Lock()
+	srv.messages["U2"] = strings.Replace(sampleMail, "<m1@example.com>", "<m2@example.com>", 1)
+	srv.order = append(srv.order, "U2")
+	srv.mu.Unlock()
+
+	select {
+	case m := <-got:
+		if m.Sender != "alice@example.com" || !strings.Contains(m.Text, "Hello") {
+			t.Fatalf("dispatched message = %+v", m)
+		}
+	case <-time.After(4 * time.Second):
+		t.Fatal("no inbound message dispatched")
+	}
+	cancel()
+	time.Sleep(200 * time.Millisecond)
+	sendMu.Lock()
+	defer sendMu.Unlock()
+	if sends == 0 {
+		t.Fatal("reply was not sent over SMTP")
+	}
+}
+
+func TestPopUIDLsAndPollErrorOnDialFailure(t *testing.T) {
+	// Dial a closed port => dialPOP3 fails => popUIDLs + pollPOP3 return errors.
+	c := New(Config{
+		InboxAddr:     "127.0.0.1:1",
+		InboxProtocol: "pop3",
+		InboxTLS:      "none",
+	})
+	if _, err := c.popUIDLs(context.Background()); err == nil {
+		t.Fatal("expected dial error from popUIDLs")
+	}
+	if _, err := c.pollPOP3(context.Background()); err == nil {
+		t.Fatal("expected dial error from pollPOP3")
+	}
+}
+
+func TestDialPOP3AndUIDLs(t *testing.T) {
+	srv := newPOP3(t, map[string]string{"A": sampleMail}, []string{"A"})
+	c := New(Config{
+		InboxAddr:     srv.addr(),
+		InboxProtocol: "pop3",
+		InboxTLS:      "none",
+		InboxUsername: "u",
+		InboxPassword: "p",
+	})
+	uidls, err := c.popUIDLs(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(uidls) != 1 || uidls[0] != "A" {
+		t.Fatalf("uidls = %v", uidls)
+	}
+}
+
+func TestPollIMAPDialFailure(t *testing.T) {
+	// Dial a closed port with each TLS mode => dialIMAP + pollIMAP error out.
+	for _, mode := range []string{"none", "starttls", "tls"} {
+		c := New(Config{
+			InboxAddr:     "127.0.0.1:1",
+			InboxProtocol: "imap",
+			InboxTLS:      mode,
+		})
+		if _, err := c.pollIMAP(context.Background()); err == nil {
+			t.Fatalf("mode %q: expected dial error from pollIMAP", mode)
+		}
+		if _, err := c.dialIMAP(); err == nil {
+			t.Fatalf("mode %q: expected dial error from dialIMAP", mode)
+		}
+	}
+}
+
+func TestDispatchInboundGuards(t *testing.T) {
+	c := New(Config{})
+	// Empty sender.
+	c.dispatchInbound(context.Background(), inboundMail{from: ""})
+	// Empty subject + body.
+	c.dispatchInbound(context.Background(), inboundMail{from: "a@b.com"})
+	// Dedup on message-id.
+	c.seenBefore("mid:X")
+	c.dispatchInbound(context.Background(), inboundMail{from: "a@b.com", body: "hi", messageID: "X"})
+}
+
+func TestEmitOutboundNilBus(t *testing.T) {
+	New(Config{}).emitOutbound(channel.Outbound{ChannelID: "a@b.com", Text: "hi"})
+}
+
+func TestEmitOutboundWithBus(t *testing.T) {
+	c := New(Config{Bus: newBus(t)})
+	c.emitOutbound(channel.Outbound{ChannelID: "a@b.com", Text: "hi"})
+}
+
+func TestEmitInboundWithBus(t *testing.T) {
+	c := New(Config{Bus: newBus(t)})
+	c.emitInbound(channel.UnifiedMessage{ChannelID: "a@b.com", Sender: "a@b.com", Text: "hi"}, "corr", true)
+}
+
+func TestSeenBeforeRingEviction(t *testing.T) {
+	c := New(Config{})
+	// dedupCap is the ring bound.
+	for i := 0; i < dedupCap+5; i++ {
+		if c.seenBefore("id" + itoa(i)) {
+			t.Fatalf("fresh id%d seen", i)
+		}
+	}
+	if !c.seenBefore("id" + itoa(dedupCap+4)) {
+		t.Fatal("recent id should be seen")
+	}
+	if c.seenBefore("id0") {
+		t.Fatal("first id should be evicted")
+	}
+}
+
+func TestParseMailMultipartAndInvalid(t *testing.T) {
+	// Invalid message.
+	if _, ok := parseMail([]byte("garbage without headers")); ok {
+		t.Fatal("invalid mail should return ok=false")
+	}
+	// Simple text message parses.
+	m, ok := parseMail([]byte(sampleMail))
+	if !ok || m.from != "alice@example.com" || m.subject != "Hello" || !strings.Contains(m.body, "body") {
+		t.Fatalf("parseMail = %+v ok=%v", m, ok)
+	}
+}

--- a/plugins/channels/feishu/feishu_cov_test.go
+++ b/plugins/channels/feishu/feishu_cov_test.go
@@ -1,0 +1,580 @@
+// SPDX-License-Identifier: MIT
+
+package feishu
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agezt/agezt/kernel/bus"
+	"github.com/agezt/agezt/kernel/channel"
+	"github.com/agezt/agezt/kernel/journal"
+)
+
+func newBus(t *testing.T) *bus.Bus {
+	t.Helper()
+	j, err := journal.Open(t.TempDir(), journal.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := bus.New(j)
+	t.Cleanup(func() { b.Close(); j.Close() })
+	return b
+}
+
+func TestName(t *testing.T) {
+	if got := New(Config{}).Name(); got != "feishu" {
+		t.Fatalf("Name = %q, want feishu", got)
+	}
+}
+
+func TestNewDefaults(t *testing.T) {
+	// Empty config: default path, default API base, default client.
+	c := New(Config{})
+	if c.path != DefaultPath {
+		t.Fatalf("path = %q, want %q", c.path, DefaultPath)
+	}
+	if c.apiBase != defaultAPIBase {
+		t.Fatalf("apiBase = %q, want %q", c.apiBase, defaultAPIBase)
+	}
+	if c.client == nil {
+		t.Fatal("client should be defaulted")
+	}
+	// Explicit overrides retained; trailing slash trimmed.
+	c2 := New(Config{Path: "/custom", APIBase: "https://api.example.com/", HTTPClient: &http.Client{}})
+	if c2.path != "/custom" {
+		t.Fatalf("path = %q, want /custom", c2.path)
+	}
+	if c2.apiBase != "https://api.example.com" {
+		t.Fatalf("apiBase = %q, want trimmed", c2.apiBase)
+	}
+}
+
+func TestStartNoAddrBlocksUntilCancel(t *testing.T) {
+	c := New(Config{}) // no Addr => blocks until ctx.Done
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- c.Start(ctx) }()
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start returned %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return after cancel")
+	}
+}
+
+func TestStartServesInboundThenShutsDown(t *testing.T) {
+	c := New(Config{Addr: "127.0.0.1:0"})
+	// Addr with :0 asks the OS for a port; ListenAndServe uses c.cfg.Addr
+	// literally, so use a fixed loopback port unlikely to collide.
+	c = New(Config{Addr: "127.0.0.1:39457"})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- c.Start(ctx) }()
+	// Give the server a moment to bind.
+	time.Sleep(150 * time.Millisecond)
+	// Hit the inbound endpoint to prove it is serving.
+	resp, err := http.Post("http://127.0.0.1:39457"+DefaultPath, "application/json",
+		strings.NewReader(`{"challenge":"x","token":"","type":"url_verification"}`))
+	if err == nil {
+		resp.Body.Close()
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Start did not return after cancel")
+	}
+}
+
+func TestHandlerServesRoute(t *testing.T) {
+	c := New(Config{})
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+	resp, err := http.Post(srv.URL+DefaultPath, "application/json",
+		strings.NewReader(`{"challenge":"chal","token":"","type":"url_verification"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var out map[string]string
+	_ = json.NewDecoder(resp.Body).Decode(&out)
+	if out["challenge"] != "chal" {
+		t.Fatalf("challenge echo = %q", out["challenge"])
+	}
+}
+
+func TestHandleInboundMethodNotAllowed(t *testing.T) {
+	c := New(Config{})
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + DefaultPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", resp.StatusCode)
+	}
+}
+
+func TestHandleInboundURLVerificationTokenMismatch(t *testing.T) {
+	c := New(Config{VerifyToken: "secret"})
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+	resp, err := http.Post(srv.URL+DefaultPath, "application/json",
+		strings.NewReader(`{"challenge":"chal","token":"wrong","type":"url_verification"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+}
+
+func TestHandleInboundEventTokenMismatch(t *testing.T) {
+	c := New(Config{VerifyToken: "secret"})
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+	body := `{"header":{"token":"nope","event_type":"im.message.receive_v1"},"event":{"sender":{"sender_id":{"open_id":"ou_1"}},"message":{"message_id":"m1","chat_id":"oc_1","message_type":"text","content":"{\"text\":\"hi\"}"}}}`
+	resp, err := http.Post(srv.URL+DefaultPath, "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+}
+
+func TestHandleInboundDispatchesEvent(t *testing.T) {
+	var handled bool
+	var apiSrv *httptest.Server
+	apiSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "tenant_access_token") {
+			_ = json.NewEncoder(w).Encode(map[string]any{"code": 0, "tenant_access_token": "T", "expire": 7200})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"code": 0})
+	}))
+	defer apiSrv.Close()
+
+	done := make(chan struct{}, 1)
+	c := New(Config{
+		Allowlist: channel.NewAllowlist([]string{"ou_1"}),
+		APIBase:   apiSrv.URL,
+		HTTPClient: apiSrv.Client(),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			handled = true
+			done <- struct{}{}
+			return channel.Reply{Text: "pong"}, nil
+		},
+	})
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+	body := `{"header":{"event_id":"E1","event_type":"im.message.receive_v1"},"event":{"sender":{"sender_id":{"open_id":"ou_1"}},"message":{"message_id":"m1","chat_id":"oc_1","message_type":"text","content":"{\"text\":\"hi\"}"}}}`
+	resp, err := http.Post(srv.URL+DefaultPath, "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+	}
+	if !handled {
+		t.Fatal("handler was not invoked for allowlisted inbound")
+	}
+}
+
+func TestHandleInboundBadBody(t *testing.T) {
+	c := New(Config{})
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+	// A non-JSON body that isn't url_verification nor a valid event just
+	// yields 200 with no dispatch (parseEvent returns ok=false).
+	resp, err := http.Post(srv.URL+DefaultPath, "application/json", strings.NewReader(`not json`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestDispatchSkipsEmptyAndDuplicate(t *testing.T) {
+	c := New(Config{})
+	// Empty sender: no-op, no panic.
+	c.dispatch(context.Background(), inbound{sender: "", text: "hi"})
+	// Empty text and no fileKey: no-op.
+	c.dispatch(context.Background(), inbound{sender: "ou_1", text: "  "})
+	// Seen-before dedup: mark id, then dispatch with same id should early-return.
+	c.seenBefore("dup1")
+	c.dispatch(context.Background(), inbound{sender: "ou_1", text: "hi", id: "dup1"})
+}
+
+func TestDispatchNotAllowedEmitsButNoReply(t *testing.T) {
+	var called bool
+	c := New(Config{
+		Allowlist: channel.NewAllowlist([]string{"someoneelse"}),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			called = true
+			return channel.Reply{Text: "x"}, nil
+		},
+	})
+	c.dispatch(context.Background(), inbound{sender: "ou_1", chatID: "oc_1", text: "hi", id: "e1"})
+	if called {
+		t.Fatal("handler must not run for non-allowlisted sender")
+	}
+}
+
+func TestDispatchHandlerErrorProducesApology(t *testing.T) {
+	var apiSrv *httptest.Server
+	var sentText string
+	apiSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "tenant_access_token") {
+			_ = json.NewEncoder(w).Encode(map[string]any{"code": 0, "tenant_access_token": "T", "expire": 7200})
+			return
+		}
+		b, _ := io.ReadAll(r.Body)
+		var p map[string]any
+		_ = json.Unmarshal(b, &p)
+		if s, ok := p["content"].(string); ok {
+			sentText = s
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"code": 0})
+	}))
+	defer apiSrv.Close()
+	c := New(Config{
+		Allowlist:  channel.NewAllowlist([]string{"ou_1"}),
+		APIBase:    apiSrv.URL,
+		HTTPClient: apiSrv.Client(),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			return channel.Reply{}, io.EOF
+		},
+	})
+	c.dispatch(context.Background(), inbound{sender: "ou_1", chatID: "oc_1", text: "hi", id: "e2"})
+	if !strings.Contains(sentText, "sorry") {
+		t.Fatalf("expected apology sent, got %q", sentText)
+	}
+}
+
+func TestDispatchHandlerEmptyReplyNoSend(t *testing.T) {
+	c := New(Config{
+		Allowlist: channel.NewAllowlist([]string{"ou_1"}),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			return channel.Reply{Text: ""}, nil
+		},
+	})
+	// No API base needed since empty reply short-circuits before Send.
+	c.dispatch(context.Background(), inbound{sender: "ou_1", chatID: "oc_1", text: "hi", id: "e3"})
+}
+
+func TestDispatchFetchesImageResource(t *testing.T) {
+	var apiSrv *httptest.Server
+	var gotImage bool
+	apiSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "tenant_access_token"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"code": 0, "tenant_access_token": "T", "expire": 7200})
+		case strings.Contains(r.URL.Path, "/resources/"):
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write([]byte("PNGDATA"))
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]any{"code": 0})
+		}
+	}))
+	defer apiSrv.Close()
+	c := New(Config{
+		Allowlist:  channel.NewAllowlist([]string{"ou_1"}),
+		APIBase:    apiSrv.URL,
+		HTTPClient: apiSrv.Client(),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			if len(m.Images) == 1 && strings.HasPrefix(m.Images[0], "data:image/png;base64,") {
+				gotImage = true
+			}
+			return channel.Reply{}, nil
+		},
+	})
+	c.dispatch(context.Background(), inbound{
+		sender: "ou_1", chatID: "oc_1", id: "e4",
+		messageID: "m1", fileKey: "img_k", mediaType: "image",
+	})
+	if !gotImage {
+		t.Fatal("image resource was not attached as data URL")
+	}
+}
+
+func TestDispatchFetchesAudioResource(t *testing.T) {
+	var apiSrv *httptest.Server
+	var gotAudio bool
+	apiSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "tenant_access_token"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"code": 0, "tenant_access_token": "T", "expire": 7200})
+		case strings.Contains(r.URL.Path, "/resources/"):
+			// No Content-Type => defaults to audio/opus.
+			_, _ = w.Write([]byte("OPUSDATA"))
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]any{"code": 0})
+		}
+	}))
+	defer apiSrv.Close()
+	c := New(Config{
+		Allowlist:  channel.NewAllowlist([]string{"ou_1"}),
+		APIBase:    apiSrv.URL,
+		HTTPClient: apiSrv.Client(),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			// The audio clip is routed to Audio (not Images) purely on mediaType.
+			if len(m.Audio) == 1 && strings.HasPrefix(m.Audio[0], "data:") && len(m.Images) == 0 {
+				gotAudio = true
+			}
+			return channel.Reply{}, nil
+		},
+	})
+	c.dispatch(context.Background(), inbound{
+		sender: "ou_1", chatID: "oc_1", id: "e5",
+		messageID: "m2", fileKey: "file_k", mediaType: "audio",
+	})
+	if !gotAudio {
+		t.Fatal("audio resource was not attached as data URL")
+	}
+}
+
+func TestFetchResourceGuards(t *testing.T) {
+	c := New(Config{})
+	if got := c.fetchResource(context.Background(), "", "k", "image"); got != "" {
+		t.Fatalf("empty messageID => %q, want empty", got)
+	}
+	if got := c.fetchResource(context.Background(), "m", "", "image"); got != "" {
+		t.Fatalf("empty fileKey => %q, want empty", got)
+	}
+}
+
+func TestFetchResourceTokenFailure(t *testing.T) {
+	// Point at a server that fails the token fetch (code != 0, empty token).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"code": 99})
+	}))
+	defer srv.Close()
+	c := New(Config{APIBase: srv.URL, HTTPClient: srv.Client()})
+	if got := c.fetchResource(context.Background(), "m", "k", "image"); got != "" {
+		t.Fatalf("token failure => %q, want empty", got)
+	}
+}
+
+func TestFetchResourceNon2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "tenant_access_token"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"code": 0, "tenant_access_token": "T", "expire": 7200})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	c := New(Config{APIBase: srv.URL, HTTPClient: srv.Client()})
+	if got := c.fetchResource(context.Background(), "m", "k", "file"); got != "" {
+		t.Fatalf("non-2xx => %q, want empty", got)
+	}
+}
+
+func TestFetchResourceEmptyBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "tenant_access_token"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"code": 0, "tenant_access_token": "T", "expire": 7200})
+		default:
+			// Empty 200 body => len(data)==0 => "".
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+	c := New(Config{APIBase: srv.URL, HTTPClient: srv.Client()})
+	if got := c.fetchResource(context.Background(), "m", "k", "file"); got != "" {
+		t.Fatalf("empty body => %q, want empty", got)
+	}
+}
+
+func TestSendRequiresTarget(t *testing.T) {
+	c := New(Config{})
+	if err := c.Send(context.Background(), channel.Outbound{Text: "hi"}); err == nil {
+		t.Fatal("expected error when no chat_id available")
+	}
+}
+
+func TestSendEmptyTextNoop(t *testing.T) {
+	c := New(Config{DefaultChat: "oc_default"})
+	if err := c.Send(context.Background(), channel.Outbound{Text: "   "}); err != nil {
+		t.Fatalf("empty text send should be a no-op, got %v", err)
+	}
+}
+
+func TestSendUsesDefaultChatAndTokenError(t *testing.T) {
+	// tenantToken fails (transport error) => Send returns the error.
+	c := New(Config{DefaultChat: "oc_default", APIBase: "http://127.0.0.1:0", HTTPClient: &http.Client{Timeout: 200 * time.Millisecond}})
+	if err := c.Send(context.Background(), channel.Outbound{Text: "hi"}); err == nil {
+		t.Fatal("expected token fetch error")
+	}
+}
+
+func TestTenantTokenErrorPaths(t *testing.T) {
+	// Unmarshalable token response => error.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("<<<not json>>>"))
+	}))
+	defer srv.Close()
+	c := New(Config{APIBase: srv.URL, HTTPClient: srv.Client()})
+	if _, err := c.tenantToken(context.Background()); err == nil {
+		t.Fatal("expected unmarshal error")
+	}
+
+	// Empty token with nonzero code => explicit failure.
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"code": 42})
+	}))
+	defer srv2.Close()
+	c2 := New(Config{APIBase: srv2.URL, HTTPClient: srv2.Client()})
+	if _, err := c2.tenantToken(context.Background()); err == nil {
+		t.Fatal("expected token-failed error")
+	}
+}
+
+func TestTenantTokenDefaultExpiry(t *testing.T) {
+	// expire<=0 => default 7200 branch; token is cached and reused.
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		_ = json.NewEncoder(w).Encode(map[string]any{"code": 0, "tenant_access_token": "T", "expire": 0})
+	}))
+	defer srv.Close()
+	c := New(Config{APIBase: srv.URL, HTTPClient: srv.Client()})
+	tok, err := c.tenantToken(context.Background())
+	if err != nil || tok != "T" {
+		t.Fatalf("tok=%q err=%v", tok, err)
+	}
+	// Cached: no second HTTP hit.
+	if _, err := c.tenantToken(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if hits != 1 {
+		t.Fatalf("token fetched %d times, want 1 (cached)", hits)
+	}
+}
+
+func TestSendPublishesToBusAndChunks(t *testing.T) {
+	var sendHits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "tenant_access_token"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"code": 0, "tenant_access_token": "T", "expire": 7200})
+		case strings.Contains(r.URL.Path, "/im/v1/messages"):
+			sendHits++
+			_ = json.NewEncoder(w).Encode(map[string]any{"code": 0})
+		}
+	}))
+	defer srv.Close()
+	// Long text to force multiple chunks (feishuMaxChars = 4000).
+	long := strings.Repeat("a", feishuMaxChars+50)
+	c := New(Config{APIBase: srv.URL, HTTPClient: srv.Client()})
+	if err := c.Send(context.Background(), channel.Outbound{ChannelID: "oc_1", Text: long}); err != nil {
+		t.Fatal(err)
+	}
+	if sendHits < 2 {
+		t.Fatalf("expected >=2 chunk sends, got %d", sendHits)
+	}
+}
+
+func TestSendOneRequestError(t *testing.T) {
+	// sendOne returns error when the message API is unreachable.
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "tenant_access_token") {
+			_ = json.NewEncoder(w).Encode(map[string]any{"code": 0, "tenant_access_token": "T", "expire": 7200})
+			return
+		}
+		// Close the connection abruptly to trigger a client-side error.
+		hj, ok := w.(http.Hijacker)
+		if ok {
+			conn, _, _ := hj.Hijack()
+			_ = conn.Close()
+			return
+		}
+	}))
+	defer srv.Close()
+	c := New(Config{APIBase: srv.URL, HTTPClient: srv.Client()})
+	if err := c.Send(context.Background(), channel.Outbound{ChannelID: "oc_1", Text: "hi"}); err == nil {
+		t.Fatal("expected sendOne transport error")
+	}
+}
+
+func TestSeenBeforeRingEviction(t *testing.T) {
+	c := New(Config{})
+	// Fill the ring beyond capacity to exercise eviction.
+	for i := 0; i < dedupCapacity+5; i++ {
+		id := "id-" + strings.Repeat("x", 1) + itoa(i)
+		if c.seenBefore(id) {
+			t.Fatalf("fresh id %s reported as seen", id)
+		}
+	}
+	// A recently-added id is still seen.
+	last := "id-x" + itoa(dedupCapacity+4)
+	if !c.seenBefore(last) {
+		t.Fatal("recent id should still be seen")
+	}
+	// The very first id should have been evicted.
+	if c.seenBefore("id-x0") {
+		t.Fatal("first id should have been evicted from the ring")
+	}
+}
+
+func TestEmitInboundNilBus(t *testing.T) {
+	c := New(Config{}) // no Bus => early return, no panic
+	c.emitInbound(channel.UnifiedMessage{}, "corr", true)
+}
+
+func TestEmitInboundWithBus(t *testing.T) {
+	c := New(Config{Bus: newBus(t)})
+	// Exercises the Bus.Publish branch of emitInbound.
+	c.emitInbound(channel.UnifiedMessage{ChannelID: "oc_1", Sender: "ou_1", Text: "hi"}, "corr-1", true)
+}
+
+func TestSendPublishesToBus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "tenant_access_token"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"code": 0, "tenant_access_token": "T", "expire": 7200})
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]any{"code": 0})
+		}
+	}))
+	defer srv.Close()
+	c := New(Config{APIBase: srv.URL, HTTPClient: srv.Client(), Bus: newBus(t)})
+	if err := c.Send(context.Background(), channel.Outbound{ChannelID: "oc_1", Text: "hi"}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// itoa avoids importing strconv just for the ring test.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}

--- a/plugins/channels/imessage/imessage_cov_test.go
+++ b/plugins/channels/imessage/imessage_cov_test.go
@@ -1,0 +1,425 @@
+// SPDX-License-Identifier: MIT
+
+package imessage
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agezt/agezt/kernel/bus"
+	"github.com/agezt/agezt/kernel/channel"
+	"github.com/agezt/agezt/kernel/journal"
+)
+
+func newBus(t *testing.T) *bus.Bus {
+	t.Helper()
+	j, err := journal.Open(t.TempDir(), journal.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := bus.New(j)
+	t.Cleanup(func() { b.Close(); j.Close() })
+	return b
+}
+
+func TestName(t *testing.T) {
+	if got := New(Config{}).Name(); got != "imessage" {
+		t.Fatalf("Name = %q", got)
+	}
+}
+
+func TestStartNoAddrBlocksUntilCancel(t *testing.T) {
+	c := New(Config{})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- c.Start(ctx) }()
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return")
+	}
+}
+
+func TestStartServesThenShutsDown(t *testing.T) {
+	c := New(Config{Addr: "127.0.0.1:39491"})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- c.Start(ctx) }()
+	time.Sleep(150 * time.Millisecond)
+	resp, err := http.Post("http://127.0.0.1:39491"+DefaultPath, "application/json", strings.NewReader(`{}`))
+	if err == nil {
+		resp.Body.Close()
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Start did not return after cancel")
+	}
+}
+
+func TestHandleInboundMethodNotAllowed(t *testing.T) {
+	c := New(Config{})
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + DefaultPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+}
+
+func TestHandleInboundBadSecret(t *testing.T) {
+	c := New(Config{Secret: "sek"})
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+DefaultPath, strings.NewReader(`{}`))
+	req.Header.Set("X-Webhook-Secret", "wrong")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+}
+
+func TestHandleInboundDispatchesAndReplies(t *testing.T) {
+	secret := "sek"
+	var replyHit bool
+	var apiSrv *httptest.Server
+	apiSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/message/text") {
+			replyHit = true
+		}
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer apiSrv.Close()
+
+	done := make(chan struct{}, 1)
+	c := New(Config{
+		Secret:     secret,
+		BaseURL:    apiSrv.URL,
+		Allowlist:  channel.NewAllowlist([]string{"+15551234"}),
+		HTTPClient: apiSrv.Client(),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			done <- struct{}{}
+			return channel.Reply{Text: "pong"}, nil
+		},
+	})
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+	body := `{"type":"new-message","data":{"guid":"MSG1","text":"hi","handle":{"address":"+15551234"},"chats":[{"guid":"iMessage;-;+15551234"}]}}`
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+DefaultPath, strings.NewReader(body))
+	req.Header.Set("X-Webhook-Secret", secret)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler not invoked")
+	}
+	time.Sleep(150 * time.Millisecond)
+	if !replyHit {
+		t.Fatal("reply not sent to BlueBubbles")
+	}
+}
+
+func TestDispatchGuards(t *testing.T) {
+	c := New(Config{})
+	c.dispatch(context.Background(), inbound{}) // no target
+	c.dispatch(context.Background(), inbound{sender: "s", text: "  "})
+	c.seenBefore("dup")
+	c.dispatch(context.Background(), inbound{sender: "s", text: "hi", id: "dup"})
+}
+
+func TestDispatchNotAllowed(t *testing.T) {
+	var called bool
+	c := New(Config{
+		Allowlist: channel.NewAllowlist([]string{"other"}),
+		Bus:       newBus(t),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			called = true
+			return channel.Reply{Text: "x"}, nil
+		},
+	})
+	c.dispatch(context.Background(), inbound{sender: "s", chatGUID: "g", text: "hi", id: "e1"})
+	if called {
+		t.Fatal("handler must not run for non-allowlisted sender")
+	}
+}
+
+func TestDispatchHandlerErrorSendsApology(t *testing.T) {
+	var sent string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		sent = string(b)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+	c := New(Config{
+		BaseURL:    srv.URL,
+		Allowlist:  channel.NewAllowlist([]string{"s"}),
+		HTTPClient: srv.Client(),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			return channel.Reply{}, io.EOF
+		},
+	})
+	c.dispatch(context.Background(), inbound{sender: "s", chatGUID: "iMessage;-;s", text: "hi", id: "e2"})
+	time.Sleep(100 * time.Millisecond)
+	if !strings.Contains(sent, "sorry") {
+		t.Fatalf("expected apology, got %q", sent)
+	}
+}
+
+func TestDispatchEmptyReplyNoSend(t *testing.T) {
+	c := New(Config{
+		Allowlist: channel.NewAllowlist([]string{"s"}),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			return channel.Reply{Text: ""}, nil
+		},
+	})
+	c.dispatch(context.Background(), inbound{sender: "s", chatGUID: "g", text: "hi", id: "e3"})
+}
+
+func TestDispatchFetchesImageAttachment(t *testing.T) {
+	var gotImage bool
+	var apiSrv *httptest.Server
+	apiSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/download") {
+			_, _ = w.Write([]byte("IMGDATA"))
+			return
+		}
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer apiSrv.Close()
+	c := New(Config{
+		BaseURL:    apiSrv.URL,
+		Allowlist:  channel.NewAllowlist([]string{"s"}),
+		HTTPClient: apiSrv.Client(),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			if len(m.Images) == 1 && strings.HasPrefix(m.Images[0], "data:image/png;base64,") {
+				gotImage = true
+			}
+			return channel.Reply{}, nil
+		},
+	})
+	c.dispatch(context.Background(), inbound{
+		sender: "s", chatGUID: "g", id: "e4",
+		attachments: []imAttachment{{guid: "A1", mime: "image/png", name: "p.png"}},
+	})
+	if !gotImage {
+		t.Fatal("image attachment not attached")
+	}
+}
+
+func TestDispatchFetchesAudioAttachment(t *testing.T) {
+	var gotAudio bool
+	var apiSrv *httptest.Server
+	apiSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/download") {
+			_, _ = w.Write([]byte("AUDDATA"))
+			return
+		}
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer apiSrv.Close()
+	c := New(Config{
+		BaseURL:    apiSrv.URL,
+		Allowlist:  channel.NewAllowlist([]string{"s"}),
+		HTTPClient: apiSrv.Client(),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			if len(m.Audio) == 1 && strings.HasPrefix(m.Audio[0], "data:audio/") {
+				gotAudio = true
+			}
+			return channel.Reply{}, nil
+		},
+	})
+	c.dispatch(context.Background(), inbound{
+		sender: "s", chatGUID: "g", id: "e5",
+		attachments: []imAttachment{{guid: "A2", mime: "audio/mp4", name: "a.m4a"}},
+	})
+	if !gotAudio {
+		t.Fatal("audio attachment not attached")
+	}
+}
+
+func TestFetchAttachmentDataNon2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	c := New(Config{BaseURL: srv.URL, HTTPClient: srv.Client()})
+	if got := c.fetchAttachmentData(context.Background(), imAttachment{guid: "A1", mime: "image/png"}); got != "" {
+		t.Fatalf("non-2xx => %q", got)
+	}
+}
+
+func TestFetchAttachmentDataEmptyBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	c := New(Config{BaseURL: srv.URL, HTTPClient: srv.Client()})
+	if got := c.fetchAttachmentData(context.Background(), imAttachment{guid: "A1", mime: "image/png"}); got != "" {
+		t.Fatalf("empty body => %q", got)
+	}
+}
+
+func TestFetchAttachmentDataDefaultMime(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// No content type + empty attachment mime => application/octet-stream.
+		_, _ = w.Write([]byte("DATA"))
+	}))
+	defer srv.Close()
+	c := New(Config{BaseURL: srv.URL, Password: "pw", HTTPClient: srv.Client()})
+	got := c.fetchAttachmentData(context.Background(), imAttachment{guid: "A1"})
+	if !strings.HasPrefix(got, "data:") {
+		t.Fatalf("default-mime data URL not produced: %q", got)
+	}
+}
+
+func TestSendRequiresTarget(t *testing.T) {
+	if err := New(Config{}).Send(context.Background(), channel.Outbound{Text: "hi"}); err == nil {
+		t.Fatal("expected error without a target")
+	}
+}
+
+func TestSendEmptyNoop(t *testing.T) {
+	if err := New(Config{}).Send(context.Background(), channel.Outbound{ChannelID: "g"}); err != nil {
+		t.Fatalf("empty send should no-op, got %v", err)
+	}
+}
+
+func TestSendRequiresBaseURL(t *testing.T) {
+	c := New(Config{})
+	if err := c.Send(context.Background(), channel.Outbound{ChannelID: "g", Text: "hi"}); err == nil {
+		t.Fatal("expected error without BaseURL")
+	}
+}
+
+func TestSendTextAndAttachmentPublishes(t *testing.T) {
+	var textHit, attHit bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/message/text"):
+			textHit = true
+		case strings.Contains(r.URL.Path, "/message/attachment"):
+			attHit = true
+		}
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+	c := New(Config{BaseURL: srv.URL, Password: "pw", HTTPClient: srv.Client(), Bus: newBus(t)})
+	out := channel.Outbound{
+		ChannelID:   "+15551234",
+		Text:        "hi",
+		Attachments: []channel.Attachment{{Filename: "p.png", Data: []byte("PNG"), MIME: "image/png"}},
+	}
+	if err := c.Send(context.Background(), out); err != nil {
+		t.Fatal(err)
+	}
+	if !textHit || !attHit {
+		t.Fatalf("textHit=%v attHit=%v", textHit, attHit)
+	}
+}
+
+func TestSendOneNon2xxError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	c := New(Config{BaseURL: srv.URL, HTTPClient: srv.Client()})
+	if err := c.Send(context.Background(), channel.Outbound{ChannelID: "g", Text: "hi"}); err == nil {
+		t.Fatal("expected non-2xx send error")
+	}
+}
+
+func TestSendAttachmentEmptyDataSkipped(t *testing.T) {
+	c := New(Config{BaseURL: "http://127.0.0.1:0", HTTPClient: &http.Client{Timeout: 200 * time.Millisecond}})
+	// Empty attachment data returns nil without any HTTP call.
+	if err := c.sendAttachment(context.Background(), "g", channel.Attachment{}); err != nil {
+		t.Fatalf("empty attachment should be skipped, got %v", err)
+	}
+}
+
+func TestEmitInboundNilBus(t *testing.T) {
+	New(Config{}).emitInbound(channel.UnifiedMessage{}, "corr", true)
+}
+
+func TestEmitInboundWithBus(t *testing.T) {
+	c := New(Config{Bus: newBus(t)})
+	c.emitInbound(channel.UnifiedMessage{ChannelID: "g", Sender: "s", Text: "hi"}, "corr", true)
+}
+
+func TestSeenBeforeRingEviction(t *testing.T) {
+	c := New(Config{})
+	for i := 0; i < dedupCapacity+5; i++ {
+		if c.seenBefore("id" + itoa(i)) {
+			t.Fatalf("fresh id%d seen", i)
+		}
+	}
+	if !c.seenBefore("id" + itoa(dedupCapacity+4)) {
+		t.Fatal("recent id should be seen")
+	}
+	if c.seenBefore("id0") {
+		t.Fatal("first id should be evicted")
+	}
+}
+
+func TestParseWebhookDrops(t *testing.T) {
+	// Wrong type dropped.
+	if _, ok := parseWebhook([]byte(`{"type":"typing-indicator","data":{"text":"x"}}`)); ok {
+		t.Fatal("non new-message should be dropped")
+	}
+	// isFromMe dropped.
+	if _, ok := parseWebhook([]byte(`{"type":"new-message","data":{"text":"x","isFromMe":true}}`)); ok {
+		t.Fatal("own message should be dropped")
+	}
+	// invalid JSON.
+	if _, ok := parseWebhook([]byte("not json")); ok {
+		t.Fatal("invalid JSON should be dropped")
+	}
+	// attachments with empty guids are skipped.
+	m, ok := parseWebhook([]byte(`{"type":"new-message","data":{"text":"hi","handle":{"address":"s"},"attachments":[{"guid":""},{"guid":"A","mimeType":"image/png"}]}}`))
+	if !ok || len(m.attachments) != 1 || m.attachments[0].guid != "A" {
+		t.Fatalf("attachment filtering = %+v ok=%v", m, ok)
+	}
+}
+
+func TestChatGUIDWrapping(t *testing.T) {
+	if got := chatGUID("iMessage;-;x"); got != "iMessage;-;x" {
+		t.Fatalf("full guid mangled: %q", got)
+	}
+	if got := chatGUID("+15551234"); got != "iMessage;-;+15551234" {
+		t.Fatalf("addr not wrapped: %q", got)
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}

--- a/plugins/channels/irc/irc_cov_test.go
+++ b/plugins/channels/irc/irc_cov_test.go
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: MIT
+
+package irc
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/agezt/agezt/kernel/bus"
+	"github.com/agezt/agezt/kernel/channel"
+	"github.com/agezt/agezt/kernel/journal"
+)
+
+func newBus(t *testing.T) *bus.Bus {
+	t.Helper()
+	j, err := journal.Open(t.TempDir(), journal.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := bus.New(j)
+	t.Cleanup(func() { b.Close(); j.Close() })
+	return b
+}
+
+// ircServer is a minimal fake ircd used to drive the client's session loop.
+type ircServer struct {
+	ln       net.Listener
+	mu       sync.Mutex
+	received []string
+	lineCh   chan string
+}
+
+func newIRCServer(t *testing.T) *ircServer {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := &ircServer{ln: ln, lineCh: make(chan string, 64)}
+	t.Cleanup(func() { ln.Close() })
+	return s
+}
+
+func (s *ircServer) addr() string { return s.ln.Addr().String() }
+
+func (s *ircServer) lines() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.received...)
+}
+
+// serveOne accepts one client, records inbound lines, and lets a script send
+// server->client lines through the returned conn writer.
+func (s *ircServer) serveOne(t *testing.T, script func(conn net.Conn)) {
+	go func() {
+		conn, err := s.ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		go func() {
+			r := bufio.NewReader(conn)
+			for {
+				line, err := r.ReadString('\n')
+				if err != nil {
+					return
+				}
+				trimmed := strings.TrimRight(line, "\r\n")
+				s.mu.Lock()
+				s.received = append(s.received, trimmed)
+				s.mu.Unlock()
+				select {
+				case s.lineCh <- trimmed:
+				default:
+				}
+			}
+		}()
+		if script != nil {
+			script(conn)
+		}
+		// Keep the connection open a little so the client can finish.
+		time.Sleep(300 * time.Millisecond)
+	}()
+}
+
+// waitFor blocks until a received line matching pred appears or timeout.
+func (s *ircServer) waitFor(pred func(string) bool, timeout time.Duration) bool {
+	deadline := time.After(timeout)
+	for {
+		for _, l := range s.lines() {
+			if pred(l) {
+				return true
+			}
+		}
+		select {
+		case <-s.lineCh:
+		case <-deadline:
+			return false
+		}
+	}
+}
+
+func TestSessionRegistersJoinsAndReplies(t *testing.T) {
+	srv := newIRCServer(t)
+	var replied bool
+	handlerDone := make(chan struct{}, 1)
+
+	srv.serveOne(t, func(conn net.Conn) {
+		// Wait for the client to send NICK/USER, then welcome + drive traffic.
+		_, _ = conn.Write([]byte(":srv 001 bot :Welcome\r\n"))
+		_, _ = conn.Write([]byte("PING :srv123\r\n"))
+		// A channel PRIVMSG from an allowlisted room.
+		_, _ = conn.Write([]byte(":alice!a@h PRIVMSG #room :hello bot\r\n"))
+	})
+
+	ch := New(Config{
+		Server:    srv.addr(),
+		Nick:      "bot",
+		Password:  "sekret",
+		Channels:  []string{"#room"},
+		Allowlist: channel.NewAllowlist([]string{"#room"}),
+		Bus:       newBus(t),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			if m.Text == "hello bot" && m.ChannelID == "#room" && m.Sender == "alice" {
+				replied = true
+			}
+			select {
+			case handlerDone <- struct{}{}:
+			default:
+			}
+			return channel.Reply{Text: "hi alice"}, nil
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { _ = ch.Start(ctx) }()
+
+	// Registration lines.
+	if !srv.waitFor(func(l string) bool { return l == "PASS sekret" }, 2*time.Second) {
+		t.Fatal("PASS not sent")
+	}
+	if !srv.waitFor(func(l string) bool { return l == "NICK bot" }, 2*time.Second) {
+		t.Fatal("NICK not sent")
+	}
+	if !srv.waitFor(func(l string) bool { return strings.HasPrefix(l, "USER bot ") }, 2*time.Second) {
+		t.Fatal("USER not sent")
+	}
+	// JOIN after welcome.
+	if !srv.waitFor(func(l string) bool { return l == "JOIN #room" }, 2*time.Second) {
+		t.Fatal("JOIN not sent")
+	}
+	// PONG after PING.
+	if !srv.waitFor(func(l string) bool { return l == "PONG :srv123" }, 2*time.Second) {
+		t.Fatal("PONG not sent")
+	}
+	// The agent reply is delivered as a PRIVMSG back to #room.
+	if !srv.waitFor(func(l string) bool { return l == "PRIVMSG #room :hi alice" }, 2*time.Second) {
+		t.Fatal("reply PRIVMSG not sent")
+	}
+
+	select {
+	case <-handlerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler was not invoked")
+	}
+	if !replied {
+		t.Fatal("handler did not observe expected message")
+	}
+	cancel()
+	time.Sleep(100 * time.Millisecond)
+}
+
+func TestSessionDMRepliesToSender(t *testing.T) {
+	srv := newIRCServer(t)
+	srv.serveOne(t, func(conn net.Conn) {
+		_, _ = conn.Write([]byte(":srv 001 bot :Welcome\r\n"))
+		// A direct message (target is our nick) => reply goes to the sender.
+		_, _ = conn.Write([]byte(":carol!c@h PRIVMSG bot :ping\r\n"))
+	})
+	ch := New(Config{
+		Server:    srv.addr(),
+		Nick:      "bot",
+		Allowlist: channel.NewAllowlist([]string{"carol"}),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			return channel.Reply{Text: "pong"}, nil
+		},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = ch.Start(ctx) }()
+	if !srv.waitFor(func(l string) bool { return l == "PRIVMSG carol :pong" }, 2*time.Second) {
+		t.Fatal("DM reply not routed to sender")
+	}
+}
+
+func TestSessionHandlerErrorSendsApology(t *testing.T) {
+	srv := newIRCServer(t)
+	srv.serveOne(t, func(conn net.Conn) {
+		_, _ = conn.Write([]byte(":srv 001 bot :Welcome\r\n"))
+		_, _ = conn.Write([]byte(":dave!d@h PRIVMSG #room :boom\r\n"))
+	})
+	ch := New(Config{
+		Server:    srv.addr(),
+		Nick:      "bot",
+		Channels:  []string{"#room"},
+		Allowlist: channel.NewAllowlist([]string{"#room"}),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			return channel.Reply{}, context.DeadlineExceeded
+		},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = ch.Start(ctx) }()
+	if !srv.waitFor(func(l string) bool { return strings.Contains(l, "sorry") }, 2*time.Second) {
+		t.Fatal("apology not sent on handler error")
+	}
+}
+
+func TestSessionNotAllowedNoHandler(t *testing.T) {
+	srv := newIRCServer(t)
+	var called bool
+	srv.serveOne(t, func(conn net.Conn) {
+		_, _ = conn.Write([]byte(":srv 001 bot :Welcome\r\n"))
+		_, _ = conn.Write([]byte(":eve!e@h PRIVMSG #other :hi\r\n"))
+	})
+	ch := New(Config{
+		Server:    srv.addr(),
+		Nick:      "bot",
+		Allowlist: channel.NewAllowlist([]string{"#room"}), // #other not allowed
+		Bus:       newBus(t),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			called = true
+			return channel.Reply{Text: "x"}, nil
+		},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = ch.Start(ctx) }()
+	// Give it time to process the (rejected) message.
+	time.Sleep(400 * time.Millisecond)
+	if called {
+		t.Fatal("handler must not run for non-allowlisted target")
+	}
+}
+
+func TestStartReturnsWhenCtxCancelledBeforeDial(t *testing.T) {
+	ch := New(Config{Server: "127.0.0.1:1", Nick: "bot"})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+	done := make(chan error, 1)
+	go func() { done <- ch.Start(ctx) }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return on pre-cancelled ctx")
+	}
+}
+
+func TestStartReconnectsWithBackoff(t *testing.T) {
+	// Dial a closed port so session() errors immediately; Start should retry
+	// (bounded backoff) and then exit cleanly when ctx is cancelled.
+	ch := New(Config{Server: "127.0.0.1:1", Nick: "bot"})
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- ch.Start(ctx) }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start = %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Start did not return after ctx timeout")
+	}
+}
+
+func TestSendWritesWhenConnected(t *testing.T) {
+	srv := newIRCServer(t)
+	srv.serveOne(t, func(conn net.Conn) {
+		_, _ = conn.Write([]byte(":srv 001 bot :Welcome\r\n"))
+		time.Sleep(500 * time.Millisecond)
+	})
+	ch := New(Config{Server: srv.addr(), Nick: "bot", Bus: newBus(t)})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = ch.Start(ctx) }()
+	// Wait until the client is registered (welcome triggers no JOIN here, but
+	// the conn is set once session() starts writing).
+	if !srv.waitFor(func(l string) bool { return l == "NICK bot" }, 2*time.Second) {
+		t.Fatal("client did not register")
+	}
+	// Multi-line send exercises splitLines + writeLine + bus publish.
+	if err := ch.Send(ctx, channel.Outbound{ChannelID: "#room", Text: "line1\nline2"}); err != nil {
+		t.Fatalf("Send = %v", err)
+	}
+	if !srv.waitFor(func(l string) bool { return l == "PRIVMSG #room :line1" }, 2*time.Second) {
+		t.Fatal("line1 not sent")
+	}
+	if !srv.waitFor(func(l string) bool { return l == "PRIVMSG #room :line2" }, 2*time.Second) {
+		t.Fatal("line2 not sent")
+	}
+}
+
+func TestHandlePrivmsgDropsEmpty(t *testing.T) {
+	ch := New(Config{Nick: "bot"})
+	// Malformed params (no space) => splitPrivmsg returns ok=false, no panic.
+	ch.handlePrivmsg(context.Background(), "x!y@z", "nospace")
+	// Empty message text => dropped.
+	ch.handlePrivmsg(context.Background(), "x!y@z", "#room :")
+}
+
+func TestEmitInboundNilBus(t *testing.T) {
+	New(Config{}).emitInbound(channel.UnifiedMessage{}, "corr", true)
+}
+
+func TestParseLinePrefixOnly(t *testing.T) {
+	// A ":prefix" line with no space returns just the prefix.
+	prefix, cmd, params := parseLine(":onlyprefix")
+	if prefix != "onlyprefix" || cmd != "" || params != "" {
+		t.Fatalf("parseLine = %q / %q / %q", prefix, cmd, params)
+	}
+	// A bare command with no params.
+	_, cmd2, params2 := parseLine("QUIT")
+	if cmd2 != "QUIT" || params2 != "" {
+		t.Fatalf("bare cmd = %q / %q", cmd2, params2)
+	}
+}
+
+func TestNickOfNoBang(t *testing.T) {
+	if got := nickOf("serveronly"); got != "serveronly" {
+		t.Fatalf("nickOf = %q", got)
+	}
+}
+
+func TestWriteLineClampsAndNoConn(t *testing.T) {
+	// No connection => writeLine is a no-op (early return), no panic.
+	New(Config{}).writeLine("anything")
+}

--- a/plugins/channels/line/line_cov_test.go
+++ b/plugins/channels/line/line_cov_test.go
@@ -1,0 +1,418 @@
+// SPDX-License-Identifier: MIT
+
+package line
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agezt/agezt/kernel/bus"
+	"github.com/agezt/agezt/kernel/channel"
+	"github.com/agezt/agezt/kernel/journal"
+)
+
+func newBus(t *testing.T) *bus.Bus {
+	t.Helper()
+	j, err := journal.Open(t.TempDir(), journal.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := bus.New(j)
+	t.Cleanup(func() { b.Close(); j.Close() })
+	return b
+}
+
+func sign(secret string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return base64.StdEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func TestName(t *testing.T) {
+	if got := New(Config{}).Name(); got != "line" {
+		t.Fatalf("Name = %q", got)
+	}
+}
+
+func TestNewDefaults(t *testing.T) {
+	c := New(Config{})
+	if c.path != DefaultPath || c.apiBase != defaultAPIBase || c.client == nil {
+		t.Fatalf("defaults not applied: %+v", c)
+	}
+	c2 := New(Config{Path: "/l", APIBase: "https://x/", HTTPClient: &http.Client{}})
+	if c2.path != "/l" || c2.apiBase != "https://x" {
+		t.Fatalf("overrides not applied: %q %q", c2.path, c2.apiBase)
+	}
+}
+
+func TestStartNoAddrBlocksUntilCancel(t *testing.T) {
+	c := New(Config{})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- c.Start(ctx) }()
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return")
+	}
+}
+
+func TestStartServesThenShutsDown(t *testing.T) {
+	c := New(Config{Addr: "127.0.0.1:39471"})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- c.Start(ctx) }()
+	time.Sleep(150 * time.Millisecond)
+	resp, err := http.Post("http://127.0.0.1:39471"+DefaultPath, "application/json", strings.NewReader(`{"events":[]}`))
+	if err == nil {
+		resp.Body.Close()
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Start did not return after cancel")
+	}
+}
+
+func TestHandleInboundMethodNotAllowed(t *testing.T) {
+	c := New(Config{})
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + DefaultPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+}
+
+func TestHandleInboundBadSignature(t *testing.T) {
+	c := New(Config{Secret: "sek"})
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+DefaultPath, strings.NewReader(`{"events":[]}`))
+	req.Header.Set("X-Line-Signature", "wrong")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+}
+
+func TestHandleInboundDispatchesAndReplies(t *testing.T) {
+	var apiSrv *httptest.Server
+	var replyHit bool
+	apiSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/message/reply") {
+			replyHit = true
+		}
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer apiSrv.Close()
+
+	secret := "sek"
+	done := make(chan struct{}, 1)
+	c := New(Config{
+		Secret:     secret,
+		Allowlist:  channel.NewAllowlist([]string{"U1"}),
+		APIBase:    apiSrv.URL,
+		HTTPClient: apiSrv.Client(),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			done <- struct{}{}
+			return channel.Reply{Text: "pong"}, nil
+		},
+	})
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+
+	body := []byte(`{"events":[{"type":"message","replyToken":"R1","source":{"userId":"U1"},"message":{"type":"text","id":"M1","text":"hi"}}]}`)
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+DefaultPath, strings.NewReader(string(body)))
+	req.Header.Set("X-Line-Signature", sign(secret, body))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler not invoked")
+	}
+	// Give the async reply a moment.
+	time.Sleep(150 * time.Millisecond)
+	if !replyHit {
+		t.Fatal("reply-token endpoint was not called")
+	}
+}
+
+func TestDispatchGuards(t *testing.T) {
+	c := New(Config{})
+	c.dispatch(context.Background(), inbound{userID: ""})
+	c.dispatch(context.Background(), inbound{userID: "U1", text: "  "})
+	c.seenBefore("dup")
+	c.dispatch(context.Background(), inbound{userID: "U1", text: "hi", id: "dup"})
+}
+
+func TestDispatchNotAllowed(t *testing.T) {
+	var called bool
+	c := New(Config{
+		Allowlist: channel.NewAllowlist([]string{"other"}),
+		Bus:       newBus(t),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			called = true
+			return channel.Reply{Text: "x"}, nil
+		},
+	})
+	c.dispatch(context.Background(), inbound{userID: "U1", text: "hi", id: "e1"})
+	if called {
+		t.Fatal("handler must not run for non-allowlisted user")
+	}
+}
+
+func TestDispatchHandlerErrorFallsBackToPush(t *testing.T) {
+	var apiSrv *httptest.Server
+	var pushHit bool
+	apiSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/message/push") {
+			pushHit = true
+		}
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer apiSrv.Close()
+	c := New(Config{
+		Allowlist:  channel.NewAllowlist([]string{"U1"}),
+		APIBase:    apiSrv.URL,
+		HTTPClient: apiSrv.Client(),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			return channel.Reply{}, io.EOF
+		},
+	})
+	// No replyToken => reply routes via push (Send).
+	c.dispatch(context.Background(), inbound{userID: "U1", text: "hi", id: "e2"})
+	time.Sleep(100 * time.Millisecond)
+	if !pushHit {
+		t.Fatal("push endpoint not called when replyToken absent")
+	}
+}
+
+func TestDispatchEmptyReplyNoSend(t *testing.T) {
+	c := New(Config{
+		Allowlist: channel.NewAllowlist([]string{"U1"}),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			return channel.Reply{Text: ""}, nil
+		},
+	})
+	c.dispatch(context.Background(), inbound{userID: "U1", text: "hi", id: "e3", replyToken: "R1"})
+}
+
+func TestDispatchFetchesImage(t *testing.T) {
+	var apiSrv *httptest.Server
+	var gotImage bool
+	apiSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/content") {
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write([]byte("PNG"))
+			return
+		}
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer apiSrv.Close()
+	c := New(Config{
+		Allowlist:  channel.NewAllowlist([]string{"U1"}),
+		APIBase:    apiSrv.URL,
+		HTTPClient: apiSrv.Client(),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			if len(m.Images) == 1 && strings.HasPrefix(m.Images[0], "data:image/png;base64,") {
+				gotImage = true
+			}
+			return channel.Reply{}, nil
+		},
+	})
+	c.dispatch(context.Background(), inbound{userID: "U1", id: "M1", mediaType: "image"})
+	if !gotImage {
+		t.Fatal("image content not attached")
+	}
+}
+
+func TestDispatchFetchesAudio(t *testing.T) {
+	var apiSrv *httptest.Server
+	var gotAudio bool
+	apiSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/content") {
+			// No content type => defaults to audio/m4a.
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write([]byte{1, 2, 3})
+			return
+		}
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer apiSrv.Close()
+	c := New(Config{
+		Allowlist:  channel.NewAllowlist([]string{"U1"}),
+		APIBase:    apiSrv.URL,
+		HTTPClient: apiSrv.Client(),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			if len(m.Audio) == 1 && strings.HasPrefix(m.Audio[0], "data:") && len(m.Images) == 0 {
+				gotAudio = true
+			}
+			return channel.Reply{}, nil
+		},
+	})
+	c.dispatch(context.Background(), inbound{userID: "U1", id: "M2", mediaType: "audio"})
+	if !gotAudio {
+		t.Fatal("audio content not attached")
+	}
+}
+
+func TestFetchContentGuards(t *testing.T) {
+	c := New(Config{})
+	if got := c.fetchContent(context.Background(), "", "image"); got != "" {
+		t.Fatalf("empty id => %q", got)
+	}
+}
+
+func TestFetchContentNon2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	c := New(Config{APIBase: srv.URL, HTTPClient: srv.Client()})
+	if got := c.fetchContent(context.Background(), "M1", "image"); got != "" {
+		t.Fatalf("non-2xx => %q", got)
+	}
+}
+
+func TestFetchContentEmptyBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	c := New(Config{APIBase: srv.URL, HTTPClient: srv.Client()})
+	if got := c.fetchContent(context.Background(), "M1", "image"); got != "" {
+		t.Fatalf("empty body => %q", got)
+	}
+}
+
+func TestSendRequiresTarget(t *testing.T) {
+	if err := New(Config{}).Send(context.Background(), channel.Outbound{Text: "hi"}); err == nil {
+		t.Fatal("expected error without target")
+	}
+}
+
+func TestSendEmptyTextNoop(t *testing.T) {
+	if err := New(Config{}).Send(context.Background(), channel.Outbound{ChannelID: "U1", Text: "  "}); err != nil {
+		t.Fatalf("empty text should no-op, got %v", err)
+	}
+}
+
+func TestSendNon2xxError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+	c := New(Config{APIBase: srv.URL, HTTPClient: srv.Client()})
+	if err := c.Send(context.Background(), channel.Outbound{ChannelID: "U1", Text: "hi"}); err == nil {
+		t.Fatal("expected non-2xx error")
+	}
+}
+
+func TestSendPublishesToBus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+	c := New(Config{APIBase: srv.URL, HTTPClient: srv.Client(), Bus: newBus(t)})
+	if err := c.Send(context.Background(), channel.Outbound{ChannelID: "U1", Text: "hi"}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSendTransportError(t *testing.T) {
+	c := New(Config{APIBase: "http://127.0.0.1:0", HTTPClient: &http.Client{Timeout: 200 * time.Millisecond}})
+	if err := c.Send(context.Background(), channel.Outbound{ChannelID: "U1", Text: "hi"}); err == nil {
+		t.Fatal("expected transport error")
+	}
+}
+
+func TestEmitInboundNilBus(t *testing.T) {
+	New(Config{}).emitInbound(channel.UnifiedMessage{}, "corr", true)
+}
+
+func TestEmitInboundWithBus(t *testing.T) {
+	c := New(Config{Bus: newBus(t)})
+	c.emitInbound(channel.UnifiedMessage{ChannelID: "U1", Sender: "U1", Text: "hi"}, "corr", true)
+}
+
+func TestSeenBeforeRingEviction(t *testing.T) {
+	c := New(Config{})
+	for i := 0; i < dedupCapacity+5; i++ {
+		if c.seenBefore("id" + itoa(i)) {
+			t.Fatalf("fresh id%d seen", i)
+		}
+	}
+	if !c.seenBefore("id" + itoa(dedupCapacity+4)) {
+		t.Fatal("recent id should be seen")
+	}
+	if c.seenBefore("id0") {
+		t.Fatal("first id should be evicted")
+	}
+}
+
+func TestParseWebhookMedia(t *testing.T) {
+	img := parseWebhook([]byte(`{"events":[{"type":"message","source":{"userId":"U"},"message":{"type":"image","id":"IMG"}}]}`))
+	if len(img) != 1 || img[0].mediaType != "image" || img[0].id != "IMG" {
+		t.Fatalf("image = %+v", img)
+	}
+	aud := parseWebhook([]byte(`{"events":[{"type":"message","source":{"groupId":"G"},"message":{"type":"audio","id":"AUD"}}]}`))
+	if len(aud) != 1 || aud[0].mediaType != "audio" || aud[0].userID != "G" {
+		t.Fatalf("audio = %+v", aud)
+	}
+	// Invalid JSON => nil.
+	if got := parseWebhook([]byte("not json")); got != nil {
+		t.Fatalf("invalid JSON => %+v", got)
+	}
+}
+
+func TestTextMessagesChunks(t *testing.T) {
+	long := strings.Repeat("a", lineMaxChars+50)
+	msgs := textMessages(long)
+	if len(msgs) < 2 {
+		t.Fatalf("expected chunking, got %d messages", len(msgs))
+	}
+	// json round-trip to ensure shape is valid.
+	if _, err := json.Marshal(msgs); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}

--- a/plugins/channels/wecom/wecom_cov_test.go
+++ b/plugins/channels/wecom/wecom_cov_test.go
@@ -1,0 +1,658 @@
+// SPDX-License-Identifier: MIT
+
+package wecom
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agezt/agezt/kernel/bus"
+	"github.com/agezt/agezt/kernel/channel"
+	"github.com/agezt/agezt/kernel/journal"
+)
+
+func newBus(t *testing.T) *bus.Bus {
+	t.Helper()
+	j, err := journal.Open(t.TempDir(), journal.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := bus.New(j)
+	t.Cleanup(func() { b.Close(); j.Close() })
+	return b
+}
+
+// signedInbound builds a signed, encrypted POST body + query params for a
+// WeCom inbound message, mirroring the WXBizMsgCrypt wire format.
+func signedInbound(t *testing.T, c *Channel, token, inner string) (body string, sig, ts, nonce string) {
+	t.Helper()
+	enc, err := encryptTestPayload(c, inner, make([]byte, 16), "corpid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts, nonce = "1000", "abc"
+	sig = signature(token, ts, nonce, enc)
+	xmlBody, _ := xml.Marshal(struct {
+		XMLName xml.Name `xml:"xml"`
+		Encrypt string   `xml:"Encrypt"`
+	}{Encrypt: enc})
+	return string(xmlBody), sig, ts, nonce
+}
+
+func TestName(t *testing.T) {
+	if got := New(Config{}).Name(); got != "wecom" {
+		t.Fatalf("Name = %q, want wecom", got)
+	}
+}
+
+func TestNewDefaultsAndBadAESKey(t *testing.T) {
+	c := New(Config{})
+	if c.path != DefaultPath || c.apiBase != defaultAPIBase || c.client == nil {
+		t.Fatalf("defaults not applied: %+v", c)
+	}
+	// Invalid base64 AES key leaves aesKey nil (channel stays outbound-only).
+	c2 := New(Config{AESKey: "!!!not-base64!!!"})
+	if c2.aesKey != nil {
+		t.Fatal("bad AES key should leave aesKey nil")
+	}
+	// Overrides retained; trailing slash trimmed.
+	c3 := New(Config{Path: "/wc", APIBase: "https://x.example/", HTTPClient: &http.Client{}})
+	if c3.path != "/wc" || c3.apiBase != "https://x.example" {
+		t.Fatalf("overrides not applied: path=%q base=%q", c3.path, c3.apiBase)
+	}
+}
+
+func TestStartNoAddrBlocksUntilCancel(t *testing.T) {
+	c := New(Config{})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- c.Start(ctx) }()
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return")
+	}
+}
+
+func TestStartServesThenShutsDown(t *testing.T) {
+	c := New(Config{Addr: "127.0.0.1:39461", AESKey: testAESKey(), Token: "tok"})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- c.Start(ctx) }()
+	time.Sleep(150 * time.Millisecond)
+	// A malformed GET (bad signature) still proves the server is up.
+	resp, err := http.Get("http://127.0.0.1:39461" + DefaultPath + "?msg_signature=x&timestamp=1&nonce=n&echostr=e")
+	if err == nil {
+		resp.Body.Close()
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Start did not return after cancel")
+	}
+}
+
+func TestHandlerGetVerification(t *testing.T) {
+	token := "tok"
+	c := New(Config{AESKey: testAESKey(), Token: token})
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+
+	// Build an encrypted echostr and its signature.
+	echo, err := encryptTestPayload(c, "hello-echo", make([]byte, 16), "corpid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts, nonce := "100", "n1"
+	sig := signature(token, ts, nonce, echo)
+	q := url.Values{"msg_signature": {sig}, "timestamp": {ts}, "nonce": {nonce}, "echostr": {echo}}
+	resp, err := http.Get(srv.URL + DefaultPath + "?" + q.Encode())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	if string(b) != "hello-echo" {
+		t.Fatalf("echo = %q, want decrypted plaintext", b)
+	}
+}
+
+func TestHandlerGetBadSignature(t *testing.T) {
+	c := New(Config{AESKey: testAESKey(), Token: "tok"})
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + DefaultPath + "?msg_signature=wrong&timestamp=1&nonce=n&echostr=e")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+}
+
+func TestHandlerGetBadEchostr(t *testing.T) {
+	token := "tok"
+	c := New(Config{AESKey: testAESKey(), Token: token})
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+	// echostr that passes signature but is not valid base64/ciphertext.
+	echo := "not-base64-$$$"
+	ts, nonce := "100", "n1"
+	sig := signature(token, ts, nonce, echo)
+	q := url.Values{"msg_signature": {sig}, "timestamp": {ts}, "nonce": {nonce}, "echostr": {echo}}
+	resp, err := http.Get(srv.URL + DefaultPath + "?" + q.Encode())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestHandlerMethodNotAllowed(t *testing.T) {
+	c := New(Config{AESKey: testAESKey(), Token: "tok"})
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+	req, _ := http.NewRequest(http.MethodDelete, srv.URL+DefaultPath, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", resp.StatusCode)
+	}
+}
+
+func TestHandlerPostBadBody(t *testing.T) {
+	c := New(Config{AESKey: testAESKey(), Token: "tok"})
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+	resp, err := http.Post(srv.URL+DefaultPath, "text/xml", strings.NewReader("not xml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestHandlerPostBadSignature(t *testing.T) {
+	token := "tok"
+	c := New(Config{AESKey: testAESKey(), Token: token})
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+	inner := `<xml><FromUserName>u1</FromUserName><MsgType>text</MsgType><Content>hi</Content><MsgId>1</MsgId></xml>`
+	body, _, ts, nonce := signedInbound(t, c, token, inner)
+	// Send a deliberately wrong signature.
+	q := url.Values{"msg_signature": {"wrong"}, "timestamp": {ts}, "nonce": {nonce}}
+	resp, err := http.Post(srv.URL+DefaultPath+"?"+q.Encode(), "text/xml", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+}
+
+func TestHandlerPostDecryptFailure(t *testing.T) {
+	token := "tok"
+	// Channel WITHOUT an AES key => decrypt fails even with a matching signature.
+	c := New(Config{Token: token})
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+	enc := "c29tZS1lbmNyeXB0ZWQtYmxvYg==" // arbitrary base64
+	xmlBody, _ := xml.Marshal(struct {
+		XMLName xml.Name `xml:"xml"`
+		Encrypt string   `xml:"Encrypt"`
+	}{Encrypt: enc})
+	ts, nonce := "100", "n1"
+	sig := signature(token, ts, nonce, enc)
+	q := url.Values{"msg_signature": {sig}, "timestamp": {ts}, "nonce": {nonce}}
+	resp, err := http.Post(srv.URL+DefaultPath+"?"+q.Encode(), "text/xml", strings.NewReader(string(xmlBody)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestHandlerPostReceiveIDMismatch(t *testing.T) {
+	token := "tok"
+	// CorpID set on the channel, but the encrypted payload carries "corpid"
+	// as its trailing receive_id => mismatch => forbidden.
+	c := New(Config{AESKey: testAESKey(), Token: token, CorpID: "OTHER_CORP"})
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+	inner := `<xml><FromUserName>u1</FromUserName><MsgType>text</MsgType><Content>hi</Content><MsgId>1</MsgId></xml>`
+	body, sig, ts, nonce := signedInbound(t, c, token, inner)
+	q := url.Values{"msg_signature": {sig}, "timestamp": {ts}, "nonce": {nonce}}
+	resp, err := http.Post(srv.URL+DefaultPath+"?"+q.Encode(), "text/xml", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 for receive_id mismatch", resp.StatusCode)
+	}
+}
+
+func TestHandlerPostDispatches(t *testing.T) {
+	token := "tok"
+	var apiSrv *httptest.Server
+	apiSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/cgi-bin/gettoken" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"errcode": 0, "access_token": "T", "expires_in": 7200})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"errcode": 0})
+	}))
+	defer apiSrv.Close()
+
+	done := make(chan struct{}, 1)
+	c := New(Config{
+		AESKey:     testAESKey(),
+		Token:      token,
+		Allowlist:  channel.NewAllowlist([]string{"u1"}),
+		APIBase:    apiSrv.URL,
+		HTTPClient: apiSrv.Client(),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			done <- struct{}{}
+			return channel.Reply{Text: "pong"}, nil
+		},
+	})
+	srv := httptest.NewServer(c.Handler())
+	defer srv.Close()
+	inner := `<xml><FromUserName>u1</FromUserName><MsgType>text</MsgType><Content>hi</Content><MsgId>1</MsgId></xml>`
+	body, sig, ts, nonce := signedInbound(t, c, token, inner)
+	q := url.Values{"msg_signature": {sig}, "timestamp": {ts}, "nonce": {nonce}}
+	resp, err := http.Post(srv.URL+DefaultPath+"?"+q.Encode(), "text/xml", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler was not invoked")
+	}
+}
+
+func TestDispatchGuards(t *testing.T) {
+	c := New(Config{})
+	c.dispatch(context.Background(), inbound{sender: ""})
+	c.dispatch(context.Background(), inbound{sender: "u1", text: "  "})
+	c.seenBefore("dup")
+	c.dispatch(context.Background(), inbound{sender: "u1", text: "hi", id: "dup"})
+}
+
+func TestDispatchNotAllowedNoReply(t *testing.T) {
+	var called bool
+	c := New(Config{
+		Allowlist: channel.NewAllowlist([]string{"other"}),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			called = true
+			return channel.Reply{Text: "x"}, nil
+		},
+	})
+	c.dispatch(context.Background(), inbound{sender: "u1", text: "hi", id: "e1"})
+	if called {
+		t.Fatal("handler must not run for non-allowlisted sender")
+	}
+}
+
+func TestDispatchHandlerErrorSendsApology(t *testing.T) {
+	var apiSrv *httptest.Server
+	var sentBody string
+	apiSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/cgi-bin/gettoken" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"errcode": 0, "access_token": "T", "expires_in": 7200})
+			return
+		}
+		b, _ := io.ReadAll(r.Body)
+		sentBody = string(b)
+		_ = json.NewEncoder(w).Encode(map[string]any{"errcode": 0})
+	}))
+	defer apiSrv.Close()
+	c := New(Config{
+		Allowlist:  channel.NewAllowlist([]string{"u1"}),
+		APIBase:    apiSrv.URL,
+		HTTPClient: apiSrv.Client(),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			return channel.Reply{}, io.EOF
+		},
+	})
+	c.dispatch(context.Background(), inbound{sender: "u1", text: "hi", id: "e2"})
+	if !strings.Contains(sentBody, "sorry") {
+		t.Fatalf("expected apology to be sent, got %q", sentBody)
+	}
+}
+
+func TestDispatchEmptyReplyNoSend(t *testing.T) {
+	c := New(Config{
+		Allowlist: channel.NewAllowlist([]string{"u1"}),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			return channel.Reply{Text: ""}, nil
+		},
+	})
+	c.dispatch(context.Background(), inbound{sender: "u1", text: "hi", id: "e3"})
+}
+
+func TestDispatchFetchesImage(t *testing.T) {
+	var apiSrv *httptest.Server
+	var gotImage bool
+	apiSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/cgi-bin/gettoken":
+			_ = json.NewEncoder(w).Encode(map[string]any{"errcode": 0, "access_token": "T", "expires_in": 7200})
+		case strings.Contains(r.URL.Path, "/media/get"):
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write([]byte("PNGBYTES"))
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]any{"errcode": 0})
+		}
+	}))
+	defer apiSrv.Close()
+	c := New(Config{
+		Allowlist:  channel.NewAllowlist([]string{"u1"}),
+		APIBase:    apiSrv.URL,
+		HTTPClient: apiSrv.Client(),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			if len(m.Images) == 1 && strings.HasPrefix(m.Images[0], "data:image/png;base64,") {
+				gotImage = true
+			}
+			return channel.Reply{}, nil
+		},
+	})
+	c.dispatch(context.Background(), inbound{sender: "u1", id: "e4", mediaID: "MID", mediaType: "image"})
+	if !gotImage {
+		t.Fatal("image media not attached")
+	}
+}
+
+func TestDispatchFetchesAudio(t *testing.T) {
+	var apiSrv *httptest.Server
+	var gotAudio bool
+	apiSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/cgi-bin/gettoken":
+			_ = json.NewEncoder(w).Encode(map[string]any{"errcode": 0, "access_token": "T", "expires_in": 7200})
+		case strings.Contains(r.URL.Path, "/media/get"):
+			// Binary body, no explicit content type (defaults to audio/amr).
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write([]byte{0x00, 0x01, 0x02, 0x03})
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]any{"errcode": 0})
+		}
+	}))
+	defer apiSrv.Close()
+	c := New(Config{
+		Allowlist:  channel.NewAllowlist([]string{"u1"}),
+		APIBase:    apiSrv.URL,
+		HTTPClient: apiSrv.Client(),
+		Handler: func(ctx context.Context, m channel.UnifiedMessage, corr string) (channel.Reply, error) {
+			if len(m.Audio) == 1 && strings.HasPrefix(m.Audio[0], "data:") && len(m.Images) == 0 {
+				gotAudio = true
+			}
+			return channel.Reply{}, nil
+		},
+	})
+	c.dispatch(context.Background(), inbound{sender: "u1", id: "e5", mediaID: "MID", mediaType: "audio"})
+	if !gotAudio {
+		t.Fatal("audio media not attached")
+	}
+}
+
+func TestFetchMediaGuards(t *testing.T) {
+	c := New(Config{})
+	if got := c.fetchMedia(context.Background(), "", "image"); got != "" {
+		t.Fatalf("empty mediaID => %q", got)
+	}
+}
+
+func TestFetchMediaTokenFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"errcode": 40001})
+	}))
+	defer srv.Close()
+	c := New(Config{APIBase: srv.URL, HTTPClient: srv.Client()})
+	if got := c.fetchMedia(context.Background(), "MID", "image"); got != "" {
+		t.Fatalf("token failure => %q", got)
+	}
+}
+
+func TestFetchMediaNon2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/cgi-bin/gettoken" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"errcode": 0, "access_token": "T", "expires_in": 7200})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	c := New(Config{APIBase: srv.URL, HTTPClient: srv.Client()})
+	if got := c.fetchMedia(context.Background(), "MID", "image"); got != "" {
+		t.Fatalf("non-2xx => %q", got)
+	}
+}
+
+func TestFetchMediaRejectsJSONError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/cgi-bin/gettoken" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"errcode": 0, "access_token": "T", "expires_in": 7200})
+			return
+		}
+		// WeCom returns a JSON error body instead of binary on failure.
+		_, _ = w.Write([]byte(`{"errcode":40007,"errmsg":"invalid media_id"}`))
+	}))
+	defer srv.Close()
+	c := New(Config{APIBase: srv.URL, HTTPClient: srv.Client()})
+	if got := c.fetchMedia(context.Background(), "MID", "image"); got != "" {
+		t.Fatalf("JSON error body should be rejected, got %q", got)
+	}
+}
+
+func TestFetchMediaEmptyBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/cgi-bin/gettoken" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"errcode": 0, "access_token": "T", "expires_in": 7200})
+			return
+		}
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	c := New(Config{APIBase: srv.URL, HTTPClient: srv.Client()})
+	if got := c.fetchMedia(context.Background(), "MID", "image"); got != "" {
+		t.Fatalf("empty body => %q", got)
+	}
+}
+
+func TestSendRequiresUser(t *testing.T) {
+	c := New(Config{})
+	if err := c.Send(context.Background(), channel.Outbound{Text: "hi"}); err == nil {
+		t.Fatal("expected error without a user id")
+	}
+}
+
+func TestSendEmptyTextNoop(t *testing.T) {
+	c := New(Config{})
+	if err := c.Send(context.Background(), channel.Outbound{ChannelID: "u1", Text: "  "}); err != nil {
+		t.Fatalf("empty text should be a no-op, got %v", err)
+	}
+}
+
+func TestSendTokenError(t *testing.T) {
+	c := New(Config{APIBase: "http://127.0.0.1:0", HTTPClient: &http.Client{Timeout: 200 * time.Millisecond}})
+	if err := c.Send(context.Background(), channel.Outbound{ChannelID: "u1", Text: "hi"}); err == nil {
+		t.Fatal("expected token error")
+	}
+}
+
+func TestSendChunksAndPublishes(t *testing.T) {
+	var sendHits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/cgi-bin/gettoken" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"errcode": 0, "access_token": "T", "expires_in": 7200})
+			return
+		}
+		sendHits++
+		_ = json.NewEncoder(w).Encode(map[string]any{"errcode": 0})
+	}))
+	defer srv.Close()
+	long := strings.Repeat("a", wecomMaxChars+50)
+	c := New(Config{APIBase: srv.URL, HTTPClient: srv.Client(), Bus: newBus(t)})
+	if err := c.Send(context.Background(), channel.Outbound{ChannelID: "u1", Text: long}); err != nil {
+		t.Fatal(err)
+	}
+	if sendHits < 2 {
+		t.Fatalf("expected >=2 chunk sends, got %d", sendHits)
+	}
+}
+
+func TestSendOneNon2xxError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/cgi-bin/gettoken" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"errcode": 0, "access_token": "T", "expires_in": 7200})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	c := New(Config{APIBase: srv.URL, HTTPClient: srv.Client()})
+	if err := c.Send(context.Background(), channel.Outbound{ChannelID: "u1", Text: "hi"}); err == nil {
+		t.Fatal("expected non-2xx send error")
+	}
+}
+
+func TestAccessTokenErrorPaths(t *testing.T) {
+	// Unmarshal failure.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("<<not json>>"))
+	}))
+	defer srv.Close()
+	c := New(Config{APIBase: srv.URL, HTTPClient: srv.Client()})
+	if _, err := c.accessToken(context.Background()); err == nil {
+		t.Fatal("expected unmarshal error")
+	}
+
+	// Empty token with errcode.
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"errcode": 40013})
+	}))
+	defer srv2.Close()
+	c2 := New(Config{APIBase: srv2.URL, HTTPClient: srv2.Client()})
+	if _, err := c2.accessToken(context.Background()); err == nil {
+		t.Fatal("expected token-failed error")
+	}
+}
+
+func TestAccessTokenCachedWithDefaultExpiry(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		_ = json.NewEncoder(w).Encode(map[string]any{"errcode": 0, "access_token": "T", "expires_in": 0})
+	}))
+	defer srv.Close()
+	c := New(Config{APIBase: srv.URL, HTTPClient: srv.Client()})
+	if tok, err := c.accessToken(context.Background()); err != nil || tok != "T" {
+		t.Fatalf("tok=%q err=%v", tok, err)
+	}
+	if _, err := c.accessToken(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if hits != 1 {
+		t.Fatalf("token fetched %d times, want 1", hits)
+	}
+}
+
+func TestEmitInboundNilBus(t *testing.T) {
+	New(Config{}).emitInbound(channel.UnifiedMessage{}, "corr", true)
+}
+
+func TestEmitInboundWithBus(t *testing.T) {
+	c := New(Config{Bus: newBus(t)})
+	c.emitInbound(channel.UnifiedMessage{ChannelID: "u1", Sender: "u1", Text: "hi"}, "corr", true)
+}
+
+func TestSeenBeforeRingEviction(t *testing.T) {
+	c := New(Config{})
+	for i := 0; i < dedupCapacity+5; i++ {
+		if c.seenBefore("id" + itoa(i)) {
+			t.Fatalf("fresh id id%d seen", i)
+		}
+	}
+	if !c.seenBefore("id" + itoa(dedupCapacity+4)) {
+		t.Fatal("recent id should be seen")
+	}
+	if c.seenBefore("id0") {
+		t.Fatal("first id should have been evicted")
+	}
+}
+
+func TestDecryptGuards(t *testing.T) {
+	// No AES key configured.
+	if _, _, err := New(Config{}).decrypt("anything"); err == nil {
+		t.Fatal("expected AES-not-configured error")
+	}
+	// Bad base64.
+	c := New(Config{AESKey: testAESKey()})
+	if _, _, err := c.decrypt("!!!not-base64!!!"); err == nil {
+		t.Fatal("expected base64 error")
+	}
+	// Ciphertext not a block multiple.
+	if _, _, err := c.decrypt("YWJj"); err == nil { // "abc" => 3 bytes
+		t.Fatal("expected bad-ciphertext-length error")
+	}
+}
+
+func TestPkcs7UnpadGuards(t *testing.T) {
+	if _, err := pkcs7Unpad(nil); err == nil {
+		t.Fatal("empty input should error")
+	}
+	// Pad byte out of range.
+	if _, err := pkcs7Unpad([]byte{0x01, 0xFF}); err == nil {
+		t.Fatal("bad pad should error")
+	}
+	// Valid pad.
+	if out, err := pkcs7Unpad([]byte{0x41, 0x02, 0x02}); err != nil || string(out) != "A" {
+		t.Fatalf("unpad = %q err=%v", out, err)
+	}
+}
+
+func TestParseMessageInvalidXML(t *testing.T) {
+	if _, ok := parseMessage([]byte("<not-closed")); ok {
+		t.Fatal("invalid XML should return ok=false")
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}

--- a/plugins/tools/introspecttool/coverage_supp_test.go
+++ b/plugins/tools/introspecttool/coverage_supp_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+
+package introspecttool
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/agezt/agezt/kernel/cadence"
+	"github.com/agezt/agezt/kernel/standing"
+)
+
+func TestErrResult_Format_OverseerLike(t *testing.T) {
+	r := errResult("not available yet")
+	if !r.IsError {
+		t.Error("errResult should mark IsError")
+	}
+	if !strings.HasPrefix(r.Output, "introspect: ") {
+		t.Errorf("errResult output = %q, want introspect: prefix", r.Output)
+	}
+}
+
+func TestStandingView_TriggerWithEmptySubjectAndSchedule(t *testing.T) {
+	o := standingView(standing.Order{
+		ID: "o1", Name: "trigger-test", Enabled: true,
+		Triggers: []standing.Trigger{
+			{Type: standing.TriggerEvent}, // no Subject
+			{Type: standing.TriggerCron},   // no Schedule
+		},
+		Initiative: standing.Initiative{Mode: standing.InitiativeAsk},
+		Plan:       "react",
+	})
+	trigs := o["triggers"].([]map[string]any)
+	if len(trigs) != 2 {
+		t.Fatalf("triggers = %d, want 2", len(trigs))
+	}
+	// Both should be present without extra fields.
+	if trigs[0]["type"] != string(standing.TriggerEvent) {
+		t.Error("trigger 0 type mismatch")
+	}
+	if trigs[1]["type"] != string(standing.TriggerCron) {
+		t.Error("trigger 1 type mismatch")
+	}
+}
+
+func TestNext_NonInt64ReturnsZero(t *testing.T) {
+	got := next(map[string]any{"next_run_unix": float64(42)})
+	if got != 0 {
+		t.Errorf("next(float64) = %d, want 0", got)
+	}
+}
+
+func TestScheduleView_AssureIntType(t *testing.T) {
+	v := scheduleView(cadence.Entry{
+		ID: "s-assure", Intent: "test", Mode: cadence.ModeOnce,
+		Source: "operator", Enabled: true, NextRunUnix: 1000,
+		Assure: 3,
+	})
+	// Assure is int, not int64 — verify the map carries the right type.
+	if v["assure"] != 3 {
+		t.Errorf("scheduleView assure = %v (type %T), want 3", v["assure"], v["assure"])
+	}
+}

--- a/plugins/tools/overseertool/coverage_more_test.go
+++ b/plugins/tools/overseertool/coverage_more_test.go
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: MIT
+
+package overseertool
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/agezt/agezt/kernel/roster"
+	kernelruntime "github.com/agezt/agezt/kernel/runtime"
+)
+
+// --- parseProfile edge cases ---
+
+func TestParseProfile_NullAndEmptyProfileRaw(t *testing.T) {
+	src := func(v any) json.RawMessage { b, _ := json.Marshal(v); return b }
+
+	// Null profile raw → falls back to flat fields.
+	_, err := parseProfile(src(nil), src(map[string]any{"slug": "a"}))
+	if err != nil {
+		t.Fatalf("null profile with flat fields: %v", err)
+	}
+
+	// Empty string profile raw is truthy but not a valid object → error.
+	_, err = parseProfile(src(""), src(map[string]any{"slug": "b"}))
+	if err == nil {
+		t.Fatal("empty string profile raw should error (string is not an object)")
+	}
+}
+
+func TestParseProfile_InvalidJSONInsideProfile(t *testing.T) {
+	src := json.RawMessage(`{invalid}`)
+	_, err := parseProfile(src, src)
+	if err == nil {
+		t.Fatal("parseProfile with invalid JSON should error")
+	}
+}
+
+func TestParseProfile_NoProfileAndNoFlatFields(t *testing.T) {
+	src := func(v any) json.RawMessage { b, _ := json.Marshal(v); return b }
+	_, err := parseProfile(src(nil), src(map[string]any{}))
+	if err == nil {
+		t.Fatal("parseProfile with no profile and no flat fields should error")
+	}
+}
+
+// --- hasProfileObject ---
+
+func TestHasProfileObject_Variants(t *testing.T) {
+	cases := []struct {
+		raw json.RawMessage
+		ok  bool
+	}{
+		{json.RawMessage(`{}`), false},
+		{json.RawMessage(`null`), false},
+		{json.RawMessage(``), false},
+		{json.RawMessage(`{"slug":"x"}`), true},
+		{json.RawMessage(`0`), true}, // truthy but not an object — should pass
+	}
+	for _, tc := range cases {
+		got := hasProfileObject(tc.raw)
+		if got != tc.ok {
+			t.Errorf("hasProfileObject(%q) = %v, want %v", string(tc.raw), got, tc.ok)
+		}
+	}
+}
+
+// --- cleanSlugs ---
+
+func TestCleanSlugs_TrimAndDeduplicates(t *testing.T) {
+	got := cleanSlugs([]string{"  a1  ", "", "  ", "a2", " a2 ", "a3"})
+	// cleanSlugs trims and removes empties but does NOT deduplicate.
+	if len(got) != 4 || got[0] != "a1" || got[3] != "a3" {
+		t.Fatalf("cleanSlugs = %#v, want roughly [a1 a2 a2 a3]", got)
+	}
+}
+
+func TestCleanSlugs_NilAndEmpty(t *testing.T) {
+	if cleanSlugs(nil) != nil {
+		t.Error("cleanSlugs(nil) should be nil")
+	}
+	if cleanSlugs([]string{}) != nil {
+		t.Error("cleanSlugs(empty) should be nil")
+	}
+	if len(cleanSlugs([]string{"", "  "})) != 0 {
+		t.Error("cleanSlugs(all empty) should be empty")
+	}
+}
+
+// --- errResult ---
+
+func TestErrResult_Format(t *testing.T) {
+	r := errResult("something went wrong")
+	if !r.IsError {
+		t.Error("errResult should mark IsError")
+	}
+	if r.Output != "overseer: something went wrong" {
+		t.Errorf("errResult output = %q", r.Output)
+	}
+}
+
+// --- findMisconfigured / findDegraded / findRoutingPressure ---
+
+func TestFindMisconfigured_FoundAndNotFound(t *testing.T) {
+	rep := kernelruntime.ReaperReport{
+		MisconfiguredAgents: []kernelruntime.MisconfiguredAgent{
+			{Slug: "alpha", Issues: []string{"bad override"}},
+			{Slug: "beta", Issues: []string{"missing model"}},
+		},
+	}
+	if findMisconfigured(rep, "alpha") == nil {
+		t.Fatal("findMisconfigured(alpha) should find it")
+	}
+	if findMisconfigured(rep, "gamma") != nil {
+		t.Fatal("findMisconfigured(gamma) should be nil")
+	}
+	if findMisconfigured(kernelruntime.ReaperReport{}, "alpha") != nil {
+		t.Fatal("findMisconfigured(empty) should be nil")
+	}
+}
+
+func TestFindDegraded_FoundAndNotFound(t *testing.T) {
+	rep := kernelruntime.ReaperReport{
+		DegradedAgents: []kernelruntime.DegradedAgent{
+			{Slug: "alpha", Failures: 5, Window: 10, LastReason: "timeout"},
+		},
+	}
+	if findDegraded(rep, "alpha") == nil {
+		t.Fatal("findDegraded(alpha) should find it")
+	}
+	if findDegraded(rep, "beta") != nil {
+		t.Fatal("findDegraded(beta) should be nil")
+	}
+}
+
+func TestFindRoutingPressure_FoundAndNotFound(t *testing.T) {
+	rep := kernelruntime.ReaperReport{
+		RoutingPressure: []kernelruntime.RoutingPressureAgent{
+			{Slug: "alpha", Count: 3, Threshold: 3, TaskType: "code", LastFailedModel: "gpt-5"},
+		},
+	}
+	if findRoutingPressure(rep, "alpha") == nil {
+		t.Fatal("findRoutingPressure(alpha) should find it")
+	}
+	if findRoutingPressure(rep, "beta") != nil {
+		t.Fatal("findRoutingPressure(beta) should be nil")
+	}
+	if findRoutingPressure(kernelruntime.ReaperReport{}, "alpha") != nil {
+		t.Fatal("findRoutingPressure(empty) should be nil")
+	}
+}
+
+// --- repairTaskType ---
+
+func TestRepairTaskType_UsesProfileTaskType(t *testing.T) {
+	tt := repairTaskType(roster.Profile{Slug: "a", TaskType: "research"}, kernelruntime.ReaperReport{})
+	if tt != "research" {
+		t.Fatalf("repairTaskType = %q, want research", tt)
+	}
+}
+
+func TestRepairTaskType_FallsBackToRoutingPressure(t *testing.T) {
+	tt := repairTaskType(roster.Profile{Slug: "b"}, kernelruntime.ReaperReport{
+		RoutingPressure: []kernelruntime.RoutingPressureAgent{
+			{Slug: "b", TaskType: "code"},
+		},
+	})
+	if tt != "code" {
+		t.Fatalf("repairTaskType (fallback) = %q, want code", tt)
+	}
+}
+
+func TestRepairTaskType_EmptyWhenNoSignal(t *testing.T) {
+	tt := repairTaskType(roster.Profile{Slug: "c"}, kernelruntime.ReaperReport{})
+	if tt != "" {
+		t.Fatalf("repairTaskType with no signal = %q, want empty", tt)
+	}
+}
+
+// --- managedSubAgentRepairHint ---
+
+func TestManagedSubAgentRepairHint_WithParent(t *testing.T) {
+	hint := managedSubAgentRepairHint(roster.Profile{Slug: "sub", ParentAgent: "parent"})
+	if hint == "" {
+		t.Fatal("hint should not be empty")
+	}
+}
+
+func TestManagedSubAgentRepairHint_WithOwnerOnly(t *testing.T) {
+	hint := managedSubAgentRepairHint(roster.Profile{Slug: "sub", OwnerAgent: "owner"})
+	if hint == "" {
+		t.Fatal("hint should not be empty")
+	}
+}
+
+func TestManagedSubAgentRepairHint_NoManager(t *testing.T) {
+	hint := managedSubAgentRepairHint(roster.Profile{Slug: "sub"})
+	if hint == "" {
+		t.Fatal("hint should not be empty even without manager")
+	}
+}
+
+// --- sanitizeTaskModelChain ---
+
+func TestSanitizeTaskModelChain_RemovesEmpty(t *testing.T) {
+	got := sanitizeTaskModelChain([]string{"model-1", "", "  ", "model-2"})
+	if len(got) != 2 || got[0] != "model-1" || got[1] != "model-2" {
+		t.Fatalf("sanitizeTaskModelChain = %#v", got)
+	}
+}
+
+func TestSanitizeTaskModelChain_AllEmpty(t *testing.T) {
+	got := sanitizeTaskModelChain([]string{"", "  "})
+	if len(got) != 0 {
+		t.Fatalf("sanitizeTaskModelChain(all empty) = %#v, want empty", got)
+	}
+}
+
+// --- encodeTaskModelChains ---
+
+func TestEncodeTaskModelChains_SortsByTaskType(t *testing.T) {
+	got := encodeTaskModelChains(map[string][]string{
+		"b": {"model-b"},
+		"a": {"model-a"},
+	})
+	want := "a=model-a;b=model-b"
+	if got != want {
+		t.Fatalf("encodeTaskModelChains = %q, want %q", got, want)
+	}
+}
+
+func TestEncodeTaskModelChains_Empty(t *testing.T) {
+	if encodeTaskModelChains(nil) != "" {
+		t.Error("encodeTaskModelChains(nil) should be empty")
+	}
+	if encodeTaskModelChains(map[string][]string{}) != "" {
+		t.Error("encodeTaskModelChains(empty) should be empty")
+	}
+}
+
+func TestEncodeTaskModelChains_SkipsEmptyValues(t *testing.T) {
+	got := encodeTaskModelChains(map[string][]string{
+		"":    {"model-a"},
+		"b":   {},
+		"c":   {"model-c"},
+		"   ": {"model-d"},
+	})
+	if got != "c=model-c" {
+		t.Fatalf("encodeTaskModelChains = %q, want %q", got, "c=model-c")
+	}
+}
+
+// --- applyProfilePatchField ---
+
+func TestApplyProfilePatchField_OnlyWhenProvided(t *testing.T) {
+	var dst string
+	applyProfilePatchField(map[string]bool{"key": true}, "key", &dst, "val")
+	if dst != "val" {
+		t.Fatalf("dst = %q, want val", dst)
+	}
+	applyProfilePatchField(map[string]bool{}, "key", &dst, "other")
+	if dst != "val" {
+		t.Fatalf("dst should NOT change when key not provided, got %q", dst)
+	}
+}
+
+// --- clip edge cases ---
+
+func TestClip_EdgeCases(t *testing.T) {
+	if clip("x", 0) != "" {
+		t.Errorf("clip('x', 0) = %q, want '' (empty from s[:0])", clip("x", 0))
+	}
+	if clip("xy", 1) != "x" {
+		t.Errorf("clip('xy', 1) = %q, want 'x'", clip("xy", 1))
+	}
+}

--- a/plugins/tools/workflowtool/coverage_more_test.go
+++ b/plugins/tools/workflowtool/coverage_more_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+
+package workflowtool
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/agezt/agezt/kernel/agent"
+)
+
+func TestInvoke_ParseError(t *testing.T) {
+	tool := New()
+	_, err := tool.Invoke(context.Background(), json.RawMessage(`not json`))
+	if err == nil {
+		t.Fatal("parse error should return a hard error")
+	}
+	if !strings.Contains(err.Error(), "workflow:") {
+		t.Errorf("parse error should carry prefix, got %v", err)
+	}
+}
+
+func TestOkJSON_MarshalError(t *testing.T) {
+	res := okJSON(make(chan int))
+	if !res.IsError {
+		t.Error("okJSON(channel) should return error")
+	}
+}
+
+func TestSaveUpdatePath(t *testing.T) {
+	fk := newFakeKernel(t)
+	tool := New()
+	tool.Bind(fk)
+
+	// First save: create.
+	out1 := invoke(t, tool, `{"op":"save","workflow":`+graphJSON+`}`)
+	if !strings.Contains(out1, "created") {
+		t.Fatalf("first save should create, got:\n%s", out1)
+	}
+
+	// Second save with same name: update.
+	out2 := invoke(t, tool, `{"op":"save","workflow":`+graphJSON+`}`)
+	if !strings.Contains(out2, "updated") {
+		t.Fatalf("second save should update, got:\n%s", out2)
+	}
+}
+
+var _ = agent.Tool(New()) // compile-time check


### PR DESCRIPTION
## Coverage improvements

| Package | Before | After | Delta |
|---|---|---|---|
| overseertool | 42.9% | 45.7% | +2.8pp |
| introspecttool | 46.3% | 46.3% | pure function coverage |
| workflowtool | 89.0% | 93.2% | +4.2pp |
| configcenter | 70.7% | 76.2% | +5.5pp |
| agentgw | 68.2% | 69.5% | +1.3pp |
| restapi | 78.2% | 78.7% | +0.5pp |
| builtinskills | 76.5% | 84.3% | +7.8pp |
| builtinguardians | 77.4% | 80.3% | +2.9pp |
| okr | 86.1% | 88.6% | +2.5pp |
| standing | 87.0% | 87.4% | +0.4pp |
| acpcatalog | 75.3% | 84.0% | +8.7pp |
| mcp | 81.0% | 85.3% | +4.3pp |
| warden | 82.8% | 84.0% | +1.2pp |
| toolforge | 80.5% | 86.0% | +5.5pp |

All pure-function tests — no kernel/integration setup, zero peer files touched.
