### PR TITLE
chore: land security override + docs-scan (housekeeping bundle)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ channel, and marketplace surfaces remain capability- and environment-dependent.
 See [CHANGELOG.md](CHANGELOG.md).
 **Recent local gates:** local validation has included `go test ./...`, frontend
 `npm test`, `npm run build`, and Playwright browser E2E against the embedded SPA
-and a live demo daemon. See [docs/SYSTEM-REVIEW.md](docs/SYSTEM-REVIEW.md) for
+and a live demo daemon. See [docs/SYSTEM-AUDIT-REPORT.md](docs/SYSTEM-AUDIT-REPORT.md) for
 the latest review artifact and validation notes.
 **Dependencies:** see [DEPENDENCIES.md](DEPENDENCIES.md) for the current `go.mod`-derived dependency inventory and justification status.
 **Positioning:** see [docs/COMPARISON.md](docs/COMPARISON.md) for how AGEZT differs from generic agent frameworks without unverifiable competitor claims.

--- a/docs/ARCHITECTURAL-REPORT.md
+++ b/docs/ARCHITECTURAL-REPORT.md
@@ -1,6 +1,6 @@
 # Agezt — Comprehensive Architectural Report
 
-> **Generated:** 2026-06-20 · **Branch at generation time:** `main` · **Version:** v1.0.0+ · **Latest phase at generation time:** M781+ (historical; see `docs/SYSTEM-AUDIT-REPORT.md` for current counts)
+> **Generated:** 2026-06-20 (last refreshed: 2026-07-06) · **Branch:** `main` (HEAD: `ef7b412d`) · **Version:** v1.0.0+ · **Latest phase at generation time:** M781+ (historical; see `docs/SYSTEM-AUDIT-REPORT.md` for current counts)
 > **Scope:** Every component, module, and technology across the entire monorepo.
 > **Note:** Version and dependency details are sourced from `go.mod`, `frontend/package.json`, and `frontend/.nvmrc`. See `docs/SDK-PARITY.md` for API coverage and `DEPENDENCIES.md` for the dependency inventory.
 > **Current-state note:** This generated report is broad but partially stale in its phase/test-count sections. For the latest review and gap plan, see `docs/SYSTEM-AUDIT-REPORT.md`, `docs/MISSING-PARTS-REPORT.md`, and `docs/MISSING-PARTS-PLAN.md`.

--- a/docs/CHANGELOG-REORG-PLAN.md
+++ b/docs/CHANGELOG-REORG-PLAN.md
@@ -1,8 +1,8 @@
 # CHANGELOG Reorg Planı (P0-5)
 
-> **Tarih:** 2026-07-04
-> **Dal:** `refactor/c4-agentdetail-phase0` (HEAD: `967de333`)
-> **Statü:** ACTIVE — `docs/MISSING-PARTS-PLAN.md` P0-5 görevi için üretildi.
+> **Tarih:** 2026-07-04 (last updated: 2026-07-06)
+> **Dal:** `main` (HEAD: `ef7b412d`)
+> **Statü:** ARCHIVED — CHANGELOG reorganization completed (root slimmed to release index, per-version bodies in `CHANGELOG/`). Branch `refactor/c4-agentdetail-phase0` merged into `main` and deleted. Plan retained for historical reference.
 > **Diğer referanslar:** `docs/MISSING-PARTS-PLAN.md`, `docs/MISSING-PARTS-REPORT.md` (H-04).
 
 ---

--- a/docs/JARVIS-VISION-2026.md
+++ b/docs/JARVIS-VISION-2026.md
@@ -15,8 +15,8 @@
 bir *agentic operating system*. Ölçek doğrulandı:
 
 - ~**170.000 satır** Go (test hariç), 5.583 `.go` dosyası, **63 kernel paketi**
-- **25 kanal**, **15 sağlayıcı ailesi**, **29 tool**, **16 yerleşik skill paketi**, **~70 CLI komut grubu**
-- Gömülü React konsolu: **67 gerçek view**, ~73.000 satır TS/TSX, **~473 Vitest testi** (view başına ~1:1 kapsam), tek-EventSource canlı akış
+- **25 kanal**, **15 sağlayıcı ailesi**, **30 tool**, **16 yerleşik skill paketi**, **~70 CLI komut grubu**
+- Gömülü React konsolu: **71 gerçek view**, ~73.000 satır TS/TSX, **~473 Vitest testi** (view başına ~1:1 kapsam), tek-EventSource canlı akış
 - **Sıfır** `panic("unimplemented")`, çekirdekte parmakla sayılır TODO — placeholder ekran yok
 
 **Rakiplere karşı konum:**

--- a/docs/MISSING-PARTS-PLAN.md
+++ b/docs/MISSING-PARTS-PLAN.md
@@ -1,8 +1,8 @@
 # AGEZT — Missing Parts Plan (Eksik Parçalar İçin Eylem Planı)
 
-> **Tarih:** 2026-07-04
-> **Dal:** `refactor/c4-agentdetail-phase0` (HEAD: `967de333`)
-> **Statü:** ACTIVE — `docs/NEXT.md` §0 referansını kapatmak için oluşturuldu. Ham envanter `docs/SYSTEM-AUDIT-REPORT.md` ve `docs/MISSING-PARTS-REPORT.md`'daki **28 fonksiyonel boşluk + 6 NEXT takip işi** üzerine kuruludur.
+> **Tarih:** 2026-07-04 (last updated: 2026-07-06)
+> **Dal:** `main` (HEAD: `ef7b412d`)
+> **Statü:** ARCHIVED — Branch `refactor/c4-agentdetail-phase0` merged into `main` and deleted. Content retained for historical reference; see `docs/SYSTEM-AUDIT-REPORT.md` for current audit state.
 > **Diğer referanslar:** `docs/OPENCLAW-HERMES-ROADMAP.md`, `docs/JARVIS-VISION-2026.md`, `docs/REFACTORING-INDEX.md`, `docs/GRAVEYARD-POLICY.md`, `docs/PLUGIN-SECURITY.md`, `docs/OPERATIONS.md`, `docs/COMPARISON.md`, `docs/THREAT-MODEL.md`.
 
 ---

--- a/docs/MISSING-PARTS-REPORT.md
+++ b/docs/MISSING-PARTS-REPORT.md
@@ -1,8 +1,8 @@
 # AGEZT — Missing Parts Report (Eksik Parçalar — Ham Envanter)
 
-> **Tarih:** 2026-07-04
-> **Dal:** `refactor/c4-agentdetail-phase0` (HEAD: `967de333`)
-> **Statü:** ACTIVE — `docs/NEXT.md` §0 referansı için **ham envanter** (önsözünde "audit" da olan çifti `docs/SYSTEM-AUDIT-REPORT.md`, execution plan `docs/MISSING-PARTS-PLAN.md`).
+> **Tarih:** 2026-07-04 (last updated: 2026-07-06)
+> **Dal:** `main` (HEAD: `ef7b412d`)
+> **Statü:** ARCHIVED — Branch `refactor/c4-agentdetail-phase0` merged into `main` and deleted. Content retained for historical reference; see `docs/SYSTEM-AUDIT-REPORT.md` for current audit state and `docs/MISSING-PARTS-PLAN.md` for the action plan.
 > **Diğer referanslar:** `docs/SYSTEM-AUDIT-REPORT.md`, `docs/MISSING-PARTS-PLAN.md`, `docs/OPENCLAW-HERMES-ROADMAP.md`, `docs/JARVIS-VISION-2026.md`, `docs/REFACTORING-INDEX.md`, `docs/GRAVEYARD-POLICY.md`.
 
 ---

--- a/docs/SPEC-IMPLEMENTATION-STATUS.md
+++ b/docs/SPEC-IMPLEMENTATION-STATUS.md
@@ -1,8 +1,8 @@
 # AGEZT — SPEC Implementation Status (SPEC ↔ Kod Durum Matrisi)
 
-> **Tarih:** 2026-07-04
-> **Dal:** `refactor/c4-agentdetail-phase0` (HEAD: `967de333`)
-> **Statü:** ACTIVE — `docs/MISSING-PARTS-PLAN.md` P0-4 görevi için üretildi.
+> **Tarih:** 2026-07-04 (last updated: 2026-07-06)
+> **Dal:** `main` (HEAD: `ef7b412d`)
+> **Statü:** ARCHIVED — Branch `refactor/c4-agentdetail-phase0` merged into `main` and deleted. Content retained for historical reference.
 > **Diğer referanslar:** `docs/SYSTEM-AUDIT-REPORT.md`, `docs/MISSING-PARTS-REPORT.md`, `docs/MISSING-PARTS-PLAN.md`, `docs/JARVIS-VISION-2026.md`, `docs/OPENCLAW-HERMES-ROADMAP.md`.
 
 ---

--- a/docs/SYSTEM-AUDIT-REPORT.md
+++ b/docs/SYSTEM-AUDIT-REPORT.md
@@ -1,7 +1,7 @@
 # AGEZT — Sistem Denetim Raporu (Eksikler, Tamamlanmamışlar, Yapılması Gerekenler)
 
-> **Tarih:** 2026-07-04
-> **Dal:** `refactor/c4-agentdetail-phase0` (HEAD: `967de333`)
+> **Tarih:** 2026-07-04 (last updated: 2026-07-06)
+> **Dal:** `main` (HEAD: `ef7b412d`)
 > **Checkout:** Ana repo (`D:\Codebox\PROJECTS\AGEZT`); `.worktrees/` ve `.claude/worktrees/` **hariç tutulmuştur**.
 > **Yöntem:** Tüm kaynak kodu (575 Go + 212 TS/TSX), dokümanlar (`.project/SPEC-*.md`, `.project/PHASE-M*.md`, `docs/*.md`), CHANGELOG, refactoring planları, frontend kodu ve SPEC ↔ kod referansları taranmış; TODO/FIXME/HACK envanteri, build/test envanteri ve özellik eşleştirmesi yapılmıştır.
 > **Sınırlamalar:** Bu denetim sırasında dış fetch (`github.com`, `web search`) çalışmadığı için rakip doküman iddiaları yalnızca repo-içi `OPENCLAW-HERMES-ROADMAP.md` ve `JARVIS-VISION-2026.md` üzerinden kontrol edilmiştir. Yerel diskte olmayan `PHASE-M1xxx` raporları **disk'e göre** değil **CHANGELOG referansına** göre işlenmiştir.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2902,9 +2902,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
       "optionalDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,6 +45,7 @@
     "vitest": "^4.1.8"
   },
   "overrides": {
+    "dompurify": "^3.4.11",
     "undici": "^7.28.0"
   }
 }

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,2 +1,6 @@
+overrides:
+  dompurify: ^3.4.11
+  undici: ^7.28.0
+
 allowBuilds:
   esbuild: set this to true or false

--- a/security-report/SECURITY-REPORT.md
+++ b/security-report/SECURITY-REPORT.md
@@ -1,9 +1,9 @@
 # Security Assessment Report
 
 **Project:** AGEZT — self-hosted autonomous multi-agent platform (Go kernel + daemon/CLI, React/TS web console, Go/TS/Python/Rust SDKs)
-**Date:** 2026-06-27
+**Date:** 2026-06-27 (last refreshed: 2026-07-06)
 **Scanner:** security-check v1.1.0 (4-phase pipeline: Recon → Hunt → Verify → Report)
-**Branch / HEAD:** `main` @ `99d2e426`
+**Branch / HEAD at scan:** `main` @ `99d2e426`; **current HEAD:** `ef7b412d`
 **Risk Score:** **2.6 / 10 — Low Risk**
 
 > **Threat model.** AGEZT is a **localhost-first, single-operator, token-gated daemon**. Every network listener


### PR DESCRIPTION
Bundles two independent, low-risk pieces of previously-unmerged work whose content `git cherry` confirmed is NOT in main:

- **fix(frontend): override vulnerable transitive dependencies** — forces patched dompurify (3.2.7→3.4.11) + undici for npm & pnpm resolver graphs (Monaco/jsdom transitive CVEs). Lockfile updated consistently; both are peer/dev deps, production bundle & committed dist unchanged. *(was local-only — existed on no remote)*
- **docs: refresh report metadata + archive merged plan docs** — 9 doc files.

`ci: stage GOCACHE+GOTMPDIR to tmpfs` was found already present in main (empty cherry-pick) and dropped.

Part of the branch-consolidation sweep: getting all unique unmerged work into main without loss.