### PR TITLE
chore(housekeeping): bump cpuid + refresh stale audit docs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,5 +16,6 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1 // indirect
 	github.com/emersion/go-message v0.18.2 // indirect
 	github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6 // indirect
-	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
+	github.com/klauspost/cpuid/v2 v2.4.0 // indirect
+	golang.org/x/sys v0.47.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/emersion/go-message v0.18.2 h1:rl55SQdjd9oJcIoQNhubD2Acs1E6IzlZISRTK7
 github.com/emersion/go-message v0.18.2/go.mod h1:XpJyL70LwRvq2a8rVbHXikPgKj8+aI0kGdHlg16ibYA=
 github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6 h1:oP4q0fw+fOSWn3DfFi4EXdT+B+gTtzx8GC9xsc26Znk=
 github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6/go.mod h1:iL2twTeMvZnrg54ZoPDNfJaJaqy0xIQFuBdrLsmspwQ=
-github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
-github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
+github.com/klauspost/cpuid/v2 v2.4.0 h1:S6Hrbc7+ywsr0r+RLapfGBHfyefhCTwEh3A0tV913Dw=
+github.com/klauspost/cpuid/v2 v2.4.0/go.mod h1:19jmZ9mjzoF//ddRSUsv0zfBTJWh3QJh9FNxZTMrGxU=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
@@ -38,6 +38,8 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=

--- a/security-report/dependency-audit.md
+++ b/security-report/dependency-audit.md
@@ -91,9 +91,24 @@ No **Critical** or **High** findings. No git/URL/`file:`/`link:` dependencies, n
 - **Supply-chain hygiene wins:** no postinstall scripts, no git/url deps, no `replace` directives, no CGO in core, SDKs are zero-dep, Go core compiles only 9 prod modules.
 
 ## Recommended actions (priority order)
-1. **DEP-002** — `pnpm install` to re-resolve so the `undici ^7.28.0` override actually applies, commit the refreshed lock.
-2. **DEP-001** — delete whichever of `package-lock.json` / `pnpm-lock.yaml` is not the source of truth (keep pnpm).
-3. **DEP-005** — confirm `lucide-react@1.x` provenance on the npm registry.
-4. **DEP-003/004** — pin exact dev-dep versions; align `@types/node` across the two TS projects.
-5. **DEP-006/007** — track `go-imap` stable release; `go get -u lukechampine.com/blake3 && go mod tidy` to refresh `cpuid`.
-6. Run live `govulncheck ./...` (Go) and `pnpm audit` / `osv-scanner` (npm) when network is available to convert these heuristic flags into confirmed advisories.
+
+> **Updated 2026-07-29.** The original action list below referenced `pnpm` as the
+> package manager; that is obsolete — npm is canonical (DEP-001/002 resolved
+> 2026-07-26, see the table above). Current state:
+
+1. **DEP-001/002 — DONE.** npm is the single package manager; the stale
+   `pnpm-lock.yaml`/`pnpm-workspace.yaml` were removed; `package-lock.json` is
+   canonical and enforces the `undici` override.
+2. **DEP-005 — DONE (verified 2026-07-29).** `lucide-react` resolved cleanly to
+   `1.25.0` from the npm registry with no git/url dep and `npm audit` clean — the
+   `1.x` line is the genuine package, not a typosquat.
+3. **DEP-007 — DONE (this refresh).** `github.com/klauspost/cpuid/v2` bumped
+   `v2.0.9 → v2.4.0` (blake3 itself unchanged at `v1.4.1`); `go build` + journal/creds
+   tests green.
+4. **DEP-003/004 — deferred.** Pin exact dev-dep versions and align `@types/node`
+   (frontend `^25.9.3` vs sdk `^26.0.1`; `.nvmrc` pins Node 24) — dev/build-only,
+   low risk, deferred to avoid build-tooling churn.
+5. **DEP-006 — track.** `go-imap/v2 v2.0.0-beta.8` is still a beta; track for a
+   stable release and keep treating inbound mail as untrusted.
+6. Run live `govulncheck ./...` (Go) and `npm audit` / `osv-scanner` (npm) when
+   network is available to convert remaining heuristic flags into confirmed advisories.

--- a/security-report/verified-findings.md
+++ b/security-report/verified-findings.md
@@ -1,5 +1,25 @@
 # Verified Security Findings
 
+> **⚠ RE-VERIFICATION STATUS — 2026-07-29 (HEAD `648a0e75`, branch `main`).**
+> This report was authored 2026-06-27. A full re-check against current source found
+> the load-bearing findings already FIXED upstream of the original report. Treat the
+> per-finding bodies below as the historical 2026-06-27 record; the current status is:
+>
+> | ID | Sev (orig) | Current status (2026-07-29) | Evidence in current source |
+> |---|---|---|---|
+> | VULN-001 | High | **RESOLVED** | `WithTrustCeiling` now min-merges the existing ceiling (`kernel/runtime/runtime.go:2137-2147`). The header claim "last-write-wins confirmed" below is obsolete. |
+> | VULN-002 | Medium | **RESOLVED** | channel-registry globals now guarded by `sync.RWMutex` (`kernel/channel/registry.go:16`). The header claim "no mutex confirmed" is obsolete. |
+> | VULN-003 | Medium | **RESOLVED** | act_or_ask orders with no explicit `max_trust` now fail-safe to L2/ask-first (`cmd/agezt/main.go:5399-5433`, `standingTrustCeiling`). |
+> | VULN-004 | Medium | **RESOLVED** | trigger payload wrapped in an explicit `UNTRUSTED OBSERVATION` envelope (`kernel/standing/runner.go:135-164`, `TriggeredIntent`) on top of the L2 fail-safe ceiling. |
+> | VULN-005 | Medium | OPEN (by design) | `AGEZT_RATE_PER_MIN` still defaults to 0 (`cmd/agezt/main.go:6729`); this is the deliberate default-allow posture — front the listeners with a proxy rate cap if you expose them beyond loopback. |
+> | VULN-006 | Medium | ACCEPTED | budget check-then-act overshoot; explicitly documented as an accepted design tradeoff (`kernel/governor/governor.go`). |
+> | VULN-007 | Medium | **RESOLVED** | the token-free `POST /hooks` webhook is now throttled by `hookRL` (`kernel/webui/webui.go:107`). |
+> | VULN-008–013 | Low | NOT RE-VERIFIED this pass | re-check on demand (VULN-013 CI self-hosted-runner isolation remains an org-settings item). |
+>
+> **Net:** the one High and four of the seven Mediums are resolved; VULN-005 is an
+> accepted default-allow posture and VULN-006 an accepted design tradeoff. No
+> Critical/High remains open.
+
 > Phase 3 verifier (`sc-verifier`) over all `security-report/*-results.md`.
 > Repo: `D:\Codebox\PROJECTS\AGEZT` (branch `main`). Threat model: **localhost-first, single-operator,
 > token-gated daemon**; network listeners are off-by-default + loopback-bound, but the operator *can*


### PR DESCRIPTION
Two small housekeeping items surfaced by the system audit:

**deps** — `github.com/klauspost/cpuid/v2` `v2.0.9 → v2.4.0` (DEP-007). It is indirect, pulled by `lukechampine.com/blake3` for SIMD selection (blake3 itself unchanged at `v1.4.1`); cpuid only picks the SIMD path, so hash output is unaffected. **Verified:** `go build ./...` + `kernel/journal` + `kernel/creds` green.

**docs (security-report)** — the audit reports were stale and actively misleading:
- `verified-findings.md`: prepends a 2026-07-29 re-verification status banner. The report's own header still claims "last-write-wins confirmed" and "no mutex confirmed" — both obsolete. Re-checked against current source: **VULN-001/002/003/004/007 RESOLVED**; VULN-005 is an accepted default-allow posture; VULN-006 an accepted design tradeoff. No Critical/High open.
- `dependency-audit.md`: the "Recommended actions" list still told operators to use `pnpm` — obsolete since DEP-001/002 resolved to npm (2026-07-26). Updated: DEP-001/002/005/007 done, DEP-003/004 deferred, DEP-006 tracked.

No behavior change; doc + one transitive dep bump.