### PR TITLE
refactor(channels): Phase 2.1 complete — channel factory, all 34 kinds, main.go section −1,400 lines

### DIFF
--- a/cmd/agezt/coverage_builders_test.go
+++ b/cmd/agezt/coverage_builders_test.go
@@ -48,6 +48,7 @@ func TestChannelBuilders_NotConfigured(t *testing.T) {
 	for _, kind := range []string{
 		"telegram", "slack", "email", "discord", "matrix", "whatsapp",
 		"webhook", "irc", "twitch", "sms", "signal",
+		"whatsappgw", "imessage", "homeassistant", "teams", "nextcloudtalk",
 	} {
 		f, ok := channelwire.Lookup(kind)
 		if !ok {
@@ -66,18 +67,13 @@ func TestChannelBuilders_NotConfigured(t *testing.T) {
 	// Builders that read os.Getenv directly. None of their env vars are set in
 	// the test process, so each must early-return an empty descriptor.
 	envBuilders := map[string]func() string{
-		"whatsappgw":    func() string { _, _, d := buildWhatsAppGateway(ctx, k); return d },
-		"imessage":      func() string { _, _, d := buildIMessage(ctx, k); return d },
-		"line":          func() string { _, _, d := buildLine(ctx, k); return d },
-		"dingtalk":      func() string { _, _, d := buildDingTalk(ctx, k); return d },
-		"feishu":        func() string { _, _, d := buildFeishu(ctx, k); return d },
-		"wecom":         func() string { _, _, d := buildWeCom(ctx, k); return d },
-		"zalo":          func() string { _, _, d := buildZalo(ctx, k); return d },
-		"nextcloudtalk": func() string { _, _, d := buildNextcloudTalk(ctx, k); return d },
-		"mastodon":      func() string { _, _, d := buildMastodon(ctx, k); return d },
-		"nostr":         func() string { _, _, d := buildNostr(ctx, k); return d },
-		"homeassistant": func() string { _, _, d := buildHomeAssistant(ctx, k); return d },
-		"teams":         func() string { _, _, d := buildTeams(ctx, k); return d },
+		"line":     func() string { _, _, d := buildLine(ctx, k); return d },
+		"dingtalk": func() string { _, _, d := buildDingTalk(ctx, k); return d },
+		"feishu":   func() string { _, _, d := buildFeishu(ctx, k); return d },
+		"wecom":    func() string { _, _, d := buildWeCom(ctx, k); return d },
+		"zalo":     func() string { _, _, d := buildZalo(ctx, k); return d },
+		"mastodon": func() string { _, _, d := buildMastodon(ctx, k); return d },
+		"nostr":    func() string { _, _, d := buildNostr(ctx, k); return d },
 	}
 	for name, fn := range envBuilders {
 		if desc := fn(); desc != "" {

--- a/cmd/agezt/coverage_builders_test.go
+++ b/cmd/agezt/coverage_builders_test.go
@@ -49,6 +49,7 @@ func TestChannelBuilders_NotConfigured(t *testing.T) {
 		"telegram", "slack", "email", "discord", "matrix", "whatsapp",
 		"webhook", "irc", "twitch", "sms", "signal",
 		"whatsappgw", "imessage", "homeassistant", "teams", "nextcloudtalk",
+		"nostr", "zalo", "qq", "wechat", "line",
 	} {
 		f, ok := channelwire.Lookup(kind)
 		if !ok {
@@ -67,13 +68,10 @@ func TestChannelBuilders_NotConfigured(t *testing.T) {
 	// Builders that read os.Getenv directly. None of their env vars are set in
 	// the test process, so each must early-return an empty descriptor.
 	envBuilders := map[string]func() string{
-		"line":     func() string { _, _, d := buildLine(ctx, k); return d },
 		"dingtalk": func() string { _, _, d := buildDingTalk(ctx, k); return d },
 		"feishu":   func() string { _, _, d := buildFeishu(ctx, k); return d },
 		"wecom":    func() string { _, _, d := buildWeCom(ctx, k); return d },
-		"zalo":     func() string { _, _, d := buildZalo(ctx, k); return d },
 		"mastodon": func() string { _, _, d := buildMastodon(ctx, k); return d },
-		"nostr":    func() string { _, _, d := buildNostr(ctx, k); return d },
 	}
 	for name, fn := range envBuilders {
 		if desc := fn(); desc != "" {
@@ -81,12 +79,9 @@ func TestChannelBuilders_NotConfigured(t *testing.T) {
 		}
 	}
 
-	// kind/prefix builders — a chat webhook + OneBot with an unset prefix.
+	// kind/prefix builder — a chat webhook with an unset prefix.
 	if _, _, d := buildChatWebhook(ctx, k, "custom", "CUSTOM"); d != "" {
 		t.Errorf("chat webhook returned %q when unconfigured", d)
-	}
-	if _, _, d := buildOneBot(ctx, k, "qq", "QQ"); d != "" {
-		t.Errorf("onebot returned %q when unconfigured", d)
 	}
 }
 

--- a/cmd/agezt/coverage_builders_test.go
+++ b/cmd/agezt/coverage_builders_test.go
@@ -45,11 +45,15 @@ func TestChannelBuilders_NotConfigured(t *testing.T) {
 	// so every config key resolves to "" and each factory must return
 	// NotConfigured (empty Desc, no channels) without any network work.
 	builtinchannels.RegisterAll()
+	// googlechat/mattermost cover the parameterized chatWebhookFactory closure
+	// (which replaced the old generic-prefix buildChatWebhook assertion — the
+	// factory registry only exposes the two registered kind/prefix pairs).
 	for _, kind := range []string{
 		"telegram", "slack", "email", "discord", "matrix", "whatsapp",
 		"webhook", "irc", "twitch", "sms", "signal",
 		"whatsappgw", "imessage", "homeassistant", "teams", "nextcloudtalk",
 		"nostr", "zalo", "qq", "wechat", "line",
+		"googlechat", "mattermost", "dingtalk", "feishu", "wecom", "mastodon",
 	} {
 		f, ok := channelwire.Lookup(kind)
 		if !ok {
@@ -63,25 +67,6 @@ func TestChannelBuilders_NotConfigured(t *testing.T) {
 		if len(built.Channels) != 0 {
 			t.Errorf("%s factory returned %d channel(s) when unconfigured", kind, len(built.Channels))
 		}
-	}
-
-	// Builders that read os.Getenv directly. None of their env vars are set in
-	// the test process, so each must early-return an empty descriptor.
-	envBuilders := map[string]func() string{
-		"dingtalk": func() string { _, _, d := buildDingTalk(ctx, k); return d },
-		"feishu":   func() string { _, _, d := buildFeishu(ctx, k); return d },
-		"wecom":    func() string { _, _, d := buildWeCom(ctx, k); return d },
-		"mastodon": func() string { _, _, d := buildMastodon(ctx, k); return d },
-	}
-	for name, fn := range envBuilders {
-		if desc := fn(); desc != "" {
-			t.Errorf("%s builder returned a non-empty desc %q when unconfigured", name, desc)
-		}
-	}
-
-	// kind/prefix builder — a chat webhook with an unset prefix.
-	if _, _, d := buildChatWebhook(ctx, k, "custom", "CUSTOM"); d != "" {
-		t.Errorf("chat webhook returned %q when unconfigured", d)
 	}
 }
 

--- a/cmd/agezt/coverage_builders_test.go
+++ b/cmd/agezt/coverage_builders_test.go
@@ -45,7 +45,10 @@ func TestChannelBuilders_NotConfigured(t *testing.T) {
 	// so every config key resolves to "" and each factory must return
 	// NotConfigured (empty Desc, no channels) without any network work.
 	builtinchannels.RegisterAll()
-	for _, kind := range []string{"telegram", "slack", "email", "discord", "matrix", "whatsapp"} {
+	for _, kind := range []string{
+		"telegram", "slack", "email", "discord", "matrix", "whatsapp",
+		"webhook", "irc", "twitch", "sms", "signal",
+	} {
 		f, ok := channelwire.Lookup(kind)
 		if !ok {
 			t.Errorf("%s: no channelwire factory registered", kind)
@@ -63,9 +66,6 @@ func TestChannelBuilders_NotConfigured(t *testing.T) {
 	// Builders that read os.Getenv directly. None of their env vars are set in
 	// the test process, so each must early-return an empty descriptor.
 	envBuilders := map[string]func() string{
-		"webhook":       func() string { _, _, d := buildWebhook(ctx, k); return d },
-		"irc":           func() string { _, _, d := buildIRC(ctx, k); return d },
-		"twitch":        func() string { _, _, d := buildTwitch(ctx, k); return d },
 		"whatsappgw":    func() string { _, _, d := buildWhatsAppGateway(ctx, k); return d },
 		"imessage":      func() string { _, _, d := buildIMessage(ctx, k); return d },
 		"line":          func() string { _, _, d := buildLine(ctx, k); return d },
@@ -76,10 +76,8 @@ func TestChannelBuilders_NotConfigured(t *testing.T) {
 		"nextcloudtalk": func() string { _, _, d := buildNextcloudTalk(ctx, k); return d },
 		"mastodon":      func() string { _, _, d := buildMastodon(ctx, k); return d },
 		"nostr":         func() string { _, _, d := buildNostr(ctx, k); return d },
-		"sms":           func() string { _, _, d := buildSMS(ctx, k); return d },
 		"homeassistant": func() string { _, _, d := buildHomeAssistant(ctx, k); return d },
 		"teams":         func() string { _, _, d := buildTeams(ctx, k); return d },
-		"signal":        func() string { _, _, d := buildSignal(ctx, k); return d },
 	}
 	for name, fn := range envBuilders {
 		if desc := fn(); desc != "" {

--- a/cmd/agezt/coverage_builders_test.go
+++ b/cmd/agezt/coverage_builders_test.go
@@ -6,7 +6,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/agezt/agezt/kernel/channelwire"
 	kernelruntime "github.com/agezt/agezt/kernel/runtime"
+	"github.com/agezt/agezt/plugins/builtinchannels"
 	"github.com/agezt/agezt/plugins/providers/mock"
 )
 
@@ -38,37 +40,23 @@ func TestChannelBuilders_NotConfigured(t *testing.T) {
 	k := newBuilderTestKernel(t)
 	ctx := context.Background()
 
-	// Builders that take a config lookup func — feed emptyGet so every key
-	// resolves to "".
-	getBuilders := map[string]func() (interface{}, interface{}, string){
-		"telegram": func() (interface{}, interface{}, string) {
-			c, s, d := buildTelegramInstance(ctx, k, "telegram", emptyGet)
-			return c, s, d
-		},
-		"slack": func() (interface{}, interface{}, string) {
-			c, s, d := buildSlackInstance(ctx, k, "slack", emptyGet)
-			return c, s, d
-		},
-		"email": func() (interface{}, interface{}, string) {
-			c, s, d := buildEmailInstance(ctx, k, "email", emptyGet)
-			return c, s, d
-		},
-		"discord": func() (interface{}, interface{}, string) {
-			c, s, d := buildDiscordInstance(ctx, k, "discord", emptyGet)
-			return c, s, d
-		},
-		"matrix": func() (interface{}, interface{}, string) {
-			c, s, d := buildMatrixInstance(ctx, k, "matrix", emptyGet)
-			return c, s, d
-		},
-		"whatsapp": func() (interface{}, interface{}, string) {
-			c, s, d := buildWhatsAppInstance(ctx, k, "whatsapp", emptyGet)
-			return c, s, d
-		},
-	}
-	for name, fn := range getBuilders {
-		if _, _, desc := fn(); desc != "" {
-			t.Errorf("%s builder returned a non-empty desc %q when unconfigured", name, desc)
+	// Factory-migrated builders (Phase 2.1) — resolved through the channelwire
+	// registry after builtinchannels.RegisterAll seeds it. Deps.Get is emptyGet
+	// so every config key resolves to "" and each factory must return
+	// NotConfigured (empty Desc, no channels) without any network work.
+	builtinchannels.RegisterAll()
+	for _, kind := range []string{"telegram", "slack", "email", "discord", "matrix", "whatsapp"} {
+		f, ok := channelwire.Lookup(kind)
+		if !ok {
+			t.Errorf("%s: no channelwire factory registered", kind)
+			continue
+		}
+		built := f(channelwire.Deps{Ctx: ctx, Bus: k.Bus(), Handler: makeChannelHandler(k), Get: emptyGet})
+		if built.Desc != "" {
+			t.Errorf("%s factory returned a non-empty desc %q when unconfigured", kind, built.Desc)
+		}
+		if len(built.Channels) != 0 {
+			t.Errorf("%s factory returned %d channel(s) when unconfigured", kind, len(built.Channels))
 		}
 	}
 

--- a/cmd/agezt/coverage_builders_test.go
+++ b/cmd/agezt/coverage_builders_test.go
@@ -54,6 +54,7 @@ func TestChannelBuilders_NotConfigured(t *testing.T) {
 		"whatsappgw", "imessage", "homeassistant", "teams", "nextcloudtalk",
 		"nostr", "zalo", "qq", "wechat", "line",
 		"googlechat", "mattermost", "dingtalk", "feishu", "wecom", "mastodon",
+		"ntfy", "pushover", "gotify", "pushbullet", "rocketchat", "zulip", "synology",
 	} {
 		f, ok := channelwire.Lookup(kind)
 		if !ok {
@@ -67,16 +68,5 @@ func TestChannelBuilders_NotConfigured(t *testing.T) {
 		if len(built.Channels) != 0 {
 			t.Errorf("%s factory returned %d channel(s) when unconfigured", kind, len(built.Channels))
 		}
-	}
-}
-
-// TestTwoWayConfigHelpers covers the pure config predicates that gate the
-// two-way (inbound) channel paths. With no env set both must report false.
-func TestTwoWayConfigHelpers(t *testing.T) {
-	if twoWayLineConfigured() {
-		t.Error("twoWayLineConfigured should be false with no LINE env set")
-	}
-	if twoWayChatConfigured("CUSTOM") {
-		t.Error("twoWayChatConfigured should be false with no prefix env set")
 	}
 }

--- a/cmd/agezt/coverage_helpers_more_test.go
+++ b/cmd/agezt/coverage_helpers_more_test.go
@@ -120,12 +120,6 @@ func TestCoverageHelperWebAndBriefFormatting(t *testing.T) {
 	if !strings.Contains(buf.String(), "Heads up") {
 		t.Fatalf("briefSink log output = %q", buf.String())
 	}
-	if got := formatBrief(pulse.Brief{Title: "T", Body: "B"}); got != "📣 T\nB" {
-		t.Fatalf("formatBrief with body = %q", got)
-	}
-	if got := formatBrief(pulse.Brief{Title: "T"}); got != "📣 T" {
-		t.Fatalf("formatBrief without body = %q", got)
-	}
 }
 
 func TestCoverageHelperTunnelAndRedaction(t *testing.T) {

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -324,24 +324,45 @@ func runDaemon(stdout, stderr io.Writer) int {
 		return 1
 	}
 
+	// Register the built-in channel manifests (Telegram, WhatsApp, …) BEFORE
+	// anything reads the channel registry: notifyTargets just below derives its
+	// env names from the manifests, the Channels wizard lists them, and
+	// collectChannels() derives `agt status`'s configured-channel view from the
+	// registry, so it must be populated by the time srv.SetChannels runs below.
+	// (This call used to sit further down, nested inside an
+	// `if k.Forge() != nil` block — pure registration has no business being
+	// conditional on the Forge.)
+	builtinchannels.RegisterAll()
+
 	// Proactive-messaging tool (`notify`, M143). Register it here — BEFORE the
 	// kernel (and its HTTP servers / channels) start — so the tool map is never
 	// written while the agent loop reads it (a fatal concurrent-map race otherwise).
 	// The sender needs the live channels (built after the kernel), so the tool is
-	// created unbound now and Bind-wired later. Decide registration from env: a
-	// channel kind contributes targets only when its token AND a non-empty allowlist
-	// are set, so a half-configured channel never advertises a tool that can't send.
+	// created unbound now and Bind-wired later. Decide registration from env,
+	// with the env names taken from each kind's manifest (RequiredEnv +
+	// AllowlistEnv, Phase 2.1 PR 8): a channel kind contributes targets only
+	// when its required env AND a non-empty allowlist are set, so a
+	// half-configured channel never advertises a tool that can't send. The
+	// kind list stays deliberately restricted to the three chat channels the
+	// notify/send_media/briefing surface has always targeted.
 	notifyTargets := map[string][]string{}
-	for _, c := range []struct{ kind, tokenEnv, idsEnv string }{
-		{"telegram", "TELEGRAM_TOKEN", "TELEGRAM_CHAT_ID"},
-		{"slack", "SLACK_TOKEN", "SLACK_CHANNELS"},
-		{"discord", "DISCORD_TOKEN", "DISCORD_CHANNELS"},
-	} {
-		if strings.TrimSpace(os.Getenv(brand.EnvPrefix+c.tokenEnv)) == "" {
+	for _, kind := range []string{"telegram", "slack", "discord"} {
+		m, ok := channel.LookupManifest(kind)
+		if !ok || m.AllowlistEnv == "" {
 			continue
 		}
-		if ids := splitNonEmpty(os.Getenv(brand.EnvPrefix + c.idsEnv)); len(ids) > 0 {
-			notifyTargets[c.kind] = ids
+		configured := len(m.RequiredEnv) > 0
+		for _, env := range m.RequiredEnv {
+			if strings.TrimSpace(os.Getenv(env)) == "" {
+				configured = false
+				break
+			}
+		}
+		if !configured {
+			continue
+		}
+		if ids := splitNonEmpty(os.Getenv(m.AllowlistEnv)); len(ids) > 0 {
+			notifyTargets[kind] = ids
 		}
 	}
 	var notifyTool *notify.Tool
@@ -1482,174 +1503,30 @@ func runDaemon(stdout, stderr io.Writer) int {
 	fmt.Fprintf(stdout, "  skill shadow-eval: %s\n", shadowEvalDesc)
 	fmt.Fprintf(stdout, "  skill auto-promo.: %s\n", autoPromoteDesc)
 
-	// Register the built-in channel manifests (Telegram, WhatsApp, …) BEFORE
-	// any channel construction or status snapshot: the Channels wizard lists
-	// them, and collectChannels() derives `agt status`'s configured-channel
-	// view from the registry, so it must be populated by the time
-	// srv.SetChannels runs below. (This call used to sit further down, nested
-	// inside an `if k.Forge() != nil` block — pure registration has no
-	// business being conditional on the Forge.)
-	builtinchannels.RegisterAll()
-
 	// The shared inbound handler, built ONCE for every factory-migrated channel
 	// (Phase 2.1): channelwire factories receive it through Deps.Handler.
 	chanHandler := makeChannelHandler(k)
 
-	// Telegram channel (SPEC-04 §1) — duplex when AGEZT_TELEGRAM_TOKEN is
-	// set. Built before Pulse so its brief sink can tee with the log sink.
-	// Telegram channel (SPEC-04 §1) — multi-account: the default instance plus any
-	// "#label" accounts (several bots) are all built and started.
-	tgInsts := wireInstances(channelwire.BuildKind(ctx, "telegram", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "telegram", "telegram", "disabled (set AGEZT_TELEGRAM_TOKEN)", tgInsts)
-
-	// Slack channel (SPEC-04 §1) — duplex when AGEZT_SLACK_TOKEN is set. Serves
-	// the Events API endpoint for inbound (HMAC-verified) and chat.postMessage for
-	// outbound; briefs tee to it like Telegram.
-	slInsts := wireInstances(channelwire.BuildKind(ctx, "slack", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "slack", "slack", "disabled (set AGEZT_SLACK_TOKEN)", slInsts)
-
-	// Discord channel (SPEC-04 §1) — duplex when AGEZT_DISCORD_TOKEN is set.
-	// Serves the Interactions endpoint for inbound slash commands (Ed25519-verified)
-	// and posts via the bot token for outbound; briefs tee to it like the others.
-	dcInsts := wireInstances(channelwire.BuildKind(ctx, "discord", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "discord", "discord", "disabled (set AGEZT_DISCORD_TOKEN)", dcInsts)
-
-	// Generic webhook channel (SPEC-04 §1) — vendor-neutral duplex. Any external
-	// system POSTs a signed JSON message and gets the agent's reply synchronously;
-	// briefs/`agt send` tee to a configured outbound URL. Enabled when a secret
-	// (inbound) or an outbound URL is set.
-	whInsts := wireInstances(channelwire.BuildKind(ctx, "webhook", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "webhook", "webhook channel", "disabled (set AGEZT_WEBHOOK_SECRET + AGEZT_WEBHOOK_ADDR)", whInsts)
-
-	// Email channel (SPEC-04 §1) — outbound-only over SMTP. Briefs/`agt send` mail
-	// the allowlisted recipients. Enabled when AGEZT_EMAIL_SMTP_ADDR is set.
-	// Email channel (SPEC-04 §1) — multi-account: the default instance plus any
-	// "#label" accounts (several mailboxes, each its own SMTP) are all built.
-	emInsts := wireInstances(channelwire.BuildKind(ctx, "email", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "email", "email channel", "disabled (set AGEZT_EMAIL_SMTP_ADDR + AGEZT_EMAIL_FROM)", emInsts)
-
-	// Matrix channel (SPEC-04 §1) — duplex over the open Matrix Client-Server API
-	// when AGEZT_MATRIX_HOMESERVER + AGEZT_MATRIX_TOKEN are set. Long-polls /sync
-	// for inbound and PUTs m.room.message for outbound; briefs tee to the
-	// allowlisted rooms like the others.
-	mxInsts := wireInstances(channelwire.BuildKind(ctx, "matrix", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "matrix", "matrix channel", "disabled (set AGEZT_MATRIX_HOMESERVER + AGEZT_MATRIX_TOKEN)", mxInsts)
-
-	// IRC channel (SPEC-04 §1) — two-way over a persistent socket to any ircd.
-	ircInsts := wireInstances(channelwire.BuildKind(ctx, "irc", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "irc", "irc channel", "disabled (set AGEZT_IRC_SERVER + AGEZT_IRC_NICK)", ircInsts)
-
-	// Twitch chat (SPEC-04 §1) — IRC over Twitch's server; reuses the IRC channel.
-	twInsts := wireInstances(channelwire.BuildKind(ctx, "twitch", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "twitch", "twitch channel", "disabled (set AGEZT_TWITCH_USERNAME + AGEZT_TWITCH_TOKEN)", twInsts)
-
-	// WhatsApp via a self-hosted gateway (WAHA/Evolution) — the easy WhatsApp path.
-	wgInsts := wireInstances(channelwire.BuildKind(ctx, "whatsappgw", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "whatsappgw", "whatsapp gateway", "disabled (set AGEZT_WHATSAPPGW_URL)", wgInsts)
-
-	// iMessage via a self-hosted BlueBubbles server — the Mac-bridge iMessage path.
-	imInsts := wireInstances(channelwire.BuildKind(ctx, "imessage", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "imessage", "imessage channel", "disabled (set AGEZT_IMESSAGE_URL)", imInsts)
-
-	// LINE two-way (official Messaging API) — supersedes the outbound-only push
-	// LINE when a channel secret is set.
-	lnInsts := wireInstances(channelwire.BuildKind(ctx, "line", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "line", "line channel", "", lnInsts)
-
-	// Two-way Google Chat / Mattermost (incoming webhook out + webhook in) —
-	// supersede the outbound-only push entries when an inbound addr is set.
-	gcInsts := wireInstances(channelwire.BuildKind(ctx, "googlechat", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "googlechat", "googlechat (2way)", "", gcInsts)
-	mmInsts := wireInstances(channelwire.BuildKind(ctx, "mattermost", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "mattermost", "mattermost (2way)", "", mmInsts)
-
-	// DingTalk / Feishu / WeCom two-way (China enterprise platforms).
-	dtInsts := wireInstances(channelwire.BuildKind(ctx, "dingtalk", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "dingtalk", "dingtalk (2way)", "", dtInsts)
-	fsInsts := wireInstances(channelwire.BuildKind(ctx, "feishu", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "feishu", "feishu (2way)", "", fsInsts)
-	wcInsts := wireInstances(channelwire.BuildKind(ctx, "wecom", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "wecom", "wecom (2way)", "", wcInsts)
-
-	// QQ / WeChat via a OneBot v11 gateway; Zalo via the Official Account API.
-	qqInsts := wireInstances(channelwire.BuildKind(ctx, "qq", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "qq", "qq channel", "", qqInsts)
-	wxInsts := wireInstances(channelwire.BuildKind(ctx, "wechat", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "wechat", "wechat channel", "", wxInsts)
-	zlInsts := wireInstances(channelwire.BuildKind(ctx, "zalo", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "zalo", "zalo channel", "", zlInsts)
-	nctInsts := wireInstances(channelwire.BuildKind(ctx, "nextcloudtalk", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "nextcloudtalk", "nextcloud talk", "", nctInsts)
-	maInsts := wireInstances(channelwire.BuildKind(ctx, "mastodon", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "mastodon", "mastodon channel", "", maInsts)
-	noInsts := wireInstances(channelwire.BuildKind(ctx, "nostr", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "nostr", "nostr channel", "", noInsts)
-
-	// SMS channel (SPEC-04 §1) — duplex over Twilio Programmable Messaging when
-	// AGEZT_SMS_ACCOUNT_SID + AGEZT_SMS_AUTH_TOKEN are set. Inbound is a signed
-	// Twilio webhook (needs AGEZT_SMS_ADDR); outbound texts go via the REST API
-	// (needs AGEZT_SMS_FROM); briefs tee to the allowlisted numbers.
-	smInsts := wireInstances(channelwire.BuildKind(ctx, "sms", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "sms", "sms channel", "disabled (set AGEZT_SMS_ACCOUNT_SID + AGEZT_SMS_AUTH_TOKEN)", smInsts)
-
-	// WhatsApp channel (SPEC-04 §1) — duplex over Meta's WhatsApp Cloud API when
-	// AGEZT_WHATSAPP_APP_SECRET + AGEZT_WHATSAPP_ACCESS_TOKEN are set. Inbound is a
-	// signed Meta webhook (needs AGEZT_WHATSAPP_ADDR); outbound goes via the Graph
-	// API (needs AGEZT_WHATSAPP_PHONE_NUMBER_ID); briefs tee to the allowlist.
-	waInsts := wireInstances(channelwire.BuildKind(ctx, "whatsapp", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "whatsapp", "whatsapp channel", "disabled (set AGEZT_WHATSAPP_APP_SECRET + AGEZT_WHATSAPP_ACCESS_TOKEN)", waInsts)
-
-	// Home Assistant channel (SPEC-04 §1) — outbound to HA's notify API when
-	// AGEZT_HOMEASSISTANT_URL + AGEZT_HOMEASSISTANT_TOKEN are set. Briefs/`agt send`
-	// land as phone pushes / TTS / persistent notifications on the allowlisted
-	// notify services. Outbound-only (drive FROM HA via the webhook channel).
-	haInsts := wireInstances(channelwire.BuildKind(ctx, "homeassistant", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "homeassistant", "homeassistant ch", "disabled (set AGEZT_HOMEASSISTANT_URL + AGEZT_HOMEASSISTANT_TOKEN)", haInsts)
-
-	// Teams channel (SPEC-04 §1) — outbound to Microsoft Teams Incoming Webhooks
-	// when AGEZT_TEAMS_WEBHOOKS is set (name=url,name2=url2). Briefs/`agt send`
-	// post a card to the named Teams channel. Outbound-only.
-	tmInsts := wireInstances(channelwire.BuildKind(ctx, "teams", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "teams", "teams channel", "disabled (set AGEZT_TEAMS_WEBHOOKS=name=url,...)", tmInsts)
-
-	// Signal channel (SPEC-04 §1) — duplex via an operator-run signal-cli-rest-api
-	// when AGEZT_SIGNAL_API_URL + AGEZT_SIGNAL_NUMBER are set. Long-polls
-	// /v1/receive for inbound and POSTs /v2/send for outbound; briefs tee to the
-	// allowlisted numbers like the others.
-	sgInsts := wireInstances(channelwire.BuildKind(ctx, "signal", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "signal", "signal channel", "disabled (set AGEZT_SIGNAL_API_URL + AGEZT_SIGNAL_NUMBER)", sgInsts)
-
-	// Push-notification channels (SPEC-04 §1): a family of simple outbound
-	// destinations, each enabled by its own env and exposed as a distinct
-	// channel. Briefs/`agt send` POST to the service. Outbound-only. The dual
-	// kinds (googlechat/mattermost/mastodon/line/feishu/dingtalk/wecom) fall
-	// back to their push entry inside their own factories when two-way is
-	// unconfigured; these seven are pure push. Silent when unconfigured
-	// (disabledHint ""), matching the old single "push channels: disabled" line.
-	ntInsts := wireInstances(channelwire.BuildKind(ctx, "ntfy", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "ntfy", "ntfy push", "", ntInsts)
-	poInsts := wireInstances(channelwire.BuildKind(ctx, "pushover", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "pushover", "pushover push", "", poInsts)
-	gfInsts := wireInstances(channelwire.BuildKind(ctx, "gotify", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "gotify", "gotify push", "", gfInsts)
-	pbInsts := wireInstances(channelwire.BuildKind(ctx, "pushbullet", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "pushbullet", "pushbullet push", "", pbInsts)
-	rcInsts := wireInstances(channelwire.BuildKind(ctx, "rocketchat", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "rocketchat", "rocketchat push", "", rcInsts)
-	zuInsts := wireInstances(channelwire.BuildKind(ctx, "zulip", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "zulip", "zulip push", "", zuInsts)
-	syInsts := wireInstances(channelwire.BuildKind(ctx, "synology", k.Bus(), chanHandler))
-	startInstances(ctx, stdout, "synology", "synology push", "", syInsts)
-
-	// Every configured channel's brief sink, teed: Pulse briefs and (M782)
-	// alert notifications share the same delivery surface.
-	// All channels are multi-account now: one brief sink per instance.
-	allInsts := [][]chanInstance{
-		tgInsts, emInsts, slInsts, dcInsts, mxInsts, waInsts,
-		whInsts, ircInsts, twInsts, wgInsts, imInsts, lnInsts, gcInsts, mmInsts,
-		dtInsts, fsInsts, wcInsts, qqInsts, wxInsts, zlInsts, nctInsts, maInsts, noInsts,
-		smInsts, haInsts, tmInsts, sgInsts,
-		ntInsts, poInsts, gfInsts, pbInsts, rcInsts, zuInsts, syInsts,
+	// Every channel kind, built and started from its registered manifest
+	// (Phase 2.1 PR 8): one uniform loop replaces the 34 hand-written
+	// build+start pairs. The per-kind boot-banner label and the "disabled
+	// (set ...)" hint live on the manifest (BannerLabel / DisabledHint;
+	// empty hint = silent when unconfigured, matching the old push family).
+	// Banner order follows Manifests() (sorted by display name) rather than
+	// the old hand-ordering.
+	//
+	// Every configured channel's brief sink is teed below: Pulse briefs and
+	// (M782) alert notifications share the same delivery surface. All
+	// channels are multi-account now: one brief sink per instance.
+	var allInsts [][]chanInstance
+	for _, m := range channel.Manifests() {
+		insts := wireInstances(channelwire.BuildKind(ctx, m.Kind, k.Bus(), chanHandler))
+		label := m.BannerLabel
+		if label == "" {
+			label = m.Kind
+		}
+		startInstances(ctx, stdout, m.Kind, label, m.DisabledHint, insts)
+		allInsts = append(allInsts, insts)
 	}
 	channelSinks := combineSinks(instanceSinks(allInsts...)...)
 

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -33,7 +33,6 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
-	"reflect"
 	stdruntime "runtime"
 	"sort"
 	"strconv"
@@ -87,12 +86,7 @@ import (
 	"github.com/agezt/agezt/plugins/builtinguardians"
 	"github.com/agezt/agezt/plugins/builtinmarket"
 	"github.com/agezt/agezt/plugins/builtinskills"
-	"github.com/agezt/agezt/plugins/channels/chatwebhook"
-	"github.com/agezt/agezt/plugins/channels/dingtalk"
-	"github.com/agezt/agezt/plugins/channels/feishu"
-	"github.com/agezt/agezt/plugins/channels/mastodon"
 	"github.com/agezt/agezt/plugins/channels/push"
-	"github.com/agezt/agezt/plugins/channels/wecom"
 	"github.com/agezt/agezt/plugins/providers/compat"
 	"github.com/agezt/agezt/plugins/providers/embed"
 	"github.com/agezt/agezt/plugins/providers/image"
@@ -1565,21 +1559,17 @@ func runDaemon(stdout, stderr io.Writer) int {
 
 	// Two-way Google Chat / Mattermost (incoming webhook out + webhook in) —
 	// supersede the outbound-only push entries when an inbound addr is set.
-	gcInsts := buildAccountsLegacy(ctx, k, "googlechat", func(c context.Context, kk *kernelruntime.Kernel) (*chatwebhook.Channel, pulse.BriefSink, string) {
-		return buildChatWebhook(c, kk, chatwebhook.KindGoogleChat, "GOOGLECHAT")
-	})
+	gcInsts := wireInstances(channelwire.BuildKind(ctx, "googlechat", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "googlechat", "googlechat (2way)", "", gcInsts)
-	mmInsts := buildAccountsLegacy(ctx, k, "mattermost", func(c context.Context, kk *kernelruntime.Kernel) (*chatwebhook.Channel, pulse.BriefSink, string) {
-		return buildChatWebhook(c, kk, chatwebhook.KindMattermost, "MATTERMOST")
-	})
+	mmInsts := wireInstances(channelwire.BuildKind(ctx, "mattermost", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "mattermost", "mattermost (2way)", "", mmInsts)
 
 	// DingTalk / Feishu / WeCom two-way (China enterprise platforms).
-	dtInsts := buildAccountsLegacy(ctx, k, "dingtalk", buildDingTalk)
+	dtInsts := wireInstances(channelwire.BuildKind(ctx, "dingtalk", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "dingtalk", "dingtalk (2way)", "", dtInsts)
-	fsInsts := buildAccountsLegacy(ctx, k, "feishu", buildFeishu)
+	fsInsts := wireInstances(channelwire.BuildKind(ctx, "feishu", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "feishu", "feishu (2way)", "", fsInsts)
-	wcInsts := buildAccountsLegacy(ctx, k, "wecom", buildWeCom)
+	wcInsts := wireInstances(channelwire.BuildKind(ctx, "wecom", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "wecom", "wecom (2way)", "", wcInsts)
 
 	// QQ / WeChat via a OneBot v11 gateway; Zalo via the Official Account API.
@@ -1591,7 +1581,7 @@ func runDaemon(stdout, stderr io.Writer) int {
 	startInstances(ctx, stdout, "zalo", "zalo channel", "", zlInsts)
 	nctInsts := wireInstances(channelwire.BuildKind(ctx, "nextcloudtalk", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "nextcloudtalk", "nextcloud talk", "", nctInsts)
-	maInsts := buildAccountsLegacy(ctx, k, "mastodon", buildMastodon)
+	maInsts := wireInstances(channelwire.BuildKind(ctx, "mastodon", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "mastodon", "mastodon channel", "", maInsts)
 	noInsts := wireInstances(channelwire.BuildKind(ctx, "nostr", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "nostr", "nostr channel", "", noInsts)
@@ -2522,8 +2512,8 @@ func extForMime(mime string) string {
 // own the "line" name (a channel secret is set) — in which case buildPushChannels
 // yields LINE to it to avoid a double registration. The two-way builder itself
 // migrated to the channelwire factory (plugins/builtinchannels); this predicate
-// only concerns the DEFAULT instance and moves with the push-suppression
-// cluster in batch D.
+// only concerns the DEFAULT instance — its sole remaining caller is
+// buildPushChannels — and moves with the push family.
 func twoWayLineConfigured() bool {
 	return strings.TrimSpace(os.Getenv(brand.EnvPrefix+"LINE_SECRET")) != ""
 }
@@ -2531,212 +2521,21 @@ func twoWayLineConfigured() bool {
 // twoWayChatConfigured reports whether the two-way chat-webhook channel for a
 // push kind (prefix "GOOGLECHAT" / "MATTERMOST") should own that name — an
 // inbound addr is set — so buildPushChannels yields the outbound-only entry.
+// The two-way builder itself migrated to the channelwire factory
+// (chatWebhookFactory in plugins/builtinchannels); this predicate only concerns
+// the DEFAULT instance and moves with the push-suppression cluster.
 func twoWayChatConfigured(prefix string) bool {
 	return strings.TrimSpace(os.Getenv(brand.EnvPrefix+prefix+"_ADDR")) != ""
 }
 
-// buildChatWebhook constructs a two-way Google Chat / Mattermost channel when its
-// inbound addr is set. Outbound + replies use the incoming-webhook URL.
-//
-//	AGEZT_<PREFIX>_WEBHOOK  incoming-webhook URL (outbound + replies)
-//	AGEZT_<PREFIX>_ADDR     host:port to serve the inbound webhook (enables two-way)
-//	AGEZT_<PREFIX>_TOKEN    verification token (Mattermost outgoing-webhook token / Google Chat ?token=)
-//	AGEZT_<PREFIX>_USERS    comma-separated allowed senders (usernames / emails)
-//	AGEZT_<PREFIX>_PATH     inbound route (default /<kind>)
-func buildChatWebhook(ctx context.Context, k *kernelruntime.Kernel, kind, prefix string) (*chatwebhook.Channel, pulse.BriefSink, string) {
-	if !twoWayChatConfigured(prefix) {
-		return nil, nil, ""
-	}
-	get := func(s string) string { return strings.TrimSpace(os.Getenv(brand.EnvPrefix + prefix + s)) }
-	users := splitNonEmpty(os.Getenv(brand.EnvPrefix + prefix + "_USERS"))
-	webhook := get("_WEBHOOK")
-
-	ch := chatwebhook.New(chatwebhook.Config{
-		Kind:       kind,
-		WebhookURL: webhook,
-		Token:      get("_TOKEN"),
-		Allowlist:  channel.NewAllowlist(users),
-		Bus:        k.Bus(),
-		Handler:    makeChannelHandler(k),
-		Addr:       get("_ADDR"),
-		Path:       get("_PATH"),
-	})
-
-	var sink pulse.BriefSink
-	if webhook != "" {
-		sink = pulse.SinkFunc(func(b pulse.Brief) error {
-			return ch.Send(ctx, channel.Outbound{Text: formatBrief(b), Priority: channel.PriorityNotify})
-		})
-	}
-
-	desc := fmt.Sprintf("%s two-way, allowlist=%d sender(s)", kind, len(users))
-	if webhook == "" {
-		desc += " (inbound-only; set AGEZT_" + prefix + "_WEBHOOK for replies/briefs)"
-	}
-	return ch, sink, desc
-}
-
-// buildDingTalk constructs the two-way DingTalk channel when AGEZT_DINGTALK_ADDR
-// is set. Replies go to each message's sessionWebhook; briefs use the custom
-// robot webhook (AGEZT_DINGTALK_WEBHOOK).
-//
-//	AGEZT_DINGTALK_WEBHOOK  custom-robot webhook (outbound briefs / agt send)
-//	AGEZT_DINGTALK_SECRET   robot secret (verifies inbound timestamp+sign)
-//	AGEZT_DINGTALK_USERS    comma-separated allowed senderStaffId / nick
-//	AGEZT_DINGTALK_ADDR     host:port to serve the inbound webhook (enables two-way)
-//	AGEZT_DINGTALK_PATH     inbound route (default /dingtalk)
-func buildDingTalk(ctx context.Context, k *kernelruntime.Kernel) (*dingtalk.Channel, pulse.BriefSink, string) {
-	addr := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "DINGTALK_ADDR"))
-	if addr == "" {
-		return nil, nil, ""
-	}
-	users := splitNonEmpty(os.Getenv(brand.EnvPrefix + "DINGTALK_USERS"))
-	webhook := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "DINGTALK_WEBHOOK"))
-	ch := dingtalk.New(dingtalk.Config{
-		WebhookURL: webhook,
-		Secret:     strings.TrimSpace(os.Getenv(brand.EnvPrefix + "DINGTALK_SECRET")),
-		Allowlist:  channel.NewAllowlist(users),
-		Bus:        k.Bus(),
-		Handler:    makeChannelHandler(k),
-		Addr:       addr,
-		Path:       strings.TrimSpace(os.Getenv(brand.EnvPrefix + "DINGTALK_PATH")),
-	})
-	var sink pulse.BriefSink
-	if webhook != "" {
-		sink = pulse.SinkFunc(func(b pulse.Brief) error {
-			return ch.Send(ctx, channel.Outbound{Text: formatBrief(b), Priority: channel.PriorityNotify})
-		})
-	}
-	return ch, sink, fmt.Sprintf("DingTalk robot, allowlist=%d sender(s)", len(users))
-}
-
-// buildFeishu constructs the two-way Feishu / Lark channel when AGEZT_FEISHU_ADDR
-// is set. Replies + briefs use the IM API (tenant_access_token from app id/secret).
-//
-//	AGEZT_FEISHU_APP_ID        app id
-//	AGEZT_FEISHU_APP_SECRET    app secret
-//	AGEZT_FEISHU_VERIFY_TOKEN  event verification token
-//	AGEZT_FEISHU_CHAT          chat_id for proactive briefs
-//	AGEZT_FEISHU_USERS         comma-separated allowed sender open_ids
-//	AGEZT_FEISHU_ADDR          host:port to serve the inbound webhook (enables two-way)
-//	AGEZT_FEISHU_PATH          inbound route (default /feishu)
-func buildFeishu(ctx context.Context, k *kernelruntime.Kernel) (*feishu.Channel, pulse.BriefSink, string) {
-	addr := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "FEISHU_ADDR"))
-	appID := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "FEISHU_APP_ID"))
-	if addr == "" || appID == "" {
-		return nil, nil, ""
-	}
-	users := splitNonEmpty(os.Getenv(brand.EnvPrefix + "FEISHU_USERS"))
-	chat := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "FEISHU_CHAT"))
-	ch := feishu.New(feishu.Config{
-		AppID:       appID,
-		AppSecret:   strings.TrimSpace(os.Getenv(brand.EnvPrefix + "FEISHU_APP_SECRET")),
-		VerifyToken: strings.TrimSpace(os.Getenv(brand.EnvPrefix + "FEISHU_VERIFY_TOKEN")),
-		DefaultChat: chat,
-		Allowlist:   channel.NewAllowlist(users),
-		Bus:         k.Bus(),
-		Handler:     makeChannelHandler(k),
-		Addr:        addr,
-		Path:        strings.TrimSpace(os.Getenv(brand.EnvPrefix + "FEISHU_PATH")),
-	})
-	var sink pulse.BriefSink
-	if chat != "" {
-		sink = pulse.SinkFunc(func(b pulse.Brief) error {
-			return ch.Send(ctx, channel.Outbound{ChannelID: chat, Text: formatBrief(b), Priority: channel.PriorityNotify})
-		})
-	}
-	return ch, sink, fmt.Sprintf("Feishu app, allowlist=%d user(s)", len(users))
-}
-
-// buildWeCom constructs the two-way WeCom (WeChat Work) channel when
-// AGEZT_WECOM_ADDR is set. Inbound is an AES-encrypted callback; replies use the
-// app message-send API (access_token from corp id/secret).
-//
-//	AGEZT_WECOM_CORP_ID      corp id
-//	AGEZT_WECOM_CORP_SECRET  app secret
-//	AGEZT_WECOM_AGENT_ID     app agent id
-//	AGEZT_WECOM_TOKEN        callback token
-//	AGEZT_WECOM_AES_KEY      callback EncodingAESKey
-//	AGEZT_WECOM_USERS        comma-separated allowed user ids
-//	AGEZT_WECOM_ADDR         host:port to serve the inbound callback (enables two-way)
-//	AGEZT_WECOM_PATH         inbound route (default /wecom)
-func buildWeCom(ctx context.Context, k *kernelruntime.Kernel) (*wecom.Channel, pulse.BriefSink, string) {
-	addr := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "WECOM_ADDR"))
-	corp := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "WECOM_CORP_ID"))
-	if addr == "" || corp == "" {
-		return nil, nil, ""
-	}
-	users := splitNonEmpty(os.Getenv(brand.EnvPrefix + "WECOM_USERS"))
-	ch := wecom.New(wecom.Config{
-		CorpID:     corp,
-		CorpSecret: strings.TrimSpace(os.Getenv(brand.EnvPrefix + "WECOM_CORP_SECRET")),
-		AgentID:    strings.TrimSpace(os.Getenv(brand.EnvPrefix + "WECOM_AGENT_ID")),
-		Token:      strings.TrimSpace(os.Getenv(brand.EnvPrefix + "WECOM_TOKEN")),
-		AESKey:     strings.TrimSpace(os.Getenv(brand.EnvPrefix + "WECOM_AES_KEY")),
-		Allowlist:  channel.NewAllowlist(users),
-		Bus:        k.Bus(),
-		Handler:    makeChannelHandler(k),
-		Addr:       addr,
-		Path:       strings.TrimSpace(os.Getenv(brand.EnvPrefix + "WECOM_PATH")),
-	})
-	var sink pulse.BriefSink
-	if len(users) > 0 {
-		sink = pulse.SinkFunc(func(b pulse.Brief) error {
-			var firstErr error
-			for _, u := range users {
-				if err := ch.Send(ctx, channel.Outbound{ChannelID: u, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
-					firstErr = err
-				}
-			}
-			return firstErr
-		})
-	}
-	return ch, sink, fmt.Sprintf("WeCom app, allowlist=%d user(s)", len(users))
-}
-
 // twoWayMastodonConfigured reports whether the dedicated two-way Mastodon channel
 // should own the "mastodon" name — true when an acct allowlist is set, signalling
-// the operator wants the agent to answer mentions (not just post).
+// the operator wants the agent to answer mentions (not just post). The two-way
+// builder itself migrated to the channelwire factory (plugins/builtinchannels);
+// this predicate only concerns the DEFAULT instance and moves with the
+// push-suppression cluster.
 func twoWayMastodonConfigured() bool {
 	return strings.TrimSpace(os.Getenv(brand.EnvPrefix+"MASTODON_USERS")) != ""
-}
-
-// buildMastodon constructs the two-way Mastodon channel when AGEZT_MASTODON_USERS
-// is set (alongside SERVER + TOKEN). It polls mention notifications and replies as
-// threaded statuses; outbound briefs post standalone statuses.
-//
-//	AGEZT_MASTODON_SERVER  instance base URL (required)
-//	AGEZT_MASTODON_TOKEN   access token, read:notifications + write:statuses (required)
-//	AGEZT_MASTODON_USERS   comma-separated acct handles allowed to drive the agent (enables two-way)
-//	AGEZT_MASTODON_POLL    poll interval seconds (default 60)
-func buildMastodon(ctx context.Context, k *kernelruntime.Kernel) (*mastodon.Channel, pulse.BriefSink, string) {
-	if !twoWayMastodonConfigured() {
-		return nil, nil, ""
-	}
-	server := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "MASTODON_SERVER"))
-	token := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "MASTODON_TOKEN"))
-	if server == "" || token == "" {
-		return nil, nil, ""
-	}
-	users := splitNonEmpty(os.Getenv(brand.EnvPrefix + "MASTODON_USERS"))
-	poll := 0
-	if v := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "MASTODON_POLL")); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			poll = n
-		}
-	}
-	ch := mastodon.New(mastodon.Config{
-		Server:    server,
-		Token:     token,
-		Allowlist: channel.NewAllowlist(users),
-		Bus:       k.Bus(),
-		Handler:   makeChannelHandler(k),
-		PollSecs:  poll,
-	})
-	sink := pulse.SinkFunc(func(b pulse.Brief) error {
-		return ch.Send(ctx, channel.Outbound{Text: formatBrief(b), Priority: channel.PriorityNotify})
-	})
-	return ch, sink, fmt.Sprintf("Mastodon (two-way), allowlist=%d acct(s)", len(users))
 }
 
 // buildPushChannels constructs every configured push-notification channel (ntfy,
@@ -2765,7 +2564,8 @@ func buildPushChannels(ctx context.Context, k *kernelruntime.Kernel) ([]*push.Ch
 		add(push.Config{Kind: push.KindPushbullet, Token: env("PUSHBULLET_TOKEN")})
 	}
 	if u := env("GOOGLECHAT_WEBHOOK"); u != "" && !twoWayChatConfigured("GOOGLECHAT") {
-		// Two-way Google Chat (AGEZT_GOOGLECHAT_ADDR) owns the name; see buildChatWebhook.
+		// Two-way Google Chat (AGEZT_GOOGLECHAT_ADDR) owns the name; see
+		// chatWebhookFactory in plugins/builtinchannels.
 		add(push.Config{Kind: push.KindGoogleChat, URL: u})
 	}
 	if u := env("MATTERMOST_WEBHOOK"); u != "" && !twoWayChatConfigured("MATTERMOST") {
@@ -2789,7 +2589,8 @@ func buildPushChannels(ctx context.Context, k *kernelruntime.Kernel) ([]*push.Ch
 		add(push.Config{Kind: push.KindZulip, Server: env("ZULIP_SERVER"), User: env("ZULIP_EMAIL"), Token: env("ZULIP_APIKEY"), Target: env("ZULIP_STREAM"), Topic: env("ZULIP_TOPIC")})
 	}
 	// Feishu/DingTalk/WeCom: the dedicated two-way channels own the name when
-	// their inbound addr is configured (see buildFeishu/buildDingTalk/buildWeCom).
+	// their inbound addr is configured (see the buildFeishu/buildDingTalk/
+	// buildWeCom factories in plugins/builtinchannels).
 	if u := env("FEISHU_WEBHOOK"); u != "" && (env("FEISHU_ADDR") == "" || env("FEISHU_APP_ID") == "") {
 		add(push.Config{Kind: push.KindFeishu, URL: u})
 	}
@@ -2902,24 +2703,6 @@ type chanInstance struct {
 // (back-compat) instance, "kind#label" for a labelled one.
 func instanceKey(kind, label string) string { return channel.InstanceKey(kind, label) }
 
-// channelLabels returns the configured NON-default instance labels for a channel
-// kind, discovered from the process env (the daemon injects store+vault keys,
-// including "#label" suffixed ones, at boot via injectConfig).
-func channelLabels(kind string) []string {
-	baseEnvs := settings.SectionEnvs(kind)
-	if len(baseEnvs) == 0 {
-		return nil
-	}
-	env := os.Environ()
-	keys := make([]string, 0, len(env))
-	for _, kv := range env {
-		if k, _, ok := strings.Cut(kv, "="); ok {
-			keys = append(keys, k)
-		}
-	}
-	return settings.AccountLabels(keys, baseEnvs)
-}
-
 // wireInstances converts channelwire's built instances (the factory-migrated
 // channels, Phase 2.1) into the daemon's chanInstance shape so the existing
 // startInstances / allInsts / registerInstances wiring stays untouched.
@@ -2996,9 +2779,11 @@ func instanceMatch(keys []string, target string) []string {
 
 // overlayEnv temporarily sets each base env to its "#label" value for a labelled
 // instance, returning a restore func; for the default instance ("") it's a no-op.
-// This lets the legacy buildXxx functions (which read os.Getenv directly) build a
+// It let the legacy buildXxx functions (which read os.Getenv directly) build a
 // labelled account without rewriting them — safe because builds are synchronous
-// and each channel reads its config into a struct before Start runs.
+// and each channel reads its config into a struct before Start runs. The two-way
+// builders have all migrated to channelwire factories; this stays for the
+// remaining os.Getenv-reading push family (buildPushChannels) until it migrates.
 func overlayEnv(baseEnvs []string, label string) func() {
 	if label == "" {
 		return func() {}
@@ -3026,25 +2811,6 @@ func overlayEnv(baseEnvs []string, label string) func() {
 			}
 		}
 	}
-}
-
-// buildAccountsLegacy builds the default + every "#label" instance of a channel
-// whose buildXxx still reads os.Getenv directly, via overlayEnv. A typed-nil
-// return (unconfigured instance) is skipped.
-func buildAccountsLegacy[T channel.Channel](ctx context.Context, k *kernelruntime.Kernel, kind string,
-	f func(context.Context, *kernelruntime.Kernel) (T, pulse.BriefSink, string)) []chanInstance {
-	baseEnvs := settings.SectionEnvs(kind)
-	var out []chanInstance
-	for _, label := range append([]string{""}, channelLabels(kind)...) {
-		restore := overlayEnv(baseEnvs, label)
-		ch, sink, desc := f(ctx, k)
-		restore()
-		if rv := reflect.ValueOf(ch); rv.Kind() == reflect.Ptr && rv.IsNil() {
-			continue
-		}
-		out = append(out, chanInstance{key: instanceKey(kind, label), desc: desc, ch: ch, sink: sink})
-	}
-	return out
 }
 
 // liveChannelKeys returns the instance keys of the live channel map (used to

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -92,17 +92,13 @@ import (
 	"github.com/agezt/agezt/plugins/channels/feishu"
 	"github.com/agezt/agezt/plugins/channels/homeassistant"
 	"github.com/agezt/agezt/plugins/channels/imessage"
-	"github.com/agezt/agezt/plugins/channels/irc"
 	linechan "github.com/agezt/agezt/plugins/channels/line"
 	"github.com/agezt/agezt/plugins/channels/mastodon"
 	"github.com/agezt/agezt/plugins/channels/nextcloudtalk"
 	"github.com/agezt/agezt/plugins/channels/nostr"
 	"github.com/agezt/agezt/plugins/channels/onebot"
 	"github.com/agezt/agezt/plugins/channels/push"
-	signalchan "github.com/agezt/agezt/plugins/channels/signal"
-	"github.com/agezt/agezt/plugins/channels/sms"
 	"github.com/agezt/agezt/plugins/channels/teams"
-	webhookchan "github.com/agezt/agezt/plugins/channels/webhook"
 	"github.com/agezt/agezt/plugins/channels/wecom"
 	"github.com/agezt/agezt/plugins/channels/whatsappgw"
 	"github.com/agezt/agezt/plugins/channels/zalo"
@@ -1538,7 +1534,7 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// system POSTs a signed JSON message and gets the agent's reply synchronously;
 	// briefs/`agt send` tee to a configured outbound URL. Enabled when a secret
 	// (inbound) or an outbound URL is set.
-	whInsts := buildAccountsLegacy(ctx, k, "webhook", buildWebhook)
+	whInsts := wireInstances(channelwire.BuildKind(ctx, "webhook", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "webhook", "webhook channel", "disabled (set AGEZT_WEBHOOK_SECRET + AGEZT_WEBHOOK_ADDR)", whInsts)
 
 	// Email channel (SPEC-04 §1) — outbound-only over SMTP. Briefs/`agt send` mail
@@ -1556,11 +1552,11 @@ func runDaemon(stdout, stderr io.Writer) int {
 	startInstances(ctx, stdout, "matrix", "matrix channel", "disabled (set AGEZT_MATRIX_HOMESERVER + AGEZT_MATRIX_TOKEN)", mxInsts)
 
 	// IRC channel (SPEC-04 §1) — two-way over a persistent socket to any ircd.
-	ircInsts := buildAccountsLegacy(ctx, k, "irc", buildIRC)
+	ircInsts := wireInstances(channelwire.BuildKind(ctx, "irc", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "irc", "irc channel", "disabled (set AGEZT_IRC_SERVER + AGEZT_IRC_NICK)", ircInsts)
 
 	// Twitch chat (SPEC-04 §1) — IRC over Twitch's server; reuses the IRC channel.
-	twInsts := buildAccountsLegacy(ctx, k, "twitch", buildTwitch)
+	twInsts := wireInstances(channelwire.BuildKind(ctx, "twitch", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "twitch", "twitch channel", "disabled (set AGEZT_TWITCH_USERNAME + AGEZT_TWITCH_TOKEN)", twInsts)
 
 	// WhatsApp via a self-hosted gateway (WAHA/Evolution) — the easy WhatsApp path.
@@ -1617,7 +1613,7 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// AGEZT_SMS_ACCOUNT_SID + AGEZT_SMS_AUTH_TOKEN are set. Inbound is a signed
 	// Twilio webhook (needs AGEZT_SMS_ADDR); outbound texts go via the REST API
 	// (needs AGEZT_SMS_FROM); briefs tee to the allowlisted numbers.
-	smInsts := buildAccountsLegacy(ctx, k, "sms", buildSMS)
+	smInsts := wireInstances(channelwire.BuildKind(ctx, "sms", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "sms", "sms channel", "disabled (set AGEZT_SMS_ACCOUNT_SID + AGEZT_SMS_AUTH_TOKEN)", smInsts)
 
 	// WhatsApp channel (SPEC-04 §1) — duplex over Meta's WhatsApp Cloud API when
@@ -1644,7 +1640,7 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// when AGEZT_SIGNAL_API_URL + AGEZT_SIGNAL_NUMBER are set. Long-polls
 	// /v1/receive for inbound and POSTs /v2/send for outbound; briefs tee to the
 	// allowlisted numbers like the others.
-	sgInsts := buildAccountsLegacy(ctx, k, "signal", buildSignal)
+	sgInsts := wireInstances(channelwire.BuildKind(ctx, "signal", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "signal", "signal channel", "disabled (set AGEZT_SIGNAL_API_URL + AGEZT_SIGNAL_NUMBER)", sgInsts)
 
 	// Push-notification channels (SPEC-04 §1): a family of simple outbound
@@ -2535,176 +2531,6 @@ func extForMime(mime string) string {
 	}
 }
 
-// buildWebhook constructs the vendor-neutral webhook channel. Enabled when an
-// inbound secret OR an outbound URL is configured. Returns (nil, nil, "") when
-// neither is set.
-//
-//	AGEZT_WEBHOOK_SECRET        HMAC-SHA256 signing key (enables signed inbound)
-//	AGEZT_WEBHOOK_ADDR          local addr to serve the inbound route (fronted by
-//	                            a tunnel/reverse proxy); empty → no inbound listener
-//	AGEZT_WEBHOOK_PATH          inbound route (default /webhook)
-//	AGEZT_WEBHOOK_CHANNELS      comma-separated allowlist of channel ids that may
-//	                            drive the agent AND receive Pulse briefs
-//	AGEZT_WEBHOOK_OUTBOUND_URL  where Send / briefs POST (signed); empty → inbound-only
-//
-// The inbound handler runs the normal agent loop under the channel's correlation,
-// so `agt why`/`agt inbox` link the webhook command to the task.
-func buildWebhook(ctx context.Context, k *kernelruntime.Kernel) (*webhookchan.Channel, pulse.BriefSink, string) {
-	secret := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "WEBHOOK_SECRET"))
-	outboundURL := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "WEBHOOK_OUTBOUND_URL"))
-	if secret == "" && outboundURL == "" {
-		return nil, nil, ""
-	}
-	addr := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "WEBHOOK_ADDR"))
-	path := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "WEBHOOK_PATH"))
-	channelIDs := splitNonEmpty(os.Getenv(brand.EnvPrefix + "WEBHOOK_CHANNELS"))
-
-	ch := webhookchan.New(webhookchan.Config{
-		Addr:        addr,
-		Path:        path,
-		Secret:      secret,
-		Allowlist:   channel.NewAllowlist(channelIDs),
-		OutboundURL: outboundURL,
-		Bus:         k.Bus(),
-		Handler:     makeChannelHandler(k),
-	})
-
-	var sink pulse.BriefSink
-	if outboundURL != "" && len(channelIDs) > 0 {
-		sink = pulse.SinkFunc(func(b pulse.Brief) error {
-			var firstErr error
-			for _, id := range channelIDs {
-				if err := ch.Send(ctx, channel.Outbound{ChannelID: id, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
-					firstErr = err
-				}
-			}
-			return firstErr
-		})
-	}
-
-	switch {
-	case secret == "":
-		return ch, sink, fmt.Sprintf("outbound-only → %s, allowlist=%d (set AGEZT_WEBHOOK_SECRET + AGEZT_WEBHOOK_ADDR for inbound)", outboundURL, len(channelIDs))
-	case addr == "":
-		return ch, sink, fmt.Sprintf("inbound configured but not listening (set AGEZT_WEBHOOK_ADDR), allowlist=%d", len(channelIDs))
-	default:
-		p := path
-		if p == "" {
-			p = webhookchan.DefaultPath
-		}
-		return ch, sink, fmt.Sprintf("inbound at %s%s, allowlist=%d channel(s)", addr, p, len(channelIDs))
-	}
-}
-
-// buildIRC constructs the two-way IRC channel when AGEZT_IRC_SERVER +
-// AGEZT_IRC_NICK are set. It joins AGEZT_IRC_CHANNELS and acts on inbound from
-// allowlisted sources (the joined channels, plus any AGEZT_IRC_ALLOWLIST nicks/
-// channels); Pulse briefs tee to the joined channels.
-//
-//	AGEZT_IRC_SERVER     host:port (e.g. irc.libera.chat:6697)   (required)
-//	AGEZT_IRC_NICK       the bot's nick                          (required)
-//	AGEZT_IRC_CHANNELS   comma-separated channels to join (#foo) — allowed by default
-//	AGEZT_IRC_PASSWORD   optional server password (PASS)
-//	AGEZT_IRC_TLS        "true" to force TLS (auto for :6697)
-//	AGEZT_IRC_ALLOWLIST  extra allowed sources (nicks for DMs / channels)
-func buildIRC(ctx context.Context, k *kernelruntime.Kernel) (*irc.Channel, pulse.BriefSink, string) {
-	server := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "IRC_SERVER"))
-	nick := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "IRC_NICK"))
-	if server == "" || nick == "" {
-		return nil, nil, ""
-	}
-	chans := splitNonEmpty(os.Getenv(brand.EnvPrefix + "IRC_CHANNELS"))
-	// The joined channels are allowed by default; extra nicks/channels widen it.
-	allowed := append([]string(nil), chans...)
-	allowed = append(allowed, splitNonEmpty(os.Getenv(brand.EnvPrefix+"IRC_ALLOWLIST"))...)
-	useTLS := strings.EqualFold(strings.TrimSpace(os.Getenv(brand.EnvPrefix+"IRC_TLS")), "true") || strings.HasSuffix(server, ":6697")
-
-	ch := irc.New(irc.Config{
-		Server:    server,
-		TLS:       useTLS,
-		Nick:      nick,
-		Password:  strings.TrimSpace(os.Getenv(brand.EnvPrefix + "IRC_PASSWORD")),
-		Channels:  chans,
-		Allowlist: channel.NewAllowlist(allowed),
-		Bus:       k.Bus(),
-		Handler:   makeChannelHandler(k),
-	})
-
-	var sink pulse.BriefSink
-	if len(chans) > 0 {
-		sink = pulse.SinkFunc(func(b pulse.Brief) error {
-			var firstErr error
-			for _, c := range chans {
-				if err := ch.Send(ctx, channel.Outbound{ChannelID: c, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
-					firstErr = err
-				}
-			}
-			return firstErr
-		})
-	}
-
-	desc := fmt.Sprintf("%s as %s, %d channel(s)", server, nick, len(chans))
-	if len(chans) == 0 {
-		desc = fmt.Sprintf("%s as %s, NO channels (set AGEZT_IRC_CHANNELS)", server, nick)
-	}
-	return ch, sink, desc
-}
-
-// buildTwitch constructs a Twitch chat channel when AGEZT_TWITCH_USERNAME +
-// AGEZT_TWITCH_TOKEN are set. Twitch chat is IRC, so this reuses the IRC channel
-// pinned to Twitch's server with an "oauth:" PASS; it joins AGEZT_TWITCH_CHANNELS
-// (lowercase #channel) and acts on inbound from those channels by default.
-//
-//	AGEZT_TWITCH_USERNAME  the bot account's login name        (required)
-//	AGEZT_TWITCH_TOKEN     OAuth token ("oauth:" prefix added) (required)
-//	AGEZT_TWITCH_CHANNELS  comma-separated #channels to join — allowed by default
-//	AGEZT_TWITCH_ALLOWLIST extra allowed sources (nicks / channels)
-func buildTwitch(ctx context.Context, k *kernelruntime.Kernel) (*irc.Channel, pulse.BriefSink, string) {
-	user := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "TWITCH_USERNAME"))
-	token := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "TWITCH_TOKEN"))
-	if user == "" || token == "" {
-		return nil, nil, ""
-	}
-	chans := splitNonEmpty(os.Getenv(brand.EnvPrefix + "TWITCH_CHANNELS"))
-	allowed := append([]string(nil), chans...)
-	allowed = append(allowed, splitNonEmpty(os.Getenv(brand.EnvPrefix+"TWITCH_ALLOWLIST"))...)
-	pass := token
-	if !strings.HasPrefix(pass, "oauth:") {
-		pass = "oauth:" + pass
-	}
-
-	ch := irc.New(irc.Config{
-		Kind:      "twitch",
-		Server:    "irc.chat.twitch.tv:6697",
-		TLS:       true,
-		Nick:      strings.ToLower(user),
-		Password:  pass,
-		Channels:  chans,
-		Allowlist: channel.NewAllowlist(allowed),
-		Bus:       k.Bus(),
-		Handler:   makeChannelHandler(k),
-	})
-
-	var sink pulse.BriefSink
-	if len(chans) > 0 {
-		sink = pulse.SinkFunc(func(b pulse.Brief) error {
-			var firstErr error
-			for _, c := range chans {
-				if err := ch.Send(ctx, channel.Outbound{ChannelID: c, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
-					firstErr = err
-				}
-			}
-			return firstErr
-		})
-	}
-
-	desc := fmt.Sprintf("as %s, %d channel(s)", user, len(chans))
-	if len(chans) == 0 {
-		desc = fmt.Sprintf("as %s, NO channels (set AGEZT_TWITCH_CHANNELS)", user)
-	}
-	return ch, sink, desc
-}
-
 // buildWhatsAppGateway constructs the easy-path WhatsApp channel — a self-hosted
 // WAHA or Evolution API gateway (QR login, no Meta) — when AGEZT_WHATSAPPGW_URL
 // is set. Outbound always; inbound (two-way) when AGEZT_WHATSAPPGW_ADDR points
@@ -3239,68 +3065,6 @@ func buildNostr(ctx context.Context, k *kernelruntime.Kernel) (*nostr.Channel, p
 	return ch, sink, fmt.Sprintf("Nostr, %d relay(s), allowlist=%d author(s)", len(relays), len(authors))
 }
 
-// buildSMS constructs the Twilio SMS channel when AGEZT_SMS_ACCOUNT_SID +
-// AGEZT_SMS_AUTH_TOKEN are set. Inbound (signed Twilio webhook) is served when
-// AGEZT_SMS_ADDR is also set; outbound texts + Pulse briefs to the allowlisted
-// numbers (AGEZT_SMS_NUMBERS) need AGEZT_SMS_FROM.
-//
-//	AGEZT_SMS_ACCOUNT_SID  Twilio Account SID  (required)
-//	AGEZT_SMS_AUTH_TOKEN   Twilio auth token   (required; signs inbound + REST)
-//	AGEZT_SMS_FROM         Twilio number to send from, E.164 (outbound)
-//	AGEZT_SMS_ADDR         host:port for the inbound webhook (inbound)
-//	AGEZT_SMS_PATH         inbound route (default /sms)
-//	AGEZT_SMS_PUBLIC_URL   exact public URL Twilio POSTs to (signature check behind a tunnel)
-//	AGEZT_SMS_NUMBERS      comma-separated allowlist of sender numbers
-func buildSMS(ctx context.Context, k *kernelruntime.Kernel) (*sms.Channel, pulse.BriefSink, string) {
-	sid := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "SMS_ACCOUNT_SID"))
-	token := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "SMS_AUTH_TOKEN"))
-	if sid == "" || token == "" {
-		return nil, nil, ""
-	}
-	from := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "SMS_FROM"))
-	addr := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "SMS_ADDR"))
-	path := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "SMS_PATH"))
-	publicURL := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "SMS_PUBLIC_URL"))
-	numbers := splitNonEmpty(os.Getenv(brand.EnvPrefix + "SMS_NUMBERS"))
-
-	ch := sms.New(sms.Config{
-		Addr:       addr,
-		Path:       path,
-		AccountSID: sid,
-		AuthToken:  token,
-		From:       from,
-		PublicURL:  publicURL,
-		Allowlist:  channel.NewAllowlist(numbers),
-		Bus:        k.Bus(),
-		Handler:    makeChannelHandler(k),
-	})
-
-	// Pulse briefs → the allowlisted numbers (needs an outbound From).
-	var sink pulse.BriefSink
-	if from != "" && len(numbers) > 0 {
-		sink = pulse.SinkFunc(func(b pulse.Brief) error {
-			var firstErr error
-			for _, id := range numbers {
-				if err := ch.Send(ctx, channel.Outbound{ChannelID: id, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
-					firstErr = err
-				}
-			}
-			return firstErr
-		})
-	}
-
-	switch {
-	case addr == "":
-		return ch, sink, fmt.Sprintf("outbound-only (set AGEZT_SMS_ADDR for inbound), allowlist=%d number(s)", len(numbers))
-	default:
-		p := path
-		if p == "" {
-			p = sms.DefaultPath
-		}
-		return ch, sink, fmt.Sprintf("inbound at %s%s, allowlist=%d number(s)", addr, p, len(numbers))
-	}
-}
-
 // buildHomeAssistant constructs the outbound Home Assistant channel when
 // AGEZT_HOMEASSISTANT_URL + AGEZT_HOMEASSISTANT_TOKEN are set. Pulse briefs +
 // `agt send` go to the allowlisted notify services (AGEZT_HOMEASSISTANT_SERVICES).
@@ -3369,65 +3133,6 @@ func buildTeams(ctx context.Context, k *kernelruntime.Kernel) (*teams.Channel, p
 	})
 
 	return ch, sink, fmt.Sprintf("outbound → %d Teams webhook(s)", len(names))
-}
-
-// buildSignal constructs the in-process Signal channel when AGEZT_SIGNAL_API_URL
-// and AGEZT_SIGNAL_NUMBER are set, plus a Pulse brief sink to the allowlisted
-// numbers. Returns (nil, nil, "") when unconfigured. Talks to an operator-run
-// signal-cli-rest-api: long-polls /v1/receive for inbound, POSTs /v2/send for
-// outbound (mirrors buildMatrix).
-//
-//	AGEZT_SIGNAL_API_URL     signal-cli-rest-api base URL (required), e.g. http://127.0.0.1:8080
-//	AGEZT_SIGNAL_NUMBER      the registered Signal number this bot is, E.164 (required)
-//	AGEZT_SIGNAL_RECIPIENTS  comma-separated allowlist of sender numbers (+ brief recipients)
-//	AGEZT_SIGNAL_TOKEN       optional bearer token (a reverse proxy fronting the API)
-//	AGEZT_SIGNAL_POLL_SECS   /v1/receive long-poll seconds (default 10)
-func buildSignal(ctx context.Context, k *kernelruntime.Kernel) (*signalchan.Channel, pulse.BriefSink, string) {
-	apiURL := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "SIGNAL_API_URL"))
-	number := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "SIGNAL_NUMBER"))
-	if apiURL == "" || number == "" {
-		return nil, nil, ""
-	}
-	recipients := splitNonEmpty(os.Getenv(brand.EnvPrefix + "SIGNAL_RECIPIENTS"))
-	token := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "SIGNAL_TOKEN"))
-	poll := 0
-	if v := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "SIGNAL_POLL_SECS")); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			poll = n
-		}
-	}
-
-	ch := signalchan.New(signalchan.Config{
-		APIURL:          apiURL,
-		Number:          number,
-		Token:           token,
-		Allowlist:       channel.NewAllowlist(recipients),
-		Bus:             k.Bus(),
-		Handler:         makeChannelHandler(k),
-		PollTimeoutSecs: poll,
-	})
-
-	// Pulse briefs → the allowlisted numbers. Nil sink when none configured (the
-	// bot can still receive commands once a number is allowlisted, and operators
-	// can still `agt send --channel signal --to <number>`).
-	var sink pulse.BriefSink
-	if len(recipients) > 0 {
-		sink = pulse.SinkFunc(func(b pulse.Brief) error {
-			var firstErr error
-			for _, id := range recipients {
-				if err := ch.Send(ctx, channel.Outbound{ChannelID: id, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
-					firstErr = err
-				}
-			}
-			return firstErr
-		})
-	}
-
-	desc := fmt.Sprintf("listening, allowlist=%d number(s)", len(recipients))
-	if len(recipients) == 0 {
-		desc = "listening, NO allowlist (outbound-only; set AGEZT_SIGNAL_RECIPIENTS to allow commands)"
-	}
-	return ch, sink, desc
 }
 
 // buildPushChannels constructs every configured push-notification channel (ntfy,

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -54,6 +54,7 @@ import (
 	"github.com/agezt/agezt/kernel/cadence"
 	"github.com/agezt/agezt/kernel/catalog"
 	"github.com/agezt/agezt/kernel/channel"
+	"github.com/agezt/agezt/kernel/channelwire"
 	"github.com/agezt/agezt/kernel/controlplane"
 	"github.com/agezt/agezt/kernel/creds"
 	"github.com/agezt/agezt/kernel/edict"
@@ -88,27 +89,21 @@ import (
 	"github.com/agezt/agezt/plugins/builtinskills"
 	"github.com/agezt/agezt/plugins/channels/chatwebhook"
 	"github.com/agezt/agezt/plugins/channels/dingtalk"
-	"github.com/agezt/agezt/plugins/channels/discord"
-	"github.com/agezt/agezt/plugins/channels/email"
 	"github.com/agezt/agezt/plugins/channels/feishu"
 	"github.com/agezt/agezt/plugins/channels/homeassistant"
 	"github.com/agezt/agezt/plugins/channels/imessage"
 	"github.com/agezt/agezt/plugins/channels/irc"
 	linechan "github.com/agezt/agezt/plugins/channels/line"
 	"github.com/agezt/agezt/plugins/channels/mastodon"
-	"github.com/agezt/agezt/plugins/channels/matrix"
 	"github.com/agezt/agezt/plugins/channels/nextcloudtalk"
 	"github.com/agezt/agezt/plugins/channels/nostr"
 	"github.com/agezt/agezt/plugins/channels/onebot"
 	"github.com/agezt/agezt/plugins/channels/push"
 	signalchan "github.com/agezt/agezt/plugins/channels/signal"
-	"github.com/agezt/agezt/plugins/channels/slack"
 	"github.com/agezt/agezt/plugins/channels/sms"
 	"github.com/agezt/agezt/plugins/channels/teams"
-	"github.com/agezt/agezt/plugins/channels/telegram"
 	webhookchan "github.com/agezt/agezt/plugins/channels/webhook"
 	"github.com/agezt/agezt/plugins/channels/wecom"
-	"github.com/agezt/agezt/plugins/channels/whatsapp"
 	"github.com/agezt/agezt/plugins/channels/whatsappgw"
 	"github.com/agezt/agezt/plugins/channels/zalo"
 	"github.com/agezt/agezt/plugins/providers/compat"
@@ -1516,23 +1511,27 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// business being conditional on the Forge.)
 	builtinchannels.RegisterAll()
 
+	// The shared inbound handler, built ONCE for every factory-migrated channel
+	// (Phase 2.1): channelwire factories receive it through Deps.Handler.
+	chanHandler := makeChannelHandler(k)
+
 	// Telegram channel (SPEC-04 §1) — duplex when AGEZT_TELEGRAM_TOKEN is
 	// set. Built before Pulse so its brief sink can tee with the log sink.
 	// Telegram channel (SPEC-04 §1) — multi-account: the default instance plus any
 	// "#label" accounts (several bots) are all built and started.
-	tgInsts := buildAccounts(ctx, k, "telegram", buildTelegramInstance)
+	tgInsts := wireInstances(channelwire.BuildKind(ctx, "telegram", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "telegram", "telegram", "disabled (set AGEZT_TELEGRAM_TOKEN)", tgInsts)
 
 	// Slack channel (SPEC-04 §1) — duplex when AGEZT_SLACK_TOKEN is set. Serves
 	// the Events API endpoint for inbound (HMAC-verified) and chat.postMessage for
 	// outbound; briefs tee to it like Telegram.
-	slInsts := buildAccounts(ctx, k, "slack", buildSlackInstance)
+	slInsts := wireInstances(channelwire.BuildKind(ctx, "slack", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "slack", "slack", "disabled (set AGEZT_SLACK_TOKEN)", slInsts)
 
 	// Discord channel (SPEC-04 §1) — duplex when AGEZT_DISCORD_TOKEN is set.
 	// Serves the Interactions endpoint for inbound slash commands (Ed25519-verified)
 	// and posts via the bot token for outbound; briefs tee to it like the others.
-	dcInsts := buildAccounts(ctx, k, "discord", buildDiscordInstance)
+	dcInsts := wireInstances(channelwire.BuildKind(ctx, "discord", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "discord", "discord", "disabled (set AGEZT_DISCORD_TOKEN)", dcInsts)
 
 	// Generic webhook channel (SPEC-04 §1) — vendor-neutral duplex. Any external
@@ -1546,14 +1545,14 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// the allowlisted recipients. Enabled when AGEZT_EMAIL_SMTP_ADDR is set.
 	// Email channel (SPEC-04 §1) — multi-account: the default instance plus any
 	// "#label" accounts (several mailboxes, each its own SMTP) are all built.
-	emInsts := buildAccounts(ctx, k, "email", buildEmailInstance)
+	emInsts := wireInstances(channelwire.BuildKind(ctx, "email", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "email", "email channel", "disabled (set AGEZT_EMAIL_SMTP_ADDR + AGEZT_EMAIL_FROM)", emInsts)
 
 	// Matrix channel (SPEC-04 §1) — duplex over the open Matrix Client-Server API
 	// when AGEZT_MATRIX_HOMESERVER + AGEZT_MATRIX_TOKEN are set. Long-polls /sync
 	// for inbound and PUTs m.room.message for outbound; briefs tee to the
 	// allowlisted rooms like the others.
-	mxInsts := buildAccounts(ctx, k, "matrix", buildMatrixInstance)
+	mxInsts := wireInstances(channelwire.BuildKind(ctx, "matrix", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "matrix", "matrix channel", "disabled (set AGEZT_MATRIX_HOMESERVER + AGEZT_MATRIX_TOKEN)", mxInsts)
 
 	// IRC channel (SPEC-04 §1) — two-way over a persistent socket to any ircd.
@@ -1625,7 +1624,7 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// AGEZT_WHATSAPP_APP_SECRET + AGEZT_WHATSAPP_ACCESS_TOKEN are set. Inbound is a
 	// signed Meta webhook (needs AGEZT_WHATSAPP_ADDR); outbound goes via the Graph
 	// API (needs AGEZT_WHATSAPP_PHONE_NUMBER_ID); briefs tee to the allowlist.
-	waInsts := buildAccounts(ctx, k, "whatsapp", buildWhatsAppInstance)
+	waInsts := wireInstances(channelwire.BuildKind(ctx, "whatsapp", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "whatsapp", "whatsapp channel", "disabled (set AGEZT_WHATSAPP_APP_SECRET + AGEZT_WHATSAPP_ACCESS_TOKEN)", waInsts)
 
 	// Home Assistant channel (SPEC-04 §1) — outbound to HA's notify API when
@@ -2536,113 +2535,6 @@ func extForMime(mime string) string {
 	}
 }
 
-// buildTelegram constructs the in-process Telegram channel when
-// AGEZT_TELEGRAM_TOKEN is set, plus a Pulse brief sink that forwards briefs to
-// the allowlisted chats. Returns (nil, nil, "") when no token is configured.
-//
-//	AGEZT_TELEGRAM_TOKEN    bot token (required to enable)
-//	AGEZT_TELEGRAM_CHAT_ID  comma-separated allowlist of chat ids that may
-//	                        drive the agent AND receive Pulse briefs
-//
-// The inbound handler runs the normal agent loop under the channel's
-// correlation, so `agt why`/`agt inbox` link the Telegram message to the task.
-func buildTelegramInstance(ctx context.Context, k *kernelruntime.Kernel, label string, get func(string) string) (channel.Channel, pulse.BriefSink, string) {
-	token := strings.TrimSpace(get(brand.EnvPrefix + "TELEGRAM_TOKEN"))
-	if token == "" {
-		return nil, nil, ""
-	}
-	chatIDs := splitNonEmpty(get(brand.EnvPrefix + "TELEGRAM_CHAT_ID"))
-	allow := channel.NewAllowlist(chatIDs)
-
-	handler := makeChannelHandler(k)
-	ch := telegram.New(telegram.Config{
-		Token:     token,
-		BaseURL:   strings.TrimSpace(get(brand.EnvPrefix + "TELEGRAM_API_BASE")), // empty → public Bot API
-		Allowlist: allow,
-		Bus:       k.Bus(),
-		Handler:   handler,
-	})
-
-	// Pulse briefs → the allowlisted chats. Nil sink when no chat configured
-	// (the bot can still receive commands once a chat is allowlisted).
-	var sink pulse.BriefSink
-	if len(chatIDs) > 0 {
-		sink = pulse.SinkFunc(func(b pulse.Brief) error {
-			var firstErr error
-			for _, id := range chatIDs {
-				if err := ch.Send(ctx, channel.Outbound{ChannelID: id, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
-					firstErr = err
-				}
-			}
-			return firstErr
-		})
-	}
-
-	desc := fmt.Sprintf("listening, allowlist=%d chat(s)", len(chatIDs))
-	if len(chatIDs) == 0 {
-		desc = "listening, NO allowlist (outbound-only; set AGEZT_TELEGRAM_CHAT_ID to allow commands)"
-	}
-	return ch, sink, desc
-}
-
-// buildSlack constructs the in-process Slack channel when AGEZT_SLACK_TOKEN is
-// set, plus a Pulse brief sink to the allowlisted channels. Returns (nil, nil,
-// "") when no token is configured.
-//
-//	AGEZT_SLACK_TOKEN           bot token (xoxb-…), required to enable
-//	AGEZT_SLACK_SIGNING_SECRET  app signing secret, required for inbound
-//	AGEZT_SLACK_ADDR            local addr to serve /slack/events (fronted by a
-//	                            tunnel/reverse proxy); empty → outbound-only
-//	AGEZT_SLACK_CHANNELS        comma-separated allowlist of channel ids that may
-//	                            drive the agent AND receive Pulse briefs
-//
-// The inbound handler runs the normal agent loop under the channel's correlation,
-// so `agt why`/`agt inbox` link the Slack message to the task.
-func buildSlackInstance(ctx context.Context, k *kernelruntime.Kernel, label string, get func(string) string) (channel.Channel, pulse.BriefSink, string) {
-	token := strings.TrimSpace(get(brand.EnvPrefix + "SLACK_TOKEN"))
-	if token == "" {
-		return nil, nil, ""
-	}
-	secret := strings.TrimSpace(get(brand.EnvPrefix + "SLACK_SIGNING_SECRET"))
-	addr := strings.TrimSpace(get(brand.EnvPrefix + "SLACK_ADDR"))
-	channelIDs := splitNonEmpty(get(brand.EnvPrefix + "SLACK_CHANNELS"))
-
-	handler := makeChannelHandler(k)
-	ch := slack.New(slack.Config{
-		Token:         token,
-		SigningSecret: secret,
-		Addr:          addr,
-		BaseURL:       strings.TrimSpace(get(brand.EnvPrefix + "SLACK_API_BASE")), // empty → public Web API
-		Allowlist:     channel.NewAllowlist(channelIDs),
-		Bus:           k.Bus(),
-		Handler:       handler,
-	})
-
-	var sink pulse.BriefSink
-	if len(channelIDs) > 0 {
-		sink = pulse.SinkFunc(func(b pulse.Brief) error {
-			var firstErr error
-			for _, id := range channelIDs {
-				if err := ch.Send(ctx, channel.Outbound{ChannelID: id, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
-					firstErr = err
-				}
-			}
-			return firstErr
-		})
-	}
-
-	switch {
-	case addr == "" && len(channelIDs) == 0:
-		return ch, sink, "outbound-only, NO allowlist (set AGEZT_SLACK_ADDR + AGEZT_SLACK_CHANNELS to receive commands)"
-	case addr == "":
-		return ch, sink, fmt.Sprintf("outbound-only, allowlist=%d channel(s) (set AGEZT_SLACK_ADDR to receive commands)", len(channelIDs))
-	case secret == "":
-		return ch, sink, "inbound DISABLED (set AGEZT_SLACK_SIGNING_SECRET); outbound only"
-	default:
-		return ch, sink, fmt.Sprintf("events at %s%s, allowlist=%d channel(s)", addr, slack.EventsPath, len(channelIDs))
-	}
-}
-
 // buildWebhook constructs the vendor-neutral webhook channel. Enabled when an
 // inbound secret OR an outbound URL is configured. Returns (nil, nil, "") when
 // neither is set.
@@ -2702,185 +2594,6 @@ func buildWebhook(ctx context.Context, k *kernelruntime.Kernel) (*webhookchan.Ch
 		}
 		return ch, sink, fmt.Sprintf("inbound at %s%s, allowlist=%d channel(s)", addr, p, len(channelIDs))
 	}
-}
-
-// buildEmailInstance constructs an email channel account when AGEZT_EMAIL_SMTP_ADDR
-// is set. Outbound over SMTP; two-way when an inbox (IMAP/POP3) is also configured.
-//
-//	AGEZT_EMAIL_SMTP_ADDR     SMTP server host:port (e.g. smtp.example.com:587), enables
-//	AGEZT_EMAIL_FROM          sender address
-//	AGEZT_EMAIL_USERNAME      SMTP AUTH username (with PASSWORD); empty → no auth
-//	AGEZT_EMAIL_PASSWORD      SMTP AUTH password
-//	AGEZT_EMAIL_RECIPIENTS    comma-separated allowlist of addresses (mail targets + inbound senders)
-//	AGEZT_EMAIL_INBOX_ADDR    IMAP/POP3 server host:port — enables two-way (poll for new mail)
-//	AGEZT_EMAIL_INBOX_PROTOCOL "imap" (default) or "pop3"
-//	AGEZT_EMAIL_INBOX_USERNAME/PASSWORD  mailbox creds (default to the SMTP ones)
-//	AGEZT_EMAIL_INBOX_TLS     "tls" (default) | "starttls" | "none"
-//	AGEZT_EMAIL_INBOX_POLL    poll interval seconds (default 60)
-func buildEmailInstance(ctx context.Context, k *kernelruntime.Kernel, label string, get func(string) string) (channel.Channel, pulse.BriefSink, string) {
-	addr := strings.TrimSpace(get(brand.EnvPrefix + "EMAIL_SMTP_ADDR"))
-	if addr == "" {
-		return nil, nil, ""
-	}
-	from := strings.TrimSpace(get(brand.EnvPrefix + "EMAIL_FROM"))
-	recipients := splitNonEmpty(get(brand.EnvPrefix + "EMAIL_RECIPIENTS"))
-	inboxAddr := strings.TrimSpace(get(brand.EnvPrefix + "EMAIL_INBOX_ADDR"))
-	pollSecs := 0
-	if v := strings.TrimSpace(get(brand.EnvPrefix + "EMAIL_INBOX_POLL")); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			pollSecs = n
-		}
-	}
-
-	var handler channel.InboundHandler
-	if inboxAddr != "" {
-		handler = makeChannelHandler(k)
-	}
-	ch := email.New(email.Config{
-		Addr:          addr,
-		From:          from,
-		Username:      strings.TrimSpace(get(brand.EnvPrefix + "EMAIL_USERNAME")),
-		Password:      get(brand.EnvPrefix + "EMAIL_PASSWORD"),
-		Allowlist:     channel.NewAllowlist(recipients),
-		Bus:           k.Bus(),
-		InboxAddr:     inboxAddr,
-		InboxProtocol: strings.TrimSpace(get(brand.EnvPrefix + "EMAIL_INBOX_PROTOCOL")),
-		InboxUsername: strings.TrimSpace(get(brand.EnvPrefix + "EMAIL_INBOX_USERNAME")),
-		InboxPassword: get(brand.EnvPrefix + "EMAIL_INBOX_PASSWORD"),
-		InboxTLS:      strings.TrimSpace(get(brand.EnvPrefix + "EMAIL_INBOX_TLS")),
-		PollSecs:      pollSecs,
-		Handler:       handler,
-	})
-
-	var sink pulse.BriefSink
-	if len(recipients) > 0 {
-		sink = pulse.SinkFunc(func(b pulse.Brief) error {
-			var firstErr error
-			for _, id := range recipients {
-				if err := ch.Send(ctx, channel.Outbound{ChannelID: id, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
-					firstErr = err
-				}
-			}
-			return firstErr
-		})
-	}
-
-	dir := "outbound"
-	if inboxAddr != "" {
-		dir = "two-way (inbox " + inboxAddr + ")"
-	}
-	switch {
-	case from == "":
-		return ch, sink, "configured but NO from address (set AGEZT_EMAIL_FROM)"
-	case len(recipients) == 0:
-		return ch, sink, fmt.Sprintf("%s via %s, NO recipients (set AGEZT_EMAIL_RECIPIENTS)", dir, addr)
-	default:
-		return ch, sink, fmt.Sprintf("%s via %s, %d recipient(s)", dir, addr, len(recipients))
-	}
-}
-
-// buildDiscord constructs the in-process Discord channel when AGEZT_DISCORD_TOKEN
-// is set, plus a Pulse brief sink to the allowlisted channels. Returns
-// (nil, nil, "") when no token is configured.
-//
-//	AGEZT_DISCORD_TOKEN       bot token, required to enable
-//	AGEZT_DISCORD_PUBLIC_KEY  app public key (hex), required for inbound verification
-//	AGEZT_DISCORD_APP_ID      application id, required for follow-up replies
-//	AGEZT_DISCORD_ADDR        local addr to serve /discord/interactions (fronted by
-//	                          a tunnel/reverse proxy); empty → outbound-only
-//	AGEZT_DISCORD_CHANNELS    comma-separated allowlist of channel ids that may
-//	                          drive the agent AND receive Pulse briefs
-//
-// The inbound handler runs the normal agent loop under the channel's correlation,
-// so `agt why`/`agt inbox` link the Discord command to the task.
-func buildDiscordInstance(ctx context.Context, k *kernelruntime.Kernel, label string, get func(string) string) (channel.Channel, pulse.BriefSink, string) {
-	token := strings.TrimSpace(get(brand.EnvPrefix + "DISCORD_TOKEN"))
-	if token == "" {
-		return nil, nil, ""
-	}
-	pubKey := strings.TrimSpace(get(brand.EnvPrefix + "DISCORD_PUBLIC_KEY"))
-	appID := strings.TrimSpace(get(brand.EnvPrefix + "DISCORD_APP_ID"))
-	addr := strings.TrimSpace(get(brand.EnvPrefix + "DISCORD_ADDR"))
-	channelIDs := splitNonEmpty(get(brand.EnvPrefix + "DISCORD_CHANNELS"))
-
-	handler := makeChannelHandler(k)
-	ch := discord.New(discord.Config{
-		Token:         token,
-		PublicKey:     pubKey,
-		ApplicationID: appID,
-		Addr:          addr,
-		BaseURL:       strings.TrimSpace(get(brand.EnvPrefix + "DISCORD_API_BASE")), // empty → public API
-		Allowlist:     channel.NewAllowlist(channelIDs),
-		Bus:           k.Bus(),
-		Handler:       handler,
-	})
-
-	var sink pulse.BriefSink
-	if len(channelIDs) > 0 {
-		sink = pulse.SinkFunc(func(b pulse.Brief) error {
-			var firstErr error
-			for _, id := range channelIDs {
-				if err := ch.Send(ctx, channel.Outbound{ChannelID: id, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
-					firstErr = err
-				}
-			}
-			return firstErr
-		})
-	}
-
-	switch {
-	case addr == "" && len(channelIDs) == 0:
-		return ch, sink, "outbound-only, NO allowlist (set AGEZT_DISCORD_ADDR + AGEZT_DISCORD_CHANNELS to receive commands)"
-	case addr == "":
-		return ch, sink, fmt.Sprintf("outbound-only, allowlist=%d channel(s) (set AGEZT_DISCORD_ADDR to receive commands)", len(channelIDs))
-	case pubKey == "":
-		return ch, sink, "inbound DISABLED (set AGEZT_DISCORD_PUBLIC_KEY); outbound only"
-	default:
-		return ch, sink, fmt.Sprintf("interactions at %s%s, allowlist=%d channel(s)", addr, discord.InteractionsPath, len(channelIDs))
-	}
-}
-
-// buildMatrix constructs the in-process Matrix channel when AGEZT_MATRIX_HOMESERVER
-// and AGEZT_MATRIX_TOKEN are set, plus a Pulse brief sink to the allowlisted rooms.
-// Returns (nil, nil, "") when unconfigured. Mirrors buildTelegram: long-polls /sync
-// for inbound, PUTs m.room.message for outbound.
-func buildMatrixInstance(ctx context.Context, k *kernelruntime.Kernel, label string, get func(string) string) (channel.Channel, pulse.BriefSink, string) {
-	homeserver := strings.TrimSpace(get(brand.EnvPrefix + "MATRIX_HOMESERVER"))
-	token := strings.TrimSpace(get(brand.EnvPrefix + "MATRIX_TOKEN"))
-	if homeserver == "" || token == "" {
-		return nil, nil, ""
-	}
-	roomIDs := splitNonEmpty(get(brand.EnvPrefix + "MATRIX_ROOMS"))
-
-	handler := makeChannelHandler(k)
-	ch := matrix.New(matrix.Config{
-		Homeserver: homeserver,
-		Token:      token,
-		Allowlist:  channel.NewAllowlist(roomIDs),
-		Bus:        k.Bus(),
-		Handler:    handler,
-	})
-
-	// Pulse briefs → the allowlisted rooms. Nil sink when no room configured (the
-	// bot can still receive commands once a room is allowlisted).
-	var sink pulse.BriefSink
-	if len(roomIDs) > 0 {
-		sink = pulse.SinkFunc(func(b pulse.Brief) error {
-			var firstErr error
-			for _, id := range roomIDs {
-				if err := ch.Send(ctx, channel.Outbound{ChannelID: id, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
-					firstErr = err
-				}
-			}
-			return firstErr
-		})
-	}
-
-	desc := fmt.Sprintf("listening, allowlist=%d room(s)", len(roomIDs))
-	if len(roomIDs) == 0 {
-		desc = "listening, NO allowlist (outbound-only; set AGEZT_MATRIX_ROOMS to allow commands)"
-	}
-	return ch, sink, desc
 }
 
 // buildIRC constructs the two-way IRC channel when AGEZT_IRC_SERVER +
@@ -3588,67 +3301,6 @@ func buildSMS(ctx context.Context, k *kernelruntime.Kernel) (*sms.Channel, pulse
 	}
 }
 
-// buildWhatsApp constructs the WhatsApp Cloud API channel when
-// AGEZT_WHATSAPP_APP_SECRET + AGEZT_WHATSAPP_ACCESS_TOKEN are set. Inbound (signed
-// Meta webhook) is served when AGEZT_WHATSAPP_ADDR is also set; outbound + Pulse
-// briefs to the allowlisted numbers need AGEZT_WHATSAPP_PHONE_NUMBER_ID.
-//
-//	AGEZT_WHATSAPP_APP_SECRET       Meta app secret (required; signs inbound)
-//	AGEZT_WHATSAPP_ACCESS_TOKEN     Graph API bearer token (required; outbound)
-//	AGEZT_WHATSAPP_PHONE_NUMBER_ID  business phone-number id (outbound endpoint)
-//	AGEZT_WHATSAPP_VERIFY_TOKEN     token echoed in Meta's GET verify handshake
-//	AGEZT_WHATSAPP_ADDR             host:port for the inbound webhook (inbound)
-//	AGEZT_WHATSAPP_PATH             inbound route (default /whatsapp)
-//	AGEZT_WHATSAPP_NUMBERS          comma-separated allowlist of sender numbers
-func buildWhatsAppInstance(ctx context.Context, k *kernelruntime.Kernel, label string, get func(string) string) (channel.Channel, pulse.BriefSink, string) {
-	appSecret := strings.TrimSpace(get(brand.EnvPrefix + "WHATSAPP_APP_SECRET"))
-	accessToken := strings.TrimSpace(get(brand.EnvPrefix + "WHATSAPP_ACCESS_TOKEN"))
-	if appSecret == "" || accessToken == "" {
-		return nil, nil, ""
-	}
-	phoneID := strings.TrimSpace(get(brand.EnvPrefix + "WHATSAPP_PHONE_NUMBER_ID"))
-	verifyToken := strings.TrimSpace(get(brand.EnvPrefix + "WHATSAPP_VERIFY_TOKEN"))
-	addr := strings.TrimSpace(get(brand.EnvPrefix + "WHATSAPP_ADDR"))
-	path := strings.TrimSpace(get(brand.EnvPrefix + "WHATSAPP_PATH"))
-	numbers := splitNonEmpty(get(brand.EnvPrefix + "WHATSAPP_NUMBERS"))
-
-	ch := whatsapp.New(whatsapp.Config{
-		Addr:          addr,
-		Path:          path,
-		VerifyToken:   verifyToken,
-		AppSecret:     appSecret,
-		AccessToken:   accessToken,
-		PhoneNumberID: phoneID,
-		Allowlist:     channel.NewAllowlist(numbers),
-		Bus:           k.Bus(),
-		Handler:       makeChannelHandler(k),
-	})
-
-	var sink pulse.BriefSink
-	if phoneID != "" && len(numbers) > 0 {
-		sink = pulse.SinkFunc(func(b pulse.Brief) error {
-			var firstErr error
-			for _, id := range numbers {
-				if err := ch.Send(ctx, channel.Outbound{ChannelID: id, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
-					firstErr = err
-				}
-			}
-			return firstErr
-		})
-	}
-
-	switch {
-	case addr == "":
-		return ch, sink, fmt.Sprintf("outbound-only (set AGEZT_WHATSAPP_ADDR for inbound), allowlist=%d number(s)", len(numbers))
-	default:
-		p := path
-		if p == "" {
-			p = whatsapp.DefaultPath
-		}
-		return ch, sink, fmt.Sprintf("inbound at %s%s, allowlist=%d number(s)", addr, p, len(numbers))
-	}
-}
-
 // buildHomeAssistant constructs the outbound Home Assistant channel when
 // AGEZT_HOMEASSISTANT_URL + AGEZT_HOMEASSISTANT_TOKEN are set. Pulse briefs +
 // `agt send` go to the allowlisted notify services (AGEZT_HOMEASSISTANT_SERVICES).
@@ -3981,19 +3633,13 @@ func channelLabels(kind string) []string {
 	return settings.AccountLabels(keys, baseEnvs)
 }
 
-// buildAccounts builds every configured instance (the default plus each labelled
-// account) of a channel kind via a per-instance builder. The builder MUST return
-// a nil channel.Channel interface (not a typed nil) when its instance is
-// unconfigured, so unconfigured instances are skipped cleanly.
-func buildAccounts(ctx context.Context, k *kernelruntime.Kernel, kind string,
-	build func(context.Context, *kernelruntime.Kernel, string, func(string) string) (channel.Channel, pulse.BriefSink, string)) []chanInstance {
+// wireInstances converts channelwire's built instances (the factory-migrated
+// channels, Phase 2.1) into the daemon's chanInstance shape so the existing
+// startInstances / allInsts / registerInstances wiring stays untouched.
+func wireInstances(insts []channelwire.Instance) []chanInstance {
 	var out []chanInstance
-	for _, label := range append([]string{""}, channelLabels(kind)...) {
-		ch, sink, desc := build(ctx, k, label, settings.FieldGetter(label))
-		if ch == nil {
-			continue
-		}
-		out = append(out, chanInstance{key: instanceKey(kind, label), desc: desc, ch: ch, sink: sink})
+	for _, in := range insts {
+		out = append(out, chanInstance{key: in.Key, desc: in.Desc, ch: in.Channel, sink: in.Sink})
 	}
 	return out
 }

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -86,7 +86,6 @@ import (
 	"github.com/agezt/agezt/plugins/builtinguardians"
 	"github.com/agezt/agezt/plugins/builtinmarket"
 	"github.com/agezt/agezt/plugins/builtinskills"
-	"github.com/agezt/agezt/plugins/channels/push"
 	"github.com/agezt/agezt/plugins/providers/compat"
 	"github.com/agezt/agezt/plugins/providers/embed"
 	"github.com/agezt/agezt/plugins/providers/image"
@@ -1621,30 +1620,38 @@ func runDaemon(stdout, stderr io.Writer) int {
 	startInstances(ctx, stdout, "signal", "signal channel", "disabled (set AGEZT_SIGNAL_API_URL + AGEZT_SIGNAL_NUMBER)", sgInsts)
 
 	// Push-notification channels (SPEC-04 §1): a family of simple outbound
-	// destinations — ntfy, Pushover, Gotify, Pushbullet, Google Chat, Mattermost —
-	// each enabled by its own env and exposed as a distinct channel. Briefs/`agt
-	// send` POST to the service. Outbound-only.
-	pushChans, pushSink, pushDesc := buildPushChannels(ctx, k)
-	for _, pc := range pushChans {
-		go pc.Start(ctx)
-	}
-	if len(pushChans) > 0 {
-		fmt.Fprintf(stdout, "  push channels    : %s\n", pushDesc)
-	} else {
-		fmt.Fprintf(stdout, "  push channels    : disabled (ntfy/pushover/gotify/pushbullet/googlechat/mattermost)\n")
-	}
+	// destinations, each enabled by its own env and exposed as a distinct
+	// channel. Briefs/`agt send` POST to the service. Outbound-only. The dual
+	// kinds (googlechat/mattermost/mastodon/line/feishu/dingtalk/wecom) fall
+	// back to their push entry inside their own factories when two-way is
+	// unconfigured; these seven are pure push. Silent when unconfigured
+	// (disabledHint ""), matching the old single "push channels: disabled" line.
+	ntInsts := wireInstances(channelwire.BuildKind(ctx, "ntfy", k.Bus(), chanHandler))
+	startInstances(ctx, stdout, "ntfy", "ntfy push", "", ntInsts)
+	poInsts := wireInstances(channelwire.BuildKind(ctx, "pushover", k.Bus(), chanHandler))
+	startInstances(ctx, stdout, "pushover", "pushover push", "", poInsts)
+	gfInsts := wireInstances(channelwire.BuildKind(ctx, "gotify", k.Bus(), chanHandler))
+	startInstances(ctx, stdout, "gotify", "gotify push", "", gfInsts)
+	pbInsts := wireInstances(channelwire.BuildKind(ctx, "pushbullet", k.Bus(), chanHandler))
+	startInstances(ctx, stdout, "pushbullet", "pushbullet push", "", pbInsts)
+	rcInsts := wireInstances(channelwire.BuildKind(ctx, "rocketchat", k.Bus(), chanHandler))
+	startInstances(ctx, stdout, "rocketchat", "rocketchat push", "", rcInsts)
+	zuInsts := wireInstances(channelwire.BuildKind(ctx, "zulip", k.Bus(), chanHandler))
+	startInstances(ctx, stdout, "zulip", "zulip push", "", zuInsts)
+	syInsts := wireInstances(channelwire.BuildKind(ctx, "synology", k.Bus(), chanHandler))
+	startInstances(ctx, stdout, "synology", "synology push", "", syInsts)
 
 	// Every configured channel's brief sink, teed: Pulse briefs and (M782)
 	// alert notifications share the same delivery surface.
-	// All channels are multi-account now: one brief sink per instance, plus the
-	// push family (its own internal multi-destination sink).
+	// All channels are multi-account now: one brief sink per instance.
 	allInsts := [][]chanInstance{
 		tgInsts, emInsts, slInsts, dcInsts, mxInsts, waInsts,
 		whInsts, ircInsts, twInsts, wgInsts, imInsts, lnInsts, gcInsts, mmInsts,
 		dtInsts, fsInsts, wcInsts, qqInsts, wxInsts, zlInsts, nctInsts, maInsts, noInsts,
 		smInsts, haInsts, tmInsts, sgInsts,
+		ntInsts, poInsts, gfInsts, pbInsts, rcInsts, zuInsts, syInsts,
 	}
-	channelSinks := combineSinks(append(instanceSinks(allInsts...), pushSink)...)
+	channelSinks := combineSinks(instanceSinks(allInsts...)...)
 
 	// Pulse — the proactive heart (SPEC-03). On by default; the resident
 	// engine runs on the daemon ctx so `agt halt`/SIGTERM/`agt shutdown`
@@ -1816,9 +1823,6 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// Every channel is multi-account: register every instance by its instance key
 	// ("telegram", "telegram#bot2", "email#work", …).
 	registerInstances(liveChannels, allInsts...)
-	for _, pc := range pushChans {
-		liveChannels[pc.Name()] = pc
-	}
 	// Record which channels actually started, so the Channels wizard can show
 	// "live" vs merely "configured (restart to start)".
 	liveKinds := make([]string, 0, len(liveChannels))
@@ -2508,120 +2512,6 @@ func extForMime(mime string) string {
 	}
 }
 
-// twoWayLineConfigured reports whether the dedicated two-way LINE channel should
-// own the "line" name (a channel secret is set) — in which case buildPushChannels
-// yields LINE to it to avoid a double registration. The two-way builder itself
-// migrated to the channelwire factory (plugins/builtinchannels); this predicate
-// only concerns the DEFAULT instance — its sole remaining caller is
-// buildPushChannels — and moves with the push family.
-func twoWayLineConfigured() bool {
-	return strings.TrimSpace(os.Getenv(brand.EnvPrefix+"LINE_SECRET")) != ""
-}
-
-// twoWayChatConfigured reports whether the two-way chat-webhook channel for a
-// push kind (prefix "GOOGLECHAT" / "MATTERMOST") should own that name — an
-// inbound addr is set — so buildPushChannels yields the outbound-only entry.
-// The two-way builder itself migrated to the channelwire factory
-// (chatWebhookFactory in plugins/builtinchannels); this predicate only concerns
-// the DEFAULT instance and moves with the push-suppression cluster.
-func twoWayChatConfigured(prefix string) bool {
-	return strings.TrimSpace(os.Getenv(brand.EnvPrefix+prefix+"_ADDR")) != ""
-}
-
-// twoWayMastodonConfigured reports whether the dedicated two-way Mastodon channel
-// should own the "mastodon" name — true when an acct allowlist is set, signalling
-// the operator wants the agent to answer mentions (not just post). The two-way
-// builder itself migrated to the channelwire factory (plugins/builtinchannels);
-// this predicate only concerns the DEFAULT instance and moves with the
-// push-suppression cluster.
-func twoWayMastodonConfigured() bool {
-	return strings.TrimSpace(os.Getenv(brand.EnvPrefix+"MASTODON_USERS")) != ""
-}
-
-// buildPushChannels constructs every configured push-notification channel (ntfy,
-// Pushover, Gotify, Pushbullet, Google Chat, Mattermost). Each is enabled by its
-// own env and added as a distinct outbound channel; a combined Pulse sink fans a
-// brief out to all of them. Returns nil when none are configured.
-func buildPushChannels(ctx context.Context, k *kernelruntime.Kernel) ([]*push.Channel, pulse.BriefSink, string) {
-	env := func(s string) string { return strings.TrimSpace(os.Getenv(brand.EnvPrefix + s)) }
-	var chans []*push.Channel
-	add := func(cfg push.Config) {
-		cfg.Bus = k.Bus()
-		if ch, err := push.New(cfg); err == nil {
-			chans = append(chans, ch)
-		}
-	}
-	if t := env("NTFY_TOPIC"); t != "" {
-		add(push.Config{Kind: push.KindNtfy, Server: env("NTFY_SERVER"), Topic: t, Token: env("NTFY_TOKEN")})
-	}
-	if env("PUSHOVER_TOKEN") != "" {
-		add(push.Config{Kind: push.KindPushover, Token: env("PUSHOVER_TOKEN"), User: env("PUSHOVER_USER")})
-	}
-	if env("GOTIFY_TOKEN") != "" {
-		add(push.Config{Kind: push.KindGotify, Server: env("GOTIFY_SERVER"), Token: env("GOTIFY_TOKEN")})
-	}
-	if env("PUSHBULLET_TOKEN") != "" {
-		add(push.Config{Kind: push.KindPushbullet, Token: env("PUSHBULLET_TOKEN")})
-	}
-	if u := env("GOOGLECHAT_WEBHOOK"); u != "" && !twoWayChatConfigured("GOOGLECHAT") {
-		// Two-way Google Chat (AGEZT_GOOGLECHAT_ADDR) owns the name; see
-		// chatWebhookFactory in plugins/builtinchannels.
-		add(push.Config{Kind: push.KindGoogleChat, URL: u})
-	}
-	if u := env("MATTERMOST_WEBHOOK"); u != "" && !twoWayChatConfigured("MATTERMOST") {
-		add(push.Config{Kind: push.KindMattermost, URL: u})
-	}
-	if u := env("ROCKETCHAT_WEBHOOK"); u != "" {
-		add(push.Config{Kind: push.KindRocketChat, URL: u})
-	}
-	if env("MASTODON_TOKEN") != "" && !twoWayMastodonConfigured() {
-		// When an allowlist is set the dedicated two-way Mastodon channel owns the
-		// "mastodon" name (it polls mentions + posts), so skip this outbound entry.
-		add(push.Config{Kind: push.KindMastodon, Server: env("MASTODON_SERVER"), Token: env("MASTODON_TOKEN")})
-	}
-	if env("LINE_TOKEN") != "" && !twoWayLineConfigured() {
-		// When AGEZT_LINE_SECRET is set the dedicated two-way LINE channel owns
-		// the "line" name (see the line factory in plugins/builtinchannels), so
-		// skip the outbound-only push entry.
-		add(push.Config{Kind: push.KindLine, Token: env("LINE_TOKEN"), Target: env("LINE_TO")})
-	}
-	if env("ZULIP_APIKEY") != "" {
-		add(push.Config{Kind: push.KindZulip, Server: env("ZULIP_SERVER"), User: env("ZULIP_EMAIL"), Token: env("ZULIP_APIKEY"), Target: env("ZULIP_STREAM"), Topic: env("ZULIP_TOPIC")})
-	}
-	// Feishu/DingTalk/WeCom: the dedicated two-way channels own the name when
-	// their inbound addr is configured (see the buildFeishu/buildDingTalk/
-	// buildWeCom factories in plugins/builtinchannels).
-	if u := env("FEISHU_WEBHOOK"); u != "" && (env("FEISHU_ADDR") == "" || env("FEISHU_APP_ID") == "") {
-		add(push.Config{Kind: push.KindFeishu, URL: u})
-	}
-	if u := env("DINGTALK_WEBHOOK"); u != "" && env("DINGTALK_ADDR") == "" {
-		add(push.Config{Kind: push.KindDingTalk, URL: u})
-	}
-	if u := env("WECOM_WEBHOOK"); u != "" && (env("WECOM_ADDR") == "" || env("WECOM_CORP_ID") == "") {
-		add(push.Config{Kind: push.KindWeCom, URL: u})
-	}
-	if u := env("SYNOLOGY_WEBHOOK"); u != "" {
-		add(push.Config{Kind: push.KindSynology, URL: u})
-	}
-	if len(chans) == 0 {
-		return nil, nil, ""
-	}
-	names := make([]string, 0, len(chans))
-	for _, ch := range chans {
-		names = append(names, ch.Name())
-	}
-	sink := pulse.SinkFunc(func(b pulse.Brief) error {
-		var firstErr error
-		for _, ch := range chans {
-			if err := ch.Send(ctx, channel.Outbound{Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
-				firstErr = err
-			}
-		}
-		return firstErr
-	})
-	return chans, sink, fmt.Sprintf("outbound → %s", strings.Join(names, ", "))
-}
-
 // collectChannels reports the configured messaging channels for `agt status`
 // (M141), read-only from the same env the buildX functions consume. A channel is
 // listed when its token is set; Inbound reflects whether it can actually receive
@@ -2777,42 +2667,6 @@ func instanceMatch(keys []string, target string) []string {
 	return out
 }
 
-// overlayEnv temporarily sets each base env to its "#label" value for a labelled
-// instance, returning a restore func; for the default instance ("") it's a no-op.
-// It let the legacy buildXxx functions (which read os.Getenv directly) build a
-// labelled account without rewriting them — safe because builds are synchronous
-// and each channel reads its config into a struct before Start runs. The two-way
-// builders have all migrated to channelwire factories; this stays for the
-// remaining os.Getenv-reading push family (buildPushChannels) until it migrates.
-func overlayEnv(baseEnvs []string, label string) func() {
-	if label == "" {
-		return func() {}
-	}
-	type saved struct {
-		key, val string
-		had      bool
-	}
-	prev := make([]saved, 0, len(baseEnvs))
-	for _, base := range baseEnvs {
-		old, had := os.LookupEnv(base)
-		prev = append(prev, saved{base, old, had})
-		if v, ok := os.LookupEnv(base + "#" + label); ok {
-			_ = os.Setenv(base, v)
-		} else {
-			_ = os.Unsetenv(base)
-		}
-	}
-	return func() {
-		for _, s := range prev {
-			if s.had {
-				_ = os.Setenv(s.key, s.val)
-			} else {
-				_ = os.Unsetenv(s.key)
-			}
-		}
-	}
-}
-
 // liveChannelKeys returns the instance keys of the live channel map (used to
 // record per-account live state for the Channels UI).
 func liveChannelKeys(live map[string]channel.Channel) []string {
@@ -2831,14 +2685,6 @@ func briefSink(stdout io.Writer, extra pulse.BriefSink) pulse.BriefSink {
 		return log
 	}
 	return pulse.MultiSink{log, extra}
-}
-
-// formatBrief renders a Pulse brief as plain Telegram text.
-func formatBrief(b pulse.Brief) string {
-	if b.Body != "" {
-		return "📣 " + b.Title + "\n" + b.Body
-	}
-	return "📣 " + b.Title
 }
 
 // splitNonEmpty splits a comma list, trimming and dropping blanks.

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -90,13 +90,9 @@ import (
 	"github.com/agezt/agezt/plugins/channels/chatwebhook"
 	"github.com/agezt/agezt/plugins/channels/dingtalk"
 	"github.com/agezt/agezt/plugins/channels/feishu"
-	linechan "github.com/agezt/agezt/plugins/channels/line"
 	"github.com/agezt/agezt/plugins/channels/mastodon"
-	"github.com/agezt/agezt/plugins/channels/nostr"
-	"github.com/agezt/agezt/plugins/channels/onebot"
 	"github.com/agezt/agezt/plugins/channels/push"
 	"github.com/agezt/agezt/plugins/channels/wecom"
-	"github.com/agezt/agezt/plugins/channels/zalo"
 	"github.com/agezt/agezt/plugins/providers/compat"
 	"github.com/agezt/agezt/plugins/providers/embed"
 	"github.com/agezt/agezt/plugins/providers/image"
@@ -1564,7 +1560,7 @@ func runDaemon(stdout, stderr io.Writer) int {
 
 	// LINE two-way (official Messaging API) — supersedes the outbound-only push
 	// LINE when a channel secret is set.
-	lnInsts := buildAccountsLegacy(ctx, k, "line", buildLine)
+	lnInsts := wireInstances(channelwire.BuildKind(ctx, "line", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "line", "line channel", "", lnInsts)
 
 	// Two-way Google Chat / Mattermost (incoming webhook out + webhook in) —
@@ -1587,21 +1583,17 @@ func runDaemon(stdout, stderr io.Writer) int {
 	startInstances(ctx, stdout, "wecom", "wecom (2way)", "", wcInsts)
 
 	// QQ / WeChat via a OneBot v11 gateway; Zalo via the Official Account API.
-	qqInsts := buildAccountsLegacy(ctx, k, "qq", func(c context.Context, kk *kernelruntime.Kernel) (*onebot.Channel, pulse.BriefSink, string) {
-		return buildOneBot(c, kk, "qq", "QQ")
-	})
+	qqInsts := wireInstances(channelwire.BuildKind(ctx, "qq", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "qq", "qq channel", "", qqInsts)
-	wxInsts := buildAccountsLegacy(ctx, k, "wechat", func(c context.Context, kk *kernelruntime.Kernel) (*onebot.Channel, pulse.BriefSink, string) {
-		return buildOneBot(c, kk, "wechat", "WECHAT")
-	})
+	wxInsts := wireInstances(channelwire.BuildKind(ctx, "wechat", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "wechat", "wechat channel", "", wxInsts)
-	zlInsts := buildAccountsLegacy(ctx, k, "zalo", buildZalo)
+	zlInsts := wireInstances(channelwire.BuildKind(ctx, "zalo", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "zalo", "zalo channel", "", zlInsts)
 	nctInsts := wireInstances(channelwire.BuildKind(ctx, "nextcloudtalk", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "nextcloudtalk", "nextcloud talk", "", nctInsts)
 	maInsts := buildAccountsLegacy(ctx, k, "mastodon", buildMastodon)
 	startInstances(ctx, stdout, "mastodon", "mastodon channel", "", maInsts)
-	noInsts := buildAccountsLegacy(ctx, k, "nostr", buildNostr)
+	noInsts := wireInstances(channelwire.BuildKind(ctx, "nostr", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "nostr", "nostr channel", "", noInsts)
 
 	// SMS channel (SPEC-04 §1) — duplex over Twilio Programmable Messaging when
@@ -2528,50 +2520,12 @@ func extForMime(mime string) string {
 
 // twoWayLineConfigured reports whether the dedicated two-way LINE channel should
 // own the "line" name (a channel secret is set) — in which case buildPushChannels
-// yields LINE to it to avoid a double registration.
+// yields LINE to it to avoid a double registration. The two-way builder itself
+// migrated to the channelwire factory (plugins/builtinchannels); this predicate
+// only concerns the DEFAULT instance and moves with the push-suppression
+// cluster in batch D.
 func twoWayLineConfigured() bool {
 	return strings.TrimSpace(os.Getenv(brand.EnvPrefix+"LINE_SECRET")) != ""
-}
-
-// buildLine constructs the two-way LINE channel (official Messaging API) when a
-// channel secret is set. Outbound push uses AGEZT_LINE_TOKEN; inbound (two-way)
-// is served when AGEZT_LINE_ADDR is set and verified with AGEZT_LINE_SECRET.
-//
-//	AGEZT_LINE_TOKEN    channel access token (Bearer for reply/push)
-//	AGEZT_LINE_SECRET   channel secret (verifies inbound signature; enables two-way)  (required)
-//	AGEZT_LINE_USERS    comma-separated allowed sender userIds
-//	AGEZT_LINE_TO       recipient id for Pulse briefs
-//	AGEZT_LINE_ADDR     host:port to serve LINE's webhook (two-way)
-//	AGEZT_LINE_PATH     inbound route (default /line)
-func buildLine(ctx context.Context, k *kernelruntime.Kernel) (*linechan.Channel, pulse.BriefSink, string) {
-	if !twoWayLineConfigured() {
-		return nil, nil, ""
-	}
-	users := splitNonEmpty(os.Getenv(brand.EnvPrefix + "LINE_USERS"))
-	addr := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "LINE_ADDR"))
-
-	ch := linechan.New(linechan.Config{
-		Secret:      strings.TrimSpace(os.Getenv(brand.EnvPrefix + "LINE_SECRET")),
-		AccessToken: strings.TrimSpace(os.Getenv(brand.EnvPrefix + "LINE_TOKEN")),
-		Allowlist:   channel.NewAllowlist(users),
-		Bus:         k.Bus(),
-		Handler:     makeChannelHandler(k),
-		Addr:        addr,
-		Path:        strings.TrimSpace(os.Getenv(brand.EnvPrefix + "LINE_PATH")),
-	})
-
-	var sink pulse.BriefSink
-	if to := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "LINE_TO")); to != "" {
-		sink = pulse.SinkFunc(func(b pulse.Brief) error {
-			return ch.Send(ctx, channel.Outbound{ChannelID: to, Text: formatBrief(b), Priority: channel.PriorityNotify})
-		})
-	}
-
-	desc := fmt.Sprintf("LINE Messaging API, allowlist=%d user(s)", len(users))
-	if addr == "" {
-		desc += " (outbound-only; set AGEZT_LINE_ADDR for two-way)"
-	}
-	return ch, sink, desc
 }
 
 // twoWayChatConfigured reports whether the two-way chat-webhook channel for a
@@ -2740,90 +2694,6 @@ func buildWeCom(ctx context.Context, k *kernelruntime.Kernel) (*wecom.Channel, p
 	return ch, sink, fmt.Sprintf("WeCom app, allowlist=%d user(s)", len(users))
 }
 
-// buildOneBot constructs a QQ / WeChat channel over a OneBot v11 gateway when its
-// inbound addr is set. QQ and WeChat have no first-party bot API; a self-hosted
-// gateway (go-cqhttp / NapCat / Lagrange for QQ; wcf / wechatbot for WeChat)
-// speaks OneBot. kind is the channel name; prefix is the env namespace.
-//
-//	AGEZT_<PREFIX>_GATEWAY  gateway HTTP API base, e.g. http://localhost:5700
-//	AGEZT_<PREFIX>_TOKEN    gateway access token (bearer)
-//	AGEZT_<PREFIX>_SECRET   HMAC-SHA1 secret verifying inbound X-Signature
-//	AGEZT_<PREFIX>_USERS    comma-separated allowed user ids
-//	AGEZT_<PREFIX>_ADDR     host:port to serve the inbound webhook (enables two-way)
-//	AGEZT_<PREFIX>_PATH     inbound route (default /<kind>)
-func buildOneBot(ctx context.Context, k *kernelruntime.Kernel, kind, prefix string) (*onebot.Channel, pulse.BriefSink, string) {
-	get := func(s string) string { return strings.TrimSpace(os.Getenv(brand.EnvPrefix + prefix + s)) }
-	addr := get("_ADDR")
-	if addr == "" {
-		return nil, nil, ""
-	}
-	users := splitNonEmpty(os.Getenv(brand.EnvPrefix + prefix + "_USERS"))
-	ch := onebot.New(onebot.Config{
-		Kind:        kind,
-		APIBase:     get("_GATEWAY"),
-		AccessToken: get("_TOKEN"),
-		Secret:      get("_SECRET"),
-		Allowlist:   channel.NewAllowlist(users),
-		Bus:         k.Bus(),
-		Handler:     makeChannelHandler(k),
-		Addr:        addr,
-		Path:        get("_PATH"),
-	})
-	var sink pulse.BriefSink
-	if len(users) > 0 && get("_GATEWAY") != "" {
-		sink = pulse.SinkFunc(func(b pulse.Brief) error {
-			var firstErr error
-			for _, u := range users {
-				if err := ch.Send(ctx, channel.Outbound{ChannelID: "private:" + u, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
-					firstErr = err
-				}
-			}
-			return firstErr
-		})
-	}
-	return ch, sink, fmt.Sprintf("%s via OneBot gateway, allowlist=%d user(s)", kind, len(users))
-}
-
-// buildZalo constructs the two-way Zalo channel (Official Account API) when
-// AGEZT_ZALO_ADDR is set. Replies + briefs use the OA message API.
-//
-//	AGEZT_ZALO_APP_ID   OA app id (part of the inbound signature)
-//	AGEZT_ZALO_TOKEN    OA access token (sends)
-//	AGEZT_ZALO_SECRET   OA secret key (verifies the inbound signature)
-//	AGEZT_ZALO_USERS    comma-separated allowed user ids
-//	AGEZT_ZALO_ADDR     host:port to serve the inbound webhook (enables two-way)
-//	AGEZT_ZALO_PATH     inbound route (default /zalo)
-func buildZalo(ctx context.Context, k *kernelruntime.Kernel) (*zalo.Channel, pulse.BriefSink, string) {
-	addr := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "ZALO_ADDR"))
-	if addr == "" {
-		return nil, nil, ""
-	}
-	users := splitNonEmpty(os.Getenv(brand.EnvPrefix + "ZALO_USERS"))
-	ch := zalo.New(zalo.Config{
-		AppID:       strings.TrimSpace(os.Getenv(brand.EnvPrefix + "ZALO_APP_ID")),
-		AccessToken: strings.TrimSpace(os.Getenv(brand.EnvPrefix + "ZALO_TOKEN")),
-		Secret:      strings.TrimSpace(os.Getenv(brand.EnvPrefix + "ZALO_SECRET")),
-		Allowlist:   channel.NewAllowlist(users),
-		Bus:         k.Bus(),
-		Handler:     makeChannelHandler(k),
-		Addr:        addr,
-		Path:        strings.TrimSpace(os.Getenv(brand.EnvPrefix + "ZALO_PATH")),
-	})
-	var sink pulse.BriefSink
-	if len(users) > 0 {
-		sink = pulse.SinkFunc(func(b pulse.Brief) error {
-			var firstErr error
-			for _, u := range users {
-				if err := ch.Send(ctx, channel.Outbound{ChannelID: u, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
-					firstErr = err
-				}
-			}
-			return firstErr
-		})
-	}
-	return ch, sink, fmt.Sprintf("Zalo OA, allowlist=%d user(s)", len(users))
-}
-
 // twoWayMastodonConfigured reports whether the dedicated two-way Mastodon channel
 // should own the "mastodon" name — true when an acct allowlist is set, signalling
 // the operator wants the agent to answer mentions (not just post).
@@ -2869,45 +2739,6 @@ func buildMastodon(ctx context.Context, k *kernelruntime.Kernel) (*mastodon.Chan
 	return ch, sink, fmt.Sprintf("Mastodon (two-way), allowlist=%d acct(s)", len(users))
 }
 
-// buildNostr constructs the Nostr channel when AGEZT_NOSTR_PRIVKEY + AGEZT_NOSTR_RELAYS
-// are set. It connects to the relays, answers kind-1 mentions of the agent's
-// pubkey from allowlisted authors, and posts briefs as standalone notes.
-//
-//	AGEZT_NOSTR_PRIVKEY  64-char hex secret key (required)
-//	AGEZT_NOSTR_RELAYS   comma-separated wss:// relay URLs (required)
-//	AGEZT_NOSTR_AUTHORS  comma-separated author pubkeys (hex) allowed to drive the agent
-func buildNostr(ctx context.Context, k *kernelruntime.Kernel) (*nostr.Channel, pulse.BriefSink, string) {
-	priv := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "NOSTR_PRIVKEY"))
-	relays := splitNonEmpty(os.Getenv(brand.EnvPrefix + "NOSTR_RELAYS"))
-	if priv == "" || len(relays) == 0 {
-		return nil, nil, ""
-	}
-	authors := splitNonEmpty(os.Getenv(brand.EnvPrefix + "NOSTR_AUTHORS"))
-	// Authors may be hex or npub… — normalize to hex so the allowlist matches the
-	// hex pubkey on inbound events.
-	norm := make([]string, 0, len(authors))
-	for _, a := range authors {
-		if h, derr := nostr.DecodePubkey(a); derr == nil {
-			norm = append(norm, h)
-		}
-	}
-	ch, err := nostr.New(nostr.Config{
-		PrivKeyHex: priv,
-		Relays:     relays,
-		Allowlist:  channel.NewAllowlist(norm),
-		Bus:        k.Bus(),
-		Handler:    makeChannelHandler(k),
-	})
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s: nostr channel disabled: %v\n", brand.Binary, err)
-		return nil, nil, ""
-	}
-	sink := pulse.SinkFunc(func(b pulse.Brief) error {
-		return ch.Send(ctx, channel.Outbound{Text: formatBrief(b), Priority: channel.PriorityNotify})
-	})
-	return ch, sink, fmt.Sprintf("Nostr, %d relay(s), allowlist=%d author(s)", len(relays), len(authors))
-}
-
 // buildPushChannels constructs every configured push-notification channel (ntfy,
 // Pushover, Gotify, Pushbullet, Google Chat, Mattermost). Each is enabled by its
 // own env and added as a distinct outbound channel; a combined Pulse sink fans a
@@ -2950,7 +2781,8 @@ func buildPushChannels(ctx context.Context, k *kernelruntime.Kernel) ([]*push.Ch
 	}
 	if env("LINE_TOKEN") != "" && !twoWayLineConfigured() {
 		// When AGEZT_LINE_SECRET is set the dedicated two-way LINE channel owns
-		// the "line" name (see buildLine), so skip the outbound-only push entry.
+		// the "line" name (see the line factory in plugins/builtinchannels), so
+		// skip the outbound-only push entry.
 		add(push.Config{Kind: push.KindLine, Token: env("LINE_TOKEN"), Target: env("LINE_TO")})
 	}
 	if env("ZULIP_APIKEY") != "" {

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -90,17 +90,12 @@ import (
 	"github.com/agezt/agezt/plugins/channels/chatwebhook"
 	"github.com/agezt/agezt/plugins/channels/dingtalk"
 	"github.com/agezt/agezt/plugins/channels/feishu"
-	"github.com/agezt/agezt/plugins/channels/homeassistant"
-	"github.com/agezt/agezt/plugins/channels/imessage"
 	linechan "github.com/agezt/agezt/plugins/channels/line"
 	"github.com/agezt/agezt/plugins/channels/mastodon"
-	"github.com/agezt/agezt/plugins/channels/nextcloudtalk"
 	"github.com/agezt/agezt/plugins/channels/nostr"
 	"github.com/agezt/agezt/plugins/channels/onebot"
 	"github.com/agezt/agezt/plugins/channels/push"
-	"github.com/agezt/agezt/plugins/channels/teams"
 	"github.com/agezt/agezt/plugins/channels/wecom"
-	"github.com/agezt/agezt/plugins/channels/whatsappgw"
 	"github.com/agezt/agezt/plugins/channels/zalo"
 	"github.com/agezt/agezt/plugins/providers/compat"
 	"github.com/agezt/agezt/plugins/providers/embed"
@@ -1560,11 +1555,11 @@ func runDaemon(stdout, stderr io.Writer) int {
 	startInstances(ctx, stdout, "twitch", "twitch channel", "disabled (set AGEZT_TWITCH_USERNAME + AGEZT_TWITCH_TOKEN)", twInsts)
 
 	// WhatsApp via a self-hosted gateway (WAHA/Evolution) — the easy WhatsApp path.
-	wgInsts := buildAccountsLegacy(ctx, k, "whatsappgw", buildWhatsAppGateway)
+	wgInsts := wireInstances(channelwire.BuildKind(ctx, "whatsappgw", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "whatsappgw", "whatsapp gateway", "disabled (set AGEZT_WHATSAPPGW_URL)", wgInsts)
 
 	// iMessage via a self-hosted BlueBubbles server — the Mac-bridge iMessage path.
-	imInsts := buildAccountsLegacy(ctx, k, "imessage", buildIMessage)
+	imInsts := wireInstances(channelwire.BuildKind(ctx, "imessage", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "imessage", "imessage channel", "disabled (set AGEZT_IMESSAGE_URL)", imInsts)
 
 	// LINE two-way (official Messaging API) — supersedes the outbound-only push
@@ -1602,7 +1597,7 @@ func runDaemon(stdout, stderr io.Writer) int {
 	startInstances(ctx, stdout, "wechat", "wechat channel", "", wxInsts)
 	zlInsts := buildAccountsLegacy(ctx, k, "zalo", buildZalo)
 	startInstances(ctx, stdout, "zalo", "zalo channel", "", zlInsts)
-	nctInsts := buildAccountsLegacy(ctx, k, "nextcloudtalk", buildNextcloudTalk)
+	nctInsts := wireInstances(channelwire.BuildKind(ctx, "nextcloudtalk", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "nextcloudtalk", "nextcloud talk", "", nctInsts)
 	maInsts := buildAccountsLegacy(ctx, k, "mastodon", buildMastodon)
 	startInstances(ctx, stdout, "mastodon", "mastodon channel", "", maInsts)
@@ -1627,13 +1622,13 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// AGEZT_HOMEASSISTANT_URL + AGEZT_HOMEASSISTANT_TOKEN are set. Briefs/`agt send`
 	// land as phone pushes / TTS / persistent notifications on the allowlisted
 	// notify services. Outbound-only (drive FROM HA via the webhook channel).
-	haInsts := buildAccountsLegacy(ctx, k, "homeassistant", buildHomeAssistant)
+	haInsts := wireInstances(channelwire.BuildKind(ctx, "homeassistant", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "homeassistant", "homeassistant ch", "disabled (set AGEZT_HOMEASSISTANT_URL + AGEZT_HOMEASSISTANT_TOKEN)", haInsts)
 
 	// Teams channel (SPEC-04 §1) — outbound to Microsoft Teams Incoming Webhooks
 	// when AGEZT_TEAMS_WEBHOOKS is set (name=url,name2=url2). Briefs/`agt send`
 	// post a card to the named Teams channel. Outbound-only.
-	tmInsts := buildAccountsLegacy(ctx, k, "teams", buildTeams)
+	tmInsts := wireInstances(channelwire.BuildKind(ctx, "teams", k.Bus(), chanHandler))
 	startInstances(ctx, stdout, "teams", "teams channel", "disabled (set AGEZT_TEAMS_WEBHOOKS=name=url,...)", tmInsts)
 
 	// Signal channel (SPEC-04 §1) — duplex via an operator-run signal-cli-rest-api
@@ -2531,117 +2526,6 @@ func extForMime(mime string) string {
 	}
 }
 
-// buildWhatsAppGateway constructs the easy-path WhatsApp channel — a self-hosted
-// WAHA or Evolution API gateway (QR login, no Meta) — when AGEZT_WHATSAPPGW_URL
-// is set. Outbound always; inbound (two-way) when AGEZT_WHATSAPPGW_ADDR points
-// the gateway's webhook at this daemon. Briefs tee to the allowlisted numbers.
-//
-//	AGEZT_WHATSAPPGW_URL      gateway base URL, e.g. http://localhost:3000  (required)
-//	AGEZT_WHATSAPPGW_BACKEND  "waha" (default) or "evolution"
-//	AGEZT_WHATSAPPGW_SESSION  WAHA session / Evolution instance (default "default")
-//	AGEZT_WHATSAPPGW_KEY      gateway API key
-//	AGEZT_WHATSAPPGW_NUMBERS  comma-separated allowed sender numbers
-//	AGEZT_WHATSAPPGW_ADDR     host:port to serve the inbound webhook (two-way)
-//	AGEZT_WHATSAPPGW_PATH     inbound route (default /whatsappgw)
-//	AGEZT_WHATSAPPGW_SECRET   optional shared secret the gateway must echo inbound
-func buildWhatsAppGateway(ctx context.Context, k *kernelruntime.Kernel) (*whatsappgw.Channel, pulse.BriefSink, string) {
-	base := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "WHATSAPPGW_URL"))
-	if base == "" {
-		return nil, nil, ""
-	}
-	numbers := splitNonEmpty(os.Getenv(brand.EnvPrefix + "WHATSAPPGW_NUMBERS"))
-	addr := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "WHATSAPPGW_ADDR"))
-	backend := strings.ToLower(strings.TrimSpace(os.Getenv(brand.EnvPrefix + "WHATSAPPGW_BACKEND")))
-
-	ch := whatsappgw.New(whatsappgw.Config{
-		Backend:   backend,
-		BaseURL:   base,
-		Session:   strings.TrimSpace(os.Getenv(brand.EnvPrefix + "WHATSAPPGW_SESSION")),
-		APIKey:    strings.TrimSpace(os.Getenv(brand.EnvPrefix + "WHATSAPPGW_KEY")),
-		Allowlist: channel.NewAllowlist(numbers),
-		Bus:       k.Bus(),
-		Handler:   makeChannelHandler(k),
-		Addr:      addr,
-		Path:      strings.TrimSpace(os.Getenv(brand.EnvPrefix + "WHATSAPPGW_PATH")),
-		Secret:    strings.TrimSpace(os.Getenv(brand.EnvPrefix + "WHATSAPPGW_SECRET")),
-	})
-
-	var sink pulse.BriefSink
-	if len(numbers) > 0 {
-		sink = pulse.SinkFunc(func(b pulse.Brief) error {
-			var firstErr error
-			for _, n := range numbers {
-				if err := ch.Send(ctx, channel.Outbound{ChannelID: n, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
-					firstErr = err
-				}
-			}
-			return firstErr
-		})
-	}
-
-	be := backend
-	if be == "" {
-		be = "waha"
-	}
-	desc := fmt.Sprintf("%s via %s, allowlist=%d number(s)", base, be, len(numbers))
-	if addr == "" {
-		desc += " (outbound-only; set AGEZT_WHATSAPPGW_ADDR for two-way)"
-	}
-	return ch, sink, desc
-}
-
-// buildIMessage constructs the iMessage channel — a self-hosted BlueBubbles
-// server (a Mac bridge; https://bluebubbles.app) — when AGEZT_IMESSAGE_URL is
-// set. Outbound always; inbound (two-way) when AGEZT_IMESSAGE_ADDR points the
-// BlueBubbles webhook back at this channel.
-//
-//	AGEZT_IMESSAGE_URL        BlueBubbles server URL, e.g. http://localhost:1234  (required)
-//	AGEZT_IMESSAGE_PASSWORD   BlueBubbles server password
-//	AGEZT_IMESSAGE_METHOD     "private-api" (default) or "apple-script"
-//	AGEZT_IMESSAGE_ADDRESSES  comma-separated allowed sender addresses (phone/email)
-//	AGEZT_IMESSAGE_ADDR       host:port to serve the inbound webhook (two-way)
-//	AGEZT_IMESSAGE_PATH       inbound route (default /imessage)
-//	AGEZT_IMESSAGE_SECRET     optional shared secret the webhook must echo (X-Webhook-Secret)
-func buildIMessage(ctx context.Context, k *kernelruntime.Kernel) (*imessage.Channel, pulse.BriefSink, string) {
-	base := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "IMESSAGE_URL"))
-	if base == "" {
-		return nil, nil, ""
-	}
-	addresses := splitNonEmpty(os.Getenv(brand.EnvPrefix + "IMESSAGE_ADDRESSES"))
-	addr := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "IMESSAGE_ADDR"))
-
-	ch := imessage.New(imessage.Config{
-		BaseURL:   base,
-		Password:  strings.TrimSpace(os.Getenv(brand.EnvPrefix + "IMESSAGE_PASSWORD")),
-		Method:    strings.ToLower(strings.TrimSpace(os.Getenv(brand.EnvPrefix + "IMESSAGE_METHOD"))),
-		Allowlist: channel.NewAllowlist(addresses),
-		Bus:       k.Bus(),
-		Handler:   makeChannelHandler(k),
-		Addr:      addr,
-		Path:      strings.TrimSpace(os.Getenv(brand.EnvPrefix + "IMESSAGE_PATH")),
-		Secret:    strings.TrimSpace(os.Getenv(brand.EnvPrefix + "IMESSAGE_SECRET")),
-	})
-
-	var sink pulse.BriefSink
-	if len(addresses) > 0 {
-		sink = pulse.SinkFunc(func(b pulse.Brief) error {
-			var firstErr error
-			for _, a := range addresses {
-				if err := ch.Send(ctx, channel.Outbound{ChannelID: a, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
-					firstErr = err
-				}
-			}
-			return firstErr
-		})
-	}
-
-	desc := fmt.Sprintf("%s via BlueBubbles, allowlist=%d address(es)", base, len(addresses))
-	if addr == "" {
-		desc += " (outbound-only; set AGEZT_IMESSAGE_ADDR for two-way)"
-	}
-	return ch, sink, desc
-}
-
 // twoWayLineConfigured reports whether the dedicated two-way LINE channel should
 // own the "line" name (a channel secret is set) — in which case buildPushChannels
 // yields LINE to it to avoid a double registration.
@@ -2940,47 +2824,6 @@ func buildZalo(ctx context.Context, k *kernelruntime.Kernel) (*zalo.Channel, pul
 	return ch, sink, fmt.Sprintf("Zalo OA, allowlist=%d user(s)", len(users))
 }
 
-// buildNextcloudTalk constructs the Nextcloud Talk channel when AGEZT_NEXTCLOUDTALK_URL
-// + AGEZT_NEXTCLOUDTALK_SECRET are set. Inbound (signed bot webhook) is served when
-// AGEZT_NEXTCLOUDTALK_ADDR is also set; outbound replies + Pulse briefs go to the
-// allowlisted conversation tokens (AGEZT_NEXTCLOUDTALK_TOKENS).
-//
-//	AGEZT_NEXTCLOUDTALK_URL     Nextcloud base URL, e.g. https://cloud.example.com (required)
-//	AGEZT_NEXTCLOUDTALK_SECRET  shared bot secret; signs/verifies (required)
-//	AGEZT_NEXTCLOUDTALK_ADDR    host:port for the inbound webhook (inbound)
-//	AGEZT_NEXTCLOUDTALK_PATH    inbound route (default /nextcloudtalk)
-//	AGEZT_NEXTCLOUDTALK_TOKENS  comma-separated allowlist of conversation tokens
-func buildNextcloudTalk(ctx context.Context, k *kernelruntime.Kernel) (*nextcloudtalk.Channel, pulse.BriefSink, string) {
-	server := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "NEXTCLOUDTALK_URL"))
-	secret := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "NEXTCLOUDTALK_SECRET"))
-	if server == "" || secret == "" {
-		return nil, nil, ""
-	}
-	tokens := splitNonEmpty(os.Getenv(brand.EnvPrefix + "NEXTCLOUDTALK_TOKENS"))
-	ch := nextcloudtalk.New(nextcloudtalk.Config{
-		ServerURL: server,
-		Secret:    secret,
-		Allowlist: channel.NewAllowlist(tokens),
-		Bus:       k.Bus(),
-		Handler:   makeChannelHandler(k),
-		Addr:      strings.TrimSpace(os.Getenv(brand.EnvPrefix + "NEXTCLOUDTALK_ADDR")),
-		Path:      strings.TrimSpace(os.Getenv(brand.EnvPrefix + "NEXTCLOUDTALK_PATH")),
-	})
-	var sink pulse.BriefSink
-	if len(tokens) > 0 {
-		sink = pulse.SinkFunc(func(b pulse.Brief) error {
-			var firstErr error
-			for _, t := range tokens {
-				if err := ch.Send(ctx, channel.Outbound{ChannelID: t, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
-					firstErr = err
-				}
-			}
-			return firstErr
-		})
-	}
-	return ch, sink, fmt.Sprintf("Nextcloud Talk, allowlist=%d token(s)", len(tokens))
-}
-
 // twoWayMastodonConfigured reports whether the dedicated two-way Mastodon channel
 // should own the "mastodon" name — true when an acct allowlist is set, signalling
 // the operator wants the agent to answer mentions (not just post).
@@ -3063,76 +2906,6 @@ func buildNostr(ctx context.Context, k *kernelruntime.Kernel) (*nostr.Channel, p
 		return ch.Send(ctx, channel.Outbound{Text: formatBrief(b), Priority: channel.PriorityNotify})
 	})
 	return ch, sink, fmt.Sprintf("Nostr, %d relay(s), allowlist=%d author(s)", len(relays), len(authors))
-}
-
-// buildHomeAssistant constructs the outbound Home Assistant channel when
-// AGEZT_HOMEASSISTANT_URL + AGEZT_HOMEASSISTANT_TOKEN are set. Pulse briefs +
-// `agt send` go to the allowlisted notify services (AGEZT_HOMEASSISTANT_SERVICES).
-//
-//	AGEZT_HOMEASSISTANT_URL       HA base, e.g. http://homeassistant.local:8123
-//	AGEZT_HOMEASSISTANT_TOKEN     long-lived access token
-//	AGEZT_HOMEASSISTANT_SERVICES  comma-separated notify service allowlist
-//	                              (e.g. mobile_app_phone,persistent_notification)
-func buildHomeAssistant(ctx context.Context, k *kernelruntime.Kernel) (*homeassistant.Channel, pulse.BriefSink, string) {
-	baseURL := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "HOMEASSISTANT_URL"))
-	token := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "HOMEASSISTANT_TOKEN"))
-	if baseURL == "" || token == "" {
-		return nil, nil, ""
-	}
-	services := splitNonEmpty(os.Getenv(brand.EnvPrefix + "HOMEASSISTANT_SERVICES"))
-
-	ch := homeassistant.New(homeassistant.Config{
-		BaseURL:   baseURL,
-		Token:     token,
-		Allowlist: channel.NewAllowlist(services),
-		Bus:       k.Bus(),
-	})
-
-	var sink pulse.BriefSink
-	if len(services) > 0 {
-		sink = pulse.SinkFunc(func(b pulse.Brief) error {
-			var firstErr error
-			for _, svc := range services {
-				if err := ch.Send(ctx, channel.Outbound{ChannelID: svc, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
-					firstErr = err
-				}
-			}
-			return firstErr
-		})
-	}
-
-	desc := fmt.Sprintf("outbound → %s, allowlist=%d service(s)", baseURL, len(services))
-	if len(services) == 0 {
-		desc = fmt.Sprintf("outbound → %s, NO allowlist (set AGEZT_HOMEASSISTANT_SERVICES to notify)", baseURL)
-	}
-	return ch, sink, desc
-}
-
-// buildTeams constructs the outbound Microsoft Teams channel when
-// AGEZT_TEAMS_WEBHOOKS is set. Pulse briefs + `agt send` post a card to the named
-// Teams Incoming Webhooks.
-//
-//	AGEZT_TEAMS_WEBHOOKS  name=url,name2=url2 — named Teams Incoming Webhook URLs;
-//	                      `agt send --channel teams --to <name>` selects one.
-func buildTeams(ctx context.Context, k *kernelruntime.Kernel) (*teams.Channel, pulse.BriefSink, string) {
-	hooks := parseNamedWebhooks(strings.TrimSpace(os.Getenv(brand.EnvPrefix + "TEAMS_WEBHOOKS")))
-	if len(hooks) == 0 {
-		return nil, nil, ""
-	}
-	ch := teams.New(teams.Config{Webhooks: hooks, Bus: k.Bus()})
-
-	names := ch.Names()
-	sink := pulse.SinkFunc(func(b pulse.Brief) error {
-		var firstErr error
-		for _, name := range names {
-			if err := ch.Send(ctx, channel.Outbound{ChannelID: name, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
-				firstErr = err
-			}
-		}
-		return firstErr
-	})
-
-	return ch, sink, fmt.Sprintf("outbound → %d Teams webhook(s)", len(names))
 }
 
 // buildPushChannels constructs every configured push-notification channel (ntfy,
@@ -3262,29 +3035,6 @@ func collectChannels() []controlplane.ChannelInfo {
 			info.Allowlist = len(splitNonEmpty(env(m.AllowlistEnv)))
 		}
 		out = append(out, info)
-	}
-	return out
-}
-
-// parseNamedWebhooks parses a "name=url,name2=url2" spec into a name→url map.
-// Each entry splits on the FIRST '=' (URLs may contain '='); blank names/urls
-// are dropped.
-func parseNamedWebhooks(spec string) map[string]string {
-	out := map[string]string{}
-	for _, entry := range strings.Split(spec, ",") {
-		entry = strings.TrimSpace(entry)
-		if entry == "" {
-			continue
-		}
-		eq := strings.IndexByte(entry, '=')
-		if eq <= 0 {
-			continue
-		}
-		name := strings.TrimSpace(entry[:eq])
-		url := strings.TrimSpace(entry[eq+1:])
-		if name != "" && url != "" {
-			out[name] = url
-		}
 	}
 	return out
 }

--- a/cmd/agezt/main_test.go
+++ b/cmd/agezt/main_test.go
@@ -51,43 +51,6 @@ func TestInstanceMatch(t *testing.T) {
 	}
 }
 
-// TestOverlayEnv verifies the legacy multi-account driver: for a labelled
-// instance each base env is temporarily set to its "#label" value (or unset when
-// the label has no value), and fully restored afterwards. The default instance
-// ("") is a no-op.
-func TestOverlayEnv(t *testing.T) {
-	base := []string{brand.EnvPrefix + "OVTEST_A", brand.EnvPrefix + "OVTEST_B"}
-	t.Setenv(base[0], "bare-a")
-	t.Setenv(base[1], "bare-b")
-	t.Setenv(base[0]+"#work", "work-a")
-	// Note: base[1]#work intentionally unset → overlay must unset base[1].
-
-	// Default instance: no change.
-	restore := overlayEnv(base, "")
-	if v, _ := os.LookupEnv(base[0]); v != "bare-a" {
-		t.Fatalf("default overlay changed %s = %q", base[0], v)
-	}
-	restore()
-
-	// Labelled instance: A becomes work-a, B is unset.
-	restore = overlayEnv(base, "work")
-	if v, _ := os.LookupEnv(base[0]); v != "work-a" {
-		t.Fatalf("overlay A = %q, want work-a", v)
-	}
-	if v, ok := os.LookupEnv(base[1]); ok {
-		t.Fatalf("overlay B = %q, want unset", v)
-	}
-	restore()
-
-	// Restored to the bare values.
-	if v, _ := os.LookupEnv(base[0]); v != "bare-a" {
-		t.Fatalf("post-restore A = %q, want bare-a", v)
-	}
-	if v, _ := os.LookupEnv(base[1]); v != "bare-b" {
-		t.Fatalf("post-restore B = %q, want bare-b", v)
-	}
-}
-
 func TestWardenOptionsFromEnv(t *testing.T) {
 	t.Setenv(brand.EnvPrefix+"WARDEN_DOCKER", "")
 	opts, desc := wardenOptionsFromEnv()

--- a/kernel/channel/registry.go
+++ b/kernel/channel/registry.go
@@ -53,6 +53,14 @@ type Manifest struct {
 	// the channel to actually receive inbound traffic. Meaningful only for
 	// Duplex channels; empty means inbound whenever configured.
 	InboundEnv []string `json:"inbound_env,omitempty"`
+
+	// BannerLabel is the short label the daemon's boot banner prints for this
+	// channel (e.g. "webhook channel", "ntfy push"). Empty → Kind is used.
+	BannerLabel string `json:"banner_label,omitempty"`
+	// DisabledHint is the boot-banner line printed when no instance of this
+	// channel is configured (e.g. "disabled (set AGEZT_TELEGRAM_TOKEN)").
+	// Empty → the channel stays silent when unconfigured.
+	DisabledHint string `json:"disabled_hint,omitempty"`
 }
 
 // MediaCaps describes a channel's non-text multimodal reach. Text is always

--- a/kernel/channelwire/channelwire.go
+++ b/kernel/channelwire/channelwire.go
@@ -51,8 +51,8 @@ type Deps struct {
 
 // Built is a factory's result. Desc == "" means "not configured — skip",
 // which kills the typed-nil-interface landmine that forced a reflect probe
-// on the legacy builders. Channels usually holds one element; the push
-// family returns several from one env family.
+// on the legacy builders. Channels usually holds one element; a factory MAY
+// return several from one env family (extras are keyed by their own Name).
 type Built struct {
 	Channels []channel.Channel
 	Sink     pulse.BriefSink

--- a/kernel/channelwire/channelwire.go
+++ b/kernel/channelwire/channelwire.go
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: MIT
+
+// Package channelwire is the channel FACTORY layer (Phase 2.1 of
+// docs/REFACTORING-SCAN-2026-08.md): each channel kind registers a Factory
+// that builds its configured instances from a Deps bundle, and BuildAll walks
+// the manifest registry so the daemon's channel section is one loop instead
+// of 27 hand-listed builder call sites (the allInsts drift surface).
+//
+// This package — not kernel/channel — owns the factory types because a
+// factory returns a pulse.BriefSink: importing pulse into kernel/channel
+// would drag kernel/agent into every transport plugin's transitive deps.
+// kernel/channel stays the pure vocabulary (Channel, UnifiedMessage,
+// Manifest); channelwire is the wiring above it.
+package channelwire
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/agezt/agezt/kernel/bus"
+	"github.com/agezt/agezt/kernel/channel"
+	"github.com/agezt/agezt/kernel/pulse"
+	"github.com/agezt/agezt/kernel/settings"
+)
+
+// Deps is everything a channel factory may touch. Empirically this is the
+// builders' ENTIRE kernel surface (verified across all 27 in cmd/agezt):
+// the event bus, the shared inbound handler, and a config getter that
+// resolves a base env name for this instance's account label.
+type Deps struct {
+	// Ctx is the daemon lifetime context; brief-sink closures capture it for
+	// their outbound Send calls.
+	Ctx context.Context
+	// Bus is the kernel event bus (k.Bus()).
+	Bus *bus.Bus
+	// Handler is the shared inbound handler (built once by the daemon).
+	Handler channel.InboundHandler
+	// Get resolves a base env name ("AGEZT_TELEGRAM_TOKEN") to this
+	// instance's value — the "#label" variant for a labelled account, the
+	// plain env for the default instance. Factories read config ONLY through
+	// Get; that is what retires the overlayEnv os.Setenv hack.
+	Get func(baseEnv string) string
+	// Label is this instance's account label ("" = default). For descs and
+	// keys only — config access goes through Get.
+	Label string
+}
+
+// Built is a factory's result. Desc == "" means "not configured — skip",
+// which kills the typed-nil-interface landmine that forced a reflect probe
+// on the legacy builders. Channels usually holds one element; the push
+// family returns several from one env family.
+type Built struct {
+	Channels []channel.Channel
+	Sink     pulse.BriefSink
+	Desc     string
+}
+
+// NotConfigured is the zero Built, returned by a factory whose env is unset.
+var NotConfigured = Built{}
+
+// Factory builds the channel instance(s) for one (kind, label) pair.
+type Factory func(Deps) Built
+
+var (
+	mu        sync.RWMutex
+	factories = map[string]Factory{}
+)
+
+// Register installs the factory for a channel kind (matching its
+// channel.Manifest Kind). Later registrations replace earlier ones, mirroring
+// the manifest registry's semantics.
+func Register(kind string, f Factory) {
+	mu.Lock()
+	defer mu.Unlock()
+	factories[kind] = f
+}
+
+// Lookup returns the factory for kind.
+func Lookup(kind string) (Factory, bool) {
+	mu.RLock()
+	defer mu.RUnlock()
+	f, ok := factories[kind]
+	return f, ok
+}
+
+// Kinds returns the registered factory kinds, sorted.
+func Kinds() []string {
+	mu.RLock()
+	defer mu.RUnlock()
+	out := make([]string, 0, len(factories))
+	for k := range factories {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Instance is one built, keyed channel instance — the unit the daemon
+// starts, registers for `agt send`, and reports on the boot banner.
+type Instance struct {
+	Kind    string
+	Label   string // "" = default
+	Key     string // channel.InstanceKey(Kind, Label)
+	Desc    string
+	Channel channel.Channel
+	Sink    pulse.BriefSink // may be nil (outbound target unknown)
+}
+
+// Labels returns the configured NON-default account labels for a channel
+// kind, discovered from the process env (the daemon injects store+vault
+// keys, including "#label" suffixed ones, at boot).
+func Labels(kind string) []string {
+	baseEnvs := settings.SectionEnvs(kind)
+	if len(baseEnvs) == 0 {
+		return nil
+	}
+	env := os.Environ()
+	keys := make([]string, 0, len(env))
+	for _, kv := range env {
+		if k, _, ok := strings.Cut(kv, "="); ok {
+			keys = append(keys, k)
+		}
+	}
+	return settings.AccountLabels(keys, baseEnvs)
+}
+
+// BuildKind builds every configured instance (default + each labelled
+// account) of one kind through its registered factory. Returns nil when the
+// kind has no factory or nothing is configured.
+func BuildKind(ctx context.Context, kind string, b *bus.Bus, handler channel.InboundHandler) []Instance {
+	f, ok := Lookup(kind)
+	if !ok {
+		return nil
+	}
+	var out []Instance
+	for _, label := range append([]string{""}, Labels(kind)...) {
+		built := f(Deps{
+			Ctx:     ctx,
+			Bus:     b,
+			Handler: handler,
+			Get:     settings.FieldGetter(label),
+			Label:   label,
+		})
+		if built.Desc == "" || len(built.Channels) == 0 {
+			continue
+		}
+		for i, ch := range built.Channels {
+			key := channel.InstanceKey(kind, label)
+			// A multi-channel Built (push family) keys extras by their own
+			// Name() so each stays individually addressable.
+			if i > 0 || (len(built.Channels) > 1 && ch.Name() != kind) {
+				key = channel.InstanceKey(ch.Name(), label)
+			}
+			inst := Instance{
+				Kind: kind, Label: label, Key: key,
+				Desc: built.Desc, Channel: ch,
+			}
+			if i == 0 {
+				inst.Sink = built.Sink // one sink per Built, not per channel
+			}
+			out = append(out, inst)
+		}
+	}
+	return out
+}
+
+// BuildAll builds every configured instance of every manifest-registered
+// kind that has a factory. The daemon's whole channel section reduces to
+// this walk once every builder has migrated (the ratchet below tracks that).
+func BuildAll(ctx context.Context, b *bus.Bus, handler channel.InboundHandler) []Instance {
+	var out []Instance
+	for _, m := range channel.Manifests() {
+		out = append(out, BuildKind(ctx, m.Kind, b, handler)...)
+	}
+	return out
+}
+
+// MissingFactories reports manifest kinds with no registered factory —
+// the migration ratchet's raw material and, post-migration, the drift alarm
+// that a new channel shipped a manifest but no wiring.
+func MissingFactories() []string {
+	var out []string
+	for _, m := range channel.Manifests() {
+		if _, ok := Lookup(m.Kind); !ok {
+			out = append(out, m.Kind)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Describe renders the standard one-line boot-banner desc for an instance
+// ("telegram#work : 2 chats allowed"). Shared so banner formatting stays
+// uniform as builders migrate.
+func Describe(in Instance) string {
+	if in.Label == "" {
+		return fmt.Sprintf("%s : %s", in.Kind, in.Desc)
+	}
+	return fmt.Sprintf("%s#%s : %s", in.Kind, in.Label, in.Desc)
+}

--- a/kernel/channelwire/channelwire_test.go
+++ b/kernel/channelwire/channelwire_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+
+package channelwire
+
+import (
+	"context"
+	"testing"
+
+	"github.com/agezt/agezt/kernel/channel"
+)
+
+type fakeChannel struct{ name string }
+
+func (f fakeChannel) Name() string                                     { return f.name }
+func (f fakeChannel) Start(ctx context.Context) error                  { <-ctx.Done(); return ctx.Err() }
+func (f fakeChannel) Send(_ context.Context, _ channel.Outbound) error { return nil }
+
+func TestRegisterLookupKinds(t *testing.T) {
+	Register("wiretest-a", func(Deps) Built { return NotConfigured })
+	Register("wiretest-b", func(Deps) Built { return NotConfigured })
+	if _, ok := Lookup("wiretest-a"); !ok {
+		t.Fatal("registered factory not found")
+	}
+	if _, ok := Lookup("wiretest-nope"); ok {
+		t.Fatal("unregistered factory found")
+	}
+	seen := map[string]bool{}
+	for _, k := range Kinds() {
+		seen[k] = true
+	}
+	if !seen["wiretest-a"] || !seen["wiretest-b"] {
+		t.Fatalf("Kinds() missing test kinds: %v", Kinds())
+	}
+}
+
+func TestBuildKind_NotConfiguredSkips(t *testing.T) {
+	Register("wiretest-off", func(Deps) Built { return NotConfigured })
+	insts := BuildKind(context.Background(), "wiretest-off", nil, nil)
+	if len(insts) != 0 {
+		t.Fatalf("unconfigured kind must yield no instances, got %d", len(insts))
+	}
+}
+
+func TestBuildKind_SingleChannel(t *testing.T) {
+	Register("wiretest-on", func(d Deps) Built {
+		return Built{
+			Channels: []channel.Channel{fakeChannel{name: "wiretest-on"}},
+			Desc:     "1 chat allowed",
+		}
+	})
+	insts := BuildKind(context.Background(), "wiretest-on", nil, nil)
+	if len(insts) != 1 {
+		t.Fatalf("want 1 instance, got %d", len(insts))
+	}
+	in := insts[0]
+	if in.Key != channel.InstanceKey("wiretest-on", "") {
+		t.Fatalf("wrong key: %s", in.Key)
+	}
+	if in.Desc != "1 chat allowed" || in.Kind != "wiretest-on" || in.Label != "" {
+		t.Fatalf("instance fields wrong: %+v", in)
+	}
+}
+
+func TestBuildKind_MultiChannelKeysByName(t *testing.T) {
+	// The push-family shape: one factory, several channels, each addressable
+	// by its own Name().
+	Register("wiretest-push", func(d Deps) Built {
+		return Built{
+			Channels: []channel.Channel{
+				fakeChannel{name: "wiretest-ntfy"},
+				fakeChannel{name: "wiretest-gotify"},
+			},
+			Desc: "2 push targets",
+		}
+	})
+	insts := BuildKind(context.Background(), "wiretest-push", nil, nil)
+	if len(insts) != 2 {
+		t.Fatalf("want 2 instances, got %d", len(insts))
+	}
+	if insts[0].Key != channel.InstanceKey("wiretest-ntfy", "") {
+		t.Fatalf("multi-channel first key should use channel name: %s", insts[0].Key)
+	}
+	if insts[1].Key != channel.InstanceKey("wiretest-gotify", "") {
+		t.Fatalf("multi-channel extra key should use channel name: %s", insts[1].Key)
+	}
+}
+
+func TestMissingFactories_ListsUnwiredManifests(t *testing.T) {
+	channel.RegisterManifest(channel.Manifest{
+		Kind: "wiretest-manifest-only", Display: "WireTest", Description: "t",
+		Transport: "rest", RequiredEnv: []string{"AGEZT_WIRETEST_TOKEN"},
+	})
+	found := false
+	for _, k := range MissingFactories() {
+		if k == "wiretest-manifest-only" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("manifest without factory should be reported missing")
+	}
+}

--- a/plans/phase2.1-channel-factory.md
+++ b/plans/phase2.1-channel-factory.md
@@ -1,0 +1,56 @@
+# Phase 2.1 — Channel factory (working plan, from live survey 2026-08-06)
+
+Goal: `Manifest.New` factory field; channel section of cmd/agezt/main.go (~1,400 lines,
+27 builders) becomes one loop. Closes 34-manifests-vs-27-wirings drift.
+
+## Verified facts
+- Manifest in kernel/channel/registry.go (14 fields incl. Phase-0 AddrEnv/AllowlistEnv/InboundEnv).
+  Registered by ONE slice literal in plugins/builtinchannels (34 entries), RegisterAll() at main.go:1517.
+- Builders' entire kernel surface = k.Bus() + makeChannelHandler(k) → Deps{Ctx, Bus, Handler, Get, Label} suffices.
+  makeChannelHandler (main.go:2320) is stateless → build ONCE, pass in.
+- 6 modern builders (telegram/slack/email/discord/matrix/whatsapp, `label` param dead — get closure carries it),
+  19 legacy funcs / 21 sites (os.Getenv direct, need overlayEnv), 1 outlier buildPushChannels (13 push kinds).
+- overlayEnv = process-global os.Setenv hack (main.go:4069), only caller buildAccountsLegacy (4101, has
+  reflect typed-nil probe because legacy builders return concrete *T). Test: main_test.go:57 TestOverlayEnv.
+- allInsts literal (main.go:1669, 27 groups) feeds: combineSinks→buildPulse, registerInstances→liveChannels
+  (agt send / notify tool / briefing), SetLive/SetLiveInstances (UI badge). Omission = silent drift.
+- 7 manifests with no chanInstance wiring: ntfy/pushover/gotify/pushbullet/rocketchat/zulip/synology
+  (built via buildPushChannels; no #label multi-account, no per-instance sink). That IS the 34-vs-27 gap.
+- Dual-path kinds w/ suppression predicates: googlechat/mattermost/mastodon/line/feishu/dingtalk/wecom
+  (two-way builder + push entry; twoWay*Configured name-ownership rules must be preserved).
+- pulse.BriefSink: acyclic to import into kernel/channel but drags kernel/agent transitively —
+  DECIDE in PR 1 (alt: local interface alias in channel).
+- Tests pinning wiring: coverage_builders_test.go (all builders by name), TestOverlayEnv,
+  coverage_helpers_more_test.go (startInstances/instanceSinks/registerInstances),
+  config_inventory_test.go (regex-scans cmd/agezt only — REPOINT at new package in same PR, it
+  never fails on extra so moving vars silently unguards them).
+
+## Factory shape (deviation from doc's bare triple, justified)
+```go
+type Deps struct{ Ctx context.Context; Bus *bus.Bus; Handler InboundHandler; Get func(string) string; Label string }
+type Built struct{ Channels []Channel; Sink pulse.BriefSink; Desc string } // Desc=="" → not configured
+// Manifest: New func(Deps) Built `json:"-"`   (Manifest is JSON-serialized to UI)
+```
+Built (not triple) because push family returns N channels and Desc-sentinel kills the
+reflect typed-nil landmine.
+
+## PR train (each green/shippable)
+1. Scaffolding: Deps/Built/Manifest.New + channel.BuildAll; move chanInstance/startInstances/
+   instanceSinks/registerInstances/channelLabels/buildAccounts into kernel/channel (pure).
+   Guard test: every manifest has New OR is on shrinking TODO allowlist (the drift alarm).
+2. The 6 modern channels → New adapters; delete their buildAccounts sites; update coverage_builders_test.
+3. Legacy batch A: webhook, irc, twitch, sms, signal (webhook flushes liveChannels special case main.go:2115).
+4. Legacy batch B: whatsappgw, imessage, homeassistant, teams (+parseNamedWebhooks), nextcloudtalk.
+5. Legacy batch C: nostr, zalo, qq, wechat (collapse buildOneBot), line (first suppression predicate).
+6. Legacy batch D (suppression cluster together): googlechat, mattermost, dingtalk, feishu, wecom, mastodon —
+   express ownership rule ONCE in manifest (Supersedes []string or IsLive ordering).
+7. Push family (7 kinds get own New → gain #label + per-instance live keys; closes drift) + DELETE:
+   overlayEnv+test, buildAccountsLegacy+reflect probe, allInsts literal, buildPushChannels,
+   25 plugins/channels imports from main.go; repoint config_inventory_test.
+8. Cleanup: notifyTargets derives from AllowlistEnv/RequiredEnv; consider deleting collectChannels (doc 0.7).
+   Banner "disabled (set X)" hints: derive from RequiredEnv or add Manifest.DisabledHint.
+
+## Final main.go section ≈ 25 lines
+RegisterAll → handler := makeChannelHandler(k) → insts := channel.BuildAll(depsFor) →
+loop: Start/liveChannels/sinks/banner → disabled lines from Manifests() → combineSinks → SetLive.
+Downstream (channelTargets/channelSend/buildPulse/briefing) consumes liveChannels/channelSinks unchanged.

--- a/plugins/builtinchannels/builtinchannels.go
+++ b/plugins/builtinchannels/builtinchannels.go
@@ -38,6 +38,11 @@ func RegisterAll() {
 	channelwire.Register("homeassistant", buildHomeAssistant)
 	channelwire.Register("teams", buildTeams)
 	channelwire.Register("nextcloudtalk", buildNextcloudTalk)
+	channelwire.Register("nostr", buildNostr)
+	channelwire.Register("zalo", buildZalo)
+	channelwire.Register("qq", oneBotFactory("qq", "QQ"))
+	channelwire.Register("wechat", oneBotFactory("wechat", "WECHAT"))
+	channelwire.Register("line", buildLine)
 }
 
 var manifests = []channel.Manifest{

--- a/plugins/builtinchannels/builtinchannels.go
+++ b/plugins/builtinchannels/builtinchannels.go
@@ -50,6 +50,13 @@ func RegisterAll() {
 	channelwire.Register("feishu", buildFeishu)
 	channelwire.Register("wecom", buildWeCom)
 	channelwire.Register("mastodon", buildMastodon)
+	channelwire.Register("ntfy", buildNtfy)
+	channelwire.Register("pushover", buildPushover)
+	channelwire.Register("gotify", buildGotify)
+	channelwire.Register("pushbullet", buildPushbullet)
+	channelwire.Register("rocketchat", buildRocketChat)
+	channelwire.Register("zulip", buildZulip)
+	channelwire.Register("synology", buildSynology)
 }
 
 var manifests = []channel.Manifest{

--- a/plugins/builtinchannels/builtinchannels.go
+++ b/plugins/builtinchannels/builtinchannels.go
@@ -28,6 +28,11 @@ func RegisterAll() {
 	channelwire.Register("discord", buildDiscord)
 	channelwire.Register("matrix", buildMatrix)
 	channelwire.Register("whatsapp", buildWhatsApp)
+	channelwire.Register("webhook", buildWebhook)
+	channelwire.Register("irc", buildIRC)
+	channelwire.Register("twitch", buildTwitch)
+	channelwire.Register("sms", buildSMS)
+	channelwire.Register("signal", buildSignal)
 }
 
 var manifests = []channel.Manifest{

--- a/plugins/builtinchannels/builtinchannels.go
+++ b/plugins/builtinchannels/builtinchannels.go
@@ -33,6 +33,11 @@ func RegisterAll() {
 	channelwire.Register("twitch", buildTwitch)
 	channelwire.Register("sms", buildSMS)
 	channelwire.Register("signal", buildSignal)
+	channelwire.Register("whatsappgw", buildWhatsAppGateway)
+	channelwire.Register("imessage", buildIMessage)
+	channelwire.Register("homeassistant", buildHomeAssistant)
+	channelwire.Register("teams", buildTeams)
+	channelwire.Register("nextcloudtalk", buildNextcloudTalk)
 }
 
 var manifests = []channel.Manifest{

--- a/plugins/builtinchannels/builtinchannels.go
+++ b/plugins/builtinchannels/builtinchannels.go
@@ -62,6 +62,7 @@ func RegisterAll() {
 var manifests = []channel.Manifest{
 	{
 		Kind: "telegram", Display: "Telegram", Transport: "long-poll", Duplex: true,
+		BannerLabel: "telegram", DisabledHint: "disabled (set AGEZT_TELEGRAM_TOKEN)",
 		Description:   "Telegram bot — two-way chat and notifications via @BotFather.",
 		ConfigSection: "telegram", RequiredEnv: []string{"AGEZT_TELEGRAM_TOKEN"},
 		AllowlistEnv:  "AGEZT_TELEGRAM_CHAT_ID",
@@ -77,6 +78,7 @@ var manifests = []channel.Manifest{
 	},
 	{
 		Kind: "whatsapp", Display: "WhatsApp", Transport: "webhook", Duplex: true,
+		BannerLabel: "whatsapp channel", DisabledHint: "disabled (set AGEZT_WHATSAPP_APP_SECRET + AGEZT_WHATSAPP_ACCESS_TOKEN)",
 		Description:   "WhatsApp Cloud API (Meta) — two-way messaging with media.",
 		ConfigSection: "whatsapp", RequiredEnv: []string{"AGEZT_WHATSAPP_ACCESS_TOKEN", "AGEZT_WHATSAPP_PHONE_NUMBER_ID"},
 		AddrEnv: "AGEZT_WHATSAPP_ADDR", AllowlistEnv: "AGEZT_WHATSAPP_NUMBERS", InboundEnv: []string{"AGEZT_WHATSAPP_ADDR"},
@@ -92,6 +94,7 @@ var manifests = []channel.Manifest{
 	},
 	{
 		Kind: "slack", Display: "Slack", Transport: "webhook", Duplex: true,
+		BannerLabel: "slack", DisabledHint: "disabled (set AGEZT_SLACK_TOKEN)",
 		Description:   "Slack bot — slash/events with signed inbound verification.",
 		ConfigSection: "slack", RequiredEnv: []string{"AGEZT_SLACK_TOKEN"},
 		AddrEnv: "AGEZT_SLACK_ADDR", AllowlistEnv: "AGEZT_SLACK_CHANNELS", InboundEnv: []string{"AGEZT_SLACK_ADDR", "AGEZT_SLACK_SIGNING_SECRET"},
@@ -107,6 +110,7 @@ var manifests = []channel.Manifest{
 	},
 	{
 		Kind: "discord", Display: "Discord", Transport: "webhook", Duplex: true,
+		BannerLabel: "discord", DisabledHint: "disabled (set AGEZT_DISCORD_TOKEN)",
 		Description:   "Discord bot — interactions via Ed25519-verified webhook.",
 		ConfigSection: "discord", RequiredEnv: []string{"AGEZT_DISCORD_TOKEN"},
 		AddrEnv: "AGEZT_DISCORD_ADDR", AllowlistEnv: "AGEZT_DISCORD_CHANNELS", InboundEnv: []string{"AGEZT_DISCORD_ADDR", "AGEZT_DISCORD_PUBLIC_KEY"},
@@ -122,6 +126,7 @@ var manifests = []channel.Manifest{
 	},
 	{
 		Kind: "matrix", Display: "Matrix", Transport: "long-poll", Duplex: true,
+		BannerLabel: "matrix channel", DisabledHint: "disabled (set AGEZT_MATRIX_HOMESERVER + AGEZT_MATRIX_TOKEN)",
 		Description:   "Matrix — two-way via /sync long-poll on any homeserver.",
 		ConfigSection: "matrix", RequiredEnv: []string{"AGEZT_MATRIX_HOMESERVER", "AGEZT_MATRIX_TOKEN"},
 		AddrEnv: "AGEZT_MATRIX_HOMESERVER", AllowlistEnv: "AGEZT_MATRIX_ROOMS",
@@ -130,6 +135,7 @@ var manifests = []channel.Manifest{
 	},
 	{
 		Kind: "sms", Display: "SMS (Twilio)", Transport: "webhook", Duplex: true,
+		BannerLabel: "sms channel", DisabledHint: "disabled (set AGEZT_SMS_ACCOUNT_SID + AGEZT_SMS_AUTH_TOKEN)",
 		Description:   "SMS via Twilio Programmable Messaging.",
 		ConfigSection: "sms", RequiredEnv: []string{"AGEZT_SMS_ACCOUNT_SID", "AGEZT_SMS_AUTH_TOKEN"},
 		AddrEnv: "AGEZT_SMS_ADDR", AllowlistEnv: "AGEZT_SMS_NUMBERS", InboundEnv: []string{"AGEZT_SMS_ADDR"},
@@ -137,6 +143,7 @@ var manifests = []channel.Manifest{
 	},
 	{
 		Kind: "signal", Display: "Signal", Transport: "rest", Duplex: true,
+		BannerLabel: "signal channel", DisabledHint: "disabled (set AGEZT_SIGNAL_API_URL + AGEZT_SIGNAL_NUMBER)",
 		Description:   "Signal via a signal-cli REST gateway.",
 		ConfigSection: "signal", RequiredEnv: []string{"AGEZT_SIGNAL_API_URL", "AGEZT_SIGNAL_NUMBER"},
 		AddrEnv: "AGEZT_SIGNAL_API_URL", AllowlistEnv: "AGEZT_SIGNAL_RECIPIENTS",
@@ -150,6 +157,7 @@ var manifests = []channel.Manifest{
 	},
 	{
 		Kind: "teams", Display: "Microsoft Teams", Transport: "webhook", Duplex: false,
+		BannerLabel: "teams channel", DisabledHint: "disabled (set AGEZT_TEAMS_WEBHOOKS=name=url,...)",
 		Description:   "Outbound notifications via Teams Incoming Webhooks.",
 		ConfigSection: "teams", RequiredEnv: []string{"AGEZT_TEAMS_WEBHOOKS"},
 		AllowlistEnv: "AGEZT_TEAMS_WEBHOOKS",
@@ -157,6 +165,7 @@ var manifests = []channel.Manifest{
 	},
 	{
 		Kind: "email", Display: "Email / SMTP", Transport: "smtp", Duplex: true,
+		BannerLabel: "email channel", DisabledHint: "disabled (set AGEZT_EMAIL_SMTP_ADDR + AGEZT_EMAIL_FROM)",
 		Description:   "Email — outbound over SMTP, two-way with an IMAP/POP3 inbox. Add several accounts, each its own server.",
 		ConfigSection: "email", RequiredEnv: []string{"AGEZT_EMAIL_SMTP_ADDR", "AGEZT_EMAIL_FROM"},
 		AddrEnv: "AGEZT_EMAIL_SMTP_ADDR", AllowlistEnv: "AGEZT_EMAIL_RECIPIENTS", InboundEnv: []string{"AGEZT_EMAIL_INBOX_ADDR"},
@@ -170,6 +179,7 @@ var manifests = []channel.Manifest{
 	},
 	{
 		Kind: "homeassistant", Display: "Home Assistant", Transport: "rest", Duplex: false,
+		BannerLabel: "homeassistant ch", DisabledHint: "disabled (set AGEZT_HOMEASSISTANT_URL + AGEZT_HOMEASSISTANT_TOKEN)",
 		Description:   "Outbound notifications via the Home Assistant notify API.",
 		ConfigSection: "homeassistant", RequiredEnv: []string{"AGEZT_HOMEASSISTANT_URL", "AGEZT_HOMEASSISTANT_TOKEN"},
 		AddrEnv: "AGEZT_HOMEASSISTANT_URL", AllowlistEnv: "AGEZT_HOMEASSISTANT_SERVICES",
@@ -177,54 +187,63 @@ var manifests = []channel.Manifest{
 	},
 	{
 		Kind: "webhook", Display: "Generic Webhook", Transport: "webhook", Duplex: true,
+		BannerLabel: "webhook channel", DisabledHint: "disabled (set AGEZT_WEBHOOK_SECRET + AGEZT_WEBHOOK_ADDR)",
 		Description:   "Vendor-neutral signed-JSON channel — bridge anything.",
 		ConfigSection: "webhook", RequiredEnv: []string{"AGEZT_WEBHOOK_SECRET"},
 		AddrEnv: "AGEZT_WEBHOOK_ADDR", AllowlistEnv: "AGEZT_WEBHOOK_CHANNELS", InboundEnv: []string{"AGEZT_WEBHOOK_ADDR", "AGEZT_WEBHOOK_SECRET"},
 	},
 	{
 		Kind: "ntfy", Display: "ntfy", Transport: "rest", Duplex: false,
+		BannerLabel:   "ntfy push",
 		Description:   "Outbound push notifications via ntfy.sh or a self-hosted server.",
 		ConfigSection: "ntfy", RequiredEnv: []string{"AGEZT_NTFY_TOPIC"},
 		DocsURL: "https://ntfy.sh",
 	},
 	{
 		Kind: "pushover", Display: "Pushover", Transport: "rest", Duplex: false,
+		BannerLabel:   "pushover push",
 		Description:   "Outbound push notifications to phones via Pushover.",
 		ConfigSection: "pushover", RequiredEnv: []string{"AGEZT_PUSHOVER_TOKEN", "AGEZT_PUSHOVER_USER"},
 		DocsURL: "https://pushover.net",
 	},
 	{
 		Kind: "gotify", Display: "Gotify", Transport: "rest", Duplex: false,
+		BannerLabel:   "gotify push",
 		Description:   "Outbound push via a self-hosted Gotify server.",
 		ConfigSection: "gotify", RequiredEnv: []string{"AGEZT_GOTIFY_SERVER", "AGEZT_GOTIFY_TOKEN"},
 		DocsURL: "https://gotify.net",
 	},
 	{
 		Kind: "pushbullet", Display: "Pushbullet", Transport: "rest", Duplex: false,
+		BannerLabel:   "pushbullet push",
 		Description:   "Outbound push notifications via Pushbullet.",
 		ConfigSection: "pushbullet", RequiredEnv: []string{"AGEZT_PUSHBULLET_TOKEN"},
 		DocsURL: "https://www.pushbullet.com",
 	},
 	{
 		Kind: "googlechat", Display: "Google Chat", Transport: "webhook", Duplex: true,
+		BannerLabel:   "googlechat (2way)",
 		Description:   "Google Chat — outbound via an Incoming Webhook, and two-way (app event webhook in) with an inbound addr.",
 		ConfigSection: "googlechat", RequiredEnv: []string{"AGEZT_GOOGLECHAT_WEBHOOK"},
 		DocsURL: "https://developers.google.com/chat/how-tos/webhooks",
 	},
 	{
 		Kind: "mattermost", Display: "Mattermost", Transport: "webhook", Duplex: true,
+		BannerLabel:   "mattermost (2way)",
 		Description:   "Mattermost — outbound via an Incoming Webhook, and two-way (outgoing-webhook in) with an inbound addr.",
 		ConfigSection: "mattermost", RequiredEnv: []string{"AGEZT_MATTERMOST_WEBHOOK"},
 		DocsURL: "https://developers.mattermost.com/integrate/webhooks/incoming/",
 	},
 	{
 		Kind: "rocketchat", Display: "Rocket.Chat", Transport: "webhook", Duplex: false,
+		BannerLabel:   "rocketchat push",
 		Description:   "Outbound messages via a Rocket.Chat Incoming Webhook.",
 		ConfigSection: "rocketchat", RequiredEnv: []string{"AGEZT_ROCKETCHAT_WEBHOOK"},
 		DocsURL: "https://docs.rocket.chat/docs/integrations",
 	},
 	{
 		Kind: "mastodon", Display: "Mastodon", Transport: "rest", Duplex: true,
+		BannerLabel:   "mastodon channel",
 		Description:   "Mastodon — outbound posts, and two-way (polls mention notifications → threaded replies) with an acct allowlist.",
 		ConfigSection: "mastodon", RequiredEnv: []string{"AGEZT_MASTODON_SERVER", "AGEZT_MASTODON_TOKEN"},
 		AddrEnv: "AGEZT_MASTODON_SERVER", AllowlistEnv: "AGEZT_MASTODON_USERS",
@@ -239,12 +258,14 @@ var manifests = []channel.Manifest{
 	},
 	{
 		Kind: "zulip", Display: "Zulip", Transport: "rest", Duplex: false,
+		BannerLabel:   "zulip push",
 		Description:   "Outbound messages to a Zulip stream via a bot.",
 		ConfigSection: "zulip", RequiredEnv: []string{"AGEZT_ZULIP_SERVER", "AGEZT_ZULIP_EMAIL", "AGEZT_ZULIP_APIKEY", "AGEZT_ZULIP_STREAM"},
 		DocsURL: "https://zulip.com/api/send-message",
 	},
 	{
 		Kind: "feishu", Display: "Feishu / Lark", Transport: "webhook", Duplex: true,
+		BannerLabel:   "feishu (2way)",
 		Description:   "Feishu/Lark — outbound via a custom bot, and two-way (app event subscription + IM API) with app credentials + an inbound addr.",
 		ConfigSection: "feishu", RequiredEnv: []string{"AGEZT_FEISHU_WEBHOOK"},
 		AddrEnv: "AGEZT_FEISHU_ADDR", AllowlistEnv: "AGEZT_FEISHU_USERS", InboundEnv: []string{"AGEZT_FEISHU_ADDR"},
@@ -253,6 +274,7 @@ var manifests = []channel.Manifest{
 	},
 	{
 		Kind: "dingtalk", Display: "DingTalk", Transport: "webhook", Duplex: true,
+		BannerLabel:   "dingtalk (2way)",
 		Description:   "DingTalk — outbound via a custom robot, and two-way (enterprise robot outgoing webhook → sessionWebhook reply) with an inbound addr.",
 		ConfigSection: "dingtalk", RequiredEnv: []string{"AGEZT_DINGTALK_WEBHOOK"},
 		AddrEnv: "AGEZT_DINGTALK_ADDR", AllowlistEnv: "AGEZT_DINGTALK_USERS", InboundEnv: []string{"AGEZT_DINGTALK_ADDR"},
@@ -260,6 +282,7 @@ var manifests = []channel.Manifest{
 	},
 	{
 		Kind: "wecom", Display: "WeChat Work (WeCom)", Transport: "webhook", Duplex: true,
+		BannerLabel:   "wecom (2way)",
 		Description:   "WeCom — outbound via a group robot, and two-way (AES-encrypted app callback + message-send API) with app credentials + an inbound addr.",
 		ConfigSection: "wecom", RequiredEnv: []string{"AGEZT_WECOM_WEBHOOK"},
 		AddrEnv: "AGEZT_WECOM_ADDR", AllowlistEnv: "AGEZT_WECOM_USERS", InboundEnv: []string{"AGEZT_WECOM_ADDR"},
@@ -268,6 +291,7 @@ var manifests = []channel.Manifest{
 	},
 	{
 		Kind: "qq", Display: "QQ", Transport: "webhook", Duplex: true,
+		BannerLabel:   "qq channel",
 		Description:   "Two-way QQ via a self-hosted OneBot v11 gateway (go-cqhttp / NapCat / Lagrange).",
 		ConfigSection: "qq", RequiredEnv: []string{"AGEZT_QQ_GATEWAY", "AGEZT_QQ_ADDR"},
 		Media:         channel.MediaCaps{ImageIn: true, VoiceIn: true},
@@ -276,6 +300,7 @@ var manifests = []channel.Manifest{
 	},
 	{
 		Kind: "wechat", Display: "WeChat", Transport: "webhook", Duplex: true,
+		BannerLabel:   "wechat channel",
 		Description:   "Two-way personal WeChat via a self-hosted OneBot-compatible gateway (wcf / wechatbot). No first-party API — gateway required.",
 		ConfigSection: "wechat", RequiredEnv: []string{"AGEZT_WECHAT_GATEWAY", "AGEZT_WECHAT_ADDR"},
 		Media:         channel.MediaCaps{ImageIn: true, VoiceIn: true},
@@ -284,6 +309,7 @@ var manifests = []channel.Manifest{
 	},
 	{
 		Kind: "nextcloudtalk", Display: "Nextcloud Talk", Transport: "webhook", Duplex: true,
+		BannerLabel:   "nextcloud talk",
 		Description:   "Two-way Nextcloud Talk via the Talk Bot API (signed webhook in + bot message API out).",
 		ConfigSection: "nextcloudtalk", RequiredEnv: []string{"AGEZT_NEXTCLOUDTALK_URL", "AGEZT_NEXTCLOUDTALK_SECRET"},
 		AddrEnv: "AGEZT_NEXTCLOUDTALK_URL",
@@ -291,24 +317,28 @@ var manifests = []channel.Manifest{
 	},
 	{
 		Kind: "nostr", Display: "Nostr", Transport: "socket", Duplex: true,
+		BannerLabel:   "nostr channel",
 		Description:   "Two-way Nostr over relays — answers signed kind-1 mentions and NIP-04 encrypted DMs of the agent's pubkey, with threaded/encrypted replies.",
 		ConfigSection: "nostr", RequiredEnv: []string{"AGEZT_NOSTR_PRIVKEY", "AGEZT_NOSTR_RELAYS"},
 		DocsURL: "https://github.com/nostr-protocol/nips/blob/master/01.md",
 	},
 	{
 		Kind: "zalo", Display: "Zalo", Transport: "webhook", Duplex: true,
+		BannerLabel:   "zalo channel",
 		Description:   "Two-way Zalo via the Official Account API (event webhook + OA message API).",
 		ConfigSection: "zalo", RequiredEnv: []string{"AGEZT_ZALO_TOKEN"},
 		DocsURL: "https://developers.zalo.me/docs/official-account",
 	},
 	{
 		Kind: "synology", Display: "Synology Chat", Transport: "webhook", Duplex: false,
+		BannerLabel:   "synology push",
 		Description:   "Outbound messages via a Synology Chat incoming webhook.",
 		ConfigSection: "synology", RequiredEnv: []string{"AGEZT_SYNOLOGY_WEBHOOK"},
 		DocsURL: "https://kb.synology.com/DSM/help/Chat/chat_integration",
 	},
 	{
 		Kind: "irc", Display: "IRC", Transport: "socket", Duplex: true,
+		BannerLabel: "irc channel", DisabledHint: "disabled (set AGEZT_IRC_SERVER + AGEZT_IRC_NICK)",
 		Description:   "Two-way IRC — connect to any ircd, join channels, chat with the agent.",
 		ConfigSection: "irc", RequiredEnv: []string{"AGEZT_IRC_SERVER", "AGEZT_IRC_NICK"},
 		AddrEnv: "AGEZT_IRC_SERVER", AllowlistEnv: "AGEZT_IRC_CHANNELS",
@@ -316,6 +346,7 @@ var manifests = []channel.Manifest{
 	},
 	{
 		Kind: "twitch", Display: "Twitch", Transport: "socket", Duplex: true,
+		BannerLabel: "twitch channel", DisabledHint: "disabled (set AGEZT_TWITCH_USERNAME + AGEZT_TWITCH_TOKEN)",
 		Description:   "Two-way Twitch chat (IRC) — read and reply in your stream's channels.",
 		ConfigSection: "twitch", RequiredEnv: []string{"AGEZT_TWITCH_USERNAME", "AGEZT_TWITCH_TOKEN"},
 		AllowlistEnv: "AGEZT_TWITCH_CHANNELS",
@@ -323,6 +354,7 @@ var manifests = []channel.Manifest{
 	},
 	{
 		Kind: "whatsappgw", Display: "WhatsApp (Gateway)", Transport: "rest", Duplex: true,
+		BannerLabel: "whatsapp gateway", DisabledHint: "disabled (set AGEZT_WHATSAPPGW_URL)",
 		Description:   "Easy WhatsApp via a self-hosted WAHA / Evolution gateway (QR login, no Meta).",
 		ConfigSection: "whatsappgw", RequiredEnv: []string{"AGEZT_WHATSAPPGW_URL"},
 		AddrEnv: "AGEZT_WHATSAPPGW_URL", AllowlistEnv: "AGEZT_WHATSAPPGW_NUMBERS",
@@ -336,6 +368,7 @@ var manifests = []channel.Manifest{
 	},
 	{
 		Kind: "imessage", Display: "iMessage", Transport: "rest", Duplex: true,
+		BannerLabel: "imessage channel", DisabledHint: "disabled (set AGEZT_IMESSAGE_URL)",
 		Description:   "iMessage via a self-hosted BlueBubbles server (a Mac bridge) — REST send + inbound webhook.",
 		ConfigSection: "imessage", RequiredEnv: []string{"AGEZT_IMESSAGE_URL"},
 		AddrEnv:       "AGEZT_IMESSAGE_URL",
@@ -345,6 +378,7 @@ var manifests = []channel.Manifest{
 	},
 	{
 		Kind: "line", Display: "LINE", Transport: "webhook", Duplex: true,
+		BannerLabel:   "line channel",
 		Description:   "LINE Messaging API — outbound push, and two-way (signed webhook + reply token) with a channel secret + inbound addr.",
 		ConfigSection: "line", RequiredEnv: []string{"AGEZT_LINE_TOKEN"},
 		AddrEnv: "AGEZT_LINE_ADDR", AllowlistEnv: "AGEZT_LINE_USERS", InboundEnv: []string{"AGEZT_LINE_ADDR"},

--- a/plugins/builtinchannels/builtinchannels.go
+++ b/plugins/builtinchannels/builtinchannels.go
@@ -12,6 +12,7 @@ package builtinchannels
 import (
 	"github.com/agezt/agezt/kernel/channel"
 	"github.com/agezt/agezt/kernel/channelwire"
+	"github.com/agezt/agezt/plugins/channels/chatwebhook"
 )
 
 // RegisterAll seeds the channel registry with the built-in manifests and the
@@ -43,6 +44,12 @@ func RegisterAll() {
 	channelwire.Register("qq", oneBotFactory("qq", "QQ"))
 	channelwire.Register("wechat", oneBotFactory("wechat", "WECHAT"))
 	channelwire.Register("line", buildLine)
+	channelwire.Register("googlechat", chatWebhookFactory(chatwebhook.KindGoogleChat, "GOOGLECHAT"))
+	channelwire.Register("mattermost", chatWebhookFactory(chatwebhook.KindMattermost, "MATTERMOST"))
+	channelwire.Register("dingtalk", buildDingTalk)
+	channelwire.Register("feishu", buildFeishu)
+	channelwire.Register("wecom", buildWeCom)
+	channelwire.Register("mastodon", buildMastodon)
 }
 
 var manifests = []channel.Manifest{

--- a/plugins/builtinchannels/builtinchannels.go
+++ b/plugins/builtinchannels/builtinchannels.go
@@ -9,14 +9,25 @@
 // out-of-tree channel can call channel.RegisterManifest itself.
 package builtinchannels
 
-import "github.com/agezt/agezt/kernel/channel"
+import (
+	"github.com/agezt/agezt/kernel/channel"
+	"github.com/agezt/agezt/kernel/channelwire"
+)
 
-// RegisterAll seeds the channel registry with the built-in manifests. Called
-// once at daemon start (idempotent).
+// RegisterAll seeds the channel registry with the built-in manifests and the
+// channelwire factories (Phase 2.1) for the migrated kinds. Called once at
+// daemon start (idempotent — manifest registration replaces by Kind, factory
+// Register replaces by kind).
 func RegisterAll() {
 	for _, m := range manifests {
 		channel.RegisterManifest(m)
 	}
+	channelwire.Register("telegram", buildTelegram)
+	channelwire.Register("slack", buildSlack)
+	channelwire.Register("email", buildEmail)
+	channelwire.Register("discord", buildDiscord)
+	channelwire.Register("matrix", buildMatrix)
+	channelwire.Register("whatsapp", buildWhatsApp)
 }
 
 var manifests = []channel.Manifest{

--- a/plugins/builtinchannels/factories.go
+++ b/plugins/builtinchannels/factories.go
@@ -17,12 +17,16 @@ import (
 	"github.com/agezt/agezt/kernel/channel"
 	"github.com/agezt/agezt/kernel/channelwire"
 	"github.com/agezt/agezt/kernel/pulse"
+	"github.com/agezt/agezt/plugins/channels/chatwebhook"
+	"github.com/agezt/agezt/plugins/channels/dingtalk"
 	"github.com/agezt/agezt/plugins/channels/discord"
 	"github.com/agezt/agezt/plugins/channels/email"
+	"github.com/agezt/agezt/plugins/channels/feishu"
 	"github.com/agezt/agezt/plugins/channels/homeassistant"
 	"github.com/agezt/agezt/plugins/channels/imessage"
 	"github.com/agezt/agezt/plugins/channels/irc"
 	linechan "github.com/agezt/agezt/plugins/channels/line"
+	"github.com/agezt/agezt/plugins/channels/mastodon"
 	"github.com/agezt/agezt/plugins/channels/matrix"
 	"github.com/agezt/agezt/plugins/channels/nextcloudtalk"
 	"github.com/agezt/agezt/plugins/channels/nostr"
@@ -33,6 +37,7 @@ import (
 	"github.com/agezt/agezt/plugins/channels/teams"
 	"github.com/agezt/agezt/plugins/channels/telegram"
 	webhookchan "github.com/agezt/agezt/plugins/channels/webhook"
+	"github.com/agezt/agezt/plugins/channels/wecom"
 	"github.com/agezt/agezt/plugins/channels/whatsapp"
 	"github.com/agezt/agezt/plugins/channels/whatsappgw"
 	"github.com/agezt/agezt/plugins/channels/zalo"
@@ -1121,4 +1126,213 @@ func parseNamedWebhooks(spec string) map[string]string {
 		}
 	}
 	return out
+}
+
+// chatWebhookFactory returns the factory for a two-way Google Chat / Mattermost
+// channel, enabled when its inbound addr is set. Outbound + replies use the
+// incoming-webhook URL. kind is the channel name; prefix is the env namespace —
+// one builder, two registered kinds (like oneBotFactory).
+//
+//	AGEZT_<PREFIX>_WEBHOOK  incoming-webhook URL (outbound + replies)
+//	AGEZT_<PREFIX>_ADDR     host:port to serve the inbound webhook (enables two-way)
+//	AGEZT_<PREFIX>_TOKEN    verification token (Mattermost outgoing-webhook token / Google Chat ?token=)
+//	AGEZT_<PREFIX>_USERS    comma-separated allowed senders (usernames / emails)
+//	AGEZT_<PREFIX>_PATH     inbound route (default /<kind>)
+//
+// The addr gate inlines cmd/agezt's twoWayChatConfigured predicate, which
+// still lives there to yield the outbound-only push entry for the DEFAULT
+// instance (the push-suppression cluster migrates with the push family).
+func chatWebhookFactory(kind, prefix string) channelwire.Factory {
+	return func(d channelwire.Deps) channelwire.Built {
+		get := func(s string) string { return strings.TrimSpace(d.Get(brand.EnvPrefix + prefix + s)) }
+		if get("_ADDR") == "" {
+			return channelwire.NotConfigured
+		}
+		users := splitNonEmpty(d.Get(brand.EnvPrefix + prefix + "_USERS"))
+		webhook := get("_WEBHOOK")
+
+		ch := chatwebhook.New(chatwebhook.Config{
+			Kind:       kind,
+			WebhookURL: webhook,
+			Token:      get("_TOKEN"),
+			Allowlist:  channel.NewAllowlist(users),
+			Bus:        d.Bus,
+			Handler:    d.Handler,
+			Addr:       get("_ADDR"),
+			Path:       get("_PATH"),
+		})
+
+		var sink pulse.BriefSink
+		if webhook != "" {
+			sink = pulse.SinkFunc(func(b pulse.Brief) error {
+				return ch.Send(d.Ctx, channel.Outbound{Text: formatBrief(b), Priority: channel.PriorityNotify})
+			})
+		}
+
+		desc := fmt.Sprintf("%s two-way, allowlist=%d sender(s)", kind, len(users))
+		if webhook == "" {
+			desc += " (inbound-only; set AGEZT_" + prefix + "_WEBHOOK for replies/briefs)"
+		}
+		return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: desc}
+	}
+}
+
+// buildDingTalk constructs the two-way DingTalk channel when AGEZT_DINGTALK_ADDR
+// is set. Replies go to each message's sessionWebhook; briefs use the custom
+// robot webhook (AGEZT_DINGTALK_WEBHOOK).
+//
+//	AGEZT_DINGTALK_WEBHOOK  custom-robot webhook (outbound briefs / agt send)
+//	AGEZT_DINGTALK_SECRET   robot secret (verifies inbound timestamp+sign)
+//	AGEZT_DINGTALK_USERS    comma-separated allowed senderStaffId / nick
+//	AGEZT_DINGTALK_ADDR     host:port to serve the inbound webhook (enables two-way)
+//	AGEZT_DINGTALK_PATH     inbound route (default /dingtalk)
+func buildDingTalk(d channelwire.Deps) channelwire.Built {
+	addr := strings.TrimSpace(d.Get(brand.EnvPrefix + "DINGTALK_ADDR"))
+	if addr == "" {
+		return channelwire.NotConfigured
+	}
+	users := splitNonEmpty(d.Get(brand.EnvPrefix + "DINGTALK_USERS"))
+	webhook := strings.TrimSpace(d.Get(brand.EnvPrefix + "DINGTALK_WEBHOOK"))
+	ch := dingtalk.New(dingtalk.Config{
+		WebhookURL: webhook,
+		Secret:     strings.TrimSpace(d.Get(brand.EnvPrefix + "DINGTALK_SECRET")),
+		Allowlist:  channel.NewAllowlist(users),
+		Bus:        d.Bus,
+		Handler:    d.Handler,
+		Addr:       addr,
+		Path:       strings.TrimSpace(d.Get(brand.EnvPrefix + "DINGTALK_PATH")),
+	})
+	var sink pulse.BriefSink
+	if webhook != "" {
+		sink = pulse.SinkFunc(func(b pulse.Brief) error {
+			return ch.Send(d.Ctx, channel.Outbound{Text: formatBrief(b), Priority: channel.PriorityNotify})
+		})
+	}
+	return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: fmt.Sprintf("DingTalk robot, allowlist=%d sender(s)", len(users))}
+}
+
+// buildFeishu constructs the two-way Feishu / Lark channel when AGEZT_FEISHU_ADDR
+// is set. Replies + briefs use the IM API (tenant_access_token from app id/secret).
+//
+//	AGEZT_FEISHU_APP_ID        app id
+//	AGEZT_FEISHU_APP_SECRET    app secret
+//	AGEZT_FEISHU_VERIFY_TOKEN  event verification token
+//	AGEZT_FEISHU_CHAT          chat_id for proactive briefs
+//	AGEZT_FEISHU_USERS         comma-separated allowed sender open_ids
+//	AGEZT_FEISHU_ADDR          host:port to serve the inbound webhook (enables two-way)
+//	AGEZT_FEISHU_PATH          inbound route (default /feishu)
+func buildFeishu(d channelwire.Deps) channelwire.Built {
+	addr := strings.TrimSpace(d.Get(brand.EnvPrefix + "FEISHU_ADDR"))
+	appID := strings.TrimSpace(d.Get(brand.EnvPrefix + "FEISHU_APP_ID"))
+	if addr == "" || appID == "" {
+		return channelwire.NotConfigured
+	}
+	users := splitNonEmpty(d.Get(brand.EnvPrefix + "FEISHU_USERS"))
+	chat := strings.TrimSpace(d.Get(brand.EnvPrefix + "FEISHU_CHAT"))
+	ch := feishu.New(feishu.Config{
+		AppID:       appID,
+		AppSecret:   strings.TrimSpace(d.Get(brand.EnvPrefix + "FEISHU_APP_SECRET")),
+		VerifyToken: strings.TrimSpace(d.Get(brand.EnvPrefix + "FEISHU_VERIFY_TOKEN")),
+		DefaultChat: chat,
+		Allowlist:   channel.NewAllowlist(users),
+		Bus:         d.Bus,
+		Handler:     d.Handler,
+		Addr:        addr,
+		Path:        strings.TrimSpace(d.Get(brand.EnvPrefix + "FEISHU_PATH")),
+	})
+	var sink pulse.BriefSink
+	if chat != "" {
+		sink = pulse.SinkFunc(func(b pulse.Brief) error {
+			return ch.Send(d.Ctx, channel.Outbound{ChannelID: chat, Text: formatBrief(b), Priority: channel.PriorityNotify})
+		})
+	}
+	return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: fmt.Sprintf("Feishu app, allowlist=%d user(s)", len(users))}
+}
+
+// buildWeCom constructs the two-way WeCom (WeChat Work) channel when
+// AGEZT_WECOM_ADDR is set. Inbound is an AES-encrypted callback; replies use the
+// app message-send API (access_token from corp id/secret).
+//
+//	AGEZT_WECOM_CORP_ID      corp id
+//	AGEZT_WECOM_CORP_SECRET  app secret
+//	AGEZT_WECOM_AGENT_ID     app agent id
+//	AGEZT_WECOM_TOKEN        callback token
+//	AGEZT_WECOM_AES_KEY      callback EncodingAESKey
+//	AGEZT_WECOM_USERS        comma-separated allowed user ids
+//	AGEZT_WECOM_ADDR         host:port to serve the inbound callback (enables two-way)
+//	AGEZT_WECOM_PATH         inbound route (default /wecom)
+func buildWeCom(d channelwire.Deps) channelwire.Built {
+	addr := strings.TrimSpace(d.Get(brand.EnvPrefix + "WECOM_ADDR"))
+	corp := strings.TrimSpace(d.Get(brand.EnvPrefix + "WECOM_CORP_ID"))
+	if addr == "" || corp == "" {
+		return channelwire.NotConfigured
+	}
+	users := splitNonEmpty(d.Get(brand.EnvPrefix + "WECOM_USERS"))
+	ch := wecom.New(wecom.Config{
+		CorpID:     corp,
+		CorpSecret: strings.TrimSpace(d.Get(brand.EnvPrefix + "WECOM_CORP_SECRET")),
+		AgentID:    strings.TrimSpace(d.Get(brand.EnvPrefix + "WECOM_AGENT_ID")),
+		Token:      strings.TrimSpace(d.Get(brand.EnvPrefix + "WECOM_TOKEN")),
+		AESKey:     strings.TrimSpace(d.Get(brand.EnvPrefix + "WECOM_AES_KEY")),
+		Allowlist:  channel.NewAllowlist(users),
+		Bus:        d.Bus,
+		Handler:    d.Handler,
+		Addr:       addr,
+		Path:       strings.TrimSpace(d.Get(brand.EnvPrefix + "WECOM_PATH")),
+	})
+	var sink pulse.BriefSink
+	if len(users) > 0 {
+		sink = pulse.SinkFunc(func(b pulse.Brief) error {
+			var firstErr error
+			for _, u := range users {
+				if err := ch.Send(d.Ctx, channel.Outbound{ChannelID: u, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+			return firstErr
+		})
+	}
+	return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: fmt.Sprintf("WeCom app, allowlist=%d user(s)", len(users))}
+}
+
+// buildMastodon constructs the two-way Mastodon channel when AGEZT_MASTODON_USERS
+// is set (alongside SERVER + TOKEN). It polls mention notifications and replies as
+// threaded statuses; outbound briefs post standalone statuses.
+//
+//	AGEZT_MASTODON_SERVER  instance base URL (required)
+//	AGEZT_MASTODON_TOKEN   access token, read:notifications + write:statuses (required)
+//	AGEZT_MASTODON_USERS   comma-separated acct handles allowed to drive the agent (enables two-way)
+//	AGEZT_MASTODON_POLL    poll interval seconds (default 60)
+//
+// The users gate inlines cmd/agezt's twoWayMastodonConfigured predicate, which
+// still lives there to yield the outbound-only push entry for the DEFAULT
+// instance (the push-suppression cluster migrates with the push family).
+func buildMastodon(d channelwire.Deps) channelwire.Built {
+	if strings.TrimSpace(d.Get(brand.EnvPrefix+"MASTODON_USERS")) == "" {
+		return channelwire.NotConfigured
+	}
+	server := strings.TrimSpace(d.Get(brand.EnvPrefix + "MASTODON_SERVER"))
+	token := strings.TrimSpace(d.Get(brand.EnvPrefix + "MASTODON_TOKEN"))
+	if server == "" || token == "" {
+		return channelwire.NotConfigured
+	}
+	users := splitNonEmpty(d.Get(brand.EnvPrefix + "MASTODON_USERS"))
+	poll := 0
+	if v := strings.TrimSpace(d.Get(brand.EnvPrefix + "MASTODON_POLL")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			poll = n
+		}
+	}
+	ch := mastodon.New(mastodon.Config{
+		Server:    server,
+		Token:     token,
+		Allowlist: channel.NewAllowlist(users),
+		Bus:       d.Bus,
+		Handler:   d.Handler,
+		PollSecs:  poll,
+	})
+	sink := pulse.SinkFunc(func(b pulse.Brief) error {
+		return ch.Send(d.Ctx, channel.Outbound{Text: formatBrief(b), Priority: channel.PriorityNotify})
+	})
+	return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: fmt.Sprintf("Mastodon (two-way), allowlist=%d acct(s)", len(users))}
 }

--- a/plugins/builtinchannels/factories.go
+++ b/plugins/builtinchannels/factories.go
@@ -18,14 +18,19 @@ import (
 	"github.com/agezt/agezt/kernel/pulse"
 	"github.com/agezt/agezt/plugins/channels/discord"
 	"github.com/agezt/agezt/plugins/channels/email"
+	"github.com/agezt/agezt/plugins/channels/homeassistant"
+	"github.com/agezt/agezt/plugins/channels/imessage"
 	"github.com/agezt/agezt/plugins/channels/irc"
 	"github.com/agezt/agezt/plugins/channels/matrix"
+	"github.com/agezt/agezt/plugins/channels/nextcloudtalk"
 	signalchan "github.com/agezt/agezt/plugins/channels/signal"
 	"github.com/agezt/agezt/plugins/channels/slack"
 	"github.com/agezt/agezt/plugins/channels/sms"
+	"github.com/agezt/agezt/plugins/channels/teams"
 	"github.com/agezt/agezt/plugins/channels/telegram"
 	webhookchan "github.com/agezt/agezt/plugins/channels/webhook"
 	"github.com/agezt/agezt/plugins/channels/whatsapp"
+	"github.com/agezt/agezt/plugins/channels/whatsappgw"
 )
 
 // formatBrief renders a Pulse brief as plain channel text. (Small copy of the
@@ -693,4 +698,249 @@ func buildSignal(d channelwire.Deps) channelwire.Built {
 		desc = "listening, NO allowlist (outbound-only; set AGEZT_SIGNAL_RECIPIENTS to allow commands)"
 	}
 	return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: desc}
+}
+
+// buildWhatsAppGateway constructs the easy-path WhatsApp channel — a self-hosted
+// WAHA or Evolution API gateway (QR login, no Meta) — when AGEZT_WHATSAPPGW_URL
+// is set. Outbound always; inbound (two-way) when AGEZT_WHATSAPPGW_ADDR points
+// the gateway's webhook at this daemon. Briefs tee to the allowlisted numbers.
+//
+//	AGEZT_WHATSAPPGW_URL      gateway base URL, e.g. http://localhost:3000  (required)
+//	AGEZT_WHATSAPPGW_BACKEND  "waha" (default) or "evolution"
+//	AGEZT_WHATSAPPGW_SESSION  WAHA session / Evolution instance (default "default")
+//	AGEZT_WHATSAPPGW_KEY      gateway API key
+//	AGEZT_WHATSAPPGW_NUMBERS  comma-separated allowed sender numbers
+//	AGEZT_WHATSAPPGW_ADDR     host:port to serve the inbound webhook (two-way)
+//	AGEZT_WHATSAPPGW_PATH     inbound route (default /whatsappgw)
+//	AGEZT_WHATSAPPGW_SECRET   optional shared secret the gateway must echo inbound
+func buildWhatsAppGateway(d channelwire.Deps) channelwire.Built {
+	base := strings.TrimSpace(d.Get(brand.EnvPrefix + "WHATSAPPGW_URL"))
+	if base == "" {
+		return channelwire.NotConfigured
+	}
+	numbers := splitNonEmpty(d.Get(brand.EnvPrefix + "WHATSAPPGW_NUMBERS"))
+	addr := strings.TrimSpace(d.Get(brand.EnvPrefix + "WHATSAPPGW_ADDR"))
+	backend := strings.ToLower(strings.TrimSpace(d.Get(brand.EnvPrefix + "WHATSAPPGW_BACKEND")))
+
+	ch := whatsappgw.New(whatsappgw.Config{
+		Backend:   backend,
+		BaseURL:   base,
+		Session:   strings.TrimSpace(d.Get(brand.EnvPrefix + "WHATSAPPGW_SESSION")),
+		APIKey:    strings.TrimSpace(d.Get(brand.EnvPrefix + "WHATSAPPGW_KEY")),
+		Allowlist: channel.NewAllowlist(numbers),
+		Bus:       d.Bus,
+		Handler:   d.Handler,
+		Addr:      addr,
+		Path:      strings.TrimSpace(d.Get(brand.EnvPrefix + "WHATSAPPGW_PATH")),
+		Secret:    strings.TrimSpace(d.Get(brand.EnvPrefix + "WHATSAPPGW_SECRET")),
+	})
+
+	var sink pulse.BriefSink
+	if len(numbers) > 0 {
+		sink = pulse.SinkFunc(func(b pulse.Brief) error {
+			var firstErr error
+			for _, n := range numbers {
+				if err := ch.Send(d.Ctx, channel.Outbound{ChannelID: n, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+			return firstErr
+		})
+	}
+
+	be := backend
+	if be == "" {
+		be = "waha"
+	}
+	desc := fmt.Sprintf("%s via %s, allowlist=%d number(s)", base, be, len(numbers))
+	if addr == "" {
+		desc += " (outbound-only; set AGEZT_WHATSAPPGW_ADDR for two-way)"
+	}
+	return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: desc}
+}
+
+// buildIMessage constructs the iMessage channel — a self-hosted BlueBubbles
+// server (a Mac bridge; https://bluebubbles.app) — when AGEZT_IMESSAGE_URL is
+// set. Outbound always; inbound (two-way) when AGEZT_IMESSAGE_ADDR points the
+// BlueBubbles webhook back at this channel.
+//
+//	AGEZT_IMESSAGE_URL        BlueBubbles server URL, e.g. http://localhost:1234  (required)
+//	AGEZT_IMESSAGE_PASSWORD   BlueBubbles server password
+//	AGEZT_IMESSAGE_METHOD     "private-api" (default) or "apple-script"
+//	AGEZT_IMESSAGE_ADDRESSES  comma-separated allowed sender addresses (phone/email)
+//	AGEZT_IMESSAGE_ADDR       host:port to serve the inbound webhook (two-way)
+//	AGEZT_IMESSAGE_PATH       inbound route (default /imessage)
+//	AGEZT_IMESSAGE_SECRET     optional shared secret the webhook must echo (X-Webhook-Secret)
+func buildIMessage(d channelwire.Deps) channelwire.Built {
+	base := strings.TrimSpace(d.Get(brand.EnvPrefix + "IMESSAGE_URL"))
+	if base == "" {
+		return channelwire.NotConfigured
+	}
+	addresses := splitNonEmpty(d.Get(brand.EnvPrefix + "IMESSAGE_ADDRESSES"))
+	addr := strings.TrimSpace(d.Get(brand.EnvPrefix + "IMESSAGE_ADDR"))
+
+	ch := imessage.New(imessage.Config{
+		BaseURL:   base,
+		Password:  strings.TrimSpace(d.Get(brand.EnvPrefix + "IMESSAGE_PASSWORD")),
+		Method:    strings.ToLower(strings.TrimSpace(d.Get(brand.EnvPrefix + "IMESSAGE_METHOD"))),
+		Allowlist: channel.NewAllowlist(addresses),
+		Bus:       d.Bus,
+		Handler:   d.Handler,
+		Addr:      addr,
+		Path:      strings.TrimSpace(d.Get(brand.EnvPrefix + "IMESSAGE_PATH")),
+		Secret:    strings.TrimSpace(d.Get(brand.EnvPrefix + "IMESSAGE_SECRET")),
+	})
+
+	var sink pulse.BriefSink
+	if len(addresses) > 0 {
+		sink = pulse.SinkFunc(func(b pulse.Brief) error {
+			var firstErr error
+			for _, a := range addresses {
+				if err := ch.Send(d.Ctx, channel.Outbound{ChannelID: a, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+			return firstErr
+		})
+	}
+
+	desc := fmt.Sprintf("%s via BlueBubbles, allowlist=%d address(es)", base, len(addresses))
+	if addr == "" {
+		desc += " (outbound-only; set AGEZT_IMESSAGE_ADDR for two-way)"
+	}
+	return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: desc}
+}
+
+// buildNextcloudTalk constructs the Nextcloud Talk channel when AGEZT_NEXTCLOUDTALK_URL
+// + AGEZT_NEXTCLOUDTALK_SECRET are set. Inbound (signed bot webhook) is served when
+// AGEZT_NEXTCLOUDTALK_ADDR is also set; outbound replies + Pulse briefs go to the
+// allowlisted conversation tokens (AGEZT_NEXTCLOUDTALK_TOKENS).
+//
+//	AGEZT_NEXTCLOUDTALK_URL     Nextcloud base URL, e.g. https://cloud.example.com (required)
+//	AGEZT_NEXTCLOUDTALK_SECRET  shared bot secret; signs/verifies (required)
+//	AGEZT_NEXTCLOUDTALK_ADDR    host:port for the inbound webhook (inbound)
+//	AGEZT_NEXTCLOUDTALK_PATH    inbound route (default /nextcloudtalk)
+//	AGEZT_NEXTCLOUDTALK_TOKENS  comma-separated allowlist of conversation tokens
+func buildNextcloudTalk(d channelwire.Deps) channelwire.Built {
+	server := strings.TrimSpace(d.Get(brand.EnvPrefix + "NEXTCLOUDTALK_URL"))
+	secret := strings.TrimSpace(d.Get(brand.EnvPrefix + "NEXTCLOUDTALK_SECRET"))
+	if server == "" || secret == "" {
+		return channelwire.NotConfigured
+	}
+	tokens := splitNonEmpty(d.Get(brand.EnvPrefix + "NEXTCLOUDTALK_TOKENS"))
+	ch := nextcloudtalk.New(nextcloudtalk.Config{
+		ServerURL: server,
+		Secret:    secret,
+		Allowlist: channel.NewAllowlist(tokens),
+		Bus:       d.Bus,
+		Handler:   d.Handler,
+		Addr:      strings.TrimSpace(d.Get(brand.EnvPrefix + "NEXTCLOUDTALK_ADDR")),
+		Path:      strings.TrimSpace(d.Get(brand.EnvPrefix + "NEXTCLOUDTALK_PATH")),
+	})
+	var sink pulse.BriefSink
+	if len(tokens) > 0 {
+		sink = pulse.SinkFunc(func(b pulse.Brief) error {
+			var firstErr error
+			for _, t := range tokens {
+				if err := ch.Send(d.Ctx, channel.Outbound{ChannelID: t, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+			return firstErr
+		})
+	}
+	return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: fmt.Sprintf("Nextcloud Talk, allowlist=%d token(s)", len(tokens))}
+}
+
+// buildHomeAssistant constructs the outbound Home Assistant channel when
+// AGEZT_HOMEASSISTANT_URL + AGEZT_HOMEASSISTANT_TOKEN are set. Pulse briefs +
+// `agt send` go to the allowlisted notify services (AGEZT_HOMEASSISTANT_SERVICES).
+//
+//	AGEZT_HOMEASSISTANT_URL       HA base, e.g. http://homeassistant.local:8123
+//	AGEZT_HOMEASSISTANT_TOKEN     long-lived access token
+//	AGEZT_HOMEASSISTANT_SERVICES  comma-separated notify service allowlist
+//	                              (e.g. mobile_app_phone,persistent_notification)
+func buildHomeAssistant(d channelwire.Deps) channelwire.Built {
+	baseURL := strings.TrimSpace(d.Get(brand.EnvPrefix + "HOMEASSISTANT_URL"))
+	token := strings.TrimSpace(d.Get(brand.EnvPrefix + "HOMEASSISTANT_TOKEN"))
+	if baseURL == "" || token == "" {
+		return channelwire.NotConfigured
+	}
+	services := splitNonEmpty(d.Get(brand.EnvPrefix + "HOMEASSISTANT_SERVICES"))
+
+	ch := homeassistant.New(homeassistant.Config{
+		BaseURL:   baseURL,
+		Token:     token,
+		Allowlist: channel.NewAllowlist(services),
+		Bus:       d.Bus,
+	})
+
+	var sink pulse.BriefSink
+	if len(services) > 0 {
+		sink = pulse.SinkFunc(func(b pulse.Brief) error {
+			var firstErr error
+			for _, svc := range services {
+				if err := ch.Send(d.Ctx, channel.Outbound{ChannelID: svc, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+			return firstErr
+		})
+	}
+
+	desc := fmt.Sprintf("outbound → %s, allowlist=%d service(s)", baseURL, len(services))
+	if len(services) == 0 {
+		desc = fmt.Sprintf("outbound → %s, NO allowlist (set AGEZT_HOMEASSISTANT_SERVICES to notify)", baseURL)
+	}
+	return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: desc}
+}
+
+// buildTeams constructs the outbound Microsoft Teams channel when
+// AGEZT_TEAMS_WEBHOOKS is set. Pulse briefs + `agt send` post a card to the named
+// Teams Incoming Webhooks.
+//
+//	AGEZT_TEAMS_WEBHOOKS  name=url,name2=url2 — named Teams Incoming Webhook URLs;
+//	                      `agt send --channel teams --to <name>` selects one.
+func buildTeams(d channelwire.Deps) channelwire.Built {
+	hooks := parseNamedWebhooks(strings.TrimSpace(d.Get(brand.EnvPrefix + "TEAMS_WEBHOOKS")))
+	if len(hooks) == 0 {
+		return channelwire.NotConfigured
+	}
+	ch := teams.New(teams.Config{Webhooks: hooks, Bus: d.Bus})
+
+	names := ch.Names()
+	sink := pulse.SinkFunc(func(b pulse.Brief) error {
+		var firstErr error
+		for _, name := range names {
+			if err := ch.Send(d.Ctx, channel.Outbound{ChannelID: name, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+		return firstErr
+	})
+
+	return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: fmt.Sprintf("outbound → %d Teams webhook(s)", len(names))}
+}
+
+// parseNamedWebhooks parses a "name=url,name2=url2" spec into a name→url map.
+// Each entry splits on the FIRST '=' (URLs may contain '='); blank names/urls
+// are dropped. (Moved from cmd/agezt/main.go with buildTeams — its only user.)
+func parseNamedWebhooks(spec string) map[string]string {
+	out := map[string]string{}
+	for _, entry := range strings.Split(spec, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		eq := strings.IndexByte(entry, '=')
+		if eq <= 0 {
+			continue
+		}
+		name := strings.TrimSpace(entry[:eq])
+		url := strings.TrimSpace(entry[eq+1:])
+		if name != "" && url != "" {
+			out[name] = url
+		}
+	}
+	return out
 }

--- a/plugins/builtinchannels/factories.go
+++ b/plugins/builtinchannels/factories.go
@@ -1,0 +1,397 @@
+// SPDX-License-Identifier: MIT
+
+// Channel factories (Phase 2.1 of docs/REFACTORING-SCAN-2026-08.md): the
+// modern per-account builders, moved verbatim out of cmd/agezt/main.go into
+// channelwire.Factory form. Each factory reads config ONLY through d.Get,
+// uses d.Bus / d.Handler for the kernel surface, and returns
+// channelwire.NotConfigured when its enabling env is unset.
+package builtinchannels
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/agezt/agezt/internal/brand"
+	"github.com/agezt/agezt/kernel/channel"
+	"github.com/agezt/agezt/kernel/channelwire"
+	"github.com/agezt/agezt/kernel/pulse"
+	"github.com/agezt/agezt/plugins/channels/discord"
+	"github.com/agezt/agezt/plugins/channels/email"
+	"github.com/agezt/agezt/plugins/channels/matrix"
+	"github.com/agezt/agezt/plugins/channels/slack"
+	"github.com/agezt/agezt/plugins/channels/telegram"
+	"github.com/agezt/agezt/plugins/channels/whatsapp"
+)
+
+// formatBrief renders a Pulse brief as plain channel text. (Small copy of the
+// cmd/agezt helper — the legacy builders still there need the original.)
+func formatBrief(b pulse.Brief) string {
+	if b.Body != "" {
+		return "📣 " + b.Title + "\n" + b.Body
+	}
+	return "📣 " + b.Title
+}
+
+// splitNonEmpty splits a comma list, trimming and dropping blanks. (Small copy
+// of the cmd/agezt helper — the legacy builders still there need the original.)
+func splitNonEmpty(s string) []string {
+	var out []string
+	for part := range strings.SplitSeq(s, ",") {
+		if p := strings.TrimSpace(part); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// buildTelegram constructs the in-process Telegram channel when
+// AGEZT_TELEGRAM_TOKEN is set, plus a Pulse brief sink that forwards briefs to
+// the allowlisted chats. Returns NotConfigured when no token is configured.
+//
+//	AGEZT_TELEGRAM_TOKEN    bot token (required to enable)
+//	AGEZT_TELEGRAM_CHAT_ID  comma-separated allowlist of chat ids that may
+//	                        drive the agent AND receive Pulse briefs
+//
+// The inbound handler runs the normal agent loop under the channel's
+// correlation, so `agt why`/`agt inbox` link the Telegram message to the task.
+func buildTelegram(d channelwire.Deps) channelwire.Built {
+	token := strings.TrimSpace(d.Get(brand.EnvPrefix + "TELEGRAM_TOKEN"))
+	if token == "" {
+		return channelwire.NotConfigured
+	}
+	chatIDs := splitNonEmpty(d.Get(brand.EnvPrefix + "TELEGRAM_CHAT_ID"))
+	allow := channel.NewAllowlist(chatIDs)
+
+	ch := telegram.New(telegram.Config{
+		Token:     token,
+		BaseURL:   strings.TrimSpace(d.Get(brand.EnvPrefix + "TELEGRAM_API_BASE")), // empty → public Bot API
+		Allowlist: allow,
+		Bus:       d.Bus,
+		Handler:   d.Handler,
+	})
+
+	// Pulse briefs → the allowlisted chats. Nil sink when no chat configured
+	// (the bot can still receive commands once a chat is allowlisted).
+	var sink pulse.BriefSink
+	if len(chatIDs) > 0 {
+		sink = pulse.SinkFunc(func(b pulse.Brief) error {
+			var firstErr error
+			for _, id := range chatIDs {
+				if err := ch.Send(d.Ctx, channel.Outbound{ChannelID: id, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+			return firstErr
+		})
+	}
+
+	desc := fmt.Sprintf("listening, allowlist=%d chat(s)", len(chatIDs))
+	if len(chatIDs) == 0 {
+		desc = "listening, NO allowlist (outbound-only; set AGEZT_TELEGRAM_CHAT_ID to allow commands)"
+	}
+	return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: desc}
+}
+
+// buildSlack constructs the in-process Slack channel when AGEZT_SLACK_TOKEN is
+// set, plus a Pulse brief sink to the allowlisted channels. Returns
+// NotConfigured when no token is configured.
+//
+//	AGEZT_SLACK_TOKEN           bot token (xoxb-…), required to enable
+//	AGEZT_SLACK_SIGNING_SECRET  app signing secret, required for inbound
+//	AGEZT_SLACK_ADDR            local addr to serve /slack/events (fronted by a
+//	                            tunnel/reverse proxy); empty → outbound-only
+//	AGEZT_SLACK_CHANNELS        comma-separated allowlist of channel ids that may
+//	                            drive the agent AND receive Pulse briefs
+//
+// The inbound handler runs the normal agent loop under the channel's correlation,
+// so `agt why`/`agt inbox` link the Slack message to the task.
+func buildSlack(d channelwire.Deps) channelwire.Built {
+	token := strings.TrimSpace(d.Get(brand.EnvPrefix + "SLACK_TOKEN"))
+	if token == "" {
+		return channelwire.NotConfigured
+	}
+	secret := strings.TrimSpace(d.Get(brand.EnvPrefix + "SLACK_SIGNING_SECRET"))
+	addr := strings.TrimSpace(d.Get(brand.EnvPrefix + "SLACK_ADDR"))
+	channelIDs := splitNonEmpty(d.Get(brand.EnvPrefix + "SLACK_CHANNELS"))
+
+	ch := slack.New(slack.Config{
+		Token:         token,
+		SigningSecret: secret,
+		Addr:          addr,
+		BaseURL:       strings.TrimSpace(d.Get(brand.EnvPrefix + "SLACK_API_BASE")), // empty → public Web API
+		Allowlist:     channel.NewAllowlist(channelIDs),
+		Bus:           d.Bus,
+		Handler:       d.Handler,
+	})
+
+	var sink pulse.BriefSink
+	if len(channelIDs) > 0 {
+		sink = pulse.SinkFunc(func(b pulse.Brief) error {
+			var firstErr error
+			for _, id := range channelIDs {
+				if err := ch.Send(d.Ctx, channel.Outbound{ChannelID: id, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+			return firstErr
+		})
+	}
+
+	var desc string
+	switch {
+	case addr == "" && len(channelIDs) == 0:
+		desc = "outbound-only, NO allowlist (set AGEZT_SLACK_ADDR + AGEZT_SLACK_CHANNELS to receive commands)"
+	case addr == "":
+		desc = fmt.Sprintf("outbound-only, allowlist=%d channel(s) (set AGEZT_SLACK_ADDR to receive commands)", len(channelIDs))
+	case secret == "":
+		desc = "inbound DISABLED (set AGEZT_SLACK_SIGNING_SECRET); outbound only"
+	default:
+		desc = fmt.Sprintf("events at %s%s, allowlist=%d channel(s)", addr, slack.EventsPath, len(channelIDs))
+	}
+	return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: desc}
+}
+
+// buildEmail constructs an email channel account when AGEZT_EMAIL_SMTP_ADDR
+// is set. Outbound over SMTP; two-way when an inbox (IMAP/POP3) is also configured.
+//
+//	AGEZT_EMAIL_SMTP_ADDR     SMTP server host:port (e.g. smtp.example.com:587), enables
+//	AGEZT_EMAIL_FROM          sender address
+//	AGEZT_EMAIL_USERNAME      SMTP AUTH username (with PASSWORD); empty → no auth
+//	AGEZT_EMAIL_PASSWORD      SMTP AUTH password
+//	AGEZT_EMAIL_RECIPIENTS    comma-separated allowlist of addresses (mail targets + inbound senders)
+//	AGEZT_EMAIL_INBOX_ADDR    IMAP/POP3 server host:port — enables two-way (poll for new mail)
+//	AGEZT_EMAIL_INBOX_PROTOCOL "imap" (default) or "pop3"
+//	AGEZT_EMAIL_INBOX_USERNAME/PASSWORD  mailbox creds (default to the SMTP ones)
+//	AGEZT_EMAIL_INBOX_TLS     "tls" (default) | "starttls" | "none"
+//	AGEZT_EMAIL_INBOX_POLL    poll interval seconds (default 60)
+func buildEmail(d channelwire.Deps) channelwire.Built {
+	addr := strings.TrimSpace(d.Get(brand.EnvPrefix + "EMAIL_SMTP_ADDR"))
+	if addr == "" {
+		return channelwire.NotConfigured
+	}
+	from := strings.TrimSpace(d.Get(brand.EnvPrefix + "EMAIL_FROM"))
+	recipients := splitNonEmpty(d.Get(brand.EnvPrefix + "EMAIL_RECIPIENTS"))
+	inboxAddr := strings.TrimSpace(d.Get(brand.EnvPrefix + "EMAIL_INBOX_ADDR"))
+	pollSecs := 0
+	if v := strings.TrimSpace(d.Get(brand.EnvPrefix + "EMAIL_INBOX_POLL")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			pollSecs = n
+		}
+	}
+
+	var handler channel.InboundHandler
+	if inboxAddr != "" {
+		handler = d.Handler
+	}
+	ch := email.New(email.Config{
+		Addr:          addr,
+		From:          from,
+		Username:      strings.TrimSpace(d.Get(brand.EnvPrefix + "EMAIL_USERNAME")),
+		Password:      d.Get(brand.EnvPrefix + "EMAIL_PASSWORD"),
+		Allowlist:     channel.NewAllowlist(recipients),
+		Bus:           d.Bus,
+		InboxAddr:     inboxAddr,
+		InboxProtocol: strings.TrimSpace(d.Get(brand.EnvPrefix + "EMAIL_INBOX_PROTOCOL")),
+		InboxUsername: strings.TrimSpace(d.Get(brand.EnvPrefix + "EMAIL_INBOX_USERNAME")),
+		InboxPassword: d.Get(brand.EnvPrefix + "EMAIL_INBOX_PASSWORD"),
+		InboxTLS:      strings.TrimSpace(d.Get(brand.EnvPrefix + "EMAIL_INBOX_TLS")),
+		PollSecs:      pollSecs,
+		Handler:       handler,
+	})
+
+	var sink pulse.BriefSink
+	if len(recipients) > 0 {
+		sink = pulse.SinkFunc(func(b pulse.Brief) error {
+			var firstErr error
+			for _, id := range recipients {
+				if err := ch.Send(d.Ctx, channel.Outbound{ChannelID: id, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+			return firstErr
+		})
+	}
+
+	dir := "outbound"
+	if inboxAddr != "" {
+		dir = "two-way (inbox " + inboxAddr + ")"
+	}
+	var desc string
+	switch {
+	case from == "":
+		desc = "configured but NO from address (set AGEZT_EMAIL_FROM)"
+	case len(recipients) == 0:
+		desc = fmt.Sprintf("%s via %s, NO recipients (set AGEZT_EMAIL_RECIPIENTS)", dir, addr)
+	default:
+		desc = fmt.Sprintf("%s via %s, %d recipient(s)", dir, addr, len(recipients))
+	}
+	return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: desc}
+}
+
+// buildDiscord constructs the in-process Discord channel when AGEZT_DISCORD_TOKEN
+// is set, plus a Pulse brief sink to the allowlisted channels. Returns
+// NotConfigured when no token is configured.
+//
+//	AGEZT_DISCORD_TOKEN       bot token, required to enable
+//	AGEZT_DISCORD_PUBLIC_KEY  app public key (hex), required for inbound verification
+//	AGEZT_DISCORD_APP_ID      application id, required for follow-up replies
+//	AGEZT_DISCORD_ADDR        local addr to serve /discord/interactions (fronted by
+//	                          a tunnel/reverse proxy); empty → outbound-only
+//	AGEZT_DISCORD_CHANNELS    comma-separated allowlist of channel ids that may
+//	                          drive the agent AND receive Pulse briefs
+//
+// The inbound handler runs the normal agent loop under the channel's correlation,
+// so `agt why`/`agt inbox` link the Discord command to the task.
+func buildDiscord(d channelwire.Deps) channelwire.Built {
+	token := strings.TrimSpace(d.Get(brand.EnvPrefix + "DISCORD_TOKEN"))
+	if token == "" {
+		return channelwire.NotConfigured
+	}
+	pubKey := strings.TrimSpace(d.Get(brand.EnvPrefix + "DISCORD_PUBLIC_KEY"))
+	appID := strings.TrimSpace(d.Get(brand.EnvPrefix + "DISCORD_APP_ID"))
+	addr := strings.TrimSpace(d.Get(brand.EnvPrefix + "DISCORD_ADDR"))
+	channelIDs := splitNonEmpty(d.Get(brand.EnvPrefix + "DISCORD_CHANNELS"))
+
+	ch := discord.New(discord.Config{
+		Token:         token,
+		PublicKey:     pubKey,
+		ApplicationID: appID,
+		Addr:          addr,
+		BaseURL:       strings.TrimSpace(d.Get(brand.EnvPrefix + "DISCORD_API_BASE")), // empty → public API
+		Allowlist:     channel.NewAllowlist(channelIDs),
+		Bus:           d.Bus,
+		Handler:       d.Handler,
+	})
+
+	var sink pulse.BriefSink
+	if len(channelIDs) > 0 {
+		sink = pulse.SinkFunc(func(b pulse.Brief) error {
+			var firstErr error
+			for _, id := range channelIDs {
+				if err := ch.Send(d.Ctx, channel.Outbound{ChannelID: id, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+			return firstErr
+		})
+	}
+
+	var desc string
+	switch {
+	case addr == "" && len(channelIDs) == 0:
+		desc = "outbound-only, NO allowlist (set AGEZT_DISCORD_ADDR + AGEZT_DISCORD_CHANNELS to receive commands)"
+	case addr == "":
+		desc = fmt.Sprintf("outbound-only, allowlist=%d channel(s) (set AGEZT_DISCORD_ADDR to receive commands)", len(channelIDs))
+	case pubKey == "":
+		desc = "inbound DISABLED (set AGEZT_DISCORD_PUBLIC_KEY); outbound only"
+	default:
+		desc = fmt.Sprintf("interactions at %s%s, allowlist=%d channel(s)", addr, discord.InteractionsPath, len(channelIDs))
+	}
+	return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: desc}
+}
+
+// buildMatrix constructs the in-process Matrix channel when AGEZT_MATRIX_HOMESERVER
+// and AGEZT_MATRIX_TOKEN are set, plus a Pulse brief sink to the allowlisted rooms.
+// Returns NotConfigured when unconfigured. Mirrors buildTelegram: long-polls /sync
+// for inbound, PUTs m.room.message for outbound.
+func buildMatrix(d channelwire.Deps) channelwire.Built {
+	homeserver := strings.TrimSpace(d.Get(brand.EnvPrefix + "MATRIX_HOMESERVER"))
+	token := strings.TrimSpace(d.Get(brand.EnvPrefix + "MATRIX_TOKEN"))
+	if homeserver == "" || token == "" {
+		return channelwire.NotConfigured
+	}
+	roomIDs := splitNonEmpty(d.Get(brand.EnvPrefix + "MATRIX_ROOMS"))
+
+	ch := matrix.New(matrix.Config{
+		Homeserver: homeserver,
+		Token:      token,
+		Allowlist:  channel.NewAllowlist(roomIDs),
+		Bus:        d.Bus,
+		Handler:    d.Handler,
+	})
+
+	// Pulse briefs → the allowlisted rooms. Nil sink when no room configured (the
+	// bot can still receive commands once a room is allowlisted).
+	var sink pulse.BriefSink
+	if len(roomIDs) > 0 {
+		sink = pulse.SinkFunc(func(b pulse.Brief) error {
+			var firstErr error
+			for _, id := range roomIDs {
+				if err := ch.Send(d.Ctx, channel.Outbound{ChannelID: id, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+			return firstErr
+		})
+	}
+
+	desc := fmt.Sprintf("listening, allowlist=%d room(s)", len(roomIDs))
+	if len(roomIDs) == 0 {
+		desc = "listening, NO allowlist (outbound-only; set AGEZT_MATRIX_ROOMS to allow commands)"
+	}
+	return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: desc}
+}
+
+// buildWhatsApp constructs the WhatsApp Cloud API channel when
+// AGEZT_WHATSAPP_APP_SECRET + AGEZT_WHATSAPP_ACCESS_TOKEN are set. Inbound (signed
+// Meta webhook) is served when AGEZT_WHATSAPP_ADDR is also set; outbound + Pulse
+// briefs to the allowlisted numbers need AGEZT_WHATSAPP_PHONE_NUMBER_ID.
+//
+//	AGEZT_WHATSAPP_APP_SECRET       Meta app secret (required; signs inbound)
+//	AGEZT_WHATSAPP_ACCESS_TOKEN     Graph API bearer token (required; outbound)
+//	AGEZT_WHATSAPP_PHONE_NUMBER_ID  business phone-number id (outbound endpoint)
+//	AGEZT_WHATSAPP_VERIFY_TOKEN     token echoed in Meta's GET verify handshake
+//	AGEZT_WHATSAPP_ADDR             host:port for the inbound webhook (inbound)
+//	AGEZT_WHATSAPP_PATH             inbound route (default /whatsapp)
+//	AGEZT_WHATSAPP_NUMBERS          comma-separated allowlist of sender numbers
+func buildWhatsApp(d channelwire.Deps) channelwire.Built {
+	appSecret := strings.TrimSpace(d.Get(brand.EnvPrefix + "WHATSAPP_APP_SECRET"))
+	accessToken := strings.TrimSpace(d.Get(brand.EnvPrefix + "WHATSAPP_ACCESS_TOKEN"))
+	if appSecret == "" || accessToken == "" {
+		return channelwire.NotConfigured
+	}
+	phoneID := strings.TrimSpace(d.Get(brand.EnvPrefix + "WHATSAPP_PHONE_NUMBER_ID"))
+	verifyToken := strings.TrimSpace(d.Get(brand.EnvPrefix + "WHATSAPP_VERIFY_TOKEN"))
+	addr := strings.TrimSpace(d.Get(brand.EnvPrefix + "WHATSAPP_ADDR"))
+	path := strings.TrimSpace(d.Get(brand.EnvPrefix + "WHATSAPP_PATH"))
+	numbers := splitNonEmpty(d.Get(brand.EnvPrefix + "WHATSAPP_NUMBERS"))
+
+	ch := whatsapp.New(whatsapp.Config{
+		Addr:          addr,
+		Path:          path,
+		VerifyToken:   verifyToken,
+		AppSecret:     appSecret,
+		AccessToken:   accessToken,
+		PhoneNumberID: phoneID,
+		Allowlist:     channel.NewAllowlist(numbers),
+		Bus:           d.Bus,
+		Handler:       d.Handler,
+	})
+
+	var sink pulse.BriefSink
+	if phoneID != "" && len(numbers) > 0 {
+		sink = pulse.SinkFunc(func(b pulse.Brief) error {
+			var firstErr error
+			for _, id := range numbers {
+				if err := ch.Send(d.Ctx, channel.Outbound{ChannelID: id, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+			return firstErr
+		})
+	}
+
+	var desc string
+	switch {
+	case addr == "":
+		desc = fmt.Sprintf("outbound-only (set AGEZT_WHATSAPP_ADDR for inbound), allowlist=%d number(s)", len(numbers))
+	default:
+		p := path
+		if p == "" {
+			p = whatsapp.DefaultPath
+		}
+		desc = fmt.Sprintf("inbound at %s%s, allowlist=%d number(s)", addr, p, len(numbers))
+	}
+	return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: desc}
+}

--- a/plugins/builtinchannels/factories.go
+++ b/plugins/builtinchannels/factories.go
@@ -18,9 +18,13 @@ import (
 	"github.com/agezt/agezt/kernel/pulse"
 	"github.com/agezt/agezt/plugins/channels/discord"
 	"github.com/agezt/agezt/plugins/channels/email"
+	"github.com/agezt/agezt/plugins/channels/irc"
 	"github.com/agezt/agezt/plugins/channels/matrix"
+	signalchan "github.com/agezt/agezt/plugins/channels/signal"
 	"github.com/agezt/agezt/plugins/channels/slack"
+	"github.com/agezt/agezt/plugins/channels/sms"
 	"github.com/agezt/agezt/plugins/channels/telegram"
+	webhookchan "github.com/agezt/agezt/plugins/channels/webhook"
 	"github.com/agezt/agezt/plugins/channels/whatsapp"
 )
 
@@ -392,6 +396,301 @@ func buildWhatsApp(d channelwire.Deps) channelwire.Built {
 			p = whatsapp.DefaultPath
 		}
 		desc = fmt.Sprintf("inbound at %s%s, allowlist=%d number(s)", addr, p, len(numbers))
+	}
+	return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: desc}
+}
+
+// buildWebhook constructs the vendor-neutral webhook channel. Enabled when an
+// inbound secret OR an outbound URL is configured. Returns NotConfigured when
+// neither is set.
+//
+//	AGEZT_WEBHOOK_SECRET        HMAC-SHA256 signing key (enables signed inbound)
+//	AGEZT_WEBHOOK_ADDR          local addr to serve the inbound route (fronted by
+//	                            a tunnel/reverse proxy); empty → no inbound listener
+//	AGEZT_WEBHOOK_PATH          inbound route (default /webhook)
+//	AGEZT_WEBHOOK_CHANNELS      comma-separated allowlist of channel ids that may
+//	                            drive the agent AND receive Pulse briefs
+//	AGEZT_WEBHOOK_OUTBOUND_URL  where Send / briefs POST (signed); empty → inbound-only
+//
+// The inbound handler runs the normal agent loop under the channel's correlation,
+// so `agt why`/`agt inbox` link the webhook command to the task.
+func buildWebhook(d channelwire.Deps) channelwire.Built {
+	secret := strings.TrimSpace(d.Get(brand.EnvPrefix + "WEBHOOK_SECRET"))
+	outboundURL := strings.TrimSpace(d.Get(brand.EnvPrefix + "WEBHOOK_OUTBOUND_URL"))
+	if secret == "" && outboundURL == "" {
+		return channelwire.NotConfigured
+	}
+	addr := strings.TrimSpace(d.Get(brand.EnvPrefix + "WEBHOOK_ADDR"))
+	path := strings.TrimSpace(d.Get(brand.EnvPrefix + "WEBHOOK_PATH"))
+	channelIDs := splitNonEmpty(d.Get(brand.EnvPrefix + "WEBHOOK_CHANNELS"))
+
+	ch := webhookchan.New(webhookchan.Config{
+		Addr:        addr,
+		Path:        path,
+		Secret:      secret,
+		Allowlist:   channel.NewAllowlist(channelIDs),
+		OutboundURL: outboundURL,
+		Bus:         d.Bus,
+		Handler:     d.Handler,
+	})
+
+	var sink pulse.BriefSink
+	if outboundURL != "" && len(channelIDs) > 0 {
+		sink = pulse.SinkFunc(func(b pulse.Brief) error {
+			var firstErr error
+			for _, id := range channelIDs {
+				if err := ch.Send(d.Ctx, channel.Outbound{ChannelID: id, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+			return firstErr
+		})
+	}
+
+	var desc string
+	switch {
+	case secret == "":
+		desc = fmt.Sprintf("outbound-only → %s, allowlist=%d (set AGEZT_WEBHOOK_SECRET + AGEZT_WEBHOOK_ADDR for inbound)", outboundURL, len(channelIDs))
+	case addr == "":
+		desc = fmt.Sprintf("inbound configured but not listening (set AGEZT_WEBHOOK_ADDR), allowlist=%d", len(channelIDs))
+	default:
+		p := path
+		if p == "" {
+			p = webhookchan.DefaultPath
+		}
+		desc = fmt.Sprintf("inbound at %s%s, allowlist=%d channel(s)", addr, p, len(channelIDs))
+	}
+	return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: desc}
+}
+
+// buildIRC constructs the two-way IRC channel when AGEZT_IRC_SERVER +
+// AGEZT_IRC_NICK are set. It joins AGEZT_IRC_CHANNELS and acts on inbound from
+// allowlisted sources (the joined channels, plus any AGEZT_IRC_ALLOWLIST nicks/
+// channels); Pulse briefs tee to the joined channels.
+//
+//	AGEZT_IRC_SERVER     host:port (e.g. irc.libera.chat:6697)   (required)
+//	AGEZT_IRC_NICK       the bot's nick                          (required)
+//	AGEZT_IRC_CHANNELS   comma-separated channels to join (#foo) — allowed by default
+//	AGEZT_IRC_PASSWORD   optional server password (PASS)
+//	AGEZT_IRC_TLS        "true" to force TLS (auto for :6697)
+//	AGEZT_IRC_ALLOWLIST  extra allowed sources (nicks for DMs / channels)
+func buildIRC(d channelwire.Deps) channelwire.Built {
+	server := strings.TrimSpace(d.Get(brand.EnvPrefix + "IRC_SERVER"))
+	nick := strings.TrimSpace(d.Get(brand.EnvPrefix + "IRC_NICK"))
+	if server == "" || nick == "" {
+		return channelwire.NotConfigured
+	}
+	chans := splitNonEmpty(d.Get(brand.EnvPrefix + "IRC_CHANNELS"))
+	// The joined channels are allowed by default; extra nicks/channels widen it.
+	allowed := append([]string(nil), chans...)
+	allowed = append(allowed, splitNonEmpty(d.Get(brand.EnvPrefix+"IRC_ALLOWLIST"))...)
+	useTLS := strings.EqualFold(strings.TrimSpace(d.Get(brand.EnvPrefix+"IRC_TLS")), "true") || strings.HasSuffix(server, ":6697")
+
+	ch := irc.New(irc.Config{
+		Server:    server,
+		TLS:       useTLS,
+		Nick:      nick,
+		Password:  strings.TrimSpace(d.Get(brand.EnvPrefix + "IRC_PASSWORD")),
+		Channels:  chans,
+		Allowlist: channel.NewAllowlist(allowed),
+		Bus:       d.Bus,
+		Handler:   d.Handler,
+	})
+
+	var sink pulse.BriefSink
+	if len(chans) > 0 {
+		sink = pulse.SinkFunc(func(b pulse.Brief) error {
+			var firstErr error
+			for _, c := range chans {
+				if err := ch.Send(d.Ctx, channel.Outbound{ChannelID: c, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+			return firstErr
+		})
+	}
+
+	desc := fmt.Sprintf("%s as %s, %d channel(s)", server, nick, len(chans))
+	if len(chans) == 0 {
+		desc = fmt.Sprintf("%s as %s, NO channels (set AGEZT_IRC_CHANNELS)", server, nick)
+	}
+	return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: desc}
+}
+
+// buildTwitch constructs a Twitch chat channel when AGEZT_TWITCH_USERNAME +
+// AGEZT_TWITCH_TOKEN are set. Twitch chat is IRC, so this reuses the IRC channel
+// pinned to Twitch's server with an "oauth:" PASS; it joins AGEZT_TWITCH_CHANNELS
+// (lowercase #channel) and acts on inbound from those channels by default.
+//
+//	AGEZT_TWITCH_USERNAME  the bot account's login name        (required)
+//	AGEZT_TWITCH_TOKEN     OAuth token ("oauth:" prefix added) (required)
+//	AGEZT_TWITCH_CHANNELS  comma-separated #channels to join — allowed by default
+//	AGEZT_TWITCH_ALLOWLIST extra allowed sources (nicks / channels)
+func buildTwitch(d channelwire.Deps) channelwire.Built {
+	user := strings.TrimSpace(d.Get(brand.EnvPrefix + "TWITCH_USERNAME"))
+	token := strings.TrimSpace(d.Get(brand.EnvPrefix + "TWITCH_TOKEN"))
+	if user == "" || token == "" {
+		return channelwire.NotConfigured
+	}
+	chans := splitNonEmpty(d.Get(brand.EnvPrefix + "TWITCH_CHANNELS"))
+	allowed := append([]string(nil), chans...)
+	allowed = append(allowed, splitNonEmpty(d.Get(brand.EnvPrefix+"TWITCH_ALLOWLIST"))...)
+	pass := token
+	if !strings.HasPrefix(pass, "oauth:") {
+		pass = "oauth:" + pass
+	}
+
+	ch := irc.New(irc.Config{
+		Kind:      "twitch",
+		Server:    "irc.chat.twitch.tv:6697",
+		TLS:       true,
+		Nick:      strings.ToLower(user),
+		Password:  pass,
+		Channels:  chans,
+		Allowlist: channel.NewAllowlist(allowed),
+		Bus:       d.Bus,
+		Handler:   d.Handler,
+	})
+
+	var sink pulse.BriefSink
+	if len(chans) > 0 {
+		sink = pulse.SinkFunc(func(b pulse.Brief) error {
+			var firstErr error
+			for _, c := range chans {
+				if err := ch.Send(d.Ctx, channel.Outbound{ChannelID: c, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+			return firstErr
+		})
+	}
+
+	desc := fmt.Sprintf("as %s, %d channel(s)", user, len(chans))
+	if len(chans) == 0 {
+		desc = fmt.Sprintf("as %s, NO channels (set AGEZT_TWITCH_CHANNELS)", user)
+	}
+	return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: desc}
+}
+
+// buildSMS constructs the Twilio SMS channel when AGEZT_SMS_ACCOUNT_SID +
+// AGEZT_SMS_AUTH_TOKEN are set. Inbound (signed Twilio webhook) is served when
+// AGEZT_SMS_ADDR is also set; outbound texts + Pulse briefs to the allowlisted
+// numbers (AGEZT_SMS_NUMBERS) need AGEZT_SMS_FROM.
+//
+//	AGEZT_SMS_ACCOUNT_SID  Twilio Account SID  (required)
+//	AGEZT_SMS_AUTH_TOKEN   Twilio auth token   (required; signs inbound + REST)
+//	AGEZT_SMS_FROM         Twilio number to send from, E.164 (outbound)
+//	AGEZT_SMS_ADDR         host:port for the inbound webhook (inbound)
+//	AGEZT_SMS_PATH         inbound route (default /sms)
+//	AGEZT_SMS_PUBLIC_URL   exact public URL Twilio POSTs to (signature check behind a tunnel)
+//	AGEZT_SMS_NUMBERS      comma-separated allowlist of sender numbers
+func buildSMS(d channelwire.Deps) channelwire.Built {
+	sid := strings.TrimSpace(d.Get(brand.EnvPrefix + "SMS_ACCOUNT_SID"))
+	token := strings.TrimSpace(d.Get(brand.EnvPrefix + "SMS_AUTH_TOKEN"))
+	if sid == "" || token == "" {
+		return channelwire.NotConfigured
+	}
+	from := strings.TrimSpace(d.Get(brand.EnvPrefix + "SMS_FROM"))
+	addr := strings.TrimSpace(d.Get(brand.EnvPrefix + "SMS_ADDR"))
+	path := strings.TrimSpace(d.Get(brand.EnvPrefix + "SMS_PATH"))
+	publicURL := strings.TrimSpace(d.Get(brand.EnvPrefix + "SMS_PUBLIC_URL"))
+	numbers := splitNonEmpty(d.Get(brand.EnvPrefix + "SMS_NUMBERS"))
+
+	ch := sms.New(sms.Config{
+		Addr:       addr,
+		Path:       path,
+		AccountSID: sid,
+		AuthToken:  token,
+		From:       from,
+		PublicURL:  publicURL,
+		Allowlist:  channel.NewAllowlist(numbers),
+		Bus:        d.Bus,
+		Handler:    d.Handler,
+	})
+
+	// Pulse briefs → the allowlisted numbers (needs an outbound From).
+	var sink pulse.BriefSink
+	if from != "" && len(numbers) > 0 {
+		sink = pulse.SinkFunc(func(b pulse.Brief) error {
+			var firstErr error
+			for _, id := range numbers {
+				if err := ch.Send(d.Ctx, channel.Outbound{ChannelID: id, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+			return firstErr
+		})
+	}
+
+	var desc string
+	switch {
+	case addr == "":
+		desc = fmt.Sprintf("outbound-only (set AGEZT_SMS_ADDR for inbound), allowlist=%d number(s)", len(numbers))
+	default:
+		p := path
+		if p == "" {
+			p = sms.DefaultPath
+		}
+		desc = fmt.Sprintf("inbound at %s%s, allowlist=%d number(s)", addr, p, len(numbers))
+	}
+	return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: desc}
+}
+
+// buildSignal constructs the in-process Signal channel when AGEZT_SIGNAL_API_URL
+// and AGEZT_SIGNAL_NUMBER are set, plus a Pulse brief sink to the allowlisted
+// numbers. Returns NotConfigured when unconfigured. Talks to an operator-run
+// signal-cli-rest-api: long-polls /v1/receive for inbound, POSTs /v2/send for
+// outbound (mirrors buildMatrix).
+//
+//	AGEZT_SIGNAL_API_URL     signal-cli-rest-api base URL (required), e.g. http://127.0.0.1:8080
+//	AGEZT_SIGNAL_NUMBER      the registered Signal number this bot is, E.164 (required)
+//	AGEZT_SIGNAL_RECIPIENTS  comma-separated allowlist of sender numbers (+ brief recipients)
+//	AGEZT_SIGNAL_TOKEN       optional bearer token (a reverse proxy fronting the API)
+//	AGEZT_SIGNAL_POLL_SECS   /v1/receive long-poll seconds (default 10)
+func buildSignal(d channelwire.Deps) channelwire.Built {
+	apiURL := strings.TrimSpace(d.Get(brand.EnvPrefix + "SIGNAL_API_URL"))
+	number := strings.TrimSpace(d.Get(brand.EnvPrefix + "SIGNAL_NUMBER"))
+	if apiURL == "" || number == "" {
+		return channelwire.NotConfigured
+	}
+	recipients := splitNonEmpty(d.Get(brand.EnvPrefix + "SIGNAL_RECIPIENTS"))
+	token := strings.TrimSpace(d.Get(brand.EnvPrefix + "SIGNAL_TOKEN"))
+	poll := 0
+	if v := strings.TrimSpace(d.Get(brand.EnvPrefix + "SIGNAL_POLL_SECS")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			poll = n
+		}
+	}
+
+	ch := signalchan.New(signalchan.Config{
+		APIURL:          apiURL,
+		Number:          number,
+		Token:           token,
+		Allowlist:       channel.NewAllowlist(recipients),
+		Bus:             d.Bus,
+		Handler:         d.Handler,
+		PollTimeoutSecs: poll,
+	})
+
+	// Pulse briefs → the allowlisted numbers. Nil sink when none configured (the
+	// bot can still receive commands once a number is allowlisted, and operators
+	// can still `agt send --channel signal --to <number>`).
+	var sink pulse.BriefSink
+	if len(recipients) > 0 {
+		sink = pulse.SinkFunc(func(b pulse.Brief) error {
+			var firstErr error
+			for _, id := range recipients {
+				if err := ch.Send(d.Ctx, channel.Outbound{ChannelID: id, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+			return firstErr
+		})
+	}
+
+	desc := fmt.Sprintf("listening, allowlist=%d number(s)", len(recipients))
+	if len(recipients) == 0 {
+		desc = "listening, NO allowlist (outbound-only; set AGEZT_SIGNAL_RECIPIENTS to allow commands)"
 	}
 	return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: desc}
 }

--- a/plugins/builtinchannels/factories.go
+++ b/plugins/builtinchannels/factories.go
@@ -31,6 +31,7 @@ import (
 	"github.com/agezt/agezt/plugins/channels/nextcloudtalk"
 	"github.com/agezt/agezt/plugins/channels/nostr"
 	"github.com/agezt/agezt/plugins/channels/onebot"
+	"github.com/agezt/agezt/plugins/channels/push"
 	signalchan "github.com/agezt/agezt/plugins/channels/signal"
 	"github.com/agezt/agezt/plugins/channels/slack"
 	"github.com/agezt/agezt/plugins/channels/sms"
@@ -43,8 +44,7 @@ import (
 	"github.com/agezt/agezt/plugins/channels/zalo"
 )
 
-// formatBrief renders a Pulse brief as plain channel text. (Small copy of the
-// cmd/agezt helper — the legacy builders still there need the original.)
+// formatBrief renders a Pulse brief as plain channel text.
 func formatBrief(b pulse.Brief) string {
 	if b.Body != "" {
 		return "📣 " + b.Title + "\n" + b.Body
@@ -53,7 +53,7 @@ func formatBrief(b pulse.Brief) string {
 }
 
 // splitNonEmpty splits a comma list, trimming and dropping blanks. (Small copy
-// of the cmd/agezt helper — the legacy builders still there need the original.)
+// of the cmd/agezt helper, which collectChannels there still needs.)
 func splitNonEmpty(s string) []string {
 	var out []string
 	for part := range strings.SplitSeq(s, ",") {
@@ -943,12 +943,20 @@ func buildTeams(d channelwire.Deps) channelwire.Built {
 //	AGEZT_LINE_ADDR     host:port to serve LINE's webhook (two-way)
 //	AGEZT_LINE_PATH     inbound route (default /line)
 //
-// The outbound-only push LINE entry yields the "line" name to this channel via
-// twoWayLineConfigured in cmd/agezt (which mirrors the secret check here for
-// the DEFAULT instance; the push-suppression cluster migrates in batch D).
+// Two-way wins the "line" name: when no channel secret is set but a token is,
+// the factory falls back to the outbound-only push entry (needs AGEZT_LINE_TO
+// for the recipient) — the suppression rule cmd/agezt's twoWayLineConfigured
+// predicate used to express, now owned here.
 func buildLine(d channelwire.Deps) channelwire.Built {
 	secret := strings.TrimSpace(d.Get(brand.EnvPrefix + "LINE_SECRET"))
 	if secret == "" {
+		if token := strings.TrimSpace(d.Get(brand.EnvPrefix + "LINE_TOKEN")); token != "" {
+			return pushBuilt(d, push.Config{
+				Kind:   push.KindLine,
+				Token:  token,
+				Target: strings.TrimSpace(d.Get(brand.EnvPrefix + "LINE_TO")),
+			})
+		}
 		return channelwire.NotConfigured
 	}
 	users := splitNonEmpty(d.Get(brand.EnvPrefix + "LINE_USERS"))
@@ -1139,13 +1147,17 @@ func parseNamedWebhooks(spec string) map[string]string {
 //	AGEZT_<PREFIX>_USERS    comma-separated allowed senders (usernames / emails)
 //	AGEZT_<PREFIX>_PATH     inbound route (default /<kind>)
 //
-// The addr gate inlines cmd/agezt's twoWayChatConfigured predicate, which
-// still lives there to yield the outbound-only push entry for the DEFAULT
-// instance (the push-suppression cluster migrates with the push family).
+// Two-way wins the kind's name: when no inbound addr is set but the
+// incoming-webhook URL is, the factory falls back to the outbound-only push
+// entry instead — the suppression rule cmd/agezt's twoWayChatConfigured
+// predicate used to express, now owned by the kind's own factory.
 func chatWebhookFactory(kind, prefix string) channelwire.Factory {
 	return func(d channelwire.Deps) channelwire.Built {
 		get := func(s string) string { return strings.TrimSpace(d.Get(brand.EnvPrefix + prefix + s)) }
 		if get("_ADDR") == "" {
+			if u := get("_WEBHOOK"); u != "" {
+				return pushBuilt(d, push.Config{Kind: kind, URL: u})
+			}
 			return channelwire.NotConfigured
 		}
 		users := splitNonEmpty(d.Get(brand.EnvPrefix + prefix + "_USERS"))
@@ -1189,6 +1201,11 @@ func chatWebhookFactory(kind, prefix string) channelwire.Factory {
 func buildDingTalk(d channelwire.Deps) channelwire.Built {
 	addr := strings.TrimSpace(d.Get(brand.EnvPrefix + "DINGTALK_ADDR"))
 	if addr == "" {
+		// Two-way unconfigured — fall back to the outbound-only push entry via
+		// the custom-robot webhook when set (two-way wins the "dingtalk" name).
+		if u := strings.TrimSpace(d.Get(brand.EnvPrefix + "DINGTALK_WEBHOOK")); u != "" {
+			return pushBuilt(d, push.Config{Kind: push.KindDingTalk, URL: u})
+		}
 		return channelwire.NotConfigured
 	}
 	users := splitNonEmpty(d.Get(brand.EnvPrefix + "DINGTALK_USERS"))
@@ -1225,6 +1242,11 @@ func buildFeishu(d channelwire.Deps) channelwire.Built {
 	addr := strings.TrimSpace(d.Get(brand.EnvPrefix + "FEISHU_ADDR"))
 	appID := strings.TrimSpace(d.Get(brand.EnvPrefix + "FEISHU_APP_ID"))
 	if addr == "" || appID == "" {
+		// Two-way unconfigured — fall back to the outbound-only push entry via
+		// the custom-bot webhook when set (two-way wins the "feishu" name).
+		if u := strings.TrimSpace(d.Get(brand.EnvPrefix + "FEISHU_WEBHOOK")); u != "" {
+			return pushBuilt(d, push.Config{Kind: push.KindFeishu, URL: u})
+		}
 		return channelwire.NotConfigured
 	}
 	users := splitNonEmpty(d.Get(brand.EnvPrefix + "FEISHU_USERS"))
@@ -1265,6 +1287,11 @@ func buildWeCom(d channelwire.Deps) channelwire.Built {
 	addr := strings.TrimSpace(d.Get(brand.EnvPrefix + "WECOM_ADDR"))
 	corp := strings.TrimSpace(d.Get(brand.EnvPrefix + "WECOM_CORP_ID"))
 	if addr == "" || corp == "" {
+		// Two-way unconfigured — fall back to the outbound-only push entry via
+		// the group-robot webhook when set (two-way wins the "wecom" name).
+		if u := strings.TrimSpace(d.Get(brand.EnvPrefix + "WECOM_WEBHOOK")); u != "" {
+			return pushBuilt(d, push.Config{Kind: push.KindWeCom, URL: u})
+		}
 		return channelwire.NotConfigured
 	}
 	users := splitNonEmpty(d.Get(brand.EnvPrefix + "WECOM_USERS"))
@@ -1304,11 +1331,19 @@ func buildWeCom(d channelwire.Deps) channelwire.Built {
 //	AGEZT_MASTODON_USERS   comma-separated acct handles allowed to drive the agent (enables two-way)
 //	AGEZT_MASTODON_POLL    poll interval seconds (default 60)
 //
-// The users gate inlines cmd/agezt's twoWayMastodonConfigured predicate, which
-// still lives there to yield the outbound-only push entry for the DEFAULT
-// instance (the push-suppression cluster migrates with the push family).
+// Two-way wins the "mastodon" name: when no acct allowlist is set but a token
+// is, the factory falls back to the outbound-only push entry (post statuses,
+// don't poll mentions) — the suppression rule cmd/agezt's
+// twoWayMastodonConfigured predicate used to express, now owned here.
 func buildMastodon(d channelwire.Deps) channelwire.Built {
 	if strings.TrimSpace(d.Get(brand.EnvPrefix+"MASTODON_USERS")) == "" {
+		if token := strings.TrimSpace(d.Get(brand.EnvPrefix + "MASTODON_TOKEN")); token != "" {
+			return pushBuilt(d, push.Config{
+				Kind:   push.KindMastodon,
+				Server: strings.TrimSpace(d.Get(brand.EnvPrefix + "MASTODON_SERVER")),
+				Token:  token,
+			})
+		}
 		return channelwire.NotConfigured
 	}
 	server := strings.TrimSpace(d.Get(brand.EnvPrefix + "MASTODON_SERVER"))
@@ -1335,4 +1370,133 @@ func buildMastodon(d channelwire.Deps) channelwire.Built {
 		return ch.Send(d.Ctx, channel.Outbound{Text: formatBrief(b), Priority: channel.PriorityNotify})
 	})
 	return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: fmt.Sprintf("Mastodon (two-way), allowlist=%d acct(s)", len(users))}
+}
+
+// pushBuilt wraps one outbound push.Channel (plugins/channels/push) as a
+// channelwire.Built: the channel itself, a brief sink that delivers via its
+// Send, and a "push → <kind>" desc. Returns NotConfigured when push.New
+// rejects the config — mirroring buildPushChannels' silent skip on a
+// construction error (e.g. LINE token set but no recipient).
+func pushBuilt(d channelwire.Deps, cfg push.Config) channelwire.Built {
+	cfg.Bus = d.Bus
+	ch, err := push.New(cfg)
+	if err != nil {
+		return channelwire.NotConfigured
+	}
+	sink := pulse.SinkFunc(func(b pulse.Brief) error {
+		return ch.Send(d.Ctx, channel.Outbound{Text: formatBrief(b), Priority: channel.PriorityNotify})
+	})
+	return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: "push → " + ch.Name()}
+}
+
+// buildNtfy constructs the outbound ntfy push channel when AGEZT_NTFY_TOPIC is
+// set. Briefs/`agt send` POST to the topic. Outbound-only.
+//
+//	AGEZT_NTFY_TOPIC   topic to publish to (required)
+//	AGEZT_NTFY_SERVER  base URL (default https://ntfy.sh)
+//	AGEZT_NTFY_TOKEN   optional bearer token
+func buildNtfy(d channelwire.Deps) channelwire.Built {
+	topic := strings.TrimSpace(d.Get(brand.EnvPrefix + "NTFY_TOPIC"))
+	if topic == "" {
+		return channelwire.NotConfigured
+	}
+	return pushBuilt(d, push.Config{
+		Kind:   push.KindNtfy,
+		Server: strings.TrimSpace(d.Get(brand.EnvPrefix + "NTFY_SERVER")),
+		Topic:  topic,
+		Token:  strings.TrimSpace(d.Get(brand.EnvPrefix + "NTFY_TOKEN")),
+	})
+}
+
+// buildPushover constructs the outbound Pushover push channel when
+// AGEZT_PUSHOVER_TOKEN is set. Outbound-only.
+//
+//	AGEZT_PUSHOVER_TOKEN  app token (required)
+//	AGEZT_PUSHOVER_USER   user/group key (required by the API)
+func buildPushover(d channelwire.Deps) channelwire.Built {
+	token := strings.TrimSpace(d.Get(brand.EnvPrefix + "PUSHOVER_TOKEN"))
+	if token == "" {
+		return channelwire.NotConfigured
+	}
+	return pushBuilt(d, push.Config{
+		Kind:  push.KindPushover,
+		Token: token,
+		User:  strings.TrimSpace(d.Get(brand.EnvPrefix + "PUSHOVER_USER")),
+	})
+}
+
+// buildGotify constructs the outbound Gotify push channel when
+// AGEZT_GOTIFY_TOKEN is set. Outbound-only.
+//
+//	AGEZT_GOTIFY_TOKEN   app token (required)
+//	AGEZT_GOTIFY_SERVER  self-hosted server base URL (required by the API)
+func buildGotify(d channelwire.Deps) channelwire.Built {
+	token := strings.TrimSpace(d.Get(brand.EnvPrefix + "GOTIFY_TOKEN"))
+	if token == "" {
+		return channelwire.NotConfigured
+	}
+	return pushBuilt(d, push.Config{
+		Kind:   push.KindGotify,
+		Server: strings.TrimSpace(d.Get(brand.EnvPrefix + "GOTIFY_SERVER")),
+		Token:  token,
+	})
+}
+
+// buildPushbullet constructs the outbound Pushbullet push channel when
+// AGEZT_PUSHBULLET_TOKEN is set. Outbound-only.
+//
+//	AGEZT_PUSHBULLET_TOKEN  access token (required)
+func buildPushbullet(d channelwire.Deps) channelwire.Built {
+	token := strings.TrimSpace(d.Get(brand.EnvPrefix + "PUSHBULLET_TOKEN"))
+	if token == "" {
+		return channelwire.NotConfigured
+	}
+	return pushBuilt(d, push.Config{Kind: push.KindPushbullet, Token: token})
+}
+
+// buildRocketChat constructs the outbound Rocket.Chat push channel when
+// AGEZT_ROCKETCHAT_WEBHOOK is set. Outbound-only.
+//
+//	AGEZT_ROCKETCHAT_WEBHOOK  incoming-webhook URL (required)
+func buildRocketChat(d channelwire.Deps) channelwire.Built {
+	u := strings.TrimSpace(d.Get(brand.EnvPrefix + "ROCKETCHAT_WEBHOOK"))
+	if u == "" {
+		return channelwire.NotConfigured
+	}
+	return pushBuilt(d, push.Config{Kind: push.KindRocketChat, URL: u})
+}
+
+// buildZulip constructs the outbound Zulip push channel when
+// AGEZT_ZULIP_APIKEY is set. Outbound-only (bot posts to a stream).
+//
+//	AGEZT_ZULIP_APIKEY  bot API key (required)
+//	AGEZT_ZULIP_SERVER  Zulip server base URL (required by the API)
+//	AGEZT_ZULIP_EMAIL   bot email (required by the API)
+//	AGEZT_ZULIP_STREAM  stream to post to (required by the API)
+//	AGEZT_ZULIP_TOPIC   topic within the stream (default "agezt")
+func buildZulip(d channelwire.Deps) channelwire.Built {
+	key := strings.TrimSpace(d.Get(brand.EnvPrefix + "ZULIP_APIKEY"))
+	if key == "" {
+		return channelwire.NotConfigured
+	}
+	return pushBuilt(d, push.Config{
+		Kind:   push.KindZulip,
+		Server: strings.TrimSpace(d.Get(brand.EnvPrefix + "ZULIP_SERVER")),
+		User:   strings.TrimSpace(d.Get(brand.EnvPrefix + "ZULIP_EMAIL")),
+		Token:  key,
+		Target: strings.TrimSpace(d.Get(brand.EnvPrefix + "ZULIP_STREAM")),
+		Topic:  strings.TrimSpace(d.Get(brand.EnvPrefix + "ZULIP_TOPIC")),
+	})
+}
+
+// buildSynology constructs the outbound Synology Chat push channel when
+// AGEZT_SYNOLOGY_WEBHOOK is set. Outbound-only.
+//
+//	AGEZT_SYNOLOGY_WEBHOOK  incoming-webhook URL (required)
+func buildSynology(d channelwire.Deps) channelwire.Built {
+	u := strings.TrimSpace(d.Get(brand.EnvPrefix + "SYNOLOGY_WEBHOOK"))
+	if u == "" {
+		return channelwire.NotConfigured
+	}
+	return pushBuilt(d, push.Config{Kind: push.KindSynology, URL: u})
 }

--- a/plugins/builtinchannels/factories.go
+++ b/plugins/builtinchannels/factories.go
@@ -9,6 +9,7 @@ package builtinchannels
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -21,8 +22,11 @@ import (
 	"github.com/agezt/agezt/plugins/channels/homeassistant"
 	"github.com/agezt/agezt/plugins/channels/imessage"
 	"github.com/agezt/agezt/plugins/channels/irc"
+	linechan "github.com/agezt/agezt/plugins/channels/line"
 	"github.com/agezt/agezt/plugins/channels/matrix"
 	"github.com/agezt/agezt/plugins/channels/nextcloudtalk"
+	"github.com/agezt/agezt/plugins/channels/nostr"
+	"github.com/agezt/agezt/plugins/channels/onebot"
 	signalchan "github.com/agezt/agezt/plugins/channels/signal"
 	"github.com/agezt/agezt/plugins/channels/slack"
 	"github.com/agezt/agezt/plugins/channels/sms"
@@ -31,6 +35,7 @@ import (
 	webhookchan "github.com/agezt/agezt/plugins/channels/webhook"
 	"github.com/agezt/agezt/plugins/channels/whatsapp"
 	"github.com/agezt/agezt/plugins/channels/whatsappgw"
+	"github.com/agezt/agezt/plugins/channels/zalo"
 )
 
 // formatBrief renders a Pulse brief as plain channel text. (Small copy of the
@@ -920,6 +925,179 @@ func buildTeams(d channelwire.Deps) channelwire.Built {
 	})
 
 	return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: fmt.Sprintf("outbound → %d Teams webhook(s)", len(names))}
+}
+
+// buildLine constructs the two-way LINE channel (official Messaging API) when a
+// channel secret is set. Outbound push uses AGEZT_LINE_TOKEN; inbound (two-way)
+// is served when AGEZT_LINE_ADDR is set and verified with AGEZT_LINE_SECRET.
+//
+//	AGEZT_LINE_TOKEN    channel access token (Bearer for reply/push)
+//	AGEZT_LINE_SECRET   channel secret (verifies inbound signature; enables two-way)  (required)
+//	AGEZT_LINE_USERS    comma-separated allowed sender userIds
+//	AGEZT_LINE_TO       recipient id for Pulse briefs
+//	AGEZT_LINE_ADDR     host:port to serve LINE's webhook (two-way)
+//	AGEZT_LINE_PATH     inbound route (default /line)
+//
+// The outbound-only push LINE entry yields the "line" name to this channel via
+// twoWayLineConfigured in cmd/agezt (which mirrors the secret check here for
+// the DEFAULT instance; the push-suppression cluster migrates in batch D).
+func buildLine(d channelwire.Deps) channelwire.Built {
+	secret := strings.TrimSpace(d.Get(brand.EnvPrefix + "LINE_SECRET"))
+	if secret == "" {
+		return channelwire.NotConfigured
+	}
+	users := splitNonEmpty(d.Get(brand.EnvPrefix + "LINE_USERS"))
+	addr := strings.TrimSpace(d.Get(brand.EnvPrefix + "LINE_ADDR"))
+
+	ch := linechan.New(linechan.Config{
+		Secret:      secret,
+		AccessToken: strings.TrimSpace(d.Get(brand.EnvPrefix + "LINE_TOKEN")),
+		Allowlist:   channel.NewAllowlist(users),
+		Bus:         d.Bus,
+		Handler:     d.Handler,
+		Addr:        addr,
+		Path:        strings.TrimSpace(d.Get(brand.EnvPrefix + "LINE_PATH")),
+	})
+
+	var sink pulse.BriefSink
+	if to := strings.TrimSpace(d.Get(brand.EnvPrefix + "LINE_TO")); to != "" {
+		sink = pulse.SinkFunc(func(b pulse.Brief) error {
+			return ch.Send(d.Ctx, channel.Outbound{ChannelID: to, Text: formatBrief(b), Priority: channel.PriorityNotify})
+		})
+	}
+
+	desc := fmt.Sprintf("LINE Messaging API, allowlist=%d user(s)", len(users))
+	if addr == "" {
+		desc += " (outbound-only; set AGEZT_LINE_ADDR for two-way)"
+	}
+	return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: desc}
+}
+
+// oneBotFactory returns the factory for a QQ / WeChat channel over a OneBot v11
+// gateway, enabled when its inbound addr is set. QQ and WeChat have no
+// first-party bot API; a self-hosted gateway (go-cqhttp / NapCat / Lagrange for
+// QQ; wcf / wechatbot for WeChat) speaks OneBot. kind is the channel name;
+// prefix is the env namespace — the parameterization the whole channel-factory
+// refactor aims for: one builder, two registered kinds.
+//
+//	AGEZT_<PREFIX>_GATEWAY  gateway HTTP API base, e.g. http://localhost:5700
+//	AGEZT_<PREFIX>_TOKEN    gateway access token (bearer)
+//	AGEZT_<PREFIX>_SECRET   HMAC-SHA1 secret verifying inbound X-Signature
+//	AGEZT_<PREFIX>_USERS    comma-separated allowed user ids
+//	AGEZT_<PREFIX>_ADDR     host:port to serve the inbound webhook (enables two-way)
+//	AGEZT_<PREFIX>_PATH     inbound route (default /<kind>)
+func oneBotFactory(kind, prefix string) channelwire.Factory {
+	return func(d channelwire.Deps) channelwire.Built {
+		get := func(s string) string { return strings.TrimSpace(d.Get(brand.EnvPrefix + prefix + s)) }
+		addr := get("_ADDR")
+		if addr == "" {
+			return channelwire.NotConfigured
+		}
+		users := splitNonEmpty(d.Get(brand.EnvPrefix + prefix + "_USERS"))
+		ch := onebot.New(onebot.Config{
+			Kind:        kind,
+			APIBase:     get("_GATEWAY"),
+			AccessToken: get("_TOKEN"),
+			Secret:      get("_SECRET"),
+			Allowlist:   channel.NewAllowlist(users),
+			Bus:         d.Bus,
+			Handler:     d.Handler,
+			Addr:        addr,
+			Path:        get("_PATH"),
+		})
+		var sink pulse.BriefSink
+		if len(users) > 0 && get("_GATEWAY") != "" {
+			sink = pulse.SinkFunc(func(b pulse.Brief) error {
+				var firstErr error
+				for _, u := range users {
+					if err := ch.Send(d.Ctx, channel.Outbound{ChannelID: "private:" + u, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
+						firstErr = err
+					}
+				}
+				return firstErr
+			})
+		}
+		return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: fmt.Sprintf("%s via OneBot gateway, allowlist=%d user(s)", kind, len(users))}
+	}
+}
+
+// buildZalo constructs the two-way Zalo channel (Official Account API) when
+// AGEZT_ZALO_ADDR is set. Replies + briefs use the OA message API.
+//
+//	AGEZT_ZALO_APP_ID   OA app id (part of the inbound signature)
+//	AGEZT_ZALO_TOKEN    OA access token (sends)
+//	AGEZT_ZALO_SECRET   OA secret key (verifies the inbound signature)
+//	AGEZT_ZALO_USERS    comma-separated allowed user ids
+//	AGEZT_ZALO_ADDR     host:port to serve the inbound webhook (enables two-way)
+//	AGEZT_ZALO_PATH     inbound route (default /zalo)
+func buildZalo(d channelwire.Deps) channelwire.Built {
+	addr := strings.TrimSpace(d.Get(brand.EnvPrefix + "ZALO_ADDR"))
+	if addr == "" {
+		return channelwire.NotConfigured
+	}
+	users := splitNonEmpty(d.Get(brand.EnvPrefix + "ZALO_USERS"))
+	ch := zalo.New(zalo.Config{
+		AppID:       strings.TrimSpace(d.Get(brand.EnvPrefix + "ZALO_APP_ID")),
+		AccessToken: strings.TrimSpace(d.Get(brand.EnvPrefix + "ZALO_TOKEN")),
+		Secret:      strings.TrimSpace(d.Get(brand.EnvPrefix + "ZALO_SECRET")),
+		Allowlist:   channel.NewAllowlist(users),
+		Bus:         d.Bus,
+		Handler:     d.Handler,
+		Addr:        addr,
+		Path:        strings.TrimSpace(d.Get(brand.EnvPrefix + "ZALO_PATH")),
+	})
+	var sink pulse.BriefSink
+	if len(users) > 0 {
+		sink = pulse.SinkFunc(func(b pulse.Brief) error {
+			var firstErr error
+			for _, u := range users {
+				if err := ch.Send(d.Ctx, channel.Outbound{ChannelID: u, Text: formatBrief(b), Priority: channel.PriorityNotify}); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+			return firstErr
+		})
+	}
+	return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: fmt.Sprintf("Zalo OA, allowlist=%d user(s)", len(users))}
+}
+
+// buildNostr constructs the Nostr channel when AGEZT_NOSTR_PRIVKEY + AGEZT_NOSTR_RELAYS
+// are set. It connects to the relays, answers kind-1 mentions of the agent's
+// pubkey from allowlisted authors, and posts briefs as standalone notes.
+//
+//	AGEZT_NOSTR_PRIVKEY  64-char hex secret key (required)
+//	AGEZT_NOSTR_RELAYS   comma-separated wss:// relay URLs (required)
+//	AGEZT_NOSTR_AUTHORS  comma-separated author pubkeys (hex) allowed to drive the agent
+func buildNostr(d channelwire.Deps) channelwire.Built {
+	priv := strings.TrimSpace(d.Get(brand.EnvPrefix + "NOSTR_PRIVKEY"))
+	relays := splitNonEmpty(d.Get(brand.EnvPrefix + "NOSTR_RELAYS"))
+	if priv == "" || len(relays) == 0 {
+		return channelwire.NotConfigured
+	}
+	authors := splitNonEmpty(d.Get(brand.EnvPrefix + "NOSTR_AUTHORS"))
+	// Authors may be hex or npub… — normalize to hex so the allowlist matches the
+	// hex pubkey on inbound events.
+	norm := make([]string, 0, len(authors))
+	for _, a := range authors {
+		if h, derr := nostr.DecodePubkey(a); derr == nil {
+			norm = append(norm, h)
+		}
+	}
+	ch, err := nostr.New(nostr.Config{
+		PrivKeyHex: priv,
+		Relays:     relays,
+		Allowlist:  channel.NewAllowlist(norm),
+		Bus:        d.Bus,
+		Handler:    d.Handler,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: nostr channel disabled: %v\n", brand.Binary, err)
+		return channelwire.NotConfigured
+	}
+	sink := pulse.SinkFunc(func(b pulse.Brief) error {
+		return ch.Send(d.Ctx, channel.Outbound{Text: formatBrief(b), Priority: channel.PriorityNotify})
+	})
+	return channelwire.Built{Channels: []channel.Channel{ch}, Sink: sink, Desc: fmt.Sprintf("Nostr, %d relay(s), allowlist=%d author(s)", len(relays), len(authors))}
 }
 
 // parseNamedWebhooks parses a "name=url,name2=url2" spec into a name→url map.

--- a/plugins/builtinchannels/factories_push_test.go
+++ b/plugins/builtinchannels/factories_push_test.go
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MIT
+
+package builtinchannels
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/agezt/agezt/internal/brand"
+	"github.com/agezt/agezt/kernel/channelwire"
+	"github.com/agezt/agezt/plugins/channels/push"
+)
+
+// mapGet adapts a fixed env map to a channelwire Deps.Get.
+func mapGet(env map[string]string) func(string) string {
+	return func(key string) string { return env[key] }
+}
+
+// TestDualKindFactories_TwoWayWinsOverPushFallback locks the ownership rule
+// that moved out of cmd/agezt's twoWay* predicates and into each dual kind's
+// own factory: two-way config wins the kind's name; with only the push env
+// set, the factory returns the outbound-only push.Channel instead of
+// NotConfigured.
+func TestDualKindFactories_TwoWayWinsOverPushFallback(t *testing.T) {
+	RegisterAll()
+	ctx := context.Background()
+	p := brand.EnvPrefix
+
+	cases := []struct {
+		kind    string
+		pushEnv map[string]string // push fallback only
+		twoWay  map[string]string // two-way config (wins, even with push env set)
+	}{
+		{
+			kind:    "googlechat",
+			pushEnv: map[string]string{p + "GOOGLECHAT_WEBHOOK": "https://chat.example/hook"},
+			twoWay: map[string]string{
+				p + "GOOGLECHAT_WEBHOOK": "https://chat.example/hook",
+				p + "GOOGLECHAT_ADDR":    "127.0.0.1:0",
+			},
+		},
+		{
+			kind:    "mattermost",
+			pushEnv: map[string]string{p + "MATTERMOST_WEBHOOK": "https://mm.example/hook"},
+			twoWay: map[string]string{
+				p + "MATTERMOST_WEBHOOK": "https://mm.example/hook",
+				p + "MATTERMOST_ADDR":    "127.0.0.1:0",
+			},
+		},
+		{
+			kind: "mastodon",
+			pushEnv: map[string]string{
+				p + "MASTODON_SERVER": "https://masto.example",
+				p + "MASTODON_TOKEN":  "tok",
+			},
+			twoWay: map[string]string{
+				p + "MASTODON_SERVER": "https://masto.example",
+				p + "MASTODON_TOKEN":  "tok",
+				p + "MASTODON_USERS":  "@al@masto.example",
+			},
+		},
+		{
+			kind: "line",
+			pushEnv: map[string]string{
+				p + "LINE_TOKEN": "tok",
+				p + "LINE_TO":    "U123",
+			},
+			twoWay: map[string]string{
+				p + "LINE_TOKEN":  "tok",
+				p + "LINE_TO":     "U123",
+				p + "LINE_SECRET": "sec",
+			},
+		},
+		{
+			kind:    "feishu",
+			pushEnv: map[string]string{p + "FEISHU_WEBHOOK": "https://open.feishu.example/hook"},
+			twoWay: map[string]string{
+				p + "FEISHU_WEBHOOK": "https://open.feishu.example/hook",
+				p + "FEISHU_ADDR":    "127.0.0.1:0",
+				p + "FEISHU_APP_ID":  "cli_x",
+			},
+		},
+		{
+			kind:    "dingtalk",
+			pushEnv: map[string]string{p + "DINGTALK_WEBHOOK": "https://oapi.dingtalk.example/hook"},
+			twoWay: map[string]string{
+				p + "DINGTALK_WEBHOOK": "https://oapi.dingtalk.example/hook",
+				p + "DINGTALK_ADDR":    "127.0.0.1:0",
+			},
+		},
+		{
+			kind:    "wecom",
+			pushEnv: map[string]string{p + "WECOM_WEBHOOK": "https://qyapi.weixin.example/hook"},
+			twoWay: map[string]string{
+				p + "WECOM_WEBHOOK": "https://qyapi.weixin.example/hook",
+				p + "WECOM_ADDR":    "127.0.0.1:0",
+				p + "WECOM_CORP_ID": "corp1",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		f, ok := channelwire.Lookup(tc.kind)
+		if !ok {
+			t.Errorf("%s: no channelwire factory registered", tc.kind)
+			continue
+		}
+
+		// Only the push env set → the outbound-only push.Channel owns the name.
+		built := f(channelwire.Deps{Ctx: ctx, Get: mapGet(tc.pushEnv)})
+		if len(built.Channels) != 1 || built.Desc == "" {
+			t.Errorf("%s push fallback: got %d channel(s), desc %q; want 1 push channel", tc.kind, len(built.Channels), built.Desc)
+			continue
+		}
+		if _, isPush := built.Channels[0].(*push.Channel); !isPush {
+			t.Errorf("%s push fallback: channel is %T, want *push.Channel", tc.kind, built.Channels[0])
+		}
+		if got := built.Channels[0].Name(); got != tc.kind {
+			t.Errorf("%s push fallback: channel Name() = %q, want the kind", tc.kind, got)
+		}
+		if built.Sink == nil {
+			t.Errorf("%s push fallback: nil brief sink, want one delivering via Send", tc.kind)
+		}
+		if !strings.HasPrefix(built.Desc, "push → ") {
+			t.Errorf("%s push fallback: desc = %q, want a push desc", tc.kind, built.Desc)
+		}
+
+		// Two-way config set (push env still present) → two-way wins the name.
+		built = f(channelwire.Deps{Ctx: ctx, Get: mapGet(tc.twoWay)})
+		if len(built.Channels) != 1 || built.Desc == "" {
+			t.Errorf("%s two-way: got %d channel(s), desc %q; want the two-way channel", tc.kind, len(built.Channels), built.Desc)
+			continue
+		}
+		if _, isPush := built.Channels[0].(*push.Channel); isPush {
+			t.Errorf("%s two-way: got the push fallback; two-way config must win the name", tc.kind)
+		}
+
+		// Nothing set → NotConfigured.
+		built = f(channelwire.Deps{Ctx: ctx, Get: mapGet(nil)})
+		if built.Desc != "" || len(built.Channels) != 0 {
+			t.Errorf("%s unconfigured: desc %q, %d channel(s); want NotConfigured", tc.kind, built.Desc, len(built.Channels))
+		}
+	}
+}
+
+// TestPurePushFactories_Configured locks the seven pure push kinds: with the
+// enabling env set each factory returns one push.Channel named after the kind,
+// with a brief sink.
+func TestPurePushFactories_Configured(t *testing.T) {
+	RegisterAll()
+	ctx := context.Background()
+	p := brand.EnvPrefix
+
+	cases := map[string]map[string]string{
+		"ntfy":       {p + "NTFY_TOPIC": "alerts"},
+		"pushover":   {p + "PUSHOVER_TOKEN": "app", p + "PUSHOVER_USER": "usr"},
+		"gotify":     {p + "GOTIFY_TOKEN": "app", p + "GOTIFY_SERVER": "https://gotify.example"},
+		"pushbullet": {p + "PUSHBULLET_TOKEN": "tok"},
+		"rocketchat": {p + "ROCKETCHAT_WEBHOOK": "https://rocket.example/hook"},
+		"zulip": {
+			p + "ZULIP_APIKEY": "key", p + "ZULIP_SERVER": "https://zulip.example",
+			p + "ZULIP_EMAIL": "bot@zulip.example", p + "ZULIP_STREAM": "general",
+		},
+		"synology": {p + "SYNOLOGY_WEBHOOK": "https://nas.example/hook"},
+	}
+
+	for kind, env := range cases {
+		f, ok := channelwire.Lookup(kind)
+		if !ok {
+			t.Errorf("%s: no channelwire factory registered", kind)
+			continue
+		}
+		built := f(channelwire.Deps{Ctx: ctx, Get: mapGet(env)})
+		if len(built.Channels) != 1 || built.Desc == "" {
+			t.Errorf("%s: got %d channel(s), desc %q; want 1 push channel", kind, len(built.Channels), built.Desc)
+			continue
+		}
+		if _, isPush := built.Channels[0].(*push.Channel); !isPush {
+			t.Errorf("%s: channel is %T, want *push.Channel", kind, built.Channels[0])
+		}
+		if got := built.Channels[0].Name(); got != kind {
+			t.Errorf("%s: channel Name() = %q, want the kind", kind, got)
+		}
+		if built.Sink == nil {
+			t.Errorf("%s: nil brief sink, want one delivering via Send", kind)
+		}
+	}
+}

--- a/plugins/builtinchannels/factory_ratchet_test.go
+++ b/plugins/builtinchannels/factory_ratchet_test.go
@@ -18,9 +18,6 @@ import (
 // silent-drift class this migration exists to close — a channel shipped with
 // a manifest but no wiring).
 var factoryTODO = map[string]bool{
-	// modern buildAccounts six (batch: PR 2)
-	"telegram": true, "slack": true, "email": true,
-	"discord": true, "matrix": true, "whatsapp": true,
 	// legacy batch A
 	"webhook": true, "irc": true, "twitch": true, "sms": true, "signal": true,
 	// legacy batch B

--- a/plugins/builtinchannels/factory_ratchet_test.go
+++ b/plugins/builtinchannels/factory_ratchet_test.go
@@ -18,8 +18,6 @@ import (
 // silent-drift class this migration exists to close — a channel shipped with
 // a manifest but no wiring).
 var factoryTODO = map[string]bool{
-	// legacy batch A
-	"webhook": true, "irc": true, "twitch": true, "sms": true, "signal": true,
 	// legacy batch B
 	"whatsappgw": true, "imessage": true, "homeassistant": true,
 	"teams": true, "nextcloudtalk": true,

--- a/plugins/builtinchannels/factory_ratchet_test.go
+++ b/plugins/builtinchannels/factory_ratchet_test.go
@@ -18,9 +18,6 @@ import (
 // silent-drift class this migration exists to close — a channel shipped with
 // a manifest but no wiring).
 var factoryTODO = map[string]bool{
-	// legacy batch D (push-suppression cluster)
-	"googlechat": true, "mattermost": true, "dingtalk": true,
-	"feishu": true, "wecom": true, "mastodon": true,
 	// push family
 	"ntfy": true, "pushover": true, "gotify": true, "pushbullet": true,
 	"rocketchat": true, "zulip": true, "synology": true,

--- a/plugins/builtinchannels/factory_ratchet_test.go
+++ b/plugins/builtinchannels/factory_ratchet_test.go
@@ -10,18 +10,13 @@ import (
 )
 
 // factoryTODO is the RATCHET for the channel-factory migration (Phase 2.1 of
-// docs/REFACTORING-SCAN-2026-08.md): manifest kinds that do NOT yet register
-// a channelwire.Factory and are still hand-wired in cmd/agezt/main.go. Each
-// migration batch DELETES its kinds from this set; a kind present here that
-// gained a factory fails the test (lock in the progress), and a manifest kind
+// docs/REFACTORING-SCAN-2026-08.md). The migration is COMPLETE — every
+// manifest kind registers a channelwire.Factory — so the set is empty; it
+// stays (with the test below) as the permanent drift alarm: a manifest kind
 // in neither the factory registry nor this set fails loudly (the 34-vs-27
-// silent-drift class this migration exists to close — a channel shipped with
-// a manifest but no wiring).
-var factoryTODO = map[string]bool{
-	// push family
-	"ntfy": true, "pushover": true, "gotify": true, "pushbullet": true,
-	"rocketchat": true, "zulip": true, "synology": true,
-}
+// silent-drift class this migration existed to close — a channel shipped
+// with a manifest but no wiring).
+var factoryTODO = map[string]bool{}
 
 // TestEveryManifestHasFactoryOrTODO is the drift alarm: every registered
 // manifest kind must either have a channelwire factory or be an acknowledged

--- a/plugins/builtinchannels/factory_ratchet_test.go
+++ b/plugins/builtinchannels/factory_ratchet_test.go
@@ -18,8 +18,6 @@ import (
 // silent-drift class this migration exists to close — a channel shipped with
 // a manifest but no wiring).
 var factoryTODO = map[string]bool{
-	// legacy batch C
-	"nostr": true, "zalo": true, "qq": true, "wechat": true, "line": true,
 	// legacy batch D (push-suppression cluster)
 	"googlechat": true, "mattermost": true, "dingtalk": true,
 	"feishu": true, "wecom": true, "mastodon": true,

--- a/plugins/builtinchannels/factory_ratchet_test.go
+++ b/plugins/builtinchannels/factory_ratchet_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+
+package builtinchannels
+
+import (
+	"testing"
+
+	"github.com/agezt/agezt/kernel/channel"
+	"github.com/agezt/agezt/kernel/channelwire"
+)
+
+// factoryTODO is the RATCHET for the channel-factory migration (Phase 2.1 of
+// docs/REFACTORING-SCAN-2026-08.md): manifest kinds that do NOT yet register
+// a channelwire.Factory and are still hand-wired in cmd/agezt/main.go. Each
+// migration batch DELETES its kinds from this set; a kind present here that
+// gained a factory fails the test (lock in the progress), and a manifest kind
+// in neither the factory registry nor this set fails loudly (the 34-vs-27
+// silent-drift class this migration exists to close — a channel shipped with
+// a manifest but no wiring).
+var factoryTODO = map[string]bool{
+	// modern buildAccounts six (batch: PR 2)
+	"telegram": true, "slack": true, "email": true,
+	"discord": true, "matrix": true, "whatsapp": true,
+	// legacy batch A
+	"webhook": true, "irc": true, "twitch": true, "sms": true, "signal": true,
+	// legacy batch B
+	"whatsappgw": true, "imessage": true, "homeassistant": true,
+	"teams": true, "nextcloudtalk": true,
+	// legacy batch C
+	"nostr": true, "zalo": true, "qq": true, "wechat": true, "line": true,
+	// legacy batch D (push-suppression cluster)
+	"googlechat": true, "mattermost": true, "dingtalk": true,
+	"feishu": true, "wecom": true, "mastodon": true,
+	// push family
+	"ntfy": true, "pushover": true, "gotify": true, "pushbullet": true,
+	"rocketchat": true, "zulip": true, "synology": true,
+}
+
+// TestEveryManifestHasFactoryOrTODO is the drift alarm: every registered
+// manifest kind must either have a channelwire factory or be an acknowledged
+// not-yet-migrated entry above — and never both.
+func TestEveryManifestHasFactoryOrTODO(t *testing.T) {
+	RegisterAll()
+	for _, m := range channel.Manifests() {
+		_, hasFactory := channelwire.Lookup(m.Kind)
+		inTODO := factoryTODO[m.Kind]
+		switch {
+		case hasFactory && inTODO:
+			t.Errorf("%s migrated to a channelwire factory — delete it from factoryTODO to lock in the progress", m.Kind)
+		case !hasFactory && !inTODO:
+			t.Errorf("%s has a manifest but neither a channelwire factory nor a factoryTODO entry — a channel shipped without wiring (the allInsts drift class); register a Factory for it", m.Kind)
+		}
+	}
+	// The inverse: a TODO entry whose manifest vanished is stale bookkeeping.
+	for kind := range factoryTODO {
+		if _, ok := channel.LookupManifest(kind); !ok {
+			t.Errorf("factoryTODO lists %s but no such manifest is registered — remove the stale entry", kind)
+		}
+	}
+}

--- a/plugins/builtinchannels/factory_ratchet_test.go
+++ b/plugins/builtinchannels/factory_ratchet_test.go
@@ -18,9 +18,6 @@ import (
 // silent-drift class this migration exists to close — a channel shipped with
 // a manifest but no wiring).
 var factoryTODO = map[string]bool{
-	// legacy batch B
-	"whatsappgw": true, "imessage": true, "homeassistant": true,
-	"teams": true, "nextcloudtalk": true,
 	// legacy batch C
 	"nostr": true, "zalo": true, "qq": true, "wechat": true, "line": true,
 	// legacy batch D (push-suppression cluster)


### PR DESCRIPTION
Phase 2.1 of docs/REFACTORING-SCAN-2026-08.md — COMPLETE in 7 commits (the plan's 8-PR train, plan in-tree at plans/phase2.1-channel-factory.md).

## What changed
- **kernel/channelwire** (new): `Deps{Ctx,Bus,Handler,Get,Label}` / `Built{Channels,Sink,Desc}` / `Register`/`BuildKind`/`BuildAll`. Lives here (not on `channel.Manifest`) so pulse never leaks into transport plugins' deps. `Built.Desc==""` replaces the typed-nil sentinel.
- **All 34 channel kinds migrated** to factories in `plugins/builtinchannels/factories.go`, in batches: modern six → webhook/irc/twitch/sms/signal → whatsappgw/imessage/homeassistant/teams/nextcloudtalk → nostr/zalo/qq/wechat/line → suppression cluster (googlechat/mattermost/dingtalk/feishu/wecom/mastodon) → push family. Parameterized builders became factory closures (`oneBotFactory`, `chatWebhookFactory`).
- **Push-suppression rule moved into each kind's own factory**: two-way env wins the name; the push fallback builds only when two-way is unconfigured. Previously spread across `buildPushChannels` + three `twoWay*` predicates.
- **The 7 pure push kinds gain `#label` multi-account, per-instance live keys, and per-instance brief sinks** — this closes the 34-manifests-vs-27-wirings drift the scan flagged.
- **Deleted**: `overlayEnv` (process-global `os.Setenv` hack) + its test, `buildAccountsLegacy` + the reflect typed-nil probe, `buildPushChannels`, `twoWay*` predicates, the 27-element `allInsts` literal, ~25 transport imports from main.go.
- **Manifest gains `BannerLabel`/`DisabledHint`**; the channel section of main.go is now ONE `Manifests()` loop (~20 lines). Adding a channel = manifest entry + factory; zero main.go edits.
- **Permanent drift alarm**: `factory_ratchet_test.go` — a manifest kind with no factory (and vice versa) fails tests instead of silently shipping unreachable.

## Behavior deltas (intentional)
- Boot banner prints in Manifests() display order (was hand-ordered); push kinds get per-kind lines instead of one combined line.
- Wrong suppression/config states behave identically (factory-level tests in `factories_push_test.go` pin two-way-wins across all 7 dual kinds).

Verified: whole-tree build + vet, GOOS=linux cross-build, full Go suite (kernel+cmd+plugins) green after every batch. (Self-hosted CI runners offline.)