### PR TITLE
feat(workflowexec): create kernel/workflowexec package with types and helpers (B1 Phase 4)

### DIFF
--- a/kernel/workflowexec/workflow.go
+++ b/kernel/workflowexec/workflow.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+
+// Package workflowexec provides workflow graph execution: the RunWorkflow
+// adapter and per-node dispatch. It is extracted from kernel/runtime to
+// narrow the composition root and make workflow execution independently
+// testable.
+package workflowexec
+
+import "encoding/json"
+
+// StepCap is a defense-in-depth bound on executed steps per run —
+// validation already rejects cycles, so this can only fire on an engine bug.
+const StepCap = 256
+
+// SnippetMax bounds the per-node data snippet journaled with each
+// workflow.node event — enough to inspect, never enough to bloat the chain.
+const SnippetMax = 2000
+
+// MaxSubflowDepth is the maximum nesting depth for subworkflow nodes.
+const MaxSubflowDepth = 3
+
+// DepthKey is a context key for subworkflow nesting depth.
+type DepthKey struct{}
+
+// Result carries one run's outcome: per-node outputs (by node id)
+// and the ordered list of executed node ids.
+type Result struct {
+	Outputs  map[string]any
+	Executed []string
+}
+
+// Snippet renders a value for the journal: strings verbatim,
+// everything else compact JSON, truncated at SnippetMax runes.
+// Returns (text, truncated) where truncated is true when clipping occurred.
+func Snippet(v any) (string, bool) {
+	var s string
+	switch t := v.(type) {
+	case nil:
+		return "", false
+	case string:
+		s = t
+	default:
+		b, err := json.Marshal(t)
+		if err != nil {
+			return "", false
+		}
+		s = string(b)
+	}
+	if r := []rune(s); len(r) > SnippetMax {
+		return string(r[:SnippetMax]) + "…", true
+	}
+	return s, false
+}

--- a/kernel/workflowexec/workflow_test.go
+++ b/kernel/workflowexec/workflow_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+
+package workflowexec_test
+
+import (
+	"testing"
+
+	"github.com/agezt/agezt/kernel/workflowexec"
+)
+
+func TestSnippet_Nil(t *testing.T) {
+	s, truncated := workflowexec.Snippet(nil)
+	if s != "" || truncated {
+		t.Fatalf("Snippet(nil) = %q, %v, want empty false", s, truncated)
+	}
+}
+
+func TestSnippet_String(t *testing.T) {
+	s, truncated := workflowexec.Snippet("hello")
+	if s != "hello" || truncated {
+		t.Fatalf("Snippet('hello') = %q, %v", s, truncated)
+	}
+}
+
+func TestSnippet_JSON(t *testing.T) {
+	s, truncated := workflowexec.Snippet(map[string]int{"a": 1})
+	if s != `{"a":1}` || truncated {
+		t.Fatalf("Snippet = %q, %v", s, truncated)
+	}
+}
+
+func TestSnippet_Truncation(t *testing.T) {
+	long := string(make([]byte, 5000))
+	s, truncated := workflowexec.Snippet(long)
+	if !truncated {
+		t.Fatal("expected truncated for long input")
+	}
+	if len([]rune(s)) > workflowexec.SnippetMax+1 { // +1 for ellipsis
+		t.Fatalf("snippet length %d exceeds max %d", len([]rune(s)), workflowexec.SnippetMax)
+	}
+}
+
+func TestStepCap_IsPositive(t *testing.T) {
+	if workflowexec.StepCap <= 0 {
+		t.Fatal("StepCap must be positive")
+	}
+}
+
+func TestMaxSubflowDepth_IsPositive(t *testing.T) {
+	if workflowexec.MaxSubflowDepth <= 0 {
+		t.Fatal("MaxSubflowDepth must be positive")
+	}
+}


### PR DESCRIPTION
Phase 4a of the B1 runtime decomposition plan.

**kernel/workflowexec** package (106 lines, 6 tests):
- Result type for workflow run outcomes
- DepthKey for subworkflow nesting
- Snippet helper for journal-friendly value rendering
- Constants: StepCap, SnippetMax, MaxSubflowDepth

Verification:
- go build ./... ✅
- go test ./kernel/workflowexec/... ✅ (6/6)