### PR TITLE
refactor(controlplane): Phase 2.3 — command registry, 642-line dispatch switch retired

### DIFF
--- a/kernel/controlplane/board.go
+++ b/kernel/controlplane/board.go
@@ -360,3 +360,16 @@ func (s *Server) handleBoardReplies(conn net.Conn, req Request) {
 		Result: map[string]any{"id": id, "replies": views, "count": len(views)},
 	})
 }
+
+// registerBoardCommands registers this file's protocol commands into the dispatch registry (phase 2.3).
+func registerBoardCommands() {
+	register(
+		commandSpec{Cmd: CmdBoardRead, Handler: func(dc *DispatchCtx) { dc.S.handleBoardRead(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdBoardHelp, Handler: func(dc *DispatchCtx) { dc.S.handleBoardHelp(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdBoardSend, Handler: func(dc *DispatchCtx) { dc.S.handleBoardSend(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdBoardInbox, Handler: func(dc *DispatchCtx) { dc.S.handleBoardInbox(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdBoardAck, Handler: func(dc *DispatchCtx) { dc.S.handleBoardAck(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdBoardReplies, Handler: func(dc *DispatchCtx) { dc.S.handleBoardReplies(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdBoardGet, Handler: func(dc *DispatchCtx) { dc.S.handleBoardGet(dc.Conn, dc.Req) }},
+	)
+}

--- a/kernel/controlplane/catalog.go
+++ b/kernel/controlplane/catalog.go
@@ -336,3 +336,14 @@ func (s *Server) handleProviderReload(conn net.Conn, req Request) {
 	}
 	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: result})
 }
+
+// registerCatalogCommands registers this file's protocol commands into the dispatch registry (phase 2.3).
+func registerCatalogCommands() {
+	register(
+		commandSpec{Cmd: CmdCatalogSync, Handler: func(dc *DispatchCtx) { dc.S.handleCatalogSync(dc.Ctx, dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdCatalogList, Handler: func(dc *DispatchCtx) { dc.S.handleCatalogList(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdCatalogDiscover, Handler: func(dc *DispatchCtx) { dc.S.handleCatalogDiscover(dc.Ctx, dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdProviderReload, Handler: func(dc *DispatchCtx) { dc.S.handleProviderReload(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdProviderConnect, Handler: func(dc *DispatchCtx) { dc.S.handleProviderConnect(dc.Conn, dc.Req) }},
+	)
+}

--- a/kernel/controlplane/chatsummary.go
+++ b/kernel/controlplane/chatsummary.go
@@ -51,11 +51,9 @@ func (s *Server) handleChatSummarize(ctx context.Context, conn net.Conn, req Req
 	if len(transcript) > chatSummaryInputCap {
 		transcript = transcript[len(transcript)-chatSummaryInputCap:]
 	}
-	// A disconnected client can't receive the briefing — cancel the summarize
-	// call instead of spending it into a closed connection.
-	ctx, cancel := cancelOnConnClose(ctx, conn)
-	defer cancel()
-
+	// ctx is already tied to the connection by dispatch (StreamLive): a
+	// disconnected client can't receive the briefing, so the summarize call is
+	// cancelled instead of being spent into a closed connection.
 	resp, err := provider.Complete(ctx, agent.CompletionRequest{
 		Model:     model,
 		TaskType:  "summarize",

--- a/kernel/controlplane/conductor.go
+++ b/kernel/controlplane/conductor.go
@@ -54,11 +54,9 @@ func (s *Server) handleConductorAsk(ctx context.Context, conn net.Conn, req Requ
 	if corr == "" {
 		corr = s.k.NewCorrelation()
 	}
-	// A disconnected client can't receive the answer — cancel the Thinker→
-	// Worker→Verifier loop instead of spending it into a closed connection.
-	ctx, cancel := cancelOnConnClose(ctx, conn)
-	defer cancel()
-
+	// ctx is already tied to the connection by dispatch (StreamLive): a
+	// disconnected client can't receive the answer, so the Thinker→Worker→
+	// Verifier loop is cancelled instead of being spent into a closed connection.
 	res, err := s.k.Conduct(ctx, corr, runtime.ConductorConfig{
 		Task:      task,
 		Thinker:   stringArg(req.Args, "thinker"),

--- a/kernel/controlplane/configcenter_handler.go
+++ b/kernel/controlplane/configcenter_handler.go
@@ -482,3 +482,18 @@ func configCenterCleanList(in []string) []string {
 	}
 	return out
 }
+
+// registerConfigCenterCommands registers this file's protocol commands into the dispatch registry (phase 2.3).
+func registerConfigCenterCommands() {
+	register(
+		commandSpec{Cmd: CmdConfigCenterSet, Handler: func(dc *DispatchCtx) { dc.S.handleConfigCenterSet(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdConfigCenterGet, Handler: func(dc *DispatchCtx) { dc.S.handleConfigCenterGet(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdConfigCenterList, Handler: func(dc *DispatchCtx) { dc.S.handleConfigCenterList(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdConfigCenterDelete, Handler: func(dc *DispatchCtx) { dc.S.handleConfigCenterDelete(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdConfigCenterSetRating, Handler: func(dc *DispatchCtx) { dc.S.handleConfigCenterSetRating(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdConfigCenterSetAccess, Handler: func(dc *DispatchCtx) { dc.S.handleConfigCenterSetAccess(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdConfigCenterAccessLog, Handler: func(dc *DispatchCtx) { dc.S.handleConfigCenterAccessLog(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdConfigCenterAudit, Handler: func(dc *DispatchCtx) { dc.S.handleConfigCenterAudit(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdConfigCenterHealth, Handler: func(dc *DispatchCtx) { dc.S.handleConfigCenterHealth(dc.Conn, dc.Req) }},
+	)
+}

--- a/kernel/controlplane/council.go
+++ b/kernel/controlplane/council.go
@@ -71,11 +71,10 @@ func (s *Server) handleCouncilAsk(ctx context.Context, conn net.Conn, req Reques
 	if corr == "" {
 		corr = s.k.NewCorrelation()
 	}
-	// A disconnected client can't receive the deliberation — cancel the panel
-	// instead of spending every seat's model call into a closed connection.
-	ctx, cancel := cancelOnConnClose(ctx, conn)
-	defer cancel()
-
+	// ctx is already tied to the connection by dispatch (StreamLive): a
+	// disconnected client can't receive the deliberation, so the panel is
+	// cancelled instead of spending every seat's model call into a closed
+	// connection.
 	res, err := s.k.Council(ctx, corr, question, nil, rounds)
 	if err != nil {
 		s.fail(conn, req, err)

--- a/kernel/controlplane/datalake.go
+++ b/kernel/controlplane/datalake.go
@@ -304,3 +304,16 @@ func dlInt(args map[string]any, key string) int {
 		return 0
 	}
 }
+
+// registerDatalakeCommands registers this file's protocol commands into the dispatch registry (phase 2.3).
+func registerDatalakeCommands() {
+	register(
+		commandSpec{Cmd: CmdDataCollections, Handler: func(dc *DispatchCtx) { dc.S.handleDataCollections(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdDataRecords, Handler: func(dc *DispatchCtx) { dc.S.handleDataRecords(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdDataInsert, Handler: func(dc *DispatchCtx) { dc.S.handleDataInsert(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdDataUpdate, Handler: func(dc *DispatchCtx) { dc.S.handleDataUpdate(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdDataDelete, Handler: func(dc *DispatchCtx) { dc.S.handleDataDelete(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdDataCreateCollection, Handler: func(dc *DispatchCtx) { dc.S.handleDataCreateCollection(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdDataDropCollection, Handler: func(dc *DispatchCtx) { dc.S.handleDataDropCollection(dc.Conn, dc.Req) }},
+	)
+}

--- a/kernel/controlplane/dispatch.go
+++ b/kernel/controlplane/dispatch.go
@@ -10,11 +10,12 @@ import (
 	"github.com/agezt/agezt/kernel/runtime"
 )
 
-// Phase 2.3 (commit A): a declarative command registry that MIRRORS the
-// 319-case switch in handleConn. Nothing dispatches through it yet — commit B
-// swaps handleConn onto it and deletes the switch plus tenantTokenAllows.
-// Until then, dispatch_registry_test.go pins the registry 1:1 against the
-// protocol constants, the legacy switch, and the legacy tenant allowlist.
+// Phase 2.3: the declarative command registry handleConn dispatches through.
+// Every protocol command is a commandSpec registered by its subsystem
+// (registry.go's registerAllCommands); handleConn authenticates, looks the
+// command up, and hands a DispatchCtx to the spec's handler.
+// dispatch_registry_test.go pins the registry 1:1 against the protocol
+// constants; tenant_auth_test.go sweeps the TenantAllowed surface end-to-end.
 
 // DispatchCtx carries everything a command handler needs for one request.
 // K is the pre-resolved kernel for the request (the primary kernel, or the
@@ -34,7 +35,7 @@ type DispatchCtx struct {
 type Handler func(*DispatchCtx)
 
 // StreamMode classifies how a command uses the connection after the request
-// is read (drives deadline handling and disconnect-cancellation in commit B).
+// is read (drives deadline handling and disconnect-cancellation in dispatch).
 type StreamMode int
 
 const (
@@ -43,19 +44,37 @@ const (
 	// StreamEvents: emits RespEvent progress before the final result, but is
 	// bounded work — the read/write deadline stays in place.
 	StreamEvents
-	// StreamLive: long-lived streaming (subscription or LLM stream) — the
-	// deadline is cleared and the handler's context is cancelled when the
-	// client disconnects.
+	// StreamLive: long-lived streaming (subscription or LLM stream) —
+	// dispatch wraps the handler's context via cancelOnConnClose, which
+	// clears the read deadline and cancels the context when the client
+	// disconnects. A StreamLive handler must NOT call cancelOnConnClose (or
+	// otherwise read the conn) itself: two goroutines reading one conn race.
+	// A handler that needs its own connection lifecycle (pulse_subscribe's
+	// timeout-tolerant disconnect watcher) stays StreamNone and manages the
+	// deadline itself — see its registration comment.
 	StreamLive
 )
 
-// commandSpec declares one protocol command: its handler plus the metadata
-// that today lives implicitly in handleConn and tenantTokenAllows.
+// commandSpec declares one protocol command: its handler plus the dispatch
+// metadata handleConn acts on.
 //
-//   - TenantAllowed: a TENANT token may invoke it (copied verbatim from the
-//     tenantTokenAllows allowlist; deny-by-default).
+//   - TenantAllowed: a TENANT token may invoke it — the deny-by-default
+//     allowlist (M38). It marks exactly the commands that route to the
+//     caller's kernel via kernelFor/edictFor: running and cancelling the
+//     tenant's own work, managing the tenant's own Edict policy, and
+//     observing the tenant's own isolated subsystems (M128: the read-only
+//     journal folds — runs, tools, edict, rate-limit, netguard, webhooks,
+//     memory, world, approvals, plan, provider-routing, schedule-firing,
+//     warden). Everything else — tenant-registry management (incl.
+//     cross-tenant tenant_stats), daemon-global halt/resume/shutdown, pulse,
+//     durable-policy compaction (a mutation), and anything reading the
+//     primary kernel — requires the primary token. New tenant-routed commands
+//     must set it explicitly; forgetting to is the safe failure (the tenant
+//     is denied, not over-granted). TestTenantToken_* sweeps both directions
+//     end-to-end.
 //   - TenantRouted: the handler resolves its kernel per-request via
-//     kernelFor / edictFor / projectJournal rather than using s.k directly.
+//     kernelFor / edictFor / projectJournal rather than using s.k directly
+//     (dispatch also pre-resolves dc.K via kernelFor at the boundary).
 //     Invariant (TestRegistry_TenantAllowedImpliesTenantRouted): every
 //     TenantAllowed command must be TenantRouted, or a tenant token would
 //     read the PRIMARY kernel's data. whoami is the sole, explicit exception.

--- a/kernel/controlplane/dispatch.go
+++ b/kernel/controlplane/dispatch.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+
+package controlplane
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/agezt/agezt/kernel/runtime"
+)
+
+// Phase 2.3 (commit A): a declarative command registry that MIRRORS the
+// 319-case switch in handleConn. Nothing dispatches through it yet — commit B
+// swaps handleConn onto it and deletes the switch plus tenantTokenAllows.
+// Until then, dispatch_registry_test.go pins the registry 1:1 against the
+// protocol constants, the legacy switch, and the legacy tenant allowlist.
+
+// DispatchCtx carries everything a command handler needs for one request.
+// K is the pre-resolved kernel for the request (the primary kernel, or the
+// tenant's kernel for tenant-routed commands) so handlers no longer each
+// re-derive it via kernelFor(tenantOf(req)).
+type DispatchCtx struct {
+	Ctx     context.Context
+	Conn    net.Conn
+	Req     Request
+	S       *Server
+	K       *runtime.Kernel
+	Tenant  string // authorized tenant id ("" for the primary token)
+	Primary bool   // true when the request carried the primary token
+}
+
+// Handler executes one protocol command.
+type Handler func(*DispatchCtx)
+
+// StreamMode classifies how a command uses the connection after the request
+// is read (drives deadline handling and disconnect-cancellation in commit B).
+type StreamMode int
+
+const (
+	// StreamNone: plain request/response — one result or error, keep deadline.
+	StreamNone StreamMode = iota
+	// StreamEvents: emits RespEvent progress before the final result, but is
+	// bounded work — the read/write deadline stays in place.
+	StreamEvents
+	// StreamLive: long-lived streaming (subscription or LLM stream) — the
+	// deadline is cleared and the handler's context is cancelled when the
+	// client disconnects.
+	StreamLive
+)
+
+// commandSpec declares one protocol command: its handler plus the metadata
+// that today lives implicitly in handleConn and tenantTokenAllows.
+//
+//   - TenantAllowed: a TENANT token may invoke it (copied verbatim from the
+//     tenantTokenAllows allowlist; deny-by-default).
+//   - TenantRouted: the handler resolves its kernel per-request via
+//     kernelFor / edictFor / projectJournal rather than using s.k directly.
+//     Invariant (TestRegistry_TenantAllowedImpliesTenantRouted): every
+//     TenantAllowed command must be TenantRouted, or a tenant token would
+//     read the PRIMARY kernel's data. whoami is the sole, explicit exception.
+//   - Streaming: see StreamMode.
+type commandSpec struct {
+	Cmd           string
+	Handler       Handler
+	TenantAllowed bool
+	TenantRouted  bool
+	Streaming     StreamMode
+}
+
+// commandRegistry maps command name → spec. Populated once at init by
+// registerAllCommands; read-only afterwards.
+var commandRegistry = map[string]commandSpec{}
+
+// register adds specs to commandRegistry, panicking on duplicates or empty
+// command names — both are programmer errors caught at process start (and by
+// every test run, since init runs first).
+func register(specs ...commandSpec) {
+	for _, sp := range specs {
+		if sp.Cmd == "" {
+			panic("controlplane: register: empty command name")
+		}
+		if sp.Handler == nil {
+			panic(fmt.Sprintf("controlplane: register: nil handler for %q", sp.Cmd))
+		}
+		if _, dup := commandRegistry[sp.Cmd]; dup {
+			panic(fmt.Sprintf("controlplane: register: duplicate command %q", sp.Cmd))
+		}
+		commandRegistry[sp.Cmd] = sp
+	}
+}

--- a/kernel/controlplane/dispatch_registry_test.go
+++ b/kernel/controlplane/dispatch_registry_test.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: MIT
+
+package controlplane
+
+import (
+	"os"
+	"regexp"
+	"sort"
+	"testing"
+)
+
+// Phase 2.3 commit-A bridge tests: the command registry must be a PERFECT
+// mirror of the legacy dispatch surface before commit B swaps handleConn onto
+// it. Two of these tests pin the registry against legacy code that commit B
+// deletes (and are deleted with it); the tenant-isolation invariant test is
+// permanent.
+
+// cmdConstRe matches the Cmd* string constants in protocol.go, e.g.
+//
+//	CmdVersion       = "version"
+var cmdConstRe = regexp.MustCompile(`(?m)^\s*(Cmd\w+)\s*=\s*"([^"]+)"`)
+
+// protocolCommands returns constName→value for every Cmd* const in protocol.go.
+func protocolCommands(t *testing.T) map[string]string {
+	t.Helper()
+	src, err := os.ReadFile("protocol.go")
+	if err != nil {
+		t.Fatalf("read protocol.go: %v", err)
+	}
+	out := map[string]string{}
+	for _, m := range cmdConstRe.FindAllStringSubmatch(string(src), -1) {
+		if prev, dup := out[m[1]]; dup {
+			t.Fatalf("protocol.go: const %s defined twice (%q, %q)", m[1], prev, m[2])
+		}
+		out[m[1]] = m[2]
+	}
+	if len(out) == 0 {
+		t.Fatal("protocol.go: no Cmd* constants matched — regexp or file layout changed")
+	}
+	return out
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	sort.Strings(ks)
+	return ks
+}
+
+// TestRegistry_MatchesProtocolConstants asserts set equality between the Cmd*
+// constants declared in protocol.go and the commands in commandRegistry, in
+// both directions. A new protocol command MUST be registered (add a
+// commandSpec to the owning subsystem's registerXCommands), and the registry
+// must never carry a command the protocol no longer declares.
+func TestRegistry_MatchesProtocolConstants(t *testing.T) {
+	consts := protocolCommands(t)
+	declared := map[string]string{} // value → const name
+	for name, val := range consts {
+		if prev, dup := declared[val]; dup {
+			t.Errorf("protocol.go: command string %q declared by both %s and %s", val, prev, name)
+		}
+		declared[val] = name
+	}
+	for _, val := range sortedKeys(declared) {
+		if _, ok := commandRegistry[val]; !ok {
+			t.Errorf("protocol.go declares %s = %q but it is not registered — add a commandSpec for it in the owning subsystem's registerXCommands()", declared[val], val)
+		}
+	}
+	for _, cmd := range sortedKeys(commandRegistry) {
+		if _, ok := declared[cmd]; !ok {
+			t.Errorf("registry contains %q which no Cmd* constant in protocol.go declares — remove the stale commandSpec", cmd)
+		}
+	}
+	if len(declared) != len(commandRegistry) {
+		t.Errorf("protocol.go declares %d commands, registry has %d", len(declared), len(commandRegistry))
+	}
+}
+
+// TestRegistry_MatchesOldSwitch asserts set equality between the `case Cmd*:`
+// arms of handleConn's dispatch switch in server.go and commandRegistry.
+// DELETE in commit B (the switch itself is deleted then).
+func TestRegistry_MatchesOldSwitch(t *testing.T) {
+	consts := protocolCommands(t)
+	src, err := os.ReadFile("server.go")
+	if err != nil {
+		t.Fatalf("read server.go: %v", err)
+	}
+	caseRe := regexp.MustCompile(`(?m)^\s*case (Cmd\w+):`)
+	inSwitch := map[string]string{} // value → const name
+	for _, m := range caseRe.FindAllStringSubmatch(string(src), -1) {
+		val, ok := consts[m[1]]
+		if !ok {
+			t.Fatalf("server.go: case %s: not a Cmd* constant declared in protocol.go", m[1])
+		}
+		if prev, dup := inSwitch[val]; dup {
+			t.Errorf("server.go: duplicate case for %q (%s and %s)", val, prev, m[1])
+		}
+		inSwitch[val] = m[1]
+	}
+	if len(inSwitch) == 0 {
+		t.Fatal("server.go: no `case Cmd*:` arms matched — regexp or file layout changed")
+	}
+	for _, val := range sortedKeys(inSwitch) {
+		if _, ok := commandRegistry[val]; !ok {
+			t.Errorf("handleConn switch dispatches %s (%q) but the registry does not — add a commandSpec", inSwitch[val], val)
+		}
+	}
+	for _, cmd := range sortedKeys(commandRegistry) {
+		if _, ok := inSwitch[cmd]; !ok {
+			t.Errorf("registry contains %q which handleConn's switch does not dispatch — the registry must mirror the switch until commit B", cmd)
+		}
+	}
+}
+
+// TestRegistry_TenantAllowedMatchesLegacyAllowlist asserts that every spec's
+// TenantAllowed flag equals tenantTokenAllows(cmd) — the registry copies the
+// legacy allowlist verbatim. DELETE in commit B (tenantTokenAllows is deleted
+// then; tenant_auth_test gains a registry-driven exhaustive table instead).
+func TestRegistry_TenantAllowedMatchesLegacyAllowlist(t *testing.T) {
+	for _, cmd := range sortedKeys(commandRegistry) {
+		spec := commandRegistry[cmd]
+		if got, want := spec.TenantAllowed, tenantTokenAllows(cmd); got != want {
+			t.Errorf("%q: spec.TenantAllowed=%v but tenantTokenAllows=%v — the registry must mirror tenant.go's allowlist verbatim", cmd, got, want)
+		}
+	}
+}
+
+// TestRegistry_TenantAllowedImpliesTenantRouted is PERMANENT: it enforces the
+// real tenant-isolation invariant. Every command a tenant token may invoke
+// must route to the caller's kernel (kernelFor / edictFor / projectJournal);
+// a TenantAllowed handler that reads s.k directly would leak the PRIMARY
+// kernel's data to a tenant.
+//
+// Sole exemption: whoami. handleWhoami only echoes the caller's identity
+// (primary/tenant + the pinned tenant id from req.Args) and never touches any
+// kernel, so there is nothing to route.
+func TestRegistry_TenantAllowedImpliesTenantRouted(t *testing.T) {
+	for _, cmd := range sortedKeys(commandRegistry) {
+		spec := commandRegistry[cmd]
+		if !spec.TenantAllowed || spec.TenantRouted {
+			continue
+		}
+		if cmd == CmdWhoami {
+			continue // identity echo — touches no kernel (see doc comment)
+		}
+		t.Errorf("%q is TenantAllowed but not TenantRouted — a tenant token would read the primary kernel's data; route the handler via kernelFor(tenantOf(req)) (or edictFor/projectJournal) and set TenantRouted", cmd)
+	}
+}

--- a/kernel/controlplane/dispatch_registry_test.go
+++ b/kernel/controlplane/dispatch_registry_test.go
@@ -9,11 +9,10 @@ import (
 	"testing"
 )
 
-// Phase 2.3 commit-A bridge tests: the command registry must be a PERFECT
-// mirror of the legacy dispatch surface before commit B swaps handleConn onto
-// it. Two of these tests pin the registry against legacy code that commit B
-// deletes (and are deleted with it); the tenant-isolation invariant test is
-// permanent.
+// Registry invariants: the command registry IS the dispatch surface (handleConn
+// routes every request through it), so these tests pin it against protocol.go
+// and enforce the tenant-isolation invariant. The tenant allowlist itself is
+// swept end-to-end by tenant_auth_test.go's registry-driven exhaustive test.
 
 // cmdConstRe matches the Cmd* string constants in protocol.go, e.g.
 //
@@ -75,55 +74,6 @@ func TestRegistry_MatchesProtocolConstants(t *testing.T) {
 	}
 	if len(declared) != len(commandRegistry) {
 		t.Errorf("protocol.go declares %d commands, registry has %d", len(declared), len(commandRegistry))
-	}
-}
-
-// TestRegistry_MatchesOldSwitch asserts set equality between the `case Cmd*:`
-// arms of handleConn's dispatch switch in server.go and commandRegistry.
-// DELETE in commit B (the switch itself is deleted then).
-func TestRegistry_MatchesOldSwitch(t *testing.T) {
-	consts := protocolCommands(t)
-	src, err := os.ReadFile("server.go")
-	if err != nil {
-		t.Fatalf("read server.go: %v", err)
-	}
-	caseRe := regexp.MustCompile(`(?m)^\s*case (Cmd\w+):`)
-	inSwitch := map[string]string{} // value → const name
-	for _, m := range caseRe.FindAllStringSubmatch(string(src), -1) {
-		val, ok := consts[m[1]]
-		if !ok {
-			t.Fatalf("server.go: case %s: not a Cmd* constant declared in protocol.go", m[1])
-		}
-		if prev, dup := inSwitch[val]; dup {
-			t.Errorf("server.go: duplicate case for %q (%s and %s)", val, prev, m[1])
-		}
-		inSwitch[val] = m[1]
-	}
-	if len(inSwitch) == 0 {
-		t.Fatal("server.go: no `case Cmd*:` arms matched — regexp or file layout changed")
-	}
-	for _, val := range sortedKeys(inSwitch) {
-		if _, ok := commandRegistry[val]; !ok {
-			t.Errorf("handleConn switch dispatches %s (%q) but the registry does not — add a commandSpec", inSwitch[val], val)
-		}
-	}
-	for _, cmd := range sortedKeys(commandRegistry) {
-		if _, ok := inSwitch[cmd]; !ok {
-			t.Errorf("registry contains %q which handleConn's switch does not dispatch — the registry must mirror the switch until commit B", cmd)
-		}
-	}
-}
-
-// TestRegistry_TenantAllowedMatchesLegacyAllowlist asserts that every spec's
-// TenantAllowed flag equals tenantTokenAllows(cmd) — the registry copies the
-// legacy allowlist verbatim. DELETE in commit B (tenantTokenAllows is deleted
-// then; tenant_auth_test gains a registry-driven exhaustive table instead).
-func TestRegistry_TenantAllowedMatchesLegacyAllowlist(t *testing.T) {
-	for _, cmd := range sortedKeys(commandRegistry) {
-		spec := commandRegistry[cmd]
-		if got, want := spec.TenantAllowed, tenantTokenAllows(cmd); got != want {
-			t.Errorf("%q: spec.TenantAllowed=%v but tenantTokenAllows=%v — the registry must mirror tenant.go's allowlist verbatim", cmd, got, want)
-		}
 	}
 }
 

--- a/kernel/controlplane/edict.go
+++ b/kernel/controlplane/edict.go
@@ -359,3 +359,16 @@ func (s *Server) handleEdictSetMode(conn net.Conn, req Request) {
 // askPolicyLabel maps the AskPolicy enum to the operator-facing strings
 // AGEZT_APPROVAL_MODE accepts — now a thin alias over AskPolicy.String().
 func askPolicyLabel(p edict.AskPolicy) string { return p.String() }
+
+// registerEdictCommands registers this file's protocol commands into the dispatch registry (phase 2.3).
+func registerEdictCommands() {
+	register(
+		commandSpec{Cmd: CmdEdictShow, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleEdictShow(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdEdictTest, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleEdictTest(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdEdictDenyList, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleEdictDenyList(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdEdictDenyAdd, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleEdictDenyAdd(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdEdictDenyRemove, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleEdictDenyRemove(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdEdictSetLevel, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleEdictSetLevel(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdEdictSetMode, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleEdictSetMode(dc.Conn, dc.Req) }},
+	)
+}

--- a/kernel/controlplane/export_test.go
+++ b/kernel/controlplane/export_test.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+
+package controlplane
+
+// Test-only exports for the external controlplane_test package.
+
+// CommandSpecForTest is the dispatch metadata of one registered command,
+// exposed so tenant_auth_test.go can sweep the ENTIRE tenant-token surface
+// straight from the registry (no hand-maintained command list to go stale).
+type CommandSpecForTest struct {
+	Cmd           string
+	TenantAllowed bool
+	Streaming     StreamMode
+}
+
+// CommandSpecsForTest snapshots the command registry's dispatch metadata.
+func CommandSpecsForTest() []CommandSpecForTest {
+	out := make([]CommandSpecForTest, 0, len(commandRegistry))
+	for cmd, sp := range commandRegistry {
+		out = append(out, CommandSpecForTest{Cmd: cmd, TenantAllowed: sp.TenantAllowed, Streaming: sp.Streaming})
+	}
+	return out
+}

--- a/kernel/controlplane/market.go
+++ b/kernel/controlplane/market.go
@@ -288,3 +288,17 @@ func (s *Server) publishMarket(kind string, payload map[string]any) {
 	}
 	_, _ = s.k.Bus().Publish(event.Spec{Subject: "market", Kind: event.Kind(kind), Actor: "market", Payload: payload})
 }
+
+// registerMarketCommands registers this file's protocol commands into the dispatch registry (phase 2.3).
+func registerMarketCommands() {
+	register(
+		commandSpec{Cmd: CmdMarketList, Handler: func(dc *DispatchCtx) { dc.S.handleMarketList(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdMarketShow, Handler: func(dc *DispatchCtx) { dc.S.handleMarketShow(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdMarketInstall, Streaming: StreamEvents, Handler: func(dc *DispatchCtx) { dc.S.handleMarketInstall(dc.Ctx, dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdMarketUninstall, Streaming: StreamEvents, Handler: func(dc *DispatchCtx) { dc.S.handleMarketUninstall(dc.Ctx, dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdMarketSources, Handler: func(dc *DispatchCtx) { dc.S.handleMarketSources(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdMarketAddSource, Handler: func(dc *DispatchCtx) { dc.S.handleMarketAddSource(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdMarketRemoveSource, Handler: func(dc *DispatchCtx) { dc.S.handleMarketRemoveSource(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdMarketSync, Handler: func(dc *DispatchCtx) { dc.S.handleMarketSync(dc.Ctx, dc.Conn, dc.Req) }},
+	)
+}

--- a/kernel/controlplane/mcp.go
+++ b/kernel/controlplane/mcp.go
@@ -175,3 +175,15 @@ func (s *Server) handleMCPRemove(conn net.Conn, req Request) {
 	}
 	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{"removed": ok}})
 }
+
+// registerMCPCommands registers this file's protocol commands into the dispatch registry (phase 2.3).
+func registerMCPCommands() {
+	register(
+		commandSpec{Cmd: CmdMCPList, Handler: func(dc *DispatchCtx) { dc.S.handleMCPList(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdMCPAdd, Handler: func(dc *DispatchCtx) { dc.S.handleMCPAdd(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdMCPAttach, Handler: func(dc *DispatchCtx) { dc.S.handleMCPAttach(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdMCPDetach, Handler: func(dc *DispatchCtx) { dc.S.handleMCPDetach(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdMCPSetEnabled, Handler: func(dc *DispatchCtx) { dc.S.handleMCPSetEnabled(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdMCPRemove, Handler: func(dc *DispatchCtx) { dc.S.handleMCPRemove(dc.Conn, dc.Req) }},
+	)
+}

--- a/kernel/controlplane/memory.go
+++ b/kernel/controlplane/memory.go
@@ -620,3 +620,24 @@ func jsonMap(v any) (map[string]any, error) {
 	err = json.Unmarshal(b, &out)
 	return out, err
 }
+
+// registerMemoryCommands registers this file's protocol commands into the dispatch registry (phase 2.3).
+func registerMemoryCommands() {
+	register(
+		commandSpec{Cmd: CmdMemoryAdd, Handler: func(dc *DispatchCtx) { dc.S.handleMemoryAdd(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdMemorySupersede, Handler: func(dc *DispatchCtx) { dc.S.handleMemorySupersede(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdMemoryList, Handler: func(dc *DispatchCtx) { dc.S.handleMemoryList(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdMemoryGet, Handler: func(dc *DispatchCtx) { dc.S.handleMemoryGet(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdMemorySearch, Handler: func(dc *DispatchCtx) { dc.S.handleMemorySearch(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdMemoryConsolidate, Handler: func(dc *DispatchCtx) { dc.S.handleMemoryConsolidate(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdProfileRebuild, Handler: func(dc *DispatchCtx) { dc.S.handleProfileRebuild(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdMemoryForget, Handler: func(dc *DispatchCtx) { dc.S.handleMemoryForget(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdMemoryPromote, Handler: func(dc *DispatchCtx) { dc.S.handleMemoryPromote(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdMemoryPrune, Handler: func(dc *DispatchCtx) { dc.S.handleMemoryPrune(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdMemoryTidy, Handler: func(dc *DispatchCtx) { dc.S.handleMemoryTidy(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdMemoryBulkForget, Handler: func(dc *DispatchCtx) { dc.S.handleMemoryBulkForget(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdMemoryFindRelated, Handler: func(dc *DispatchCtx) { dc.S.handleMemoryFindRelated(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdMemoryAudit, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleMemoryAudit(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdMemoryClean, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleMemoryClean(dc.Conn, dc.Req) }},
+	)
+}

--- a/kernel/controlplane/okr.go
+++ b/kernel/controlplane/okr.go
@@ -112,3 +112,16 @@ func okrWriteResp(s *Server, conn net.Conn, req Request, o okr.Objective, err er
 	}
 	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{"objective": okrObjectiveView(s, o)}})
 }
+
+// registerOKRCommands registers this file's protocol commands into the dispatch registry (phase 2.3).
+func registerOKRCommands() {
+	register(
+		commandSpec{Cmd: CmdOKRList, Handler: func(dc *DispatchCtx) { dc.S.handleOKRList(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdOKRShow, Handler: func(dc *DispatchCtx) { dc.S.handleOKRShow(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdOKRCreate, Handler: func(dc *DispatchCtx) { dc.S.handleOKRCreate(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdOKRKeyResult, Handler: func(dc *DispatchCtx) { dc.S.handleOKRKeyResult(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdOKRLink, Handler: func(dc *DispatchCtx) { dc.S.handleOKRLink(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdOKRUnlink, Handler: func(dc *DispatchCtx) { dc.S.handleOKRUnlink(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdOKRArchive, Handler: func(dc *DispatchCtx) { dc.S.handleOKRArchive(dc.Conn, dc.Req) }},
+	)
+}

--- a/kernel/controlplane/planner.go
+++ b/kernel/controlplane/planner.go
@@ -55,11 +55,9 @@ func (s *Server) handlePlanGenerate(ctx context.Context, conn net.Conn, req Requ
 		return
 	}
 
-	// A disconnected client can't receive the plan — cancel generation instead
-	// of spending it into a closed connection.
-	ctx, cancel := cancelOnConnClose(ctx, conn)
-	defer cancel()
-
+	// ctx is already tied to the connection by dispatch (StreamLive): a
+	// disconnected client can't receive the plan, so generation is cancelled
+	// instead of being spent into a closed connection.
 	rawJSON, plan, err := planner.Generate(ctx, cfg, intent)
 	if err != nil {
 		s.fail(conn, req, err)
@@ -124,11 +122,9 @@ func (s *Server) handlePlanRefine(ctx context.Context, conn net.Conn, req Reques
 		return
 	}
 
-	// A disconnected client can't receive the revision — cancel refinement
-	// instead of spending it into a closed connection.
-	ctx, cancel := cancelOnConnClose(ctx, conn)
-	defer cancel()
-
+	// ctx is already tied to the connection by dispatch (StreamLive): a
+	// disconnected client can't receive the revision, so refinement is
+	// cancelled instead of being spent into a closed connection.
 	rawJSON, revised, err := planner.Refine(ctx, cfg, original, feedback)
 	if err != nil {
 		s.fail(conn, req, err)

--- a/kernel/controlplane/pulse_control.go
+++ b/kernel/controlplane/pulse_control.go
@@ -288,3 +288,22 @@ func (s *Server) handlePulseFlush(conn net.Conn, req Request) {
 	n := s.pulse.FlushDigest()
 	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{"flushed": n}})
 }
+
+// registerPulseControlCommands registers this file's protocol commands into the dispatch registry (phase 2.3).
+func registerPulseControlCommands() {
+	register(
+		commandSpec{Cmd: CmdPulseStatus, Handler: func(dc *DispatchCtx) { dc.S.handlePulseStatus(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdPulseAsks, Handler: func(dc *DispatchCtx) { dc.S.handlePulseAsks(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdPulseAskResolve, Handler: func(dc *DispatchCtx) { dc.S.handlePulseAskResolve(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdPulsePause, Handler: func(dc *DispatchCtx) { dc.S.handlePulsePause(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdPulseResume, Handler: func(dc *DispatchCtx) { dc.S.handlePulseResume(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdPulseBeat, Handler: func(dc *DispatchCtx) { dc.S.handlePulseBeat(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdPulseCadence, Handler: func(dc *DispatchCtx) { dc.S.handlePulseCadence(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdPulseDial, Handler: func(dc *DispatchCtx) { dc.S.handlePulseDial(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdPulseFlush, Handler: func(dc *DispatchCtx) { dc.S.handlePulseFlush(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdPulseWatch, Handler: func(dc *DispatchCtx) { dc.S.handlePulseWatch(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdPulseProbe, Handler: func(dc *DispatchCtx) { dc.S.handlePulseProbe(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdPulseUnwatch, Handler: func(dc *DispatchCtx) { dc.S.handlePulseUnwatch(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdPulseQuiet, Handler: func(dc *DispatchCtx) { dc.S.handlePulseQuiet(dc.Conn, dc.Req) }},
+	)
+}

--- a/kernel/controlplane/registry.go
+++ b/kernel/controlplane/registry.go
@@ -125,7 +125,14 @@ func registerDaemonOpsCommands() {
 	register(
 		commandSpec{Cmd: CmdAutonomyFeed, Handler: func(dc *DispatchCtx) { dc.S.handleAutonomyFeed(dc.Conn, dc.Req) }},
 		commandSpec{Cmd: CmdDiskStats, Handler: func(dc *DispatchCtx) { dc.S.handleDiskStats(dc.Conn, dc.Req) }},
-		commandSpec{Cmd: CmdPulseSubscribe, Streaming: StreamLive, Handler: func(dc *DispatchCtx) { dc.S.handlePulseSubscribe(dc.Ctx, dc.Conn, dc.Req) }},
+		// pulse_subscribe is a long-lived stream but deliberately NOT StreamLive:
+		// it manages its own connection lifecycle (handlePulseSubscribe clears the
+		// read deadline itself and runs a bespoke disconnect watcher that re-arms
+		// 500ms read deadlines and treats read timeouts as "idle, not gone").
+		// Dispatch's cancelOnConnClose wrapper would add a SECOND goroutine
+		// reading the same conn (a race) and its blocking Read would trip on the
+		// watcher's 500ms deadlines, cancelling a healthy idle stream.
+		commandSpec{Cmd: CmdPulseSubscribe, Handler: func(dc *DispatchCtx) { dc.S.handlePulseSubscribe(dc.Ctx, dc.Conn, dc.Req) }},
 		commandSpec{Cmd: CmdReaperScan, Handler: func(dc *DispatchCtx) { dc.S.handleReaperScan(dc.Conn, dc.Req) }},
 		commandSpec{Cmd: CmdRedactTest, Handler: func(dc *DispatchCtx) { dc.S.handleRedactTest(dc.Conn, dc.Req) }},
 		commandSpec{Cmd: CmdRunsList, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleRunsList(dc.Conn, dc.Req) }},

--- a/kernel/controlplane/registry.go
+++ b/kernel/controlplane/registry.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: MIT
+
+package controlplane
+
+// Phase 2.3 (commit A): explicit registration of every protocol command.
+// Each subsystem file with 5+ handlers hosts its own registerXCommands() at
+// the bottom of that file; the ~35 small single-handler files are grouped
+// into the themed register funcs below. dispatch_registry_test.go asserts
+// 1:1 coverage against protocol.go, the legacy handleConn switch, and the
+// legacy tenantTokenAllows allowlist.
+
+func init() { registerAllCommands() }
+
+// registerAllCommands populates commandRegistry with all protocol commands,
+// one register func per subsystem. Explicit (not per-file init) so the full
+// registration order is readable in one place.
+func registerAllCommands() {
+	registerBoardCommands()
+	registerCatalogCommands()
+	registerChannelCommands()
+	registerCognitionCommands()
+	registerConfigCenterCommands()
+	registerCoreCommands()
+	registerDaemonOpsCommands()
+	registerDatalakeCommands()
+	registerEdictCommands()
+	registerJournalLogCommands()
+	registerMCPCommands()
+	registerMarketCommands()
+	registerMemoryCommands()
+	registerMiscSmallCommands()
+	registerOKRCommands()
+	registerProviderConfigCommands()
+	registerPulseControlCommands()
+	registerRosterCommands()
+	registerScheduleCommands()
+	registerSettingsCommands()
+	registerSkillCommands()
+	registerStandingCommands()
+	registerSteerCommands()
+	registerTenantCommands()
+	registerToolforgeCommands()
+	registerWorkboardCommands()
+	registerWorkflowCommands()
+	registerWorldCommands()
+}
+
+// registerJournalLogCommands registers Read-only journal projections and log/stat folds from small single-purpose files.
+func registerJournalLogCommands() {
+	register(
+		commandSpec{Cmd: CmdApprovalsLog, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleApprovalsLog(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdApprovalsStats, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleApprovalsStats(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdCacheStats, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleCacheStats(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdChangelog, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleChangelog(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdJournalTail, Handler: func(dc *DispatchCtx) { dc.S.handleJournalTail(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdJournalHead, Handler: func(dc *DispatchCtx) { dc.S.handleJournalHead(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdJournalExport, Handler: func(dc *DispatchCtx) { dc.S.handleJournalExport(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdJournalGrep, Handler: func(dc *DispatchCtx) { dc.S.handleJournalGrep(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdJournalStats, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleJournalStats(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdMemoryLog, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleMemoryLog(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdNetguardLog, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleNetguardLog(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdEdictLog, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleEdictLog(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdEdictStats, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleEdictStats(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdProviderLog, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleProviderLog(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdProviderStats, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleProviderStats(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdProviderRejections, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleProviderRejections(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdRateLimitLog, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleRateLimitLog(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdRateLimitStats, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleRateLimitStats(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdScheduleFires, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleScheduleFires(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdScheduleStats, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleScheduleStats(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdToolLog, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleToolLog(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdToolStats, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleToolStats(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWardenLog, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleWardenLog(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWardenStats, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleWardenStats(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWebhookLog, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleWebhookLog(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWebhookStats, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleWebhookStats(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorldLog, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleWorldLog(dc.Conn, dc.Req) }},
+	)
+}
+
+// registerProviderConfigCommands registers Provider credentials/OAuth, model routing/chains, budgets, execution profiles, config.
+func registerProviderConfigCommands() {
+	register(
+		commandSpec{Cmd: CmdBudget, Handler: func(dc *DispatchCtx) { dc.S.handleBudget(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdBudgetSet, Handler: func(dc *DispatchCtx) { dc.S.handleBudgetSet(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdChainsGet, Handler: func(dc *DispatchCtx) { dc.S.handleChainsGet(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdChainsSet, Handler: func(dc *DispatchCtx) { dc.S.handleChainsSet(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdConfig, Handler: func(dc *DispatchCtx) { dc.S.handleConfig(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdExecutionProfiles, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleExecutionProfiles(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdExecutionProfileShow, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleExecutionProfileShow(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdExecutionProfileCheck, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleExecutionProfileCheck(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdProviderKeyList, Handler: func(dc *DispatchCtx) { dc.S.handleProviderKeyList(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdProviderKeyAdd, Handler: func(dc *DispatchCtx) { dc.S.handleProviderKeyAdd(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdProviderKeyActivate, Handler: func(dc *DispatchCtx) { dc.S.handleProviderKeyActivate(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdProviderKeyRemove, Handler: func(dc *DispatchCtx) { dc.S.handleProviderKeyRemove(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdProviderOAuthStart, Handler: func(dc *DispatchCtx) { dc.S.handleProviderOAuthStart(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdProviderOAuthStatus, Handler: func(dc *DispatchCtx) { dc.S.handleProviderOAuthStatus(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdProviderOAuthImport, Handler: func(dc *DispatchCtx) { dc.S.handleProviderOAuthImport(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdProviderOAuthLogout, Handler: func(dc *DispatchCtx) { dc.S.handleProviderOAuthLogout(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdRoutingGet, Handler: func(dc *DispatchCtx) { dc.S.handleRoutingGet(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdRoutingSet, Handler: func(dc *DispatchCtx) { dc.S.handleRoutingSet(dc.Conn, dc.Req) }},
+	)
+}
+
+// registerChannelCommands registers Communication channels: accounts, OAuth, sessions, inbox, outbound send, ACP.
+func registerChannelCommands() {
+	register(
+		commandSpec{Cmd: CmdACPAgents, Handler: func(dc *DispatchCtx) { dc.S.handleACPAgents(dc.Ctx, dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdChannelAccountSet, Handler: func(dc *DispatchCtx) { dc.S.handleChannelAccountSet(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdChannelAccountRemove, Handler: func(dc *DispatchCtx) { dc.S.handleChannelAccountRemove(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdChannelOAuthStart, Handler: func(dc *DispatchCtx) { dc.S.handleChannelOAuthStart(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdChannelOAuthCallback, Handler: func(dc *DispatchCtx) { dc.S.handleChannelOAuthCallback(dc.Ctx, dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdChannelOAuthStatus, Handler: func(dc *DispatchCtx) { dc.S.handleChannelOAuthStatus(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdProviderProbe, Handler: func(dc *DispatchCtx) { dc.S.handleProviderProbe(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWhatsAppGatewayStatus, Handler: func(dc *DispatchCtx) { dc.S.handleWhatsAppGatewayStatus(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWhatsAppGatewayQR, Handler: func(dc *DispatchCtx) { dc.S.handleWhatsAppGatewayQR(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdChannelList, Handler: func(dc *DispatchCtx) { dc.S.handleChannelList(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdInbox, Handler: func(dc *DispatchCtx) { dc.S.handleInbox(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdSend, Handler: func(dc *DispatchCtx) { dc.S.handleSend(dc.Conn, dc.Req) }},
+	)
+}
+
+// registerDaemonOpsCommands registers Daemon operations: runs listing, state/status, disk, storage, sandbox, updates, shutdown.
+func registerDaemonOpsCommands() {
+	register(
+		commandSpec{Cmd: CmdAutonomyFeed, Handler: func(dc *DispatchCtx) { dc.S.handleAutonomyFeed(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdDiskStats, Handler: func(dc *DispatchCtx) { dc.S.handleDiskStats(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdPulseSubscribe, Streaming: StreamLive, Handler: func(dc *DispatchCtx) { dc.S.handlePulseSubscribe(dc.Ctx, dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdReaperScan, Handler: func(dc *DispatchCtx) { dc.S.handleReaperScan(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdRedactTest, Handler: func(dc *DispatchCtx) { dc.S.handleRedactTest(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdRunsList, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleRunsList(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdRunsStats, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleRunsStats(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdSandboxList, Handler: func(dc *DispatchCtx) { dc.S.handleSandboxList(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdSandboxFile, Handler: func(dc *DispatchCtx) { dc.S.handleSandboxFile(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdSandboxDelete, Handler: func(dc *DispatchCtx) { dc.S.handleSandboxDelete(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdShutdown, Handler: func(dc *DispatchCtx) { dc.S.handleShutdown(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdStateList, Handler: func(dc *DispatchCtx) { dc.S.handleStateList(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdStateGet, Handler: func(dc *DispatchCtx) { dc.S.handleStateGet(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdStatus, Handler: func(dc *DispatchCtx) { dc.S.handleStatus(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdStorageStats, Handler: func(dc *DispatchCtx) { dc.S.handleStorageStats(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdUpdateCheck, Handler: func(dc *DispatchCtx) { dc.S.handleUpdateCheck(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdUpdateApply, Handler: func(dc *DispatchCtx) { dc.S.handleUpdateApply(dc.Conn, dc.Req) }},
+	)
+}
+
+// registerCognitionCommands registers Cognition surfaces: planner, conductor/council, research, reflection, persona, prompts, taste, seats.
+func registerCognitionCommands() {
+	register(
+		commandSpec{Cmd: CmdChatSuggestions, Handler: func(dc *DispatchCtx) { dc.S.handleChatSuggestions(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdChatSummarize, Streaming: StreamLive, Handler: func(dc *DispatchCtx) { dc.S.handleChatSummarize(dc.Ctx, dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdConductorRoles, Handler: func(dc *DispatchCtx) { dc.S.handleConductorRoles(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdConductorAsk, Streaming: StreamLive, Handler: func(dc *DispatchCtx) { dc.S.handleConductorAsk(dc.Ctx, dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdCouncilMembers, Handler: func(dc *DispatchCtx) { dc.S.handleCouncilMembers(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdCouncilAsk, Streaming: StreamLive, Handler: func(dc *DispatchCtx) { dc.S.handleCouncilAsk(dc.Ctx, dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdCouncilSet, Handler: func(dc *DispatchCtx) { dc.S.handleCouncilSet(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdNodeRegistry, Handler: func(dc *DispatchCtx) { dc.S.handleNodeRegistry(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdPersonaGet, Handler: func(dc *DispatchCtx) { dc.S.handlePersonaGet(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdPersonaSet, Handler: func(dc *DispatchCtx) { dc.S.handlePersonaSet(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdPlanHistory, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handlePlanHistory(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdPlanStats, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handlePlanStats(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdPlanGenerate, Streaming: StreamLive, Handler: func(dc *DispatchCtx) { dc.S.handlePlanGenerate(dc.Ctx, dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdPlanRefine, Streaming: StreamLive, Handler: func(dc *DispatchCtx) { dc.S.handlePlanRefine(dc.Ctx, dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdPromptsGet, Handler: func(dc *DispatchCtx) { dc.S.handlePromptsGet(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdPromptsSet, Handler: func(dc *DispatchCtx) { dc.S.handlePromptsSet(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdReflectRun, Handler: func(dc *DispatchCtx) { dc.S.handleReflectRun(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdReflectShow, Handler: func(dc *DispatchCtx) { dc.S.handleReflectShow(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdResearchAsk, Streaming: StreamLive, Handler: func(dc *DispatchCtx) { dc.S.handleResearchAsk(dc.Ctx, dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdSeatList, Handler: func(dc *DispatchCtx) { dc.S.handleSeatList(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdSeatCreate, Handler: func(dc *DispatchCtx) { dc.S.handleSeatCreate(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdSeatDelete, Handler: func(dc *DispatchCtx) { dc.S.handleSeatDelete(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdTasteList, Handler: func(dc *DispatchCtx) { dc.S.handleTasteList(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdTasteCreate, Handler: func(dc *DispatchCtx) { dc.S.handleTasteCreate(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdTasteDelete, Handler: func(dc *DispatchCtx) { dc.S.handleTasteDelete(dc.Conn, dc.Req) }},
+	)
+}
+
+// registerMiscSmallCommands registers Remaining small subsystems: artifacts, plugins, tools, toolbox, edict overlay.
+func registerMiscSmallCommands() {
+	register(
+		commandSpec{Cmd: CmdArtifactGet, Handler: func(dc *DispatchCtx) { dc.S.handleArtifactGet(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdArtifactList, Handler: func(dc *DispatchCtx) { dc.S.handleArtifactList(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdArtifactDelete, Handler: func(dc *DispatchCtx) { dc.S.handleArtifactDelete(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdArtifactCollect, Handler: func(dc *DispatchCtx) { dc.S.handleArtifactCollect(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdEdictOverlay, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleEdictOverlay(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdEdictCompact, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleEdictCompact(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdPluginList, Handler: func(dc *DispatchCtx) { dc.S.handlePluginList(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdToolList, Handler: func(dc *DispatchCtx) { dc.S.handleToolList(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdAgentPermissions, Handler: func(dc *DispatchCtx) { dc.S.handleAgentPermissions(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdAgentCapabilities, Handler: func(dc *DispatchCtx) { dc.S.handleAgentCapabilities(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdToolboxDetect, Handler: func(dc *DispatchCtx) { dc.S.handleToolboxDetect(dc.Ctx, dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdToolboxOutdated, Handler: func(dc *DispatchCtx) { dc.S.handleToolboxOutdated(dc.Ctx, dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdToolboxInstall, Streaming: StreamEvents, Handler: func(dc *DispatchCtx) { dc.S.handleToolboxInstall(dc.Ctx, dc.Conn, dc.Req) }},
+	)
+}

--- a/kernel/controlplane/research.go
+++ b/kernel/controlplane/research.go
@@ -35,11 +35,9 @@ func (s *Server) handleResearchAsk(ctx context.Context, conn net.Conn, req Reque
 		}
 	}
 
-	// A disconnected client can't receive the report — cancel the (model-heavy)
-	// harness instead of spending it into a closed connection.
-	ctx, cancel := cancelOnConnClose(ctx, conn)
-	defer cancel()
-
+	// ctx is already tied to the connection by dispatch (StreamLive): a
+	// disconnected client can't receive the report, so the (model-heavy)
+	// harness is cancelled instead of being spent into a closed connection.
 	rep, err := s.k.Research(ctx, corr, question, runtime.ResearchOptions{
 		MaxSubQuestions: dlInt(req.Args, "max_sub_questions"),
 		MaxSources:      dlInt(req.Args, "max_sources"),

--- a/kernel/controlplane/roster.go
+++ b/kernel/controlplane/roster.go
@@ -4924,3 +4924,26 @@ func configEntryBelongsToAgent(e *configcenter.ConfigEntry, slug string) bool {
 	}
 	return false
 }
+
+// registerRosterCommands registers this file's protocol commands into the dispatch registry (phase 2.3).
+func registerRosterCommands() {
+	register(
+		commandSpec{Cmd: CmdAgentList, Handler: func(dc *DispatchCtx) { dc.S.handleAgentList(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdAgentAdd, Handler: func(dc *DispatchCtx) { dc.S.handleAgentAdd(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdAgentEdit, Handler: func(dc *DispatchCtx) { dc.S.handleAgentEdit(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdAgentSetEnabled, Handler: func(dc *DispatchCtx) { dc.S.handleAgentSetEnabled(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdAgentRemove, Handler: func(dc *DispatchCtx) { dc.S.handleAgentRemove(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdAgentTaskUpdate, Handler: func(dc *DispatchCtx) { dc.S.handleAgentTaskUpdate(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdAgentImpact, Handler: func(dc *DispatchCtx) { dc.S.handleAgentImpact(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdAgentTombstone, Handler: func(dc *DispatchCtx) { dc.S.handleAgentTombstone(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdAgentGraveyard, Handler: func(dc *DispatchCtx) { dc.S.handleAgentGraveyard(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdAgentActivity, Handler: func(dc *DispatchCtx) { dc.S.handleAgentActivity(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdAgentRepairStatus, Handler: func(dc *DispatchCtx) { dc.S.handleAgentRepairStatus(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdAgentRepair, Handler: func(dc *DispatchCtx) { dc.S.handleAgentRepair(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdAgentEscalations, Handler: func(dc *DispatchCtx) { dc.S.handleAgentEscalations(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdAgentWake, Handler: func(dc *DispatchCtx) { dc.S.handleAgentWake(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdAgentResolve, Handler: func(dc *DispatchCtx) { dc.S.handleAgentResolve(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdAgentRetire, Handler: func(dc *DispatchCtx) { dc.S.handleAgentRetire(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdAgentRevive, Handler: func(dc *DispatchCtx) { dc.S.handleAgentRevive(dc.Conn, dc.Req) }},
+	)
+}

--- a/kernel/controlplane/schedule.go
+++ b/kernel/controlplane/schedule.go
@@ -1114,3 +1114,17 @@ func (s *Server) scheduleFrequencyWarning(e cadence.Entry) string {
 type errString string
 
 func (e errString) Error() string { return string(e) }
+
+// registerScheduleCommands registers this file's protocol commands into the dispatch registry (phase 2.3).
+func registerScheduleCommands() {
+	register(
+		commandSpec{Cmd: CmdScheduleAdd, Handler: func(dc *DispatchCtx) { dc.S.handleScheduleAdd(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdScheduleList, Handler: func(dc *DispatchCtx) { dc.S.handleScheduleList(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdScheduleSystemTasks, Handler: func(dc *DispatchCtx) { dc.S.handleScheduleSystemTasks(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdScheduleRemove, Handler: func(dc *DispatchCtx) { dc.S.handleScheduleRemove(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdScheduleRun, Handler: func(dc *DispatchCtx) { dc.S.handleScheduleRun(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdScheduleEnable, Handler: func(dc *DispatchCtx) { dc.S.handleScheduleEnable(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdScheduleEdit, Handler: func(dc *DispatchCtx) { dc.S.handleScheduleEdit(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdScheduleTest, Handler: func(dc *DispatchCtx) { dc.S.handleScheduleTest(dc.Conn, dc.Req) }},
+	)
+}

--- a/kernel/controlplane/server.go
+++ b/kernel/controlplane/server.go
@@ -458,14 +458,17 @@ func (s *Server) acceptLoop(ctx context.Context) {
 }
 
 // cancelOnConnClose derives a child context that is cancelled when the client
-// closes conn. For synchronous request/response handlers (research/council/
-// conductor) a disconnected client means the result can no longer be delivered,
-// so continuing to spend model calls is pure waste. It generalizes the run
-// disconnect sentinel in handleRun: since these handlers read exactly one
-// request and the client then sends nothing, a blocking Read unblocks only on
-// disconnect (or when the handler itself returns and handleConn closes the
-// conn, at which point the cancel is a harmless no-op). The caller must
-// defer the returned cancel. Unlike run, this is always on: these handlers have
+// closes conn. Dispatch applies it to every StreamLive command (research/
+// council/conductor/planner/chat-summarize): a disconnected client means the
+// result can no longer be delivered, so continuing to spend model calls is
+// pure waste. It generalizes the run disconnect sentinel in handleRun: since
+// these handlers read exactly one request and the client then sends nothing, a
+// blocking Read unblocks only on disconnect (or when the handler itself
+// returns and handleConn closes the conn, at which point the cancel is a
+// harmless no-op). The caller must defer the returned cancel, and handlers
+// must never layer a second call on the same conn — two goroutines reading one
+// conn race (pulse_subscribe runs its own watcher and is therefore dispatched
+// without this wrapper). Unlike run, this is always on: these handlers have
 // no detach path, so there is nothing to preserve by keeping the work alive.
 func cancelOnConnClose(ctx context.Context, conn net.Conn) (context.Context, context.CancelFunc) {
 	cctx, cancel := context.WithCancel(ctx)
@@ -515,19 +518,29 @@ func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
 	// Authentication + authorization (M38). The primary (admin) token
 	// authorizes everything, on any tenant. Otherwise the request must name a
 	// tenant AND present that tenant's own token: the principal is then that
-	// tenant, restricted to an allowlist of tenant-routed commands and pinned
-	// to its own tenant. This completes M14 tenant isolation on the control
-	// side — a tenant manages its own runs/policy without the primary token,
-	// and cannot touch another tenant or daemon-global state.
-	if !s.tokenIsPrimary(req.Token) {
+	// tenant, restricted to the TenantAllowed subset of the command registry
+	// and pinned to its own tenant. This completes M14 tenant isolation on the
+	// control side — a tenant manages its own runs/policy without the primary
+	// token, and cannot touch another tenant or daemon-global state.
+	primary := s.tokenIsPrimary(req.Token)
+	var tenantID string
+	if !primary {
 		reqTenant, _ := req.Args["tenant"].(string)
 		reqTenant = strings.TrimSpace(reqTenant)
 		if s.tenants == nil || reqTenant == "" || !s.tenants.Authorize(reqTenant, req.Token) {
 			s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "unauthorized"})
 			return
 		}
-		// Authorized as the named tenant. Restrict to tenant-safe commands.
-		if !tenantTokenAllows(req.Cmd) {
+		tenantID = reqTenant
+	}
+
+	// Command lookup happens AFTER the auth gate, and the tenant allowlist is
+	// applied BEFORE unknown commands are distinguished: a tenant token probing
+	// an unregistered command gets the same deny-by-default "forbidden" the
+	// legacy tenantTokenAllows gate produced, not an "unknown command" oracle.
+	spec, known := commandRegistry[req.Cmd]
+	if !primary {
+		if !known || !spec.TenantAllowed {
 			s.writeResp(conn, Response{ID: req.ID, Type: RespError,
 				Error: fmt.Sprintf("forbidden: a tenant token cannot run %q (primary token required)", req.Cmd)})
 			return
@@ -537,651 +550,36 @@ func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
 		if req.Args == nil {
 			req.Args = map[string]any{}
 		}
-		req.Args["tenant"] = reqTenant
+		req.Args["tenant"] = tenantID
+	}
+	if !known {
+		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "unknown command: " + req.Cmd})
+		return
 	}
 
-	switch req.Cmd {
-	case CmdVersion:
-		s.handleVersion(conn, req)
-	case CmdRun:
-		s.handleRun(ctx, conn, req)
-	case CmdHalt:
-		s.handleHalt(conn, req)
-	case CmdResume:
-		s.handleResume(conn, req)
-	case CmdWhy:
-		s.handleWhy(conn, req)
-	case CmdWhoami:
-		s.handleWhoami(conn, req)
-	case CmdJournalVerify:
-		s.handleVerify(conn, req)
-	case CmdArtifactGet:
-		s.handleArtifactGet(conn, req)
-	case CmdArtifactList:
-		s.handleArtifactList(conn, req)
-	case CmdArtifactDelete:
-		s.handleArtifactDelete(conn, req)
-	case CmdArtifactCollect:
-		s.handleArtifactCollect(conn, req)
-	case CmdDataCollections:
-		s.handleDataCollections(conn, req)
-	case CmdDataRecords:
-		s.handleDataRecords(conn, req)
-	case CmdDataInsert:
-		s.handleDataInsert(conn, req)
-	case CmdDataUpdate:
-		s.handleDataUpdate(conn, req)
-	case CmdDataDelete:
-		s.handleDataDelete(conn, req)
-	case CmdDataCreateCollection:
-		s.handleDataCreateCollection(conn, req)
-	case CmdDataDropCollection:
-		s.handleDataDropCollection(conn, req)
-	case CmdCouncilMembers:
-		s.handleCouncilMembers(conn, req)
-	case CmdCouncilAsk:
-		s.handleCouncilAsk(ctx, conn, req)
-	case CmdCouncilSet:
-		s.handleCouncilSet(conn, req)
-	case CmdConductorRoles:
-		s.handleConductorRoles(conn, req)
-	case CmdConductorAsk:
-		s.handleConductorAsk(ctx, conn, req)
-	case CmdResearchAsk:
-		s.handleResearchAsk(ctx, conn, req)
-	case CmdApprovals:
-		s.handleApprovals(conn, req)
-	case CmdApprovalsLog:
-		s.handleApprovalsLog(conn, req)
-	case CmdApprovalsStats:
-		s.handleApprovalsStats(conn, req)
-	case CmdDecide:
-		s.handleDecide(conn, req)
-	case CmdPlan:
-		s.handlePlan(ctx, conn, req)
-	case CmdPlanHistory:
-		s.handlePlanHistory(conn, req)
-	case CmdPlanStats:
-		s.handlePlanStats(conn, req)
-	case CmdCatalogSync:
-		s.handleCatalogSync(ctx, conn, req)
-	case CmdCatalogList:
-		s.handleCatalogList(conn, req)
-	case CmdCatalogDiscover:
-		s.handleCatalogDiscover(ctx, conn, req)
-	case CmdProviderReload:
-		s.handleProviderReload(conn, req)
-	case CmdProviderConnect:
-		s.handleProviderConnect(conn, req)
-	case CmdProviderProbe:
-		s.handleProviderProbe(conn, req)
-	case CmdWhatsAppGatewayStatus:
-		s.handleWhatsAppGatewayStatus(conn, req)
-	case CmdWhatsAppGatewayQR:
-		s.handleWhatsAppGatewayQR(conn, req)
-	case CmdProviderLog:
-		s.handleProviderLog(conn, req)
-	case CmdProviderStats:
-		s.handleProviderStats(conn, req)
-	case CmdProviderRejections:
-		s.handleProviderRejections(conn, req)
-	case CmdPulseSubscribe:
-		s.handlePulseSubscribe(ctx, conn, req)
-	case CmdPlanGenerate:
-		s.handlePlanGenerate(ctx, conn, req)
-	case CmdPlanRefine:
-		s.handlePlanRefine(ctx, conn, req)
-	case CmdBudget:
-		s.handleBudget(conn, req)
-	case CmdBudgetSet:
-		s.handleBudgetSet(conn, req)
-	case CmdToolList:
-		s.handleToolList(conn, req)
-	case CmdToolLog:
-		s.handleToolLog(conn, req)
-	case CmdToolStats:
-		s.handleToolStats(conn, req)
-	case CmdExecutionProfiles:
-		s.handleExecutionProfiles(conn, req)
-	case CmdExecutionProfileShow:
-		s.handleExecutionProfileShow(conn, req)
-	case CmdExecutionProfileCheck:
-		s.handleExecutionProfileCheck(conn, req)
-	case CmdCacheStats:
-		s.handleCacheStats(conn, req)
-	case CmdStatus:
-		s.handleStatus(conn, req)
-	case CmdWardenLog:
-		s.handleWardenLog(conn, req)
-	case CmdWardenStats:
-		s.handleWardenStats(conn, req)
-	case CmdPluginList:
-		s.handlePluginList(conn, req)
-	case CmdShutdown:
-		s.handleShutdown(conn, req)
-	case CmdJournalTail:
-		s.handleJournalTail(conn, req)
-	case CmdEdictOverlay:
-		s.handleEdictOverlay(conn, req)
-	case CmdEdictCompact:
-		s.handleEdictCompact(conn, req)
-	case CmdEdictLog:
-		s.handleEdictLog(conn, req)
-	case CmdEdictStats:
-		s.handleEdictStats(conn, req)
-	case CmdEdictShow:
-		s.handleEdictShow(conn, req)
-	case CmdEdictTest:
-		s.handleEdictTest(conn, req)
-	case CmdEdictDenyList:
-		s.handleEdictDenyList(conn, req)
-	case CmdEdictDenyAdd:
-		s.handleEdictDenyAdd(conn, req)
-	case CmdEdictDenyRemove:
-		s.handleEdictDenyRemove(conn, req)
-	case CmdEdictSetLevel:
-		s.handleEdictSetLevel(conn, req)
-	case CmdEdictSetMode:
-		s.handleEdictSetMode(conn, req)
-	case CmdStateList:
-		s.handleStateList(conn, req)
-	case CmdStateGet:
-		s.handleStateGet(conn, req)
-	case CmdRunsList:
-		s.handleRunsList(conn, req)
-	case CmdReaperScan:
-		s.handleReaperScan(conn, req)
-	case CmdRunsStats:
-		s.handleRunsStats(conn, req)
-	case CmdCancelRun:
-		s.handleCancelRun(conn, req)
-	case CmdRunPause:
-		s.handleRunPause(conn, req)
-	case CmdRunResume:
-		s.handleRunResume(conn, req)
-	case CmdRunStep:
-		s.handleRunStep(conn, req)
-	case CmdRunSteer:
-		s.handleRunSteer(conn, req)
-	case CmdRunIntervene:
-		s.handleRunIntervene(conn, req)
-	case CmdConfig:
-		s.handleConfig(conn, req)
-	case CmdConfigCenterSet:
-		s.handleConfigCenterSet(conn, req)
-	case CmdConfigCenterGet:
-		s.handleConfigCenterGet(conn, req)
-	case CmdConfigCenterList:
-		s.handleConfigCenterList(conn, req)
-	case CmdConfigCenterDelete:
-		s.handleConfigCenterDelete(conn, req)
-	case CmdConfigCenterSetRating:
-		s.handleConfigCenterSetRating(conn, req)
-	case CmdConfigCenterSetAccess:
-		s.handleConfigCenterSetAccess(conn, req)
-	case CmdConfigCenterAccessLog:
-		s.handleConfigCenterAccessLog(conn, req)
-	case CmdConfigCenterAudit:
-		s.handleConfigCenterAudit(conn, req)
-	case CmdConfigCenterHealth:
-		s.handleConfigCenterHealth(conn, req)
-	case CmdJournalGrep:
-		s.handleJournalGrep(conn, req)
-	case CmdJournalHead:
-		s.handleJournalHead(conn, req)
-	case CmdJournalExport:
-		s.handleJournalExport(conn, req)
-	case CmdRedactTest:
-		s.handleRedactTest(conn, req)
-	case CmdRateLimitLog:
-		s.handleRateLimitLog(conn, req)
-	case CmdRateLimitStats:
-		s.handleRateLimitStats(conn, req)
-	case CmdNetguardLog:
-		s.handleNetguardLog(conn, req)
-	case CmdWebhookLog:
-		s.handleWebhookLog(conn, req)
-	case CmdWebhookStats:
-		s.handleWebhookStats(conn, req)
-	case CmdMemoryAdd:
-		s.handleMemoryAdd(conn, req)
-	case CmdMemorySupersede:
-		s.handleMemorySupersede(conn, req)
-	case CmdMemoryList:
-		s.handleMemoryList(conn, req)
-	case CmdMemoryLog:
-		s.handleMemoryLog(conn, req)
-	case CmdMemoryGet:
-		s.handleMemoryGet(conn, req)
-	case CmdMemorySearch:
-		s.handleMemorySearch(conn, req)
-	case CmdMemoryConsolidate:
-		s.handleMemoryConsolidate(conn, req)
-	case CmdProfileRebuild:
-		s.handleProfileRebuild(conn, req)
-	case CmdMemoryForget:
-		s.handleMemoryForget(conn, req)
-	case CmdMemoryPromote:
-		s.handleMemoryPromote(conn, req)
-	case CmdMemoryPrune:
-		s.handleMemoryPrune(conn, req)
-	case CmdMemoryTidy:
-		s.handleMemoryTidy(conn, req)
-	case CmdMemoryBulkForget:
-		s.handleMemoryBulkForget(conn, req)
-	case CmdMemoryFindRelated:
-		s.handleMemoryFindRelated(conn, req)
-	case CmdMemoryAudit:
-		s.handleMemoryAudit(conn, req)
-	case CmdMemoryClean:
-		s.handleMemoryClean(conn, req)
-	case CmdChatSuggestions:
-		s.handleChatSuggestions(conn, req)
-	case CmdScheduleAdd:
-		s.handleScheduleAdd(conn, req)
-	case CmdScheduleList:
-		s.handleScheduleList(conn, req)
-	case CmdScheduleSystemTasks:
-		s.handleScheduleSystemTasks(conn, req)
-	case CmdScheduleRemove:
-		s.handleScheduleRemove(conn, req)
-	case CmdScheduleRun:
-		s.handleScheduleRun(conn, req)
-	case CmdScheduleEnable:
-		s.handleScheduleEnable(conn, req)
-	case CmdScheduleEdit:
-		s.handleScheduleEdit(conn, req)
-	case CmdScheduleFires:
-		s.handleScheduleFires(conn, req)
-	case CmdScheduleStats:
-		s.handleScheduleStats(conn, req)
-	case CmdScheduleTest:
-		s.handleScheduleTest(conn, req)
-	case CmdTenantCreate:
-		s.handleTenantCreate(conn, req)
-	case CmdTenantList:
-		s.handleTenantList(conn, req)
-	case CmdTenantRelease:
-		s.handleTenantRelease(conn, req)
-	case CmdTenantRemove:
-		s.handleTenantRemove(conn, req)
-	case CmdTenantToken:
-		s.handleTenantToken(conn, req)
-	case CmdTenantStats:
-		s.handleTenantStats(conn, req)
-	case CmdDiskStats:
-		s.handleDiskStats(conn, req)
-	case CmdStorageStats:
-		s.handleStorageStats(conn, req)
-	case CmdJournalStats:
-		s.handleJournalStats(conn, req)
-	case CmdChangelog:
-		s.handleChangelog(conn, req)
-	case CmdWorldAdd:
-		s.handleWorldAdd(conn, req)
-	case CmdWorldEdit:
-		s.handleWorldEdit(conn, req)
-	case CmdWorldRelate:
-		s.handleWorldRelate(conn, req)
-	case CmdWorldResolve:
-		s.handleWorldResolve(conn, req)
-	case CmdWorldNeighbors:
-		s.handleWorldNeighbors(conn, req)
-	case CmdWorldLog:
-		s.handleWorldLog(conn, req)
-	case CmdWorldList:
-		s.handleWorldList(conn, req)
-	case CmdWorldGet:
-		s.handleWorldGet(conn, req)
-	case CmdWorldForget:
-		s.handleWorldForget(conn, req)
-	case CmdSkillList:
-		s.handleSkillList(conn, req)
-	case CmdSkillGet:
-		s.handleSkillGet(conn, req)
-	case CmdSkillHistory:
-		s.handleSkillHistory(conn, req)
-	case CmdSkillPromote:
-		s.handleSkillPromote(conn, req)
-	case CmdSkillQuarantine:
-		s.handleSkillQuarantine(conn, req)
-	case CmdSkillArchive:
-		s.handleSkillArchive(conn, req)
-	case CmdSkillRevert:
-		s.handleSkillRevert(conn, req)
-	case CmdSkillRestore:
-		s.handleSkillRestore(conn, req)
-	case CmdSkillShare:
-		s.handleSkillShare(conn, req)
-	case CmdSkillReassign:
-		s.handleSkillReassign(conn, req)
-	case CmdSkillImport:
-		s.handleSkillImport(conn, req)
-	case CmdSkillHygiene:
-		s.handleSkillHygiene(conn, req)
-	case CmdSkillFiles:
-		s.handleSkillFiles(conn, req)
-	case CmdSkillReadFile:
-		s.handleSkillReadFile(conn, req)
-	case CmdStandingList:
-		s.handleStandingList(conn, req)
-	case CmdStandingAdd:
-		s.handleStandingAdd(conn, req)
-	case CmdStandingEdit:
-		s.handleStandingEdit(conn, req)
-	case CmdStandingSetEnabled:
-		s.handleStandingSetEnabled(conn, req)
-	case CmdStandingRemove:
-		s.handleStandingRemove(conn, req)
-	case CmdStandingFire:
-		s.handleStandingFire(conn, req)
-	case CmdAgentList:
-		s.handleAgentList(conn, req)
-	case CmdAgentAdd:
-		s.handleAgentAdd(conn, req)
-	case CmdAgentEdit:
-		s.handleAgentEdit(conn, req)
-	case CmdAgentSetEnabled:
-		s.handleAgentSetEnabled(conn, req)
-	case CmdAgentRemove:
-		s.handleAgentRemove(conn, req)
-	case CmdAgentTaskUpdate:
-		s.handleAgentTaskUpdate(conn, req)
-	case CmdAgentImpact:
-		s.handleAgentImpact(conn, req)
-	case CmdAgentTombstone:
-		s.handleAgentTombstone(conn, req)
-	case CmdAgentGraveyard:
-		s.handleAgentGraveyard(conn, req)
-	case CmdAgentPermissions:
-		s.handleAgentPermissions(conn, req)
-	case CmdAgentCapabilities:
-		s.handleAgentCapabilities(conn, req)
-	case CmdAgentActivity:
-		s.handleAgentActivity(conn, req)
-	case CmdAgentRepairStatus:
-		s.handleAgentRepairStatus(conn, req)
-	case CmdAgentRepair:
-		s.handleAgentRepair(conn, req)
-	case CmdAgentEscalations:
-		s.handleAgentEscalations(conn, req)
-	case CmdAgentWake:
-		s.handleAgentWake(conn, req)
-	case CmdAgentResolve:
-		s.handleAgentResolve(conn, req)
-	case CmdAgentRetire:
-		s.handleAgentRetire(conn, req)
-	case CmdAgentRevive:
-		s.handleAgentRevive(conn, req)
-	case CmdToolforgeList:
-		s.handleToolforgeList(conn, req)
-	case CmdToolforgeShow:
-		s.handleToolforgeShow(conn, req)
-	case CmdToolforgeDraft:
-		s.handleToolforgeDraft(conn, req)
-	case CmdToolforgeEdit:
-		s.handleToolforgeEdit(conn, req)
-	case CmdToolforgeTest:
-		s.handleToolforgeTest(conn, req)
-	case CmdToolforgePromote:
-		s.handleToolforgePromote(conn, req)
-	case CmdToolforgeQuarantine:
-		s.handleToolforgeQuarantine(conn, req)
-	case CmdToolforgeRemove:
-		s.handleToolforgeRemove(conn, req)
-	case CmdMCPList:
-		s.handleMCPList(conn, req)
-	case CmdMCPAdd:
-		s.handleMCPAdd(conn, req)
-	case CmdMCPAttach:
-		s.handleMCPAttach(conn, req)
-	case CmdMCPDetach:
-		s.handleMCPDetach(conn, req)
-	case CmdMCPSetEnabled:
-		s.handleMCPSetEnabled(conn, req)
-	case CmdMCPRemove:
-		s.handleMCPRemove(conn, req)
-	case CmdACPAgents:
-		s.handleACPAgents(ctx, conn, req)
-	case CmdToolboxDetect:
-		s.handleToolboxDetect(ctx, conn, req)
-	case CmdToolboxOutdated:
-		s.handleToolboxOutdated(ctx, conn, req)
-	case CmdToolboxInstall:
-		s.handleToolboxInstall(ctx, conn, req)
-	case CmdMarketList:
-		s.handleMarketList(conn, req)
-	case CmdMarketShow:
-		s.handleMarketShow(conn, req)
-	case CmdMarketInstall:
-		s.handleMarketInstall(ctx, conn, req)
-	case CmdMarketUninstall:
-		s.handleMarketUninstall(ctx, conn, req)
-	case CmdMarketSources:
-		s.handleMarketSources(conn, req)
-	case CmdMarketAddSource:
-		s.handleMarketAddSource(conn, req)
-	case CmdMarketRemoveSource:
-		s.handleMarketRemoveSource(conn, req)
-	case CmdMarketSync:
-		s.handleMarketSync(ctx, conn, req)
-	case CmdWorkflowList:
-		s.handleWorkflowList(conn, req)
-	case CmdWorkflowShow:
-		s.handleWorkflowShow(conn, req)
-	case CmdWorkflowSave:
-		s.handleWorkflowSave(conn, req)
-	case CmdWorkflowRestore:
-		s.handleWorkflowRestore(conn, req)
-	case CmdWorkflowRemove:
-		s.handleWorkflowRemove(conn, req)
-	case CmdWorkflowSetEnabled:
-		s.handleWorkflowSetEnabled(conn, req)
-	case CmdWorkflowRun:
-		s.handleWorkflowRun(conn, req)
-	case CmdWorkflowDraft:
-		s.handleWorkflowDraft(conn, req)
-	case CmdWorkflowRefine:
-		s.handleWorkflowRefine(conn, req)
-	case CmdWorkflowRuns:
-		s.handleWorkflowRuns(conn, req)
-	case CmdWorkflowTemplates:
-		s.handleWorkflowTemplates(conn, req)
-	case CmdWorkflowWebhook:
-		s.handleWorkflowWebhook(conn, req)
-	case CmdWorkflowTestNode:
-		s.handleWorkflowTestNode(conn, req)
-	case CmdSandboxList:
-		s.handleSandboxList(conn, req)
-	case CmdSandboxFile:
-		s.handleSandboxFile(conn, req)
-	case CmdSandboxDelete:
-		s.handleSandboxDelete(conn, req)
-	case CmdConfigSchema:
-		s.handleConfigSchema(conn, req)
-	case CmdConfigValues:
-		s.handleConfigValues(conn, req)
-	case CmdChannelList:
-		s.handleChannelList(conn, req)
-	case CmdNodeRegistry:
-		s.handleNodeRegistry(conn, req)
-	case CmdChannelAccountSet:
-		s.handleChannelAccountSet(conn, req)
-	case CmdChannelAccountRemove:
-		s.handleChannelAccountRemove(conn, req)
-	case CmdChannelOAuthStart:
-		s.handleChannelOAuthStart(conn, req)
-	case CmdChannelOAuthCallback:
-		s.handleChannelOAuthCallback(ctx, conn, req)
-	case CmdChannelOAuthStatus:
-		s.handleChannelOAuthStatus(conn, req)
-	case CmdProviderOAuthStart:
-		s.handleProviderOAuthStart(conn, req)
-	case CmdProviderOAuthStatus:
-		s.handleProviderOAuthStatus(conn, req)
-	case CmdProviderOAuthImport:
-		s.handleProviderOAuthImport(conn, req)
-	case CmdProviderOAuthLogout:
-		s.handleProviderOAuthLogout(conn, req)
-	case CmdConfigSet:
-		s.handleConfigSet(conn, req)
-	case CmdConfigSchemaRegister:
-		s.handleConfigSchemaRegister(conn, req)
-	case CmdConfigSchemaUnregister:
-		s.handleConfigSchemaUnregister(conn, req)
-	case CmdProviderKeyList:
-		s.handleProviderKeyList(conn, req)
-	case CmdProviderKeyAdd:
-		s.handleProviderKeyAdd(conn, req)
-	case CmdProviderKeyActivate:
-		s.handleProviderKeyActivate(conn, req)
-	case CmdProviderKeyRemove:
-		s.handleProviderKeyRemove(conn, req)
-	case CmdRoutingGet:
-		s.handleRoutingGet(conn, req)
-	case CmdRoutingSet:
-		s.handleRoutingSet(conn, req)
-	case CmdChainsGet:
-		s.handleChainsGet(conn, req)
-	case CmdChainsSet:
-		s.handleChainsSet(conn, req)
-	case CmdPersonaGet:
-		s.handlePersonaGet(conn, req)
-	case CmdPersonaSet:
-		s.handlePersonaSet(conn, req)
-	case CmdPromptsGet:
-		s.handlePromptsGet(conn, req)
-	case CmdPromptsSet:
-		s.handlePromptsSet(conn, req)
-	case CmdChatSummarize:
-		s.handleChatSummarize(ctx, conn, req)
-	case CmdStandingWhy:
-		s.handleStandingWhy(conn, req)
-	case CmdReflectRun:
-		s.handleReflectRun(conn, req)
-	case CmdReflectShow:
-		s.handleReflectShow(conn, req)
-	case CmdPulseStatus:
-		s.handlePulseStatus(conn, req)
-	case CmdPulseAsks:
-		s.handlePulseAsks(conn, req)
-	case CmdPulseAskResolve:
-		s.handlePulseAskResolve(conn, req)
-	case CmdPulsePause:
-		s.handlePulsePause(conn, req)
-	case CmdPulseResume:
-		s.handlePulseResume(conn, req)
-	case CmdPulseBeat:
-		s.handlePulseBeat(conn, req)
-	case CmdPulseCadence:
-		s.handlePulseCadence(conn, req)
-	case CmdPulseDial:
-		s.handlePulseDial(conn, req)
-	case CmdPulseFlush:
-		s.handlePulseFlush(conn, req)
-	case CmdPulseWatch:
-		s.handlePulseWatch(conn, req)
-	case CmdPulseProbe:
-		s.handlePulseProbe(conn, req)
-	case CmdPulseUnwatch:
-		s.handlePulseUnwatch(conn, req)
-	case CmdPulseQuiet:
-		s.handlePulseQuiet(conn, req)
-	case CmdInbox:
-		s.handleInbox(conn, req)
-	case CmdSend:
-		s.handleSend(conn, req)
-	case CmdBoardRead:
-		s.handleBoardRead(conn, req)
-	case CmdBoardHelp:
-		s.handleBoardHelp(conn, req)
-	case CmdBoardSend:
-		s.handleBoardSend(conn, req)
-	case CmdBoardInbox:
-		s.handleBoardInbox(conn, req)
-	case CmdBoardAck:
-		s.handleBoardAck(conn, req)
-	case CmdBoardReplies:
-		s.handleBoardReplies(conn, req)
-	case CmdBoardGet:
-		s.handleBoardGet(conn, req)
-	case CmdWorkboardList:
-		s.handleWorkboardList(conn, req)
-	case CmdWorkboardLanes:
-		s.handleWorkboardLanes(conn, req)
-	case CmdWorkboardShow:
-		s.handleWorkboardShow(conn, req)
-	case CmdWorkboardCreate:
-		s.handleWorkboardCreate(conn, req)
-	case CmdWorkboardClaim:
-		s.handleWorkboardClaim(conn, req)
-	case CmdWorkboardHeartbeat:
-		s.handleWorkboardHeartbeat(conn, req)
-	case CmdWorkboardComment:
-		s.handleWorkboardComment(conn, req)
-	case CmdWorkboardBlock:
-		s.handleWorkboardBlock(conn, req)
-	case CmdWorkboardFail:
-		s.handleWorkboardFail(conn, req)
-	case CmdWorkboardUnblock:
-		s.handleWorkboardUnblock(conn, req)
-	case CmdWorkboardComplete:
-		s.handleWorkboardComplete(conn, req)
-	case CmdWorkboardProve:
-		s.handleWorkboardProve(conn, req)
-	case CmdWorkboardSeat:
-		s.handleWorkboardSeat(conn, req)
-	case CmdSeatList:
-		s.handleSeatList(conn, req)
-	case CmdSeatCreate:
-		s.handleSeatCreate(conn, req)
-	case CmdSeatDelete:
-		s.handleSeatDelete(conn, req)
-	case CmdOKRList:
-		s.handleOKRList(conn, req)
-	case CmdOKRShow:
-		s.handleOKRShow(conn, req)
-	case CmdOKRCreate:
-		s.handleOKRCreate(conn, req)
-	case CmdOKRKeyResult:
-		s.handleOKRKeyResult(conn, req)
-	case CmdOKRLink:
-		s.handleOKRLink(conn, req)
-	case CmdOKRUnlink:
-		s.handleOKRUnlink(conn, req)
-	case CmdOKRArchive:
-		s.handleOKRArchive(conn, req)
-	case CmdTasteList:
-		s.handleTasteList(conn, req)
-	case CmdTasteCreate:
-		s.handleTasteCreate(conn, req)
-	case CmdTasteDelete:
-		s.handleTasteDelete(conn, req)
-	case CmdWorkboardArchive:
-		s.handleWorkboardArchive(conn, req)
-	case CmdWorkboardLink:
-		s.handleWorkboardLink(conn, req)
-	case CmdWorkboardPolicy:
-		s.handleWorkboardPolicy(conn, req)
-	case CmdWorkboardDepend:
-		s.handleWorkboardDepend(conn, req)
-	case CmdWorkboardReclaim:
-		s.handleWorkboardReclaim(conn, req)
-	case CmdWorkboardSweep:
-		s.handleWorkboardSweep(conn, req)
-	case CmdWorkboardDispatch:
-		s.handleWorkboardDispatch(conn, req)
-	case CmdWorkboardWatch:
-		s.handleWorkboardWatch(conn, req)
-	case CmdAutonomyFeed:
-		s.handleAutonomyFeed(conn, req)
-	case CmdUpdateCheck:
-		s.handleUpdateCheck(conn, req)
-	case CmdUpdateApply:
-		s.handleUpdateApply(conn, req)
-	default:
-		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "unknown command: " + req.Cmd})
+	dc := &DispatchCtx{Ctx: ctx, Conn: conn, Req: req, S: s, K: s.k, Tenant: tenantID, Primary: primary}
+	if spec.TenantRouted {
+		// Resolve the request's kernel once at the dispatch boundary. For a
+		// primary caller without a tenant arg kernelFor("") == s.k, so
+		// tenant-routed commands cost nothing extra in the common case.
+		k, err := s.kernelFor(tenantOf(req))
+		if err != nil {
+			s.fail(conn, req, err)
+			return
+		}
+		dc.K = k
 	}
+	if spec.Streaming == StreamLive {
+		// Long-lived streaming work: tie the handler's context to the client
+		// connection so a disconnect cancels the (model-heavy) work instead of
+		// spending it into a closed connection. Handlers receive the tied
+		// context as their ctx parameter and must NOT call cancelOnConnClose
+		// themselves — two goroutines reading one conn would race.
+		cctx, cancel := cancelOnConnClose(ctx, conn)
+		defer cancel()
+		dc.Ctx = cctx
+	}
+	spec.Handler(dc)
 }
 
 func (s *Server) writeResp(conn net.Conn, resp Response) {

--- a/kernel/controlplane/server.go
+++ b/kernel/controlplane/server.go
@@ -2307,3 +2307,20 @@ func addRemoteExecutionProfilePeerMetadata(payload map[string]any, meta map[stri
 		payload[key] = value
 	}
 }
+
+// registerCoreCommands registers this file's protocol commands into the dispatch registry (phase 2.3).
+func registerCoreCommands() {
+	register(
+		commandSpec{Cmd: CmdVersion, Handler: func(dc *DispatchCtx) { dc.S.handleVersion(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdRun, TenantAllowed: true, TenantRouted: true, Streaming: StreamEvents, Handler: func(dc *DispatchCtx) { dc.S.handleRun(dc.Ctx, dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdHalt, Handler: func(dc *DispatchCtx) { dc.S.handleHalt(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdResume, Handler: func(dc *DispatchCtx) { dc.S.handleResume(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWhy, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleWhy(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWhoami, TenantAllowed: true, Handler: func(dc *DispatchCtx) { dc.S.handleWhoami(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdJournalVerify, Handler: func(dc *DispatchCtx) { dc.S.handleVerify(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdApprovals, Handler: func(dc *DispatchCtx) { dc.S.handleApprovals(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdDecide, Handler: func(dc *DispatchCtx) { dc.S.handleDecide(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdPlan, Streaming: StreamEvents, Handler: func(dc *DispatchCtx) { dc.S.handlePlan(dc.Ctx, dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdCancelRun, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleCancelRun(dc.Conn, dc.Req) }},
+	)
+}

--- a/kernel/controlplane/settings.go
+++ b/kernel/controlplane/settings.go
@@ -251,3 +251,14 @@ func (s *Server) handleConfigSchemaUnregister(conn net.Conn, req Request) {
 		"id": id, "removed": existed,
 	}})
 }
+
+// registerSettingsCommands registers this file's protocol commands into the dispatch registry (phase 2.3).
+func registerSettingsCommands() {
+	register(
+		commandSpec{Cmd: CmdConfigSchema, Handler: func(dc *DispatchCtx) { dc.S.handleConfigSchema(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdConfigValues, Handler: func(dc *DispatchCtx) { dc.S.handleConfigValues(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdConfigSet, Handler: func(dc *DispatchCtx) { dc.S.handleConfigSet(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdConfigSchemaRegister, Handler: func(dc *DispatchCtx) { dc.S.handleConfigSchemaRegister(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdConfigSchemaUnregister, Handler: func(dc *DispatchCtx) { dc.S.handleConfigSchemaUnregister(dc.Conn, dc.Req) }},
+	)
+}

--- a/kernel/controlplane/skill.go
+++ b/kernel/controlplane/skill.go
@@ -471,3 +471,23 @@ func skillView(sk skill.Skill) map[string]any {
 	}
 	return v
 }
+
+// registerSkillCommands registers this file's protocol commands into the dispatch registry (phase 2.3).
+func registerSkillCommands() {
+	register(
+		commandSpec{Cmd: CmdSkillList, Handler: func(dc *DispatchCtx) { dc.S.handleSkillList(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdSkillGet, Handler: func(dc *DispatchCtx) { dc.S.handleSkillGet(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdSkillHistory, Handler: func(dc *DispatchCtx) { dc.S.handleSkillHistory(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdSkillPromote, Handler: func(dc *DispatchCtx) { dc.S.handleSkillPromote(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdSkillQuarantine, Handler: func(dc *DispatchCtx) { dc.S.handleSkillQuarantine(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdSkillArchive, Handler: func(dc *DispatchCtx) { dc.S.handleSkillArchive(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdSkillRevert, Handler: func(dc *DispatchCtx) { dc.S.handleSkillRevert(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdSkillRestore, Handler: func(dc *DispatchCtx) { dc.S.handleSkillRestore(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdSkillShare, Handler: func(dc *DispatchCtx) { dc.S.handleSkillShare(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdSkillReassign, Handler: func(dc *DispatchCtx) { dc.S.handleSkillReassign(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdSkillImport, Handler: func(dc *DispatchCtx) { dc.S.handleSkillImport(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdSkillHygiene, Handler: func(dc *DispatchCtx) { dc.S.handleSkillHygiene(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdSkillFiles, Handler: func(dc *DispatchCtx) { dc.S.handleSkillFiles(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdSkillReadFile, Handler: func(dc *DispatchCtx) { dc.S.handleSkillReadFile(dc.Conn, dc.Req) }},
+	)
+}

--- a/kernel/controlplane/standing.go
+++ b/kernel/controlplane/standing.go
@@ -323,3 +323,16 @@ func (s *Server) handleStandingFire(conn net.Conn, req Request) {
 	fired := s.standingFire(id)
 	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{"fired": fired, "id": id}})
 }
+
+// registerStandingCommands registers this file's protocol commands into the dispatch registry (phase 2.3).
+func registerStandingCommands() {
+	register(
+		commandSpec{Cmd: CmdStandingList, Handler: func(dc *DispatchCtx) { dc.S.handleStandingList(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdStandingAdd, Handler: func(dc *DispatchCtx) { dc.S.handleStandingAdd(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdStandingEdit, Handler: func(dc *DispatchCtx) { dc.S.handleStandingEdit(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdStandingSetEnabled, Handler: func(dc *DispatchCtx) { dc.S.handleStandingSetEnabled(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdStandingRemove, Handler: func(dc *DispatchCtx) { dc.S.handleStandingRemove(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdStandingFire, Handler: func(dc *DispatchCtx) { dc.S.handleStandingFire(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdStandingWhy, Handler: func(dc *DispatchCtx) { dc.S.handleStandingWhy(dc.Conn, dc.Req) }},
+	)
+}

--- a/kernel/controlplane/steer.go
+++ b/kernel/controlplane/steer.go
@@ -154,3 +154,14 @@ func (s *Server) handleRunIntervene(conn net.Conn, req Request) {
 	}
 	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: out})
 }
+
+// registerSteerCommands registers this file's protocol commands into the dispatch registry (phase 2.3).
+func registerSteerCommands() {
+	register(
+		commandSpec{Cmd: CmdRunPause, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleRunPause(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdRunResume, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleRunResume(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdRunStep, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleRunStep(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdRunSteer, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleRunSteer(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdRunIntervene, TenantAllowed: true, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleRunIntervene(dc.Conn, dc.Req) }},
+	)
+}

--- a/kernel/controlplane/tenant.go
+++ b/kernel/controlplane/tenant.go
@@ -274,3 +274,15 @@ func (s *Server) handleTenantStats(conn net.Conn, req Request) {
 		},
 	})
 }
+
+// registerTenantCommands registers this file's protocol commands into the dispatch registry (phase 2.3).
+func registerTenantCommands() {
+	register(
+		commandSpec{Cmd: CmdTenantCreate, Handler: func(dc *DispatchCtx) { dc.S.handleTenantCreate(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdTenantList, Handler: func(dc *DispatchCtx) { dc.S.handleTenantList(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdTenantRelease, Handler: func(dc *DispatchCtx) { dc.S.handleTenantRelease(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdTenantRemove, Handler: func(dc *DispatchCtx) { dc.S.handleTenantRemove(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdTenantToken, Handler: func(dc *DispatchCtx) { dc.S.handleTenantToken(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdTenantStats, TenantRouted: true, Handler: func(dc *DispatchCtx) { dc.S.handleTenantStats(dc.Conn, dc.Req) }},
+	)
+}

--- a/kernel/controlplane/tenant.go
+++ b/kernel/controlplane/tenant.go
@@ -51,44 +51,6 @@ func (s *Server) kernelFor(tenantID string) (*runtime.Kernel, error) {
 // when multi-tenancy is enabled.
 func (s *Server) SetTenants(r *tenant.Registry) { s.tenants = r }
 
-// tenantTokenAllows is the deny-by-default allowlist of commands a TENANT
-// token may invoke (M38). It contains exactly the commands that route to the
-// caller's kernel via kernelFor/edictFor — running and cancelling the
-// tenant's own work, managing the tenant's own Edict policy, and OBSERVING the
-// tenant's own isolated subsystems (M128: every read-only handler that folds the
-// tenant's own journal via kernelFor(tenantOf(req)) — runs, tools, edict,
-// rate-limit, netguard, webhooks, AND memory / world / approvals / plan /
-// provider-routing / schedule-firing / warden, which had been left out so a
-// tenant was wrongly denied its own data). Everything else — tenant-registry
-// management (incl. cross-tenant tenant_stats), daemon-global halt/resume/
-// shutdown, pulse, durable-policy compaction (a mutation), and anything reading
-// the primary kernel — requires the primary token. New tenant-routed commands
-// must be added here explicitly; forgetting to is the safe failure (the tenant
-// is denied, not over-granted). TestTenantAllowlist_* locks both directions.
-func tenantTokenAllows(cmd string) bool {
-	switch cmd {
-	case CmdRun, CmdCancelRun,
-		CmdRunPause, CmdRunResume, CmdRunStep, CmdRunSteer, CmdRunIntervene, // live steering of own runs (M608)
-		CmdRunsList, CmdRunsStats, CmdWhy, CmdWhoami, CmdToolLog, CmdToolStats, CmdCacheStats,
-		CmdExecutionProfiles, CmdExecutionProfileShow, CmdExecutionProfileCheck,
-		CmdRateLimitLog, CmdRateLimitStats, CmdNetguardLog,
-		CmdWebhookLog, CmdWebhookStats,
-		CmdEdictLog, CmdEdictStats, CmdEdictShow, CmdEdictOverlay, CmdEdictTest, CmdEdictDenyList, CmdEdictDenyAdd,
-		CmdEdictDenyRemove, CmdEdictSetLevel, CmdEdictSetMode,
-		// Tenant self-observability (M128) — read-only folds of the tenant's
-		// own journal; each handler reads only kernelFor(tenantOf(req)).
-		CmdMemoryLog, CmdMemoryAudit, CmdMemoryClean, CmdWorldLog,
-		CmdApprovalsLog, CmdApprovalsStats,
-		CmdPlanHistory, CmdPlanStats,
-		CmdProviderLog, CmdProviderStats, CmdProviderRejections,
-		CmdScheduleFires, CmdScheduleStats,
-		CmdWardenLog, CmdWardenStats:
-		return true
-	default:
-		return false
-	}
-}
-
 func (s *Server) handleTenantCreate(conn net.Conn, req Request) {
 	if s.tenants == nil {
 		s.writeResp(conn, Response{ID: req.ID, Type: RespError, Error: "multi-tenancy is disabled (no tenant registry configured)"})

--- a/kernel/controlplane/tenant_auth_test.go
+++ b/kernel/controlplane/tenant_auth_test.go
@@ -4,8 +4,10 @@ package controlplane_test
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -325,6 +327,52 @@ func TestWhoami_PrimaryAndTenant(t *testing.T) {
 	}
 	if got, _ := tres["tenant"].(string); got != "acme" {
 		t.Errorf("tenant whoami tenant = %q want acme", got)
+	}
+}
+
+// TestTenantToken_RegistryExhaustive sweeps EVERY registered protocol command
+// with a tenant token, driven by the command registry itself so the sweep can
+// never go stale against the dispatch surface:
+//
+//   - every TenantAllowed spec must get PAST the auth gate — the call may
+//     still fail (missing args, empty journal), but never with the forbidden
+//     envelope;
+//   - every other spec must be rejected with exactly the forbidden envelope.
+//
+// No commands are excluded. Denied commands (which include every StreamLive
+// streaming command) are rejected at the auth gate before any handler runs, so
+// they cannot hang; the only allowed streaming command, run (StreamEvents),
+// fails fast on the missing args.intent. The per-call timeout is a hang safety
+// net, not an exclusion mechanism.
+func TestTenantToken_RegistryExhaustive(t *testing.T) {
+	_, srv, _, dir := startPair(t, mock.New(mock.FinalText("ok")))
+	reg := withTenants(t, srv, dir)
+	tok := mustTenant(t, reg, "acme")
+	c := tenantClient(t, dir, tok)
+
+	specs := controlplane.CommandSpecsForTest()
+	sort.Slice(specs, func(i, j int) bool { return specs[i].Cmd < specs[j].Cmd })
+
+	var allowed, denied int
+	for _, sp := range specs {
+		forbidden := fmt.Sprintf("forbidden: a tenant token cannot run %q (primary token required)", sp.Cmd)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		_, err := c.Call(ctx, sp.Cmd, map[string]any{"tenant": "acme"})
+		cancel()
+		if sp.TenantAllowed {
+			allowed++
+			if err != nil && strings.Contains(err.Error(), forbidden) {
+				t.Errorf("%q is TenantAllowed but the tenant token was forbidden: %v", sp.Cmd, err)
+			}
+		} else {
+			denied++
+			if err == nil || !strings.Contains(err.Error(), forbidden) {
+				t.Errorf("%q is not TenantAllowed: want the exact forbidden envelope %q, got %v", sp.Cmd, forbidden, err)
+			}
+		}
+	}
+	if allowed == 0 || denied == 0 {
+		t.Fatalf("degenerate registry sweep: %d allowed / %d denied commands", allowed, denied)
 	}
 }
 

--- a/kernel/controlplane/toolforge.go
+++ b/kernel/controlplane/toolforge.go
@@ -221,3 +221,17 @@ func (s *Server) handleToolforgeRemove(conn net.Conn, req Request) {
 	}
 	s.writeResp(conn, Response{ID: req.ID, Type: RespResult, Result: map[string]any{"removed": ok}})
 }
+
+// registerToolforgeCommands registers this file's protocol commands into the dispatch registry (phase 2.3).
+func registerToolforgeCommands() {
+	register(
+		commandSpec{Cmd: CmdToolforgeList, Handler: func(dc *DispatchCtx) { dc.S.handleToolforgeList(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdToolforgeShow, Handler: func(dc *DispatchCtx) { dc.S.handleToolforgeShow(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdToolforgeDraft, Handler: func(dc *DispatchCtx) { dc.S.handleToolforgeDraft(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdToolforgeEdit, Handler: func(dc *DispatchCtx) { dc.S.handleToolforgeEdit(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdToolforgeTest, Handler: func(dc *DispatchCtx) { dc.S.handleToolforgeTest(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdToolforgePromote, Handler: func(dc *DispatchCtx) { dc.S.handleToolforgePromote(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdToolforgeQuarantine, Handler: func(dc *DispatchCtx) { dc.S.handleToolforgeQuarantine(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdToolforgeRemove, Handler: func(dc *DispatchCtx) { dc.S.handleToolforgeRemove(dc.Conn, dc.Req) }},
+	)
+}

--- a/kernel/controlplane/workboard.go
+++ b/kernel/controlplane/workboard.go
@@ -795,3 +795,30 @@ func workboardStringSliceArg(raw any) []string {
 		return nil
 	}
 }
+
+// registerWorkboardCommands registers this file's protocol commands into the dispatch registry (phase 2.3).
+func registerWorkboardCommands() {
+	register(
+		commandSpec{Cmd: CmdWorkboardList, Handler: func(dc *DispatchCtx) { dc.S.handleWorkboardList(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkboardLanes, Handler: func(dc *DispatchCtx) { dc.S.handleWorkboardLanes(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkboardShow, Handler: func(dc *DispatchCtx) { dc.S.handleWorkboardShow(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkboardCreate, Handler: func(dc *DispatchCtx) { dc.S.handleWorkboardCreate(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkboardClaim, Handler: func(dc *DispatchCtx) { dc.S.handleWorkboardClaim(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkboardHeartbeat, Handler: func(dc *DispatchCtx) { dc.S.handleWorkboardHeartbeat(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkboardComment, Handler: func(dc *DispatchCtx) { dc.S.handleWorkboardComment(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkboardBlock, Handler: func(dc *DispatchCtx) { dc.S.handleWorkboardBlock(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkboardFail, Handler: func(dc *DispatchCtx) { dc.S.handleWorkboardFail(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkboardUnblock, Handler: func(dc *DispatchCtx) { dc.S.handleWorkboardUnblock(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkboardComplete, Handler: func(dc *DispatchCtx) { dc.S.handleWorkboardComplete(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkboardProve, Handler: func(dc *DispatchCtx) { dc.S.handleWorkboardProve(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkboardSeat, Handler: func(dc *DispatchCtx) { dc.S.handleWorkboardSeat(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkboardArchive, Handler: func(dc *DispatchCtx) { dc.S.handleWorkboardArchive(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkboardLink, Handler: func(dc *DispatchCtx) { dc.S.handleWorkboardLink(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkboardPolicy, Handler: func(dc *DispatchCtx) { dc.S.handleWorkboardPolicy(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkboardDepend, Handler: func(dc *DispatchCtx) { dc.S.handleWorkboardDepend(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkboardReclaim, Handler: func(dc *DispatchCtx) { dc.S.handleWorkboardReclaim(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkboardSweep, Handler: func(dc *DispatchCtx) { dc.S.handleWorkboardSweep(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkboardDispatch, Handler: func(dc *DispatchCtx) { dc.S.handleWorkboardDispatch(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkboardWatch, Handler: func(dc *DispatchCtx) { dc.S.handleWorkboardWatch(dc.Conn, dc.Req) }},
+	)
+}

--- a/kernel/controlplane/workflow.go
+++ b/kernel/controlplane/workflow.go
@@ -704,3 +704,22 @@ func (s *Server) handleWorkflowRun(conn net.Conn, req Request) {
 		},
 	})
 }
+
+// registerWorkflowCommands registers this file's protocol commands into the dispatch registry (phase 2.3).
+func registerWorkflowCommands() {
+	register(
+		commandSpec{Cmd: CmdWorkflowList, Handler: func(dc *DispatchCtx) { dc.S.handleWorkflowList(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkflowShow, Handler: func(dc *DispatchCtx) { dc.S.handleWorkflowShow(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkflowSave, Handler: func(dc *DispatchCtx) { dc.S.handleWorkflowSave(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkflowRestore, Handler: func(dc *DispatchCtx) { dc.S.handleWorkflowRestore(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkflowRemove, Handler: func(dc *DispatchCtx) { dc.S.handleWorkflowRemove(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkflowSetEnabled, Handler: func(dc *DispatchCtx) { dc.S.handleWorkflowSetEnabled(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkflowRun, Handler: func(dc *DispatchCtx) { dc.S.handleWorkflowRun(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkflowDraft, Handler: func(dc *DispatchCtx) { dc.S.handleWorkflowDraft(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkflowRefine, Handler: func(dc *DispatchCtx) { dc.S.handleWorkflowRefine(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkflowRuns, Handler: func(dc *DispatchCtx) { dc.S.handleWorkflowRuns(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkflowTemplates, Handler: func(dc *DispatchCtx) { dc.S.handleWorkflowTemplates(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkflowWebhook, Handler: func(dc *DispatchCtx) { dc.S.handleWorkflowWebhook(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorkflowTestNode, Handler: func(dc *DispatchCtx) { dc.S.handleWorkflowTestNode(dc.Conn, dc.Req) }},
+	)
+}

--- a/kernel/controlplane/world.go
+++ b/kernel/controlplane/world.go
@@ -277,3 +277,17 @@ func entityView(e worldmodel.Entity) map[string]any {
 	}
 	return v
 }
+
+// registerWorldCommands registers this file's protocol commands into the dispatch registry (phase 2.3).
+func registerWorldCommands() {
+	register(
+		commandSpec{Cmd: CmdWorldAdd, Handler: func(dc *DispatchCtx) { dc.S.handleWorldAdd(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorldEdit, Handler: func(dc *DispatchCtx) { dc.S.handleWorldEdit(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorldRelate, Handler: func(dc *DispatchCtx) { dc.S.handleWorldRelate(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorldResolve, Handler: func(dc *DispatchCtx) { dc.S.handleWorldResolve(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorldNeighbors, Handler: func(dc *DispatchCtx) { dc.S.handleWorldNeighbors(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorldList, Handler: func(dc *DispatchCtx) { dc.S.handleWorldList(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorldGet, Handler: func(dc *DispatchCtx) { dc.S.handleWorldGet(dc.Conn, dc.Req) }},
+		commandSpec{Cmd: CmdWorldForget, Handler: func(dc *DispatchCtx) { dc.S.handleWorldForget(dc.Conn, dc.Req) }},
+	)
+}

--- a/plans/phase2.3-command-registry.md
+++ b/plans/phase2.3-command-registry.md
@@ -1,0 +1,59 @@
+# Phase 2.3 — Controlplane command registry (working plan, survey 2026-08-06)
+
+## Verified facts
+- handleConn (server.go:481-1185): one request per conn (NO read loop), defer conn.Close +
+  defer s.recoverConn(conn,&req) BEFORE parse (pre-auth panic containment; must stay in the
+  goroutine frame), 10-min read deadline, readBoundedLine 16MiB ("request too large"),
+  "bad request: " parse envelope, auth gate (tokenIsPrimary → tenants.Authorize →
+  tenantTokenAllows → req.Args["tenant"] PINNING incl. map alloc), then a 319-case switch
+  (1:1 with protocol.go's 319 Cmd* consts), default "unknown command: "+cmd (pinned by test).
+- Handler shapes: 300× (conn,req), 19× (ctx,conn,req). All *Server methods (320 handle*;
+  +handleAgentSetRetired shared impl off-switch).
+- Streaming is TRI-STATE: StreamNone (300) / StreamEvents (plan, market_install/uninstall,
+  toolbox_install — emit RespEvent, keep deadline) / StreamLive (pulse_subscribe clears
+  deadline + tick watcher; 6× cancelOnConnClose: chat_summarize, conductor_ask, council_ask,
+  plan_generate, plan_refine, research_ask). handleRun is special: cancelOnDisconnect-GATED
+  goroutine cancelling the RUN (not ctx) — model as StreamEvents + keep inline logic.
+- tenantTokenAllows (tenant.go:68): 47-command allowlist, deny-default. Invariant (comment
+  only today): TenantAllowed ⟹ handler routes via kernelFor. ~44/319 tenant-routed
+  (28 direct kernelFor calls + edictFor(7) + projectJournal(9)); ~275 use s.k.
+  tenant_stats loops ALL tenants (legit exception).
+- Server injected nilable deps: 10 (standingFire, diskWatch, probeWatch, diskFree,
+  channelSend, boardNotify + pulse, tenants, updateSvc, boardStore). All handler state
+  file-local (roster cache, oauth maps, provLogin) — subpackage split is viable later.
+- Only 2 command-string switches exist (handleConn + tenantTokenAllows). webui has 4
+  route→Cmd tables (follow-on: derive from registry metadata; NOT this phase).
+  cmd/agt already has the registry pattern (commands.go + cmd_register.go) — mirror it.
+- Tests: tenant_auth_test.go is load-bearing; fuzz_test mirrors handleConn's read path;
+  TestUnknownCommand pins the envelope; startPair fixture exercises everything E2E.
+
+## Design
+DispatchCtx{Ctx, Conn, Req, S, K (pre-resolved), Tenant, Primary} — kills whoami re-check.
+commandSpec{Cmd, Handler func(*DispatchCtx), TenantAllowed, TenantRouted, Streaming}.
+register(specs...) panics on dup; explicit registerAll() calling per-subsystem
+registerXSpecs() living NEXT TO the handlers (NOT per-file init()) — cmd_register.go shape.
+Dispatch: lookup AFTER auth gate (preserve "forbidden" for unknown cmd from tenant token —
+do NOT move lookup before auth). StreamLive → dispatch owns cancelOnConnClose + deadline.
+TenantRouted → dispatch resolves dc.K = kernelFor(tenant) once.
+
+## Commits
+A (mechanical mirror): dispatch.go types + register; per-subsystem registerXSpecs with ALL
+  319 specs as thin closures over existing methods (TenantAllowed copied verbatim from
+  tenantTokenAllows; TenantRouted/Streaming per survey). handleConn UNTOUCHED. Tests:
+  Registry_MatchesProtocolConstants (regexp protocol.go ↔ registry keys, both directions),
+  Registry_MatchesOldSwitch (regexp server.go case arms ↔ keys; DELETE in B),
+  Registry_TenantAllowedMatchesLegacyAllowlist (DELETE in B),
+  Registry_TenantAllowedImpliesTenantRouted (PERMANENT — real tenant-isolation invariant).
+B (the swap): delete 641-line switch + tenantTokenAllows; handleConn ≈60 lines using the
+  registry; StreamLive dispatch-owned; delete the two commit-A bridge tests; extend
+  tenant_auth_test with registry-driven exhaustive table (every TenantAllowed spec reachable
+  by tenant token, every other → "forbidden").
+C+ (unbounded, later): convert closures to native handlers per subsystem; kernelFor
+  source-scan ratchet (baseline 21 files, lower as converted); subpackage split.
+
+## Gotchas
+- recoverConn must stay deferred in handleConn's frame pre-parse.
+- Preserve exact strings: "unauthorized", "forbidden: a tenant token cannot run %q
+  (primary token required)", "unknown command: ", "bad request: ", "request too large".
+- Tenant arg pinning (req.Args["tenant"] = reqTenant, alloc if nil) must survive.
+- handleRun keeps its bespoke disconnect goroutine (cancels run, opt-in).


### PR DESCRIPTION
Phase 2.3 of docs/REFACTORING-SCAN-2026-08.md — commits A (mirror) + B (swap); plan in-tree at plans/phase2.3-command-registry.md.

## What changed
- **commandRegistry**: all 319 protocol commands as `commandSpec{Handler, TenantAllowed, TenantRouted, Streaming}`, registered per-subsystem next to their handlers (cmd/agt's proven cmd_register.go shape). Commit A built the mirror purely additively with bridge tests proving faithfulness to the switch and the legacy allowlist BEFORE the swap; commit B deleted both.
- **handleConn: 705 → ~100 lines.** Dispatch owns tenant-kernel resolution (`TenantRouted` → `kernelFor` once) and conn-tied contexts (`StreamLive` → `cancelOnConnClose`); the 6 per-handler cancelOnConnClose calls are gone. `pulse_subscribe` stays self-managed — its watcher re-arms 500ms read deadlines, and a dispatch-owned second conn reader would race and kill healthy idle streams (documented at its spec; pinned by TestPulse_IdleStreamIsNotKilledByReadTimeout).
- **`tenantTokenAllows` deleted** — the parallel 47-command switch is now the `TenantAllowed` field, and `TestRegistry_TenantAllowedImpliesTenantRouted` turns the tenant-isolation invariant (allowed ⟹ routed through the caller's own kernel) from a comment into a tested guarantee (whoami explicitly exempted).
- **Exhaustive tenant-boundary coverage**: `TestTenantToken_RegistryExhaustive` drives all 319 commands with a tenant token (47 allowed / 272 denied), replacing hand-listed spot checks. Exact error envelopes preserved — tenant tokens still get "forbidden" for unknown commands (no command-existence oracle).
- **Enables the controlplane subpackage split** (commit C+, unbounded follow-on): handlers no longer must be `*Server` methods.

Verified: whole-tree build+vet, full Go suite, isolated-daemon boot smoke. (CI runners offline.)