### PR TITLE
%TITLE%

### DIFF
--- a/kernel/agentgw/gateway.go
+++ b/kernel/agentgw/gateway.go
@@ -161,22 +161,29 @@ func (g *Gateway) Listen(ctx context.Context) error {
 	var err error
 
 	// Support both TCP (tcp://host:port) and Unix socket (unix:/path or /path)
+	// Use a ListenConfig with SO_REUSEADDR so that consecutive test runs
+	// (-count=N) don't fail with "address already in use" when the
+	// previous listener's abstract socket hasn't fully released yet.
+	lc := net.ListenConfig{
+		Control: setSockOpt,
+	}
+
 	switch {
 	case len(g.sockPath) >= 1 && g.sockPath[0] == '@':
 		// Abstract unix socket (the default, e.g. @agezt/agentgw.sock). Go maps
 		// the leading @ to the abstract namespace on Linux; without this case it
 		// fell through to net.Listen("tcp", ...) and failed everywhere.
-		ln, err = net.Listen("unix", g.sockPath)
+		ln, err = lc.Listen(ctx, "unix", g.sockPath)
 	case len(g.sockPath) >= 7 && g.sockPath[:6] == "unix://":
 		// Unix socket with explicit prefix
 		socketPath := g.sockPath[6:]
-		ln, err = net.Listen("unix", socketPath)
+		ln, err = lc.Listen(ctx, "unix", socketPath)
 	case len(g.sockPath) >= 4 && g.sockPath[0] == '/' && g.sockPath[1] != '/':
 		// Unix socket path (starts with / but not //)
-		ln, err = net.Listen("unix", g.sockPath)
+		ln, err = lc.Listen(ctx, "unix", g.sockPath)
 	default:
 		// TCP socket
-		ln, err = net.Listen("tcp", g.sockPath)
+		ln, err = lc.Listen(ctx, "tcp", g.sockPath)
 	}
 
 	if err != nil {

--- a/kernel/agentgw/sockopt_other.go
+++ b/kernel/agentgw/sockopt_other.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+
+//go:build !unix
+
+package agentgw
+
+import "syscall"
+
+// setSockOpt is a no-op on non-Unix platforms (Windows). SO_REUSEADDR
+// has different semantics there and Go sets it by default for TCP.
+func setSockOpt(network, address string, c syscall.RawConn) error {
+	return nil
+}

--- a/kernel/agentgw/sockopt_unix.go
+++ b/kernel/agentgw/sockopt_unix.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+
+//go:build unix
+
+package agentgw
+
+import "syscall"
+
+// setSockOpt sets SO_REUSEADDR on the socket so that consecutive test
+// runs (-count=N) don't fail with "address already in use" when the
+// previous listener's socket hasn't fully released yet.
+func setSockOpt(network, address string, c syscall.RawConn) error {
+	var sockErr error
+	err := c.Control(func(fd uintptr) {
+		sockErr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+	})
+	if err != nil {
+		return err
+	}
+	return sockErr
+}


### PR DESCRIPTION
## fix(agentgw): set SO_REUSEADDR to prevent socket bind failures under -count=N

### Why

race-depth runs `kernel/controlplane` tests with `-count=20`. Each iteration starts a Gateway that binds the abstract Unix socket `@agezt/agentgw.sock`. When the previous iteration's listener hasn't fully released the socket, the next bind fails with:

```
agentgw: listen: listen unix @agezt/agentgw.sock: bind: address already in use
```

This causes `kernel/controlplane` to FAIL after 510s, and the entire race-depth job to fail after 5 retries (~41 minutes total).

### What

Use `net.ListenConfig` with a `Control` function that sets `SO_REUSEADDR` on the socket fd before bind.

Platform-split:
- `sockopt_unix.go` — real `SO_REUSEADDR` via `syscall.SetsockoptInt`
- `sockopt_other.go` — no-op (Windows, where Go sets `SO_REUSEADDR` by default for TCP and Unix sockets aren't abstract)

### Verification

```
go build ./kernel/agentgw/...    PASS (windows + linux cross-compile)
gofmt -l kernel/agentgw/         clean
```

### Context

This was the 4th commit on PR #534 (`fix-client-call-cancellation`), which was merged before this commit was pushed. Cherry-picked to its own branch so the race-depth socket fix lands independently.