### PR TITLE
refactor: fold six truncate copies into rune-safe strutil.Ellipsis

### DIFF
--- a/kernel/controlplane/roster.go
+++ b/kernel/controlplane/roster.go
@@ -3766,11 +3766,7 @@ func plStrings(pl map[string]any, key string) []string {
 }
 
 func truncate(s string, n int) string {
-	s = strings.TrimSpace(s)
-	if len(s) <= n {
-		return s
-	}
-	return s[:n] + "…"
+	return strutil.Ellipsis(strings.TrimSpace(s), n, "…")
 }
 
 func firstNonEmpty(items ...string) string { return strutil.FirstNonEmpty(items...) }

--- a/plugins/channels/nostr/nostr.go
+++ b/plugins/channels/nostr/nostr.go
@@ -28,6 +28,8 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+
+	"github.com/agezt/agezt/internal/strutil"
 	"time"
 
 	btcec "github.com/btcsuite/btcd/btcec/v2"
@@ -332,10 +334,7 @@ func (c *Channel) signAndBroadcast(ev nostrEvent, journalText, corr string) erro
 }
 
 func truncate(s string) string {
-	if len(s) > maxChars {
-		return s[:maxChars]
-	}
-	return s
+	return strutil.Ellipsis(s, maxChars, "")
 }
 
 // parseXOnly turns a 32-byte hex x-only pubkey into a btcec public key.

--- a/plugins/tools/acpagent/acpagent.go
+++ b/plugins/tools/acpagent/acpagent.go
@@ -28,6 +28,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/agezt/agezt/internal/strutil"
+
 	"github.com/agezt/agezt/kernel/acp"
 	"github.com/agezt/agezt/kernel/acpcatalog"
 	"github.com/agezt/agezt/kernel/agent"
@@ -215,7 +217,8 @@ func truncate(s string, max int) string {
 	if len(s) <= max {
 		return s
 	}
-	return s[:max] + fmt.Sprintf("\n… [truncated %d bytes]", len(s)-max)
+	prefix := strutil.Ellipsis(s, max, "")
+	return prefix + fmt.Sprintf("\n… [truncated %d bytes]", len(s)-len(prefix))
 }
 
 func platformShell() (string, string) {

--- a/plugins/tools/browser/action.go
+++ b/plugins/tools/browser/action.go
@@ -17,8 +17,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-	"unicode/utf8"
 
+	"github.com/agezt/agezt/internal/strutil"
 	"github.com/agezt/agezt/kernel/agent"
 	"github.com/agezt/agezt/kernel/artifact"
 	"github.com/agezt/agezt/kernel/envscrub"
@@ -1006,14 +1006,7 @@ func isBrowserActionTempPath(path string) bool {
 }
 
 func truncateUTF8(s string, max int) string {
-	if len(s) <= max {
-		return s
-	}
-	cut := max
-	for cut > 0 && !utf8.RuneStart(s[cut]) {
-		cut--
-	}
-	return s[:cut]
+	return strutil.Ellipsis(s, max, "")
 }
 
 func truncateActionOutput(s string) string {

--- a/plugins/tools/coding/coding.go
+++ b/plugins/tools/coding/coding.go
@@ -25,8 +25,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
-	"unicode/utf8"
 
+	"github.com/agezt/agezt/internal/strutil"
 	"github.com/agezt/agezt/kernel/agent"
 	"github.com/agezt/agezt/kernel/envscrub"
 )
@@ -190,13 +190,8 @@ func truncate(s string, max int) string {
 	if len(s) <= max {
 		return s
 	}
-	// Back up to a UTF-8 rune boundary so a multi-byte rune straddling the cut
-	// (common in non-ASCII diffs) is never split into invalid UTF-8.
-	cut := max
-	for cut > 0 && !utf8.RuneStart(s[cut]) {
-		cut--
-	}
-	return s[:cut] + fmt.Sprintf("\n… [truncated %d bytes]", len(s)-cut)
+	prefix := strutil.Ellipsis(s, max, "") // rune-safe cut
+	return prefix + fmt.Sprintf("\n… [truncated %d bytes]", len(s)-len(prefix))
 }
 
 func platformShell() (string, string) {

--- a/plugins/tools/peer/peer.go
+++ b/plugins/tools/peer/peer.go
@@ -27,8 +27,8 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"unicode/utf8"
 
+	"github.com/agezt/agezt/internal/strutil"
 	"github.com/agezt/agezt/kernel/agent"
 	"github.com/agezt/agezt/kernel/meshctx"
 	"github.com/agezt/agezt/kernel/tenantctx"
@@ -394,11 +394,8 @@ func truncate(s string, max int) string {
 	// Back up to a UTF-8 rune boundary so a multi-byte rune straddling the cut
 	// (common in non-ASCII peer answers) is never split into invalid UTF-8 — the
 	// same fix the browser and coding tools already carry. (M468)
-	cut := max
-	for cut > 0 && !utf8.RuneStart(s[cut]) {
-		cut--
-	}
-	return s[:cut] + fmt.Sprintf("\n… [truncated %d bytes]", len(s)-cut)
+	prefix := strutil.Ellipsis(s, max, "")
+	return prefix + fmt.Sprintf("\n… [truncated %d bytes]", len(s)-len(prefix))
 }
 
 // httpPost is the default poster: a JSON POST with a Bearer token.


### PR DESCRIPTION
Follow-up to #511's consolidation track. Six hand-rolled truncate helpers collapse onto `strutil.Ellipsis`; two of them (controlplane roster, nostr channel) cut at raw byte indexes and could emit invalid UTF-8 on non-ASCII text — they gain rune safety. coding/peer/browser wrappers produce byte-identical output to before.

Test plan: go build/vet + staticcheck clean; package tests green for controlplane, nostr, acpagent, coding, peer, browser, strutil; gofmt clean.