### PR TITLE
feat(testfixtures): consolidate 3 duplicate mock_helpers into shared package

### DIFF
--- a/kernel/agent/mock_helpers_test.go
+++ b/kernel/agent/mock_helpers_test.go
@@ -3,26 +3,18 @@
 package agent_test
 
 import (
-	"encoding/json"
-
 	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/internal/testfixtures"
 )
 
+// testWithUsage sets the usage on a CompletionResponse.
+// Delegates to kernel/internal/testfixtures for the canonical implementation.
 func testWithUsage(resp agent.CompletionResponse, usage agent.Usage) agent.CompletionResponse {
-	resp.Usage = usage
-	return resp
+	return testfixtures.WithUsage(resp, usage)
 }
 
+// testToolUse constructs a tool-use CompletionResponse.
+// Delegates to kernel/internal/testfixtures for the canonical implementation.
 func testToolUse(callID, toolName string, input any) agent.CompletionResponse {
-	raw, err := json.Marshal(input)
-	if err != nil {
-		panic("testToolUse: marshal input: " + err.Error())
-	}
-	return agent.CompletionResponse{
-		Message: agent.Message{
-			Role:      agent.RoleAssistant,
-			ToolCalls: []agent.ToolCall{{ID: callID, Name: toolName, Input: raw}},
-		},
-		StopReason: agent.StopToolUse,
-	}
+	return testfixtures.ToolUse(callID, toolName, input)
 }

--- a/kernel/controlplane/mock_helpers_test.go
+++ b/kernel/controlplane/mock_helpers_test.go
@@ -3,26 +3,18 @@
 package controlplane_test
 
 import (
-	"encoding/json"
-
 	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/internal/testfixtures"
 )
 
+// testWithUsage sets the usage on a CompletionResponse.
+// Delegates to kernel/internal/testfixtures for the canonical implementation.
 func testWithUsage(resp agent.CompletionResponse, usage agent.Usage) agent.CompletionResponse {
-	resp.Usage = usage
-	return resp
+	return testfixtures.WithUsage(resp, usage)
 }
 
+// testToolUse constructs a tool-use CompletionResponse.
+// Delegates to kernel/internal/testfixtures for the canonical implementation.
 func testToolUse(callID, toolName string, input any) agent.CompletionResponse {
-	raw, err := json.Marshal(input)
-	if err != nil {
-		panic("testToolUse: marshal input: " + err.Error())
-	}
-	return agent.CompletionResponse{
-		Message: agent.Message{
-			Role:      agent.RoleAssistant,
-			ToolCalls: []agent.ToolCall{{ID: callID, Name: toolName, Input: raw}},
-		},
-		StopReason: agent.StopToolUse,
-	}
+	return testfixtures.ToolUse(callID, toolName, input)
 }

--- a/kernel/internal/testfixtures/helpers.go
+++ b/kernel/internal/testfixtures/helpers.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+
+// Package testfixtures provides shared test helpers for kernel packages.
+// It is internal to the kernel tree and only imported by _test.go files.
+package testfixtures
+
+import (
+	"encoding/json"
+
+	"github.com/agezt/agezt/kernel/agent"
+)
+
+// WithUsage sets the usage on a CompletionResponse (test helper).
+func WithUsage(resp agent.CompletionResponse, usage agent.Usage) agent.CompletionResponse {
+	resp.Usage = usage
+	return resp
+}
+
+// ToolUse constructs a tool-use CompletionResponse (test helper).
+func ToolUse(callID, toolName string, input any) agent.CompletionResponse {
+	raw, err := json.Marshal(input)
+	if err != nil {
+		panic("ToolUse: marshal input: " + err.Error())
+	}
+	return agent.CompletionResponse{
+		Message: agent.Message{
+			Role:      agent.RoleAssistant,
+			ToolCalls: []agent.ToolCall{{ID: callID, Name: toolName, Input: raw}},
+		},
+		StopReason: agent.StopToolUse,
+	}
+}

--- a/kernel/runtime/mock_helpers_test.go
+++ b/kernel/runtime/mock_helpers_test.go
@@ -3,26 +3,18 @@
 package runtime_test
 
 import (
-	"encoding/json"
-
 	"github.com/agezt/agezt/kernel/agent"
+	"github.com/agezt/agezt/kernel/internal/testfixtures"
 )
 
+// testWithUsage sets the usage on a CompletionResponse.
+// Delegates to kernel/internal/testfixtures for the canonical implementation.
 func testWithUsage(resp agent.CompletionResponse, usage agent.Usage) agent.CompletionResponse {
-	resp.Usage = usage
-	return resp
+	return testfixtures.WithUsage(resp, usage)
 }
 
+// testToolUse constructs a tool-use CompletionResponse.
+// Delegates to kernel/internal/testfixtures for the canonical implementation.
 func testToolUse(callID, toolName string, input any) agent.CompletionResponse {
-	raw, err := json.Marshal(input)
-	if err != nil {
-		panic("testToolUse: marshal input: " + err.Error())
-	}
-	return agent.CompletionResponse{
-		Message: agent.Message{
-			Role:      agent.RoleAssistant,
-			ToolCalls: []agent.ToolCall{{ID: callID, Name: toolName, Input: raw}},
-		},
-		StopReason: agent.StopToolUse,
-	}
+	return testfixtures.ToolUse(callID, toolName, input)
 }

--- a/tools/deadcodecheck/main.go
+++ b/tools/deadcodecheck/main.go
@@ -76,6 +76,8 @@ func findingLines(out []byte) []string {
 
 func isAllowedSDKFinding(line string) bool {
 	normalized := strings.ReplaceAll(line, `\`, "/")
-	return strings.HasPrefix(normalized, "sdk/") &&
-		strings.Contains(normalized, ": unreachable func:")
+	return (strings.HasPrefix(normalized, "sdk/") &&
+		strings.Contains(normalized, ": unreachable func:")) ||
+		(strings.HasPrefix(normalized, "kernel/internal/testfixtures/") &&
+			strings.Contains(normalized, ": unreachable func:"))
 }


### PR DESCRIPTION
New **kernel/internal/testfixtures** package consolidates the byte-identical
testWithUsage/testToolUse functions previously duplicated across
kernel/{agent,controlplane,runtime}/mock_helpers_test.go.

Each mock_helpers_test.go now delegates to the shared package via a thin
wrapper. No call-site changes needed. 45 lines of duplication eliminated.

Updates tools/deadcodecheck to allowlist test-only unreachable functions
in the testfixtures package.

Verification:
- go build ./... ✅
- go test ./kernel/agent/... ./kernel/internal/testfixtures/... ✅
- go run ./tools/deadcodecheck ✅