### PR TITLE
refactor(daemonconfig): Phase 2.5 — typed Load() replaces runDaemon's inline env parsing

### DIFF
--- a/cmd/agezt/internal/daemonconfig/daemonconfig.go
+++ b/cmd/agezt/internal/daemonconfig/daemonconfig.go
@@ -1,0 +1,590 @@
+// SPDX-License-Identifier: MIT
+
+// Package daemonconfig parses the daemon's AGEZT_* boot environment into one
+// typed Config (Phase 2.5). It replaces the ~450 lines of inline env parsing
+// that lived in runDaemon, so every parse shape, default, warning string, and
+// fatal-vs-warn decision is unit-testable without booting a daemon.
+//
+// Load MUST be called after injectConfig has bridged the Config Center store +
+// vault into the process environment (the reads here see injected values, same
+// as the inline code they replace). Reads that must NOT go through Load stay in
+// runDaemon:
+//
+//   - AGEZT_FORCE_START — read before injectConfig runs (single-instance guard).
+//   - AGEZT_COUNCIL_MEMBERS, AGEZT_DRAIN_TIMEOUT, and the tenant lazy-open's
+//     AGEZT_EDICT_DURABLE — read live at call time (the Config Center
+//     live-applies edits via os.Setenv, so a boot-time capture would regress
+//     restart-free reconfiguration).
+//   - channel-manifest RequiredEnv/AllowlistEnv names — dynamic, not AGEZT_*
+//     statics.
+//   - AGEZT_WEB_ADDR / AGEZT_REST_ADDR / AGEZT_API_ADDR — owned by their
+//     buildWebUI/buildRESTAPI/buildOpenAIAPI helpers.
+//
+// Semantics contract: Load returns an error ONLY for the values that were a
+// hard startup failure in the inline code (malformed durations/integers on the
+// run-loop caps, malformed USD amounts, malformed deny rules, malformed tenant
+// quotas when multi-tenancy is on). Everything else warns to the writer with
+// the exact historical message and falls back to its default. Error strings
+// carry the env name ("AGEZT_X: want ..."), so runDaemon's
+// `fmt.Fprintf(stderr, "%s: %v\n", brand.Binary, err)` reproduces the
+// historical output byte-for-byte.
+package daemonconfig
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/agezt/agezt/internal/brand"
+	"github.com/agezt/agezt/kernel/edict"
+	"github.com/agezt/agezt/plugins/providers/voice"
+)
+
+// Config is every post-inject AGEZT_* boot setting runDaemon consumes, grouped
+// by the natural clusters of the old inline code.
+type Config struct {
+	Policy    Policy
+	Knowledge Knowledge
+	RunLoop   RunLoop
+	SubAgents SubAgents
+	Context   ContextBudget
+	Sidecars  Sidecars
+	Guards    Guards
+	Tenancy   Tenancy
+	Lifecycle Lifecycle
+	Misc      Misc
+}
+
+// Policy groups the Edict/approval settings (M611/M17/M20/M100).
+type Policy struct {
+	// AllowAll is AGEZT_ALLOW_ALL == "1": every governed capability at L4.
+	AllowAll bool
+	// EdictDeny is the operator-extensible hard-deny extras parsed from
+	// AGEZT_EDICT_DENY (nil when unset). A malformed spec is a Load error.
+	EdictDeny []edict.HardDenyRule
+	// EdictDurable is AGEZT_EDICT_DURABLE == "on" at boot: replay journaled
+	// policy.changed events onto the fresh engine. The tenant lazy-open path
+	// re-reads the env live (see the package comment).
+	EdictDurable bool
+	// ApprovalTimeout is AGEZT_APPROVAL_TIMEOUT: how long a prompt-mode HITL
+	// approval blocks before auto-deny. 0 = kernel default (5m). Malformed is
+	// a Load error; a non-positive duration means "use default" (stays 0).
+	ApprovalTimeout time.Duration
+}
+
+// Knowledge groups the memory / world-model / skills switches (ROADMAP §2.3,
+// SPEC-05, M993/M1000).
+type Knowledge struct {
+	// Memory is AGEZT_MEMORY != "off": per-run inject/tool/distill.
+	Memory bool
+	// MemoryDistillMinTools is AGEZT_MEMORY_DISTILL_MIN_TOOLS (default 6;
+	// malformed or non-positive silently falls back to the default).
+	MemoryDistillMinTools int
+	// UserProfile is Memory && AGEZT_USER_PROFILE != "off" (M1000).
+	UserProfile bool
+	// TasteInject is AGEZT_TASTE_INJECT != "off".
+	TasteInject bool
+	// WorldModel is AGEZT_WORLDMODEL != "off".
+	WorldModel bool
+	// Skills is AGEZT_SKILLS != "off" (skill injection).
+	Skills bool
+	// Forge is AGEZT_FORGE != "off" (post-run skill proposal).
+	Forge bool
+	// SkillShadowEval is AGEZT_SKILL_SHADOWEVAL == "on" (SPEC-05 §5.2).
+	SkillShadowEval bool
+	// SkillAutoQuarantine is AGEZT_SKILL_AUTOQUARANTINE != "off" (default on).
+	SkillAutoQuarantine bool
+	// SkillAutoShadow is AGEZT_SKILL_AUTOSHADOW == "on" (default off).
+	SkillAutoShadow bool
+	// SkillAutoPromote is AGEZT_SKILL_AUTOPROMOTE != "off" (default on).
+	SkillAutoPromote bool
+}
+
+// RunLoop groups the per-run execution caps (M31/M824/M833/M880/M34/CH-03).
+// Every malformed value here was a hard startup error inline and is a Load
+// error now.
+type RunLoop struct {
+	// RunTimeout is AGEZT_RUN_TIMEOUT: per-run wall-clock cap. 0 = off
+	// (a valid but non-positive duration also disarms).
+	RunTimeout time.Duration
+	// MaxIter is AGEZT_MAX_ITER: tool-call rounds per run. 0 = agent default.
+	MaxIter int
+	// MaxAutoContinue / MaxAutoContinueSet carry AGEZT_MAX_AUTO_CONTINUE.
+	// The env accepts any integer (negative disables auto-continue), so a
+	// separate Set flag distinguishes "unset" from an explicit 0.
+	MaxAutoContinue    int
+	MaxAutoContinueSet bool
+	// AutoContinueWait is AGEZT_AUTO_CONTINUE_WAIT (non-negative duration).
+	AutoContinueWait time.Duration
+	// MaxParallelTools is AGEZT_PARALLEL_TOOLS. 0 = agent default.
+	MaxParallelTools int
+	// ToolDiscoveryMax is AGEZT_TOOL_DISCOVERY_MAX. 0 = off (also the
+	// explicit-"0" value; both leave the kernel offering every tool).
+	ToolDiscoveryMax int
+	// ToolTimeout is AGEZT_TOOL_TIMEOUT: per-tool-call cap. 0 = off.
+	ToolTimeout time.Duration
+}
+
+// SubAgents groups the delegation rails (P6-MULTI-01, M843/M46/M48/M629).
+type SubAgents struct {
+	// Enabled is AGEZT_SUBAGENT != "off".
+	Enabled bool
+	// Depth is AGEZT_SUBAGENT_DEPTH (default 3; malformed/non-positive
+	// silently falls back).
+	Depth int
+	// Fanout is AGEZT_SUBAGENT_FANOUT (0 = unbounded).
+	Fanout int
+	// SpendCapMicrocents is AGEZT_SUBAGENT_SPEND_CAP (USD) × 1e9. Malformed
+	// or negative is a Load error. 0 = unbounded.
+	SpendCapMicrocents int64
+	// MaxTotal is AGEZT_SUBAGENT_MAX_TOTAL, with the M843 derivation applied:
+	// unset (0) while Depth > 1 becomes 48 so deep delegation stays bounded.
+	MaxTotal int
+}
+
+// ContextBudget groups the context-assembly caps (SPEC-04 §3 / SPEC-10 §3).
+// Malformed values here warn and fall back (never fatal).
+type ContextBudget struct {
+	// ArtifactThreshold is AGEZT_ARTIFACT_THRESHOLD (bytes). 0 = kernel
+	// default (agent.DefaultArtifactThreshold).
+	ArtifactThreshold int
+	// Budget / BudgetAuto carry AGEZT_CONTEXT_BUDGET: a positive char count,
+	// or "auto" to derive from the model's catalog context window.
+	Budget     int
+	BudgetAuto bool
+	// ProtectFirst is AGEZT_CONTEXT_PROTECT_FIRST (M395). 0 = oldest-first.
+	ProtectFirst int
+	// Summarize is AGEZT_CONTEXT_SUMMARIZE == "1" (M398).
+	Summarize bool
+}
+
+// Sidecars groups the five near-identical OpenAI-compatible model-service
+// clusters (M901 embeddings, M997 image + rerank, M998 voice).
+type Sidecars struct {
+	Embed  ModelService // AGEZT_EMBED_URL / _MODEL / _KEY
+	Image  ModelService // AGEZT_IMAGE_URL / _MODEL / _KEY
+	Rerank ModelService // AGEZT_RERANK_URL / _MODEL / _KEY
+	STT    VoiceHalf    // AGEZT_STT_PROVIDER / _URL / _MODEL / _KEY
+	TTS    VoiceHalf    // AGEZT_TTS_PROVIDER / _URL / _MODEL / _KEY / _VOICE
+}
+
+// ModelService is one URL+model+key sidecar. When URL is set but Model is
+// empty, Load warns ("… disabled") and Enabled() reports false — the service
+// degrades, never fails the boot.
+type ModelService struct {
+	URL   string
+	Model string
+	Key   string
+}
+
+// Enabled reports whether the sidecar should be constructed (URL and model
+// both present).
+func (s ModelService) Enabled() bool { return s.URL != "" && s.Model != "" }
+
+// VoiceHalf is one STT or TTS half. Native providers (ElevenLabs, Deepgram,
+// Cartesia) supply their own base URL, so URL is optional for them; Attempt
+// carries the historical gate: (URL set OR native provider) AND NOT
+// (model empty on a non-native provider — which warns instead).
+type VoiceHalf struct {
+	Provider string
+	URL      string
+	Model    string
+	Key      string
+	// Voice is the TTS voice id (AGEZT_TTS_VOICE); unused for STT.
+	Voice string
+	// Attempt is true when runDaemon should construct this half's client.
+	Attempt bool
+}
+
+// Guards groups the run-safety gates (observation deltas, epistemic/intent
+// gating, prompt-injection guard).
+type Guards struct {
+	// ObservationDeltas is AGEZT_OBSERVATION_DELTAS == "on"/"1".
+	ObservationDeltas bool
+	// EpistemicEscalation is AGEZT_EPISTEMIC_ESCALATION == "on"/"1".
+	EpistemicEscalation bool
+	// IntentRegretGating is AGEZT_INTENT_REGRET_GATING == "on"/"1".
+	IntentRegretGating bool
+	// PromptInjectionGuard is the RAW AGEZT_PROMPT_INJECTION_GUARD value;
+	// runDaemon parses it with kernelruntime.ParsePromptInjectionMode (any
+	// string is valid — unset/unknown means warn mode).
+	PromptInjectionGuard string
+	// DisableHeuristicBypass is AGEZT_DISABLE_HEURISTIC_BYPASS == "on"/"1".
+	DisableHeuristicBypass bool
+}
+
+// Tenancy groups the multi-tenant registry settings (ROADMAP P6-MULTI, M14).
+// The TENANT_* quotas are parsed ONLY when Multitenant is on — a malformed
+// value with tenancy off was ignored inline and still is.
+type Tenancy struct {
+	// Multitenant is AGEZT_MULTITENANT == "on".
+	Multitenant bool
+	// DailyCeiling* carry AGEZT_TENANT_DAILY_CEILING (USD). Set distinguishes
+	// an explicit value (including 0) from "inherit the primary's ceiling".
+	DailyCeilingSet        bool
+	DailyCeilingUSD        float64
+	DailyCeilingMicrocents int64
+	// RatePerMin* carry AGEZT_TENANT_RATE_PER_MIN. Set distinguishes an
+	// explicit 0 ("0/min") from unset ("unlimited").
+	RatePerMinSet bool
+	RatePerMin    int
+}
+
+// Lifecycle groups restart/update/disconnect behaviour (M1002, M35, M860).
+type Lifecycle struct {
+	// Resume is AGEZT_RESUME != "off" (M1002 durable run resume).
+	Resume bool
+	// ResumeSnapshotMaxBytes is AGEZT_RESUME_SNAPSHOT_MAX_BYTES (0 = package
+	// default; malformed/non-positive silently falls back).
+	ResumeSnapshotMaxBytes int
+	// CancelOnDisconnect is AGEZT_CANCEL_ON_DISCONNECT == "on" (M35).
+	CancelOnDisconnect bool
+	// UpdateEndpoint is AGEZT_UPDATE_ENDPOINT (raw; empty = not configured).
+	UpdateEndpoint string
+	// UpdateDrainTimeout is AGEZT_UPDATE_DRAIN_TIMEOUT (default 30s; a
+	// malformed value silently keeps the default). Consumed only by the
+	// endpoint source — the GitHub source hardcodes 30s, as inline did.
+	UpdateDrainTimeout time.Duration
+	// UpdateCheckInterval is AGEZT_UPDATE_CHECK_INTERVAL (default 0 =
+	// disabled; only a valid positive duration arms it).
+	UpdateCheckInterval time.Duration
+	// UpdateGitHubOwner / UpdateGitHubRepo are AGEZT_UPDATE_GITHUB_OWNER /
+	// _REPO. When the owner is set and the repo empty, the repo defaults to
+	// the binary name (as inline did).
+	UpdateGitHubOwner string
+	UpdateGitHubRepo  string
+}
+
+// Misc is the remainder: single strings and switches with no larger cluster.
+type Misc struct {
+	// SystemPrompt is AGEZT_SYSTEM_PROMPT, raw and untrimmed.
+	SystemPrompt string
+	// Redact is AGEZT_REDACT != "off" (M15 / SPEC-06 journal scrubbing).
+	Redact bool
+	// EnvInject is AGEZT_ENV_INJECT != "off" (M609 host-env preamble).
+	EnvInject bool
+	// CouncilWebSearch is AGEZT_COUNCIL_WEBSEARCH != "off". (The
+	// COUNCIL_MEMBERS list stays a live read in its closure.)
+	CouncilWebSearch bool
+	// ScheduleNotify is AGEZT_SCHEDULE_NOTIFY == "on" (trimmed; M152).
+	ScheduleNotify bool
+	// WebhookChannels is the AGEZT_WEBHOOK_CHANNELS comma list (trimmed,
+	// blanks dropped) — the standing-order briefing allowlist for `webhook`.
+	WebhookChannels []string
+	// ToolforgeAutoPromote is AGEZT_TOOLFORGE_AUTO_PROMOTE != "off".
+	ToolforgeAutoPromote bool
+}
+
+// Load parses the daemon's boot configuration from the environment. get is the
+// env accessor (nil = os.Getenv; inject a map lookup in tests); warn receives
+// the warn-and-degrade messages (nil = discard). The returned error is non-nil
+// only for the historically fatal cases, carries the env name, and is emitted
+// in the same source order as the inline code so a boot with several bad
+// values fails on the same one it always did.
+func Load(get func(string) string, warn io.Writer) (Config, error) {
+	if get == nil {
+		get = os.Getenv
+	}
+	if warn == nil {
+		warn = io.Discard
+	}
+	var c Config
+
+	// --- Policy: operator deny rules + master permissive switch (M17/M611) ---
+	if spec := strings.TrimSpace(get(brand.EnvPrefix + "EDICT_DENY")); spec != "" {
+		extra, derr := edict.ParseDenyRules(spec)
+		if derr != nil {
+			return Config{}, fmt.Errorf("%sEDICT_DENY: %w", brand.EnvPrefix, derr)
+		}
+		c.Policy.EdictDeny = extra
+	}
+	c.Policy.AllowAll = get(brand.EnvPrefix+"ALLOW_ALL") == "1"
+
+	// --- Knowledge: memory / taste / world / skills switches ---
+	c.Knowledge.Memory = !strings.EqualFold(get(brand.EnvPrefix+"MEMORY"), "off")
+	c.Knowledge.MemoryDistillMinTools = 6
+	if v := strings.TrimSpace(get(brand.EnvPrefix + "MEMORY_DISTILL_MIN_TOOLS")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			c.Knowledge.MemoryDistillMinTools = n
+		}
+	}
+	c.Knowledge.UserProfile = c.Knowledge.Memory && !strings.EqualFold(get(brand.EnvPrefix+"USER_PROFILE"), "off")
+	c.Knowledge.TasteInject = !strings.EqualFold(get(brand.EnvPrefix+"TASTE_INJECT"), "off")
+	c.Knowledge.WorldModel = !strings.EqualFold(get(brand.EnvPrefix+"WORLDMODEL"), "off")
+	c.Knowledge.Skills = !strings.EqualFold(get(brand.EnvPrefix+"SKILLS"), "off")
+	c.Knowledge.Forge = !strings.EqualFold(get(brand.EnvPrefix+"FORGE"), "off")
+	c.Misc.EnvInject = !strings.EqualFold(get(brand.EnvPrefix+"ENV_INJECT"), "off")
+
+	// --- Lifecycle: durable resume (M1002) ---
+	c.Lifecycle.Resume = !strings.EqualFold(get(brand.EnvPrefix+"RESUME"), "off")
+	if v := strings.TrimSpace(get(brand.EnvPrefix + "RESUME_SNAPSHOT_MAX_BYTES")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			c.Lifecycle.ResumeSnapshotMaxBytes = n
+		}
+	}
+
+	// --- SubAgents: delegation rails ---
+	c.SubAgents.Enabled = !strings.EqualFold(get(brand.EnvPrefix+"SUBAGENT"), "off")
+	c.SubAgents.Depth = 3
+	if v := strings.TrimSpace(get(brand.EnvPrefix + "SUBAGENT_DEPTH")); v != "" {
+		if d, err := strconv.Atoi(v); err == nil && d > 0 {
+			c.SubAgents.Depth = d
+		}
+	}
+	if v := strings.TrimSpace(get(brand.EnvPrefix + "SUBAGENT_FANOUT")); v != "" {
+		if f, err := strconv.Atoi(v); err == nil && f > 0 {
+			c.SubAgents.Fanout = f
+		}
+	}
+	if v := strings.TrimSpace(get(brand.EnvPrefix + "SUBAGENT_SPEND_CAP")); v != "" {
+		usd, perr := strconv.ParseFloat(v, 64)
+		if perr != nil || usd < 0 {
+			return Config{}, fmt.Errorf("%sSUBAGENT_SPEND_CAP: want a non-negative USD amount, got %q", brand.EnvPrefix, v)
+		}
+		c.SubAgents.SpendCapMicrocents = int64(usd * 1e9)
+	}
+	if v := strings.TrimSpace(get(brand.EnvPrefix + "SUBAGENT_MAX_TOTAL")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			c.SubAgents.MaxTotal = n
+		}
+	}
+	// M843: deep delegation gets a finite tree rail when the operator set none.
+	if c.SubAgents.MaxTotal == 0 && c.SubAgents.Depth > 1 {
+		c.SubAgents.MaxTotal = 48
+	}
+
+	// --- ContextBudget: artifact offload + context caps (warn + default) ---
+	if v := get(brand.EnvPrefix + "ARTIFACT_THRESHOLD"); v != "" {
+		if n, perr := strconv.Atoi(v); perr == nil && n > 0 {
+			c.Context.ArtifactThreshold = n
+		} else {
+			fmt.Fprintf(warn, "%s: %sARTIFACT_THRESHOLD: want a positive byte count, got %q (using default)\n", brand.Binary, brand.EnvPrefix, v)
+		}
+	}
+	if v := get(brand.EnvPrefix + "CONTEXT_BUDGET"); v != "" {
+		if strings.EqualFold(v, "auto") {
+			c.Context.BudgetAuto = true // derive from the model's catalog context window
+		} else if n, perr := strconv.Atoi(v); perr == nil && n > 0 {
+			c.Context.Budget = n
+		} else {
+			fmt.Fprintf(warn, "%s: %sCONTEXT_BUDGET: want a positive char count or \"auto\", got %q (ignored)\n", brand.Binary, brand.EnvPrefix, v)
+		}
+	}
+	if v := get(brand.EnvPrefix + "CONTEXT_PROTECT_FIRST"); v != "" {
+		if n, perr := strconv.Atoi(v); perr == nil && n >= 0 {
+			c.Context.ProtectFirst = n
+		} else {
+			fmt.Fprintf(warn, "%s: %sCONTEXT_PROTECT_FIRST: want a non-negative count, got %q (ignored)\n", brand.Binary, brand.EnvPrefix, v)
+		}
+	}
+	c.Context.Summarize = get(brand.EnvPrefix+"CONTEXT_SUMMARIZE") == "1"
+
+	// --- Guards ---
+	obsRaw := strings.TrimSpace(get(brand.EnvPrefix + "OBSERVATION_DELTAS"))
+	c.Guards.ObservationDeltas = strings.EqualFold(obsRaw, "on") || obsRaw == "1"
+	epiRaw := strings.TrimSpace(get(brand.EnvPrefix + "EPISTEMIC_ESCALATION"))
+	c.Guards.EpistemicEscalation = strings.EqualFold(epiRaw, "on") || epiRaw == "1"
+	intRaw := strings.TrimSpace(get(brand.EnvPrefix + "INTENT_REGRET_GATING"))
+	c.Guards.IntentRegretGating = strings.EqualFold(intRaw, "on") || intRaw == "1"
+	c.Guards.PromptInjectionGuard = get(brand.EnvPrefix + "PROMPT_INJECTION_GUARD")
+	c.Misc.ToolforgeAutoPromote = !strings.EqualFold(get(brand.EnvPrefix+"TOOLFORGE_AUTO_PROMOTE"), "off")
+	dhbRaw := strings.TrimSpace(get(brand.EnvPrefix + "DISABLE_HEURISTIC_BYPASS"))
+	c.Guards.DisableHeuristicBypass = strings.EqualFold(dhbRaw, "on") || dhbRaw == "1"
+	c.Knowledge.SkillShadowEval = strings.EqualFold(get(brand.EnvPrefix+"SKILL_SHADOWEVAL"), "on")
+
+	// --- Sidecars: embeddings / voice / image / rerank (warn + degrade) ---
+	c.Sidecars.Embed.URL = strings.TrimSpace(get(brand.EnvPrefix + "EMBED_URL"))
+	c.Sidecars.Embed.Model = strings.TrimSpace(get(brand.EnvPrefix + "EMBED_MODEL"))
+	c.Sidecars.Embed.Key = strings.TrimSpace(get(brand.EnvPrefix + "EMBED_KEY"))
+	if c.Sidecars.Embed.URL != "" && c.Sidecars.Embed.Model == "" {
+		fmt.Fprintf(warn, "%s: %sEMBED_URL is set but %sEMBED_MODEL is empty — provider embeddings disabled\n", brand.Binary, brand.EnvPrefix, brand.EnvPrefix)
+	}
+
+	c.Sidecars.STT.Provider = strings.TrimSpace(get(brand.EnvPrefix + "STT_PROVIDER"))
+	c.Sidecars.STT.URL = strings.TrimSpace(get(brand.EnvPrefix + "STT_URL"))
+	c.Sidecars.STT.Model = strings.TrimSpace(get(brand.EnvPrefix + "STT_MODEL"))
+	c.Sidecars.STT.Key = strings.TrimSpace(get(brand.EnvPrefix + "STT_KEY"))
+	if native := voiceProviderIsNative(c.Sidecars.STT.Provider); c.Sidecars.STT.URL != "" || native {
+		if c.Sidecars.STT.Model == "" && !native {
+			fmt.Fprintf(warn, "%s: %sSTT_URL is set but %sSTT_MODEL is empty — transcription disabled\n", brand.Binary, brand.EnvPrefix, brand.EnvPrefix)
+		} else {
+			c.Sidecars.STT.Attempt = true
+		}
+	}
+	c.Sidecars.TTS.Provider = strings.TrimSpace(get(brand.EnvPrefix + "TTS_PROVIDER"))
+	c.Sidecars.TTS.URL = strings.TrimSpace(get(brand.EnvPrefix + "TTS_URL"))
+	c.Sidecars.TTS.Model = strings.TrimSpace(get(brand.EnvPrefix + "TTS_MODEL"))
+	c.Sidecars.TTS.Key = strings.TrimSpace(get(brand.EnvPrefix + "TTS_KEY"))
+	c.Sidecars.TTS.Voice = strings.TrimSpace(get(brand.EnvPrefix + "TTS_VOICE"))
+	if native := voiceProviderIsNative(c.Sidecars.TTS.Provider); c.Sidecars.TTS.URL != "" || native {
+		if c.Sidecars.TTS.Model == "" && !native {
+			fmt.Fprintf(warn, "%s: %sTTS_URL is set but %sTTS_MODEL is empty — synthesis disabled\n", brand.Binary, brand.EnvPrefix, brand.EnvPrefix)
+		} else {
+			c.Sidecars.TTS.Attempt = true
+		}
+	}
+
+	c.Sidecars.Image.URL = strings.TrimSpace(get(brand.EnvPrefix + "IMAGE_URL"))
+	c.Sidecars.Image.Model = strings.TrimSpace(get(brand.EnvPrefix + "IMAGE_MODEL"))
+	c.Sidecars.Image.Key = strings.TrimSpace(get(brand.EnvPrefix + "IMAGE_KEY"))
+	if c.Sidecars.Image.URL != "" && c.Sidecars.Image.Model == "" {
+		fmt.Fprintf(warn, "%s: %sIMAGE_URL is set but %sIMAGE_MODEL is empty — image generation disabled\n", brand.Binary, brand.EnvPrefix, brand.EnvPrefix)
+	}
+	c.Sidecars.Rerank.URL = strings.TrimSpace(get(brand.EnvPrefix + "RERANK_URL"))
+	c.Sidecars.Rerank.Model = strings.TrimSpace(get(brand.EnvPrefix + "RERANK_MODEL"))
+	c.Sidecars.Rerank.Key = strings.TrimSpace(get(brand.EnvPrefix + "RERANK_KEY"))
+	if c.Sidecars.Rerank.URL != "" && c.Sidecars.Rerank.Model == "" {
+		fmt.Fprintf(warn, "%s: %sRERANK_URL is set but %sRERANK_MODEL is empty — reranking disabled\n", brand.Binary, brand.EnvPrefix, brand.EnvPrefix)
+	}
+
+	// --- Misc: system prompt (raw, untrimmed — inline never trimmed it) ---
+	c.Misc.SystemPrompt = get(brand.EnvPrefix + "SYSTEM_PROMPT")
+
+	// --- RunLoop: per-run caps (every malformed value is fatal) ---
+	if spec := strings.TrimSpace(get(brand.EnvPrefix + "RUN_TIMEOUT")); spec != "" {
+		d, derr := time.ParseDuration(spec)
+		if derr != nil {
+			return Config{}, fmt.Errorf("%sRUN_TIMEOUT: want a Go duration (e.g. 90s, 5m), got %q", brand.EnvPrefix, spec)
+		}
+		if d > 0 {
+			c.RunLoop.RunTimeout = d
+		}
+	}
+	if spec := strings.TrimSpace(get(brand.EnvPrefix + "MAX_ITER")); spec != "" {
+		n, perr := strconv.Atoi(spec)
+		if perr != nil || n <= 0 {
+			return Config{}, fmt.Errorf("%sMAX_ITER: want a positive integer, got %q", brand.EnvPrefix, spec)
+		}
+		c.RunLoop.MaxIter = n
+	}
+	if spec := strings.TrimSpace(get(brand.EnvPrefix + "MAX_AUTO_CONTINUE")); spec != "" {
+		n, perr := strconv.Atoi(spec)
+		if perr != nil {
+			return Config{}, fmt.Errorf("%sMAX_AUTO_CONTINUE: want an integer, got %q", brand.EnvPrefix, spec)
+		}
+		c.RunLoop.MaxAutoContinue = n
+		c.RunLoop.MaxAutoContinueSet = true
+	}
+	if spec := strings.TrimSpace(get(brand.EnvPrefix + "AUTO_CONTINUE_WAIT")); spec != "" {
+		d, perr := time.ParseDuration(spec)
+		if perr != nil || d < 0 {
+			return Config{}, fmt.Errorf("%sAUTO_CONTINUE_WAIT: want a non-negative duration, got %q", brand.EnvPrefix, spec)
+		}
+		c.RunLoop.AutoContinueWait = d
+	}
+	if spec := strings.TrimSpace(get(brand.EnvPrefix + "PARALLEL_TOOLS")); spec != "" {
+		n, perr := strconv.Atoi(spec)
+		if perr != nil || n <= 0 {
+			return Config{}, fmt.Errorf("%sPARALLEL_TOOLS: want a positive integer, got %q", brand.EnvPrefix, spec)
+		}
+		c.RunLoop.MaxParallelTools = n
+	}
+	if spec := strings.TrimSpace(get(brand.EnvPrefix + "TOOL_DISCOVERY_MAX")); spec != "" {
+		n, perr := strconv.Atoi(spec)
+		if perr != nil || n < 0 {
+			return Config{}, fmt.Errorf("%sTOOL_DISCOVERY_MAX: want a non-negative integer, got %q", brand.EnvPrefix, spec)
+		}
+		c.RunLoop.ToolDiscoveryMax = n
+	}
+	if spec := strings.TrimSpace(get(brand.EnvPrefix + "TOOL_TIMEOUT")); spec != "" {
+		d, derr := time.ParseDuration(spec)
+		if derr != nil {
+			return Config{}, fmt.Errorf("%sTOOL_TIMEOUT: want a Go duration (e.g. 30s, 2m), got %q", brand.EnvPrefix, spec)
+		}
+		if d > 0 {
+			c.RunLoop.ToolTimeout = d
+		}
+	}
+	if spec := strings.TrimSpace(get(brand.EnvPrefix + "APPROVAL_TIMEOUT")); spec != "" {
+		d, derr := time.ParseDuration(spec)
+		if derr != nil {
+			return Config{}, fmt.Errorf("%sAPPROVAL_TIMEOUT: want a Go duration (e.g. 2m, 30s), got %q", brand.EnvPrefix, spec)
+		}
+		if d > 0 {
+			c.Policy.ApprovalTimeout = d
+		}
+	}
+
+	// --- Misc switches ---
+	c.Misc.Redact = !strings.EqualFold(get(brand.EnvPrefix+"REDACT"), "off")
+	c.Misc.CouncilWebSearch = !strings.EqualFold(get(brand.EnvPrefix+"COUNCIL_WEBSEARCH"), "off")
+	c.Knowledge.SkillAutoQuarantine = !strings.EqualFold(get(brand.EnvPrefix+"SKILL_AUTOQUARANTINE"), "off")
+	c.Knowledge.SkillAutoShadow = strings.EqualFold(get(brand.EnvPrefix+"SKILL_AUTOSHADOW"), "on")
+	c.Knowledge.SkillAutoPromote = !strings.EqualFold(get(brand.EnvPrefix+"SKILL_AUTOPROMOTE"), "off")
+	c.Policy.EdictDurable = strings.EqualFold(get(brand.EnvPrefix+"EDICT_DURABLE"), "on")
+
+	// --- Lifecycle: disconnect + self-update (M35, M860) ---
+	c.Lifecycle.CancelOnDisconnect = strings.EqualFold(get(brand.EnvPrefix+"CANCEL_ON_DISCONNECT"), "on")
+	c.Lifecycle.UpdateEndpoint = get(brand.EnvPrefix + "UPDATE_ENDPOINT")
+	c.Lifecycle.UpdateDrainTimeout = 30 * time.Second
+	if t := get(brand.EnvPrefix + "UPDATE_DRAIN_TIMEOUT"); t != "" {
+		if d, err := time.ParseDuration(t); err == nil {
+			c.Lifecycle.UpdateDrainTimeout = d
+		}
+	}
+	if t := get(brand.EnvPrefix + "UPDATE_CHECK_INTERVAL"); t != "" {
+		if d, err := time.ParseDuration(t); err == nil && d > 0 {
+			c.Lifecycle.UpdateCheckInterval = d
+		}
+	}
+	c.Lifecycle.UpdateGitHubOwner = get(brand.EnvPrefix + "UPDATE_GITHUB_OWNER")
+	c.Lifecycle.UpdateGitHubRepo = get(brand.EnvPrefix + "UPDATE_GITHUB_REPO")
+	if c.Lifecycle.UpdateGitHubOwner != "" && c.Lifecycle.UpdateGitHubRepo == "" {
+		c.Lifecycle.UpdateGitHubRepo = brand.Binary // default repo to the binary name
+	}
+
+	// --- Tenancy (quotas parsed only when multi-tenancy is on) ---
+	c.Tenancy.Multitenant = strings.EqualFold(get(brand.EnvPrefix+"MULTITENANT"), "on")
+	if c.Tenancy.Multitenant {
+		if spec := strings.TrimSpace(get(brand.EnvPrefix + "TENANT_DAILY_CEILING")); spec != "" {
+			usd, perr := strconv.ParseFloat(spec, 64)
+			if perr != nil || usd < 0 {
+				return Config{}, fmt.Errorf("%sTENANT_DAILY_CEILING: want a non-negative USD amount, got %q", brand.EnvPrefix, spec)
+			}
+			c.Tenancy.DailyCeilingSet = true
+			c.Tenancy.DailyCeilingUSD = usd
+			c.Tenancy.DailyCeilingMicrocents = int64(usd * 1e9)
+		}
+		if spec := strings.TrimSpace(get(brand.EnvPrefix + "TENANT_RATE_PER_MIN")); spec != "" {
+			n, perr := strconv.Atoi(spec)
+			if perr != nil || n < 0 {
+				return Config{}, fmt.Errorf("%sTENANT_RATE_PER_MIN: want a non-negative integer, got %q", brand.EnvPrefix, spec)
+			}
+			c.Tenancy.RatePerMinSet = true
+			c.Tenancy.RatePerMin = n
+		}
+	}
+
+	// --- Misc: scheduled-run delivery + webhook briefing allowlist ---
+	c.Misc.ScheduleNotify = strings.TrimSpace(get(brand.EnvPrefix+"SCHEDULE_NOTIFY")) == "on"
+	c.Misc.WebhookChannels = splitNonEmpty(get(brand.EnvPrefix + "WEBHOOK_CHANNELS"))
+
+	return c, nil
+}
+
+// voiceProviderIsNative mirrors runDaemon's helper: a native (non-OpenAI-
+// compatible) STT/TTS backend supplies its own default base URL, so a URL
+// isn't required to enable that half.
+func voiceProviderIsNative(p string) bool {
+	switch strings.ToLower(strings.TrimSpace(p)) {
+	case voice.ProviderElevenLabs, voice.ProviderDeepgram, voice.ProviderCartesia:
+		return true
+	default:
+		return false
+	}
+}
+
+// splitNonEmpty splits a comma list, trimming and dropping blanks (mirrors
+// cmd/agezt's helper).
+func splitNonEmpty(s string) []string {
+	var out []string
+	for part := range strings.SplitSeq(s, ",") {
+		if p := strings.TrimSpace(part); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/cmd/agezt/internal/daemonconfig/daemonconfig_test.go
+++ b/cmd/agezt/internal/daemonconfig/daemonconfig_test.go
@@ -1,0 +1,478 @@
+// SPDX-License-Identifier: MIT
+
+package daemonconfig
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// envOf returns a Load getter backed by a map — the unit-test seam that makes
+// the whole boot-config surface testable without touching the process env.
+func envOf(m map[string]string) func(string) string {
+	return func(name string) string { return m[name] }
+}
+
+func load(t *testing.T, env map[string]string) (Config, string) {
+	t.Helper()
+	var warn strings.Builder
+	c, err := Load(envOf(env), &warn)
+	if err != nil {
+		t.Fatalf("Load: unexpected error: %v", err)
+	}
+	return c, warn.String()
+}
+
+func loadErr(t *testing.T, env map[string]string) error {
+	t.Helper()
+	_, err := Load(envOf(env), nil)
+	if err == nil {
+		t.Fatalf("Load(%v): want error, got nil", env)
+	}
+	return err
+}
+
+func TestLoad_Defaults(t *testing.T) {
+	c, warn := load(t, nil)
+	if warn != "" {
+		t.Errorf("empty env produced warnings: %q", warn)
+	}
+
+	// Knowledge: everything on by default except the opt-ins.
+	k := c.Knowledge
+	if !k.Memory || !k.UserProfile || !k.TasteInject || !k.WorldModel || !k.Skills || !k.Forge {
+		t.Errorf("knowledge defaults not all on: %+v", k)
+	}
+	if k.MemoryDistillMinTools != 6 {
+		t.Errorf("MemoryDistillMinTools = %d, want 6", k.MemoryDistillMinTools)
+	}
+	if k.SkillShadowEval || k.SkillAutoShadow {
+		t.Errorf("shadow opt-ins should default off: %+v", k)
+	}
+	if !k.SkillAutoQuarantine || !k.SkillAutoPromote {
+		t.Errorf("skill auto-quarantine/promote should default on: %+v", k)
+	}
+
+	// SubAgents: enabled, depth 3, and the M843 derived tree rail of 48.
+	sa := c.SubAgents
+	if !sa.Enabled || sa.Depth != 3 || sa.Fanout != 0 || sa.SpendCapMicrocents != 0 || sa.MaxTotal != 48 {
+		t.Errorf("subagent defaults wrong: %+v", sa)
+	}
+
+	// RunLoop / Context / Guards: zero values (kernel defaults).
+	if c.RunLoop != (RunLoop{}) {
+		t.Errorf("RunLoop defaults not zero: %+v", c.RunLoop)
+	}
+	if c.Context != (ContextBudget{}) {
+		t.Errorf("Context defaults not zero: %+v", c.Context)
+	}
+	if c.Guards != (Guards{}) {
+		t.Errorf("Guards defaults not zero: %+v", c.Guards)
+	}
+
+	// Policy.
+	if c.Policy.AllowAll || c.Policy.EdictDurable || c.Policy.ApprovalTimeout != 0 || c.Policy.EdictDeny != nil {
+		t.Errorf("policy defaults wrong: %+v", c.Policy)
+	}
+
+	// Lifecycle: resume on, update drain default 30s, check interval off.
+	lc := c.Lifecycle
+	if !lc.Resume || lc.ResumeSnapshotMaxBytes != 0 || lc.CancelOnDisconnect {
+		t.Errorf("lifecycle defaults wrong: %+v", lc)
+	}
+	if lc.UpdateDrainTimeout != 30*time.Second || lc.UpdateCheckInterval != 0 {
+		t.Errorf("update timing defaults wrong: drain=%s check=%s", lc.UpdateDrainTimeout, lc.UpdateCheckInterval)
+	}
+
+	// Tenancy off; Misc defaults.
+	if c.Tenancy != (Tenancy{}) {
+		t.Errorf("tenancy defaults not zero: %+v", c.Tenancy)
+	}
+	m := c.Misc
+	if !m.Redact || !m.EnvInject || !m.CouncilWebSearch || !m.ToolforgeAutoPromote {
+		t.Errorf("misc default-on switches wrong: %+v", m)
+	}
+	if m.ScheduleNotify || m.SystemPrompt != "" || m.WebhookChannels != nil {
+		t.Errorf("misc default-off values wrong: %+v", m)
+	}
+
+	// Sidecars all unconfigured.
+	if c.Sidecars.Embed.Enabled() || c.Sidecars.Image.Enabled() || c.Sidecars.Rerank.Enabled() ||
+		c.Sidecars.STT.Attempt || c.Sidecars.TTS.Attempt {
+		t.Errorf("sidecars should be unconfigured by default: %+v", c.Sidecars)
+	}
+}
+
+func TestLoad_KnowledgeSwitches(t *testing.T) {
+	// MEMORY=off also forces the profile off, regardless of USER_PROFILE.
+	c, _ := load(t, map[string]string{"AGEZT_MEMORY": "off"})
+	if c.Knowledge.Memory || c.Knowledge.UserProfile {
+		t.Errorf("MEMORY=off: got memory=%v profile=%v", c.Knowledge.Memory, c.Knowledge.UserProfile)
+	}
+	c, _ = load(t, map[string]string{"AGEZT_USER_PROFILE": "OFF"}) // EqualFold
+	if !c.Knowledge.Memory || c.Knowledge.UserProfile {
+		t.Errorf("USER_PROFILE=OFF: got memory=%v profile=%v", c.Knowledge.Memory, c.Knowledge.UserProfile)
+	}
+	c, _ = load(t, map[string]string{
+		"AGEZT_MEMORY_DISTILL_MIN_TOOLS": "12",
+		"AGEZT_SKILL_SHADOWEVAL":         "on",
+		"AGEZT_SKILL_AUTOQUARANTINE":     "off",
+		"AGEZT_SKILL_AUTOSHADOW":         "on",
+		"AGEZT_SKILL_AUTOPROMOTE":        "off",
+	})
+	if c.Knowledge.MemoryDistillMinTools != 12 || !c.Knowledge.SkillShadowEval ||
+		c.Knowledge.SkillAutoQuarantine || !c.Knowledge.SkillAutoShadow || c.Knowledge.SkillAutoPromote {
+		t.Errorf("knowledge switches wrong: %+v", c.Knowledge)
+	}
+	// Malformed / non-positive distill threshold silently keeps the default.
+	c, warn := load(t, map[string]string{"AGEZT_MEMORY_DISTILL_MIN_TOOLS": "-3"})
+	if c.Knowledge.MemoryDistillMinTools != 6 || warn != "" {
+		t.Errorf("bad distill threshold: got %d, warn=%q", c.Knowledge.MemoryDistillMinTools, warn)
+	}
+}
+
+func TestLoad_Policy(t *testing.T) {
+	c, _ := load(t, map[string]string{
+		"AGEZT_ALLOW_ALL":        "1",
+		"AGEZT_EDICT_DENY":       "git push;shell:/etc/shadow",
+		"AGEZT_EDICT_DURABLE":    "on",
+		"AGEZT_APPROVAL_TIMEOUT": "2m",
+	})
+	if !c.Policy.AllowAll || !c.Policy.EdictDurable || c.Policy.ApprovalTimeout != 2*time.Minute {
+		t.Errorf("policy wrong: %+v", c.Policy)
+	}
+	if len(c.Policy.EdictDeny) != 2 {
+		t.Errorf("EdictDeny = %d rules, want 2", len(c.Policy.EdictDeny))
+	}
+	// ALLOW_ALL is the exact string "1" — "true" is not honored (inline parity).
+	c, _ = load(t, map[string]string{"AGEZT_ALLOW_ALL": "true"})
+	if c.Policy.AllowAll {
+		t.Error(`ALLOW_ALL="true" should not enable the permissive switch`)
+	}
+	// Non-positive approval timeout means "use the kernel default".
+	c, _ = load(t, map[string]string{"AGEZT_APPROVAL_TIMEOUT": "0s"})
+	if c.Policy.ApprovalTimeout != 0 {
+		t.Errorf("APPROVAL_TIMEOUT=0s: got %s, want 0", c.Policy.ApprovalTimeout)
+	}
+	// Malformed deny spec is fatal with the historical env-name prefix.
+	err := loadErr(t, map[string]string{"AGEZT_EDICT_DENY": "shell:"})
+	if !strings.HasPrefix(err.Error(), "AGEZT_EDICT_DENY: ") {
+		t.Errorf("EDICT_DENY error = %q, want AGEZT_EDICT_DENY: prefix", err)
+	}
+}
+
+func TestLoad_SubAgents(t *testing.T) {
+	c, _ := load(t, map[string]string{
+		"AGEZT_SUBAGENT":           "off",
+		"AGEZT_SUBAGENT_DEPTH":     "5",
+		"AGEZT_SUBAGENT_FANOUT":    "2",
+		"AGEZT_SUBAGENT_SPEND_CAP": "2.5",
+		"AGEZT_SUBAGENT_MAX_TOTAL": "10",
+	})
+	want := SubAgents{Enabled: false, Depth: 5, Fanout: 2, SpendCapMicrocents: 2_500_000_000, MaxTotal: 10}
+	if c.SubAgents != want {
+		t.Errorf("subagents = %+v, want %+v", c.SubAgents, want)
+	}
+	// Depth 1 leaves the tree total unbounded (no M843 derivation).
+	c, _ = load(t, map[string]string{"AGEZT_SUBAGENT_DEPTH": "1"})
+	if c.SubAgents.MaxTotal != 0 {
+		t.Errorf("depth=1: MaxTotal = %d, want 0", c.SubAgents.MaxTotal)
+	}
+	// Malformed / negative spend cap is fatal with the historical wording.
+	for _, v := range []string{"abc", "-1"} {
+		err := loadErr(t, map[string]string{"AGEZT_SUBAGENT_SPEND_CAP": v})
+		want := `AGEZT_SUBAGENT_SPEND_CAP: want a non-negative USD amount, got "` + v + `"`
+		if err.Error() != want {
+			t.Errorf("spend cap %q: error = %q, want %q", v, err, want)
+		}
+	}
+}
+
+func TestLoad_ContextBudget_WarnAndDegrade(t *testing.T) {
+	c, warn := load(t, map[string]string{
+		"AGEZT_ARTIFACT_THRESHOLD":    "-5",
+		"AGEZT_CONTEXT_BUDGET":        "abc",
+		"AGEZT_CONTEXT_PROTECT_FIRST": "-1",
+	})
+	if c.Context.ArtifactThreshold != 0 || c.Context.Budget != 0 || c.Context.BudgetAuto || c.Context.ProtectFirst != 0 {
+		t.Errorf("bad values should keep defaults: %+v", c.Context)
+	}
+	for _, wantLine := range []string{
+		`agezt: AGEZT_ARTIFACT_THRESHOLD: want a positive byte count, got "-5" (using default)`,
+		`agezt: AGEZT_CONTEXT_BUDGET: want a positive char count or "auto", got "abc" (ignored)`,
+		`agezt: AGEZT_CONTEXT_PROTECT_FIRST: want a non-negative count, got "-1" (ignored)`,
+	} {
+		if !strings.Contains(warn, wantLine) {
+			t.Errorf("warning output missing %q; got:\n%s", wantLine, warn)
+		}
+	}
+
+	c, warn = load(t, map[string]string{
+		"AGEZT_ARTIFACT_THRESHOLD":    "65536",
+		"AGEZT_CONTEXT_BUDGET":        "AUTO", // EqualFold
+		"AGEZT_CONTEXT_PROTECT_FIRST": "4",
+		"AGEZT_CONTEXT_SUMMARIZE":     "1",
+	})
+	if warn != "" {
+		t.Errorf("happy path warned: %q", warn)
+	}
+	want := ContextBudget{ArtifactThreshold: 65536, BudgetAuto: true, ProtectFirst: 4, Summarize: true}
+	if c.Context != want {
+		t.Errorf("context = %+v, want %+v", c.Context, want)
+	}
+	c, _ = load(t, map[string]string{"AGEZT_CONTEXT_BUDGET": "120000"})
+	if c.Context.Budget != 120000 || c.Context.BudgetAuto {
+		t.Errorf("numeric budget wrong: %+v", c.Context)
+	}
+}
+
+func TestLoad_Guards(t *testing.T) {
+	c, _ := load(t, map[string]string{
+		"AGEZT_OBSERVATION_DELTAS":       "ON", // EqualFold + trims
+		"AGEZT_EPISTEMIC_ESCALATION":     " 1 ",
+		"AGEZT_INTENT_REGRET_GATING":     "on",
+		"AGEZT_PROMPT_INJECTION_GUARD":   "block",
+		"AGEZT_DISABLE_HEURISTIC_BYPASS": "1",
+	})
+	want := Guards{
+		ObservationDeltas: true, EpistemicEscalation: true, IntentRegretGating: true,
+		PromptInjectionGuard: "block", DisableHeuristicBypass: true,
+	}
+	if c.Guards != want {
+		t.Errorf("guards = %+v, want %+v", c.Guards, want)
+	}
+	// Anything other than on/1 stays off.
+	c, _ = load(t, map[string]string{"AGEZT_OBSERVATION_DELTAS": "yes"})
+	if c.Guards.ObservationDeltas {
+		t.Error(`OBSERVATION_DELTAS="yes" should stay off`)
+	}
+}
+
+func TestLoad_Sidecars(t *testing.T) {
+	// URL without model: warn + disabled, for each URL/model cluster.
+	for _, tc := range []struct{ urlVar, wantMsg string }{
+		{"AGEZT_EMBED_URL", "AGEZT_EMBED_URL is set but AGEZT_EMBED_MODEL is empty — provider embeddings disabled"},
+		{"AGEZT_IMAGE_URL", "AGEZT_IMAGE_URL is set but AGEZT_IMAGE_MODEL is empty — image generation disabled"},
+		{"AGEZT_RERANK_URL", "AGEZT_RERANK_URL is set but AGEZT_RERANK_MODEL is empty — reranking disabled"},
+		{"AGEZT_STT_URL", "AGEZT_STT_URL is set but AGEZT_STT_MODEL is empty — transcription disabled"},
+		{"AGEZT_TTS_URL", "AGEZT_TTS_URL is set but AGEZT_TTS_MODEL is empty — synthesis disabled"},
+	} {
+		c, warn := load(t, map[string]string{tc.urlVar: "http://localhost:9999"})
+		if !strings.Contains(warn, "agezt: "+tc.wantMsg) {
+			t.Errorf("%s without model: warn = %q, want %q", tc.urlVar, warn, tc.wantMsg)
+		}
+		if c.Sidecars.Embed.Enabled() || c.Sidecars.Image.Enabled() || c.Sidecars.Rerank.Enabled() ||
+			c.Sidecars.STT.Attempt || c.Sidecars.TTS.Attempt {
+			t.Errorf("%s without model should leave every sidecar disabled", tc.urlVar)
+		}
+	}
+
+	// Happy path: URL + model (values trimmed).
+	c, warn := load(t, map[string]string{
+		"AGEZT_EMBED_URL":   " http://localhost:11434 ",
+		"AGEZT_EMBED_MODEL": "nomic-embed-text",
+		"AGEZT_EMBED_KEY":   " k1 ",
+		"AGEZT_STT_URL":     "http://localhost:8001",
+		"AGEZT_STT_MODEL":   "whisper-1",
+		"AGEZT_TTS_URL":     "http://localhost:8002",
+		"AGEZT_TTS_MODEL":   "kokoro",
+		"AGEZT_TTS_VOICE":   "af_bella",
+	})
+	if warn != "" {
+		t.Errorf("configured sidecars warned: %q", warn)
+	}
+	if e := c.Sidecars.Embed; !e.Enabled() || e.URL != "http://localhost:11434" || e.Key != "k1" {
+		t.Errorf("embed = %+v", e)
+	}
+	if s := c.Sidecars.STT; !s.Attempt || s.Model != "whisper-1" {
+		t.Errorf("stt = %+v", s)
+	}
+	if tts := c.Sidecars.TTS; !tts.Attempt || tts.Voice != "af_bella" {
+		t.Errorf("tts = %+v", tts)
+	}
+
+	// Native voice providers need neither URL nor model.
+	c, warn = load(t, map[string]string{"AGEZT_STT_PROVIDER": "ElevenLabs", "AGEZT_TTS_PROVIDER": "deepgram"})
+	if warn != "" {
+		t.Errorf("native providers warned: %q", warn)
+	}
+	if !c.Sidecars.STT.Attempt || !c.Sidecars.TTS.Attempt {
+		t.Errorf("native providers should attempt: stt=%+v tts=%+v", c.Sidecars.STT, c.Sidecars.TTS)
+	}
+}
+
+func TestLoad_RunLoop(t *testing.T) {
+	c, _ := load(t, map[string]string{
+		"AGEZT_RUN_TIMEOUT":        "5m",
+		"AGEZT_MAX_ITER":           "50",
+		"AGEZT_MAX_AUTO_CONTINUE":  "-1",
+		"AGEZT_AUTO_CONTINUE_WAIT": "30s",
+		"AGEZT_PARALLEL_TOOLS":     "4",
+		"AGEZT_TOOL_DISCOVERY_MAX": "0",
+		"AGEZT_TOOL_TIMEOUT":       "45s",
+	})
+	want := RunLoop{
+		RunTimeout: 5 * time.Minute, MaxIter: 50,
+		MaxAutoContinue: -1, MaxAutoContinueSet: true,
+		AutoContinueWait: 30 * time.Second, MaxParallelTools: 4,
+		ToolDiscoveryMax: 0, ToolTimeout: 45 * time.Second,
+	}
+	if c.RunLoop != want {
+		t.Errorf("runloop = %+v, want %+v", c.RunLoop, want)
+	}
+	// A valid but non-positive run/tool timeout means "off", not an error.
+	c, _ = load(t, map[string]string{"AGEZT_RUN_TIMEOUT": "-5m", "AGEZT_TOOL_TIMEOUT": "0s"})
+	if c.RunLoop.RunTimeout != 0 || c.RunLoop.ToolTimeout != 0 {
+		t.Errorf("non-positive timeouts should disarm: %+v", c.RunLoop)
+	}
+	// An explicit auto-continue of 0 is Set (banner shows the default label).
+	c, _ = load(t, map[string]string{"AGEZT_MAX_AUTO_CONTINUE": "0"})
+	if !c.RunLoop.MaxAutoContinueSet || c.RunLoop.MaxAutoContinue != 0 {
+		t.Errorf("MAX_AUTO_CONTINUE=0: %+v", c.RunLoop)
+	}
+
+	// Fatal cases carry the historical wording, env name first.
+	for _, tc := range []struct{ env, val, want string }{
+		{"AGEZT_RUN_TIMEOUT", "xyz", `AGEZT_RUN_TIMEOUT: want a Go duration (e.g. 90s, 5m), got "xyz"`},
+		{"AGEZT_MAX_ITER", "0", `AGEZT_MAX_ITER: want a positive integer, got "0"`},
+		{"AGEZT_MAX_ITER", "abc", `AGEZT_MAX_ITER: want a positive integer, got "abc"`},
+		{"AGEZT_MAX_AUTO_CONTINUE", "many", `AGEZT_MAX_AUTO_CONTINUE: want an integer, got "many"`},
+		{"AGEZT_AUTO_CONTINUE_WAIT", "-1s", `AGEZT_AUTO_CONTINUE_WAIT: want a non-negative duration, got "-1s"`},
+		{"AGEZT_PARALLEL_TOOLS", "0", `AGEZT_PARALLEL_TOOLS: want a positive integer, got "0"`},
+		{"AGEZT_TOOL_DISCOVERY_MAX", "-1", `AGEZT_TOOL_DISCOVERY_MAX: want a non-negative integer, got "-1"`},
+		{"AGEZT_TOOL_TIMEOUT", "soon", `AGEZT_TOOL_TIMEOUT: want a Go duration (e.g. 30s, 2m), got "soon"`},
+		{"AGEZT_APPROVAL_TIMEOUT", "later", `AGEZT_APPROVAL_TIMEOUT: want a Go duration (e.g. 2m, 30s), got "later"`},
+	} {
+		err := loadErr(t, map[string]string{tc.env: tc.val})
+		if err.Error() != tc.want {
+			t.Errorf("%s=%s: error = %q, want %q", tc.env, tc.val, err, tc.want)
+		}
+	}
+}
+
+func TestLoad_Tenancy(t *testing.T) {
+	// Quotas are ignored (even malformed) while multi-tenancy is off.
+	c, warn := load(t, map[string]string{
+		"AGEZT_TENANT_DAILY_CEILING": "not-a-number",
+		"AGEZT_TENANT_RATE_PER_MIN":  "-9",
+	})
+	if c.Tenancy != (Tenancy{}) || warn != "" {
+		t.Errorf("quotas with tenancy off should be ignored: %+v warn=%q", c.Tenancy, warn)
+	}
+
+	c, _ = load(t, map[string]string{
+		"AGEZT_MULTITENANT":          "ON", // EqualFold
+		"AGEZT_TENANT_DAILY_CEILING": "1.5",
+		"AGEZT_TENANT_RATE_PER_MIN":  "0",
+	})
+	want := Tenancy{
+		Multitenant:     true,
+		DailyCeilingSet: true, DailyCeilingUSD: 1.5, DailyCeilingMicrocents: 1_500_000_000,
+		RatePerMinSet: true, RatePerMin: 0,
+	}
+	if c.Tenancy != want {
+		t.Errorf("tenancy = %+v, want %+v", c.Tenancy, want)
+	}
+
+	// With tenancy on, malformed quotas are fatal with the historical wording.
+	err := loadErr(t, map[string]string{"AGEZT_MULTITENANT": "on", "AGEZT_TENANT_DAILY_CEILING": "-1"})
+	if err.Error() != `AGEZT_TENANT_DAILY_CEILING: want a non-negative USD amount, got "-1"` {
+		t.Errorf("ceiling error = %q", err)
+	}
+	err = loadErr(t, map[string]string{"AGEZT_MULTITENANT": "on", "AGEZT_TENANT_RATE_PER_MIN": "fast"})
+	if err.Error() != `AGEZT_TENANT_RATE_PER_MIN: want a non-negative integer, got "fast"` {
+		t.Errorf("rate error = %q", err)
+	}
+}
+
+func TestLoad_Lifecycle(t *testing.T) {
+	c, _ := load(t, map[string]string{
+		"AGEZT_RESUME":                    "off",
+		"AGEZT_RESUME_SNAPSHOT_MAX_BYTES": "1048576",
+		"AGEZT_CANCEL_ON_DISCONNECT":      "on",
+		"AGEZT_UPDATE_ENDPOINT":           "https://updates.example/check",
+		"AGEZT_UPDATE_DRAIN_TIMEOUT":      "5s",
+		"AGEZT_UPDATE_CHECK_INTERVAL":     "1h",
+	})
+	lc := c.Lifecycle
+	if lc.Resume || lc.ResumeSnapshotMaxBytes != 1048576 || !lc.CancelOnDisconnect {
+		t.Errorf("lifecycle switches wrong: %+v", lc)
+	}
+	if lc.UpdateEndpoint != "https://updates.example/check" ||
+		lc.UpdateDrainTimeout != 5*time.Second || lc.UpdateCheckInterval != time.Hour {
+		t.Errorf("update settings wrong: %+v", lc)
+	}
+	// Malformed drain timeout silently keeps 30s; non-positive interval stays off.
+	c, warn := load(t, map[string]string{
+		"AGEZT_UPDATE_DRAIN_TIMEOUT":  "whenever",
+		"AGEZT_UPDATE_CHECK_INTERVAL": "-1h",
+	})
+	if warn != "" || c.Lifecycle.UpdateDrainTimeout != 30*time.Second || c.Lifecycle.UpdateCheckInterval != 0 {
+		t.Errorf("update fallback wrong: %+v warn=%q", c.Lifecycle, warn)
+	}
+	// GitHub source: repo defaults to the binary name when only the owner is set.
+	c, _ = load(t, map[string]string{"AGEZT_UPDATE_GITHUB_OWNER": "agezt"})
+	if c.Lifecycle.UpdateGitHubRepo != "agezt" {
+		t.Errorf("github repo default = %q, want binary name", c.Lifecycle.UpdateGitHubRepo)
+	}
+	c, _ = load(t, map[string]string{"AGEZT_UPDATE_GITHUB_OWNER": "agezt", "AGEZT_UPDATE_GITHUB_REPO": "kernel"})
+	if c.Lifecycle.UpdateGitHubRepo != "kernel" {
+		t.Errorf("explicit github repo = %q", c.Lifecycle.UpdateGitHubRepo)
+	}
+}
+
+func TestLoad_Misc(t *testing.T) {
+	c, _ := load(t, map[string]string{
+		"AGEZT_SYSTEM_PROMPT":          "  keep my spaces  ",
+		"AGEZT_REDACT":                 "off",
+		"AGEZT_ENV_INJECT":             "off",
+		"AGEZT_COUNCIL_WEBSEARCH":      "off",
+		"AGEZT_SCHEDULE_NOTIFY":        " on ",
+		"AGEZT_WEBHOOK_CHANNELS":       "a, b,,c",
+		"AGEZT_TOOLFORGE_AUTO_PROMOTE": "off",
+	})
+	m := c.Misc
+	if m.SystemPrompt != "  keep my spaces  " {
+		t.Errorf("SystemPrompt must stay untrimmed, got %q", m.SystemPrompt)
+	}
+	if m.Redact || m.EnvInject || m.CouncilWebSearch || m.ToolforgeAutoPromote {
+		t.Errorf("misc off-switches wrong: %+v", m)
+	}
+	if !m.ScheduleNotify {
+		t.Error("SCHEDULE_NOTIFY should trim before comparing to \"on\"")
+	}
+	if got := strings.Join(m.WebhookChannels, "|"); got != "a|b|c" {
+		t.Errorf("WebhookChannels = %q, want a|b|c", got)
+	}
+}
+
+// TestLoad_FatalOrder pins the fail-fast order: with several bad values set,
+// Load reports the same first one the old inline code exited on (EDICT_DENY
+// was parsed before the run-loop caps).
+func TestLoad_FatalOrder(t *testing.T) {
+	err := loadErr(t, map[string]string{
+		"AGEZT_EDICT_DENY":  "shell:",
+		"AGEZT_RUN_TIMEOUT": "xyz",
+	})
+	if !strings.HasPrefix(err.Error(), "AGEZT_EDICT_DENY: ") {
+		t.Errorf("first fatal should be EDICT_DENY, got %q", err)
+	}
+	err = loadErr(t, map[string]string{
+		"AGEZT_SUBAGENT_SPEND_CAP": "-2",
+		"AGEZT_MAX_ITER":           "abc",
+	})
+	if !strings.HasPrefix(err.Error(), "AGEZT_SUBAGENT_SPEND_CAP: ") {
+		t.Errorf("spend cap should fail before MAX_ITER, got %q", err)
+	}
+}
+
+// TestLoad_NilAccessorAndWriter exercises the documented nil conveniences
+// (os.Getenv + discarded warnings) without asserting on ambient env values.
+func TestLoad_NilAccessorAndWriter(t *testing.T) {
+	if _, err := Load(nil, nil); err != nil {
+		// The ambient environment could legitimately carry a malformed value;
+		// only fail on the classes of error this test can't explain.
+		t.Logf("Load with ambient env returned: %v (tolerated)", err)
+	}
+}

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -41,6 +41,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/agezt/agezt/cmd/agezt/internal/daemonconfig"
 	"github.com/agezt/agezt/internal/brand"
 	"github.com/agezt/agezt/internal/paths"
 	"github.com/agezt/agezt/kernel/agent"
@@ -166,6 +167,8 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// two kernels writing the same journal — `agt` would silently reach
 	// whichever started last. Refuse if a live daemon already answers.
 	// AGEZT_FORCE_START=1 overrides (e.g. to reclaim after a confirmed crash).
+	// (Deliberately NOT in daemonconfig.Load: this read happens before
+	// injectConfig bridges the config store/vault into the env.)
 	if addr, alive := controlplane.ProbeExisting(baseDir); alive {
 		if strings.TrimSpace(os.Getenv(brand.EnvPrefix+"FORCE_START")) != "1" {
 			fmt.Fprintf(stderr, "%s: a daemon is already running at %s (base dir %s)\n", brand.Binary, addr, baseDir)
@@ -215,6 +218,20 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// channel construction read the env. configPinned (schema vars set in the real env) is
 	// handed to the control plane so the Config Center can show them read-only.
 	configPinned := injectConfig(baseDir, credStore, stdout)
+
+	// Typed boot config (Phase 2.5): one Load call parses every post-inject
+	// AGEZT_* boot setting — parse shapes, defaults, warn-and-degrade messages,
+	// and the historically-fatal cases (which surface here as an error with the
+	// same wording and exit). MUST run after injectConfig so the reads see
+	// operator edits from the Config Center store + vault. Reads that must stay
+	// live at call time (COUNCIL_MEMBERS, DRAIN_TIMEOUT, the tenant lazy-open's
+	// EDICT_DURABLE) or that happen pre-inject (FORCE_START) stay inline —
+	// see the daemonconfig package comment.
+	dcfg, derr := daemonconfig.Load(nil, stderr)
+	if derr != nil {
+		fmt.Fprintf(stderr, "%s: %v\n", brand.Binary, derr)
+		return 1
+	}
 
 	// Make ChatGPT ("Sign in with ChatGPT") discoverable in Models; it only
 	// registers as a live provider once the operator signs in.
@@ -266,13 +283,9 @@ func runDaemon(stdout, stderr io.Writer) int {
 	askPolicy, askPolicyDesc := selectAskPolicy()
 	// Operator-extensible hard-deny rules (M17): AGEZT_EDICT_DENY appends
 	// site-specific rules to the built-in set (e.g. "git push;shell:/etc/shadow").
+	// Parsed (and rejected when malformed) by daemonconfig.Load above.
 	hardDeny := edict.DefaultHardDeny()
-	if spec := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "EDICT_DENY")); spec != "" {
-		extra, derr := edict.ParseDenyRules(spec)
-		if derr != nil {
-			fmt.Fprintf(stderr, "%s: %sEDICT_DENY: %v\n", brand.Binary, brand.EnvPrefix, derr)
-			return 1
-		}
+	if extra := dcfg.Policy.EdictDeny; len(extra) > 0 {
 		hardDeny = append(hardDeny, extra...)
 		askPolicyDesc += fmt.Sprintf("; +%d operator deny rule(s)", len(extra))
 	}
@@ -283,7 +296,7 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// catastrophe hard-deny rails (fork-bomb, dd-to-raw-device) deliberately stay,
 	// since they guard against self-destruction rather than gate normal tools, and
 	// are no-ops on Windows anyway. Loud banner so this is never silent.
-	permissive := os.Getenv(brand.EnvPrefix+"ALLOW_ALL") == "1"
+	permissive := dcfg.Policy.AllowAll
 	if permissive {
 		lv := make(map[edict.Capability]edict.TrustLevel, len(edict.AllCapabilities()))
 		for _, c := range edict.AllCapabilities() {
@@ -364,188 +377,76 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// in-process `memory` tool, and multi-tool runs are auto-distilled into
 	// durable facts. Set AGEZT_MEMORY=off to disable the per-run behaviour
 	// (the store and `agt memory` CLI stay available either way).
-	memOn := !strings.EqualFold(os.Getenv(brand.EnvPrefix+"MEMORY"), "off")
+	memOn := dcfg.Knowledge.Memory
 	// How many tool calls a run must make before it's worth an auto-distillation
 	// pass (M993). Higher = fewer, more meaningful auto-memories — simple/short
 	// runs no longer each spawn distilled notes. Default 6 (was 4); override with
 	// AGEZT_MEMORY_DISTILL_MIN_TOOLS (0 or negative falls back to the default).
-	distillMinTools := 6
-	if v := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "MEMORY_DISTILL_MIN_TOOLS")); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			distillMinTools = n
-		}
-	}
+	distillMinTools := dcfg.Knowledge.MemoryDistillMinTools
 	// Operator profile (M1000): learn who the operator is and inject it into every
 	// run. Requires memory; default on, AGEZT_USER_PROFILE=off disables both the
 	// injection and the daily auto-synthesis.
-	profileOn := memOn && !strings.EqualFold(os.Getenv(brand.EnvPrefix+"USER_PROFILE"), "off")
+	profileOn := dcfg.Knowledge.UserProfile
 	// Taste overlay: inject curated "what good looks like" exemplars into runs.
 	// Default on; AGEZT_TASTE_INJECT=off disables the injection (the store and
 	// `agt taste` CLI stay live regardless).
-	tasteOn := !strings.EqualFold(os.Getenv(brand.EnvPrefix+"TASTE_INJECT"), "off")
+	tasteOn := dcfg.Knowledge.TasteInject
 	// World-model per-run behaviour (entity injection + the `world` tool).
 	// The graph store and `agt world` CLI always work; this only gates the
 	// in-run wiring. AGEZT_WORLDMODEL=off disables it.
-	worldOn := !strings.EqualFold(os.Getenv(brand.EnvPrefix+"WORLDMODEL"), "off")
+	worldOn := dcfg.Knowledge.WorldModel
 	// Forge / skills (SPEC-05 §4-5). Active skills inject into runs and Forge
 	// proposes drafts after complex tasks. Store + `agt skill` CLI stay live
 	// regardless. AGEZT_SKILLS=off disables injection; AGEZT_FORGE=off
 	// disables post-run proposal.
-	skillOn := !strings.EqualFold(os.Getenv(brand.EnvPrefix+"SKILLS"), "off")
-	forgeOn := !strings.EqualFold(os.Getenv(brand.EnvPrefix+"FORGE"), "off")
+	skillOn := dcfg.Knowledge.Skills
+	forgeOn := dcfg.Knowledge.Forge
 	// Host-environment preamble (M609): on by default — the model needs to know
 	// its OS/shell/workspace to act correctly (esp. on Windows). AGEZT_ENV_INJECT=off
 	// disables it for operators who pin everything via a custom system prompt.
-	envInjectOn := !strings.EqualFold(os.Getenv(brand.EnvPrefix+"ENV_INJECT"), "off")
+	envInjectOn := dcfg.Misc.EnvInject
 	// Durable run resume (M1002): on by default (default-allow posture). A root
 	// run's dispatch context + conversation snapshot are persisted so a restart
 	// — stop/start, self-update, or hard kill — re-dispatches the run instead of
-	// abandoning it. AGEZT_RESUME=off restores the historical cancel-and-drop.
-	resumeOn := !strings.EqualFold(os.Getenv(brand.EnvPrefix+"RESUME"), "off")
-	// AGEZT_RESUME_SNAPSHOT_MAX_BYTES caps a serialized ticket; a larger snapshot
-	// is dropped (the run then resumes by intent-replay). 0 → package default.
-	resumeSnapshotMaxBytes := 0
-	if v := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "RESUME_SNAPSHOT_MAX_BYTES")); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			resumeSnapshotMaxBytes = n
-		}
-	}
+	// abandoning it. AGEZT_RESUME=off restores the historical cancel-and-drop;
+	// AGEZT_RESUME_SNAPSHOT_MAX_BYTES caps a serialized ticket.
+	resumeOn := dcfg.Lifecycle.Resume
+	resumeSnapshotMaxBytes := dcfg.Lifecycle.ResumeSnapshotMaxBytes
 	// Multi-agent delegation (P6-MULTI-01): the `delegate` tool lets a lead
-	// agent spawn bounded sub-agents. On by default; AGEZT_SUBAGENT=off disables
-	// it, AGEZT_SUBAGENT_DEPTH sets how deep delegation may nest (default 1).
-	subAgentOn := !strings.EqualFold(os.Getenv(brand.EnvPrefix+"SUBAGENT"), "off")
-	// Default depth 3 (M843): a lead agent can decompose a task, delegate the parts
-	// to sub-agents, and THOSE sub-agents can delegate further — a real leader/worker
-	// tree, not just one flat layer. The owner wants agents to "split tasks and run
-	// more agents", and the default-allow posture favours capability; the tree-total
-	// rail below keeps deep delegation bounded. AGEZT_SUBAGENT_DEPTH overrides.
-	subAgentDepth := 3
-	if v := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "SUBAGENT_DEPTH")); v != "" {
-		if d, err := strconv.Atoi(v); err == nil && d > 0 {
-			subAgentDepth = d
-		}
-	}
-	// AGEZT_SUBAGENT_FANOUT bounds how many sub-agents a single run may spawn at
-	// its level (M46). 0 / absent = unbounded (the historical default); a
-	// positive value refuses the Nth+1 delegate call with a tool error.
-	subAgentFanout := 0
-	if v := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "SUBAGENT_FANOUT")); v != "" {
-		if f, err := strconv.Atoi(v); err == nil && f > 0 {
-			subAgentFanout = f
-		}
-	}
-	// AGEZT_SUBAGENT_SPEND_CAP caps the total spend a single run's sub-agents
-	// may collectively consume (M48), given as a USD amount (matching the
-	// AGEZT_*_DAILY_CEILING convention) and stored as microcents. Once a lead's
-	// delegations have spent past it, the next delegate is refused. 0 / absent =
-	// unbounded; a malformed value is a hard startup error (fast feedback).
-	var subAgentSpendCap int64
-	if v := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "SUBAGENT_SPEND_CAP")); v != "" {
-		usd, perr := strconv.ParseFloat(v, 64)
-		if perr != nil || usd < 0 {
-			fmt.Fprintf(stderr, "%s: %sSUBAGENT_SPEND_CAP: want a non-negative USD amount, got %q\n", brand.Binary, brand.EnvPrefix, v)
-			return 1
-		}
-		subAgentSpendCap = int64(usd * 1e9)
-	}
-	// AGEZT_SUBAGENT_MAX_TOTAL caps the total number of sub-agents in one
-	// delegation TREE across all depths (M629) — the rail that makes
-	// AGEZT_SUBAGENT_DEPTH>1 safe, since depth×fan-out alone can't bound a
-	// tree's overall size. 0 / absent = unbounded; a positive value refuses the
-	// (N+1)th spawn anywhere in the tree.
-	subAgentTotal := 0
-	if v := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "SUBAGENT_MAX_TOTAL")); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			subAgentTotal = n
-		}
-	}
-	// With deep delegation on by default (depth>1), give the tree a generous but
-	// finite size rail when the operator hasn't set one (M843) — depth×fan-out
-	// alone can't bound a tree, so an unbounded total + deep recursion risks a
-	// fork-bomb. 48 total sub-agents is far more than any real leader/worker task
-	// needs while still preventing runaway. depth==1 stays unbounded (unchanged);
-	// AGEZT_SUBAGENT_MAX_TOTAL overrides.
-	if subAgentTotal == 0 && subAgentDepth > 1 {
-		subAgentTotal = 48
-	}
+	// agent spawn bounded sub-agents (AGEZT_SUBAGENT / _DEPTH / _FANOUT /
+	// _SPEND_CAP / _MAX_TOTAL — defaults, rails, and the M843 deep-delegation
+	// tree bound live in daemonconfig.Load).
+	subAgentOn := dcfg.SubAgents.Enabled
+	subAgentDepth := dcfg.SubAgents.Depth
+	subAgentFanout := dcfg.SubAgents.Fanout
+	subAgentSpendCap := dcfg.SubAgents.SpendCapMicrocents
+	subAgentTotal := dcfg.SubAgents.MaxTotal
 
-	// Artifact offload threshold (SPEC-04 §3.6): tool outputs larger than this are
-	// stored content-addressed and the journal event carries a raw_ref + preview.
-	// Unset/invalid → the kernel default (agent.DefaultArtifactThreshold).
-	artifactThreshold := 0
-	if v := os.Getenv(brand.EnvPrefix + "ARTIFACT_THRESHOLD"); v != "" {
-		if n, perr := strconv.Atoi(v); perr == nil && n > 0 {
-			artifactThreshold = n
-		} else {
-			fmt.Fprintf(stderr, "%s: %sARTIFACT_THRESHOLD: want a positive byte count, got %q (using default)\n", brand.Binary, brand.EnvPrefix, v)
-		}
-	}
+	// Artifact offload threshold (SPEC-04 §3.6) + context budget caps
+	// (SPEC-04 §3 / SPEC-10 §3 / M395 / M398): parsed (with their
+	// warn-and-degrade messages) by daemonconfig.Load.
+	artifactThreshold := dcfg.Context.ArtifactThreshold
+	contextBudget := dcfg.Context.Budget
+	contextBudgetAuto := dcfg.Context.BudgetAuto
+	contextProtectFirst := dcfg.Context.ProtectFirst
+	contextSummarize := dcfg.Context.Summarize
 
-	// Context budget (SPEC-04 §3 / SPEC-10 §3): cap the assembled-context chars
-	// the loop sends per call; over-budget runs elide their oldest tool outputs.
-	// 0 (unset) = full history (current behaviour).
-	contextBudget := 0
-	contextBudgetAuto := false
-	if v := os.Getenv(brand.EnvPrefix + "CONTEXT_BUDGET"); v != "" {
-		if strings.EqualFold(v, "auto") {
-			contextBudgetAuto = true // derive from the model's catalog context window
-		} else if n, perr := strconv.Atoi(v); perr == nil && n > 0 {
-			contextBudget = n
-		} else {
-			fmt.Fprintf(stderr, "%s: %sCONTEXT_BUDGET: want a positive char count or \"auto\", got %q (ignored)\n", brand.Binary, brand.EnvPrefix, v)
-		}
-	}
-
-	// AGEZT_CONTEXT_PROTECT_FIRST=<n> shields the first n messages from context
-	// compaction so the run's original grounding survives even as the oldest
-	// middle turns are elided (SPEC-10 §3 / M395). 0 (unset) = oldest-first.
-	contextProtectFirst := 0
-	if v := os.Getenv(brand.EnvPrefix + "CONTEXT_PROTECT_FIRST"); v != "" {
-		if n, perr := strconv.Atoi(v); perr == nil && n >= 0 {
-			contextProtectFirst = n
-		} else {
-			fmt.Fprintf(stderr, "%s: %sCONTEXT_PROTECT_FIRST: want a non-negative count, got %q (ignored)\n", brand.Binary, brand.EnvPrefix, v)
-		}
-	}
-
-	// AGEZT_CONTEXT_SUMMARIZE=1 replaces the deterministic head-snippet stub of an
-	// elided tool output with a one-line abstractive summary from a bounded
-	// provider call (SPEC-10 §3 / M398). Off by default — it spends extra (cached,
-	// once-per-output) provider calls, so the operator opts in.
-	contextSummarize := os.Getenv(brand.EnvPrefix+"CONTEXT_SUMMARIZE") == "1"
-
-	// AGEZT_OBSERVATION_DELTAS=on (or 1) makes repeated identical tool/input
-	// observations return a compact delta to the model while the journal keeps
-	// the raw output. Off by default for compatibility.
-	obsDeltasRaw := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "OBSERVATION_DELTAS"))
-	observationDeltas := strings.EqualFold(obsDeltasRaw, "on") || obsDeltasRaw == "1"
-	// AGEZT_EPISTEMIC_ESCALATION=on routes otherwise-allowed tool proposals
-	// through HITL when the runtime's external calibration gate sees matching
-	// historical failures, low effect confidence, temporal sensitivity, or novel
-	// dynamic tool conditions. Off by default; signals are still journaled.
-	epistemicEscalationRaw := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "EPISTEMIC_ESCALATION"))
-	epistemicEscalation := strings.EqualFold(epistemicEscalationRaw, "on") || epistemicEscalationRaw == "1"
-	// AGEZT_INTENT_REGRET_GATING=on routes otherwise-allowed tool proposals
-	// through HITL when the user's utterance is underdetermined and the proposed
-	// action has high wrong-action regret. Off by default; intent frames are
-	// still journaled.
-	intentRegretGatingRaw := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "INTENT_REGRET_GATING"))
-	intentRegretGating := strings.EqualFold(intentRegretGatingRaw, "on") || intentRegretGatingRaw == "1"
-	// AGEZT_PROMPT_INJECTION_GUARD selects the guard posture for effectful actions
-	// proposed within the causal window of directive-like untrusted web/file/API
-	// content: unset/anything → warn (allow + journal), "on"/"block" → HITL
-	// approval, "off"/"0" → no active intervention. The observation boundary and
-	// audit metadata remain enabled in all modes.
-	promptInjectionMode := kernelruntime.ParsePromptInjectionMode(os.Getenv(brand.EnvPrefix + "PROMPT_INJECTION_GUARD"))
+	// Run-safety guards: observation deltas, epistemic/intent HITL gating, and
+	// the prompt-injection guard posture (raw value parsed here — unset/unknown
+	// means warn mode; "on"/"block" → HITL approval; "off"/"0" → no active
+	// intervention).
+	observationDeltas := dcfg.Guards.ObservationDeltas
+	epistemicEscalation := dcfg.Guards.EpistemicEscalation
+	intentRegretGating := dcfg.Guards.IntentRegretGating
+	promptInjectionMode := kernelruntime.ParsePromptInjectionMode(dcfg.Guards.PromptInjectionGuard)
 	autoApproveCaps, autoApproveDesc := selectAutoApproveCapabilities()
-	autoPromoteScriptTools := !strings.EqualFold(os.Getenv(brand.EnvPrefix+"TOOLFORGE_AUTO_PROMOTE"), "off")
-	disableHeuristicBypassRaw := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "DISABLE_HEURISTIC_BYPASS"))
-	disableHeuristicBypass := strings.EqualFold(disableHeuristicBypassRaw, "on") || disableHeuristicBypassRaw == "1"
+	autoPromoteScriptTools := dcfg.Misc.ToolforgeAutoPromote
+	disableHeuristicBypass := dcfg.Guards.DisableHeuristicBypass
 
 	// AGEZT_SKILL_SHADOWEVAL=on judges the shadow skills relevant to a completed
 	// run against what actually happened (SPEC-05 §5.2). Off by default — it spends
 	// extra provider calls per run, so the operator opts in.
-	shadowEval := strings.EqualFold(os.Getenv(brand.EnvPrefix+"SKILL_SHADOWEVAL"), "on")
+	shadowEval := dcfg.Knowledge.SkillShadowEval
 
 	// Provider embeddings for memory recall (M901, DECISIONS C5 opt-in): when
 	// AGEZT_EMBED_URL + AGEZT_EMBED_MODEL are both set, recall ranks by TRUE
@@ -556,13 +457,8 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// Recall falls back to local on any embedder failure, so a wrong URL
 	// degrades quality, never availability.
 	var memEmbedder kernelmemory.Embedder
-	if embedURL := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "EMBED_URL")); embedURL != "" {
-		embedModel := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "EMBED_MODEL"))
-		if embedModel == "" {
-			fmt.Fprintf(stderr, "%s: %sEMBED_URL is set but %sEMBED_MODEL is empty — provider embeddings disabled\n", brand.Binary, brand.EnvPrefix, brand.EnvPrefix)
-		} else {
-			memEmbedder = embed.New(embedURL, embedModel, strings.TrimSpace(os.Getenv(brand.EnvPrefix+"EMBED_KEY")))
-		}
+	if ec := dcfg.Sidecars.Embed; ec.Enabled() {
+		memEmbedder = embed.New(ec.URL, ec.Model, ec.Key)
 	}
 
 	// Voice adapter (STT + TTS) over an OpenAI-compatible endpoint, same shape as
@@ -577,25 +473,15 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// base URL, so a URL is optional for them. Boot-resilient: a misconfigured
 	// half warns and disables itself rather than failing the daemon.
 	voiceAdapter := &voice.Adapter{}
-	sttProvider := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "STT_PROVIDER"))
-	sttURL := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "STT_URL"))
-	sttModel := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "STT_MODEL"))
-	if sttURL != "" || voiceProviderIsNative(sttProvider) {
-		if sttModel == "" && !voiceProviderIsNative(sttProvider) {
-			fmt.Fprintf(stderr, "%s: %sSTT_URL is set but %sSTT_MODEL is empty — transcription disabled\n", brand.Binary, brand.EnvPrefix, brand.EnvPrefix)
-		} else if sttClient, err := voice.NewSTT(sttProvider, voice.Config{BaseURL: sttURL, Model: sttModel, APIKey: strings.TrimSpace(os.Getenv(brand.EnvPrefix + "STT_KEY"))}); err != nil {
+	if sc := dcfg.Sidecars.STT; sc.Attempt {
+		if sttClient, err := voice.NewSTT(sc.Provider, voice.Config{BaseURL: sc.URL, Model: sc.Model, APIKey: sc.Key}); err != nil {
 			fmt.Fprintf(stderr, "%s: transcription disabled: %v\n", brand.Binary, err)
 		} else {
 			voiceAdapter.STT = sttClient
 		}
 	}
-	ttsProvider := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "TTS_PROVIDER"))
-	ttsURL := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "TTS_URL"))
-	ttsModel := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "TTS_MODEL"))
-	if ttsURL != "" || voiceProviderIsNative(ttsProvider) {
-		if ttsModel == "" && !voiceProviderIsNative(ttsProvider) {
-			fmt.Fprintf(stderr, "%s: %sTTS_URL is set but %sTTS_MODEL is empty — synthesis disabled\n", brand.Binary, brand.EnvPrefix, brand.EnvPrefix)
-		} else if ttsClient, err := voice.NewTTS(ttsProvider, voice.Config{BaseURL: ttsURL, Model: ttsModel, Voice: strings.TrimSpace(os.Getenv(brand.EnvPrefix + "TTS_VOICE")), APIKey: strings.TrimSpace(os.Getenv(brand.EnvPrefix + "TTS_KEY"))}); err != nil {
+	if tc := dcfg.Sidecars.TTS; tc.Attempt {
+		if ttsClient, err := voice.NewTTS(tc.Provider, voice.Config{BaseURL: tc.URL, Model: tc.Model, Voice: tc.Voice, APIKey: tc.Key}); err != nil {
 			fmt.Fprintf(stderr, "%s: synthesis disabled: %v\n", brand.Binary, err)
 		} else {
 			voiceAdapter.TTS = ttsClient
@@ -611,24 +497,16 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// OpenAI-compatible /v1/images/generations endpoint (api.openai.com/v1 +
 	// dall-e-3 + AGEZT_IMAGE_KEY, or a local/compatible gateway). Unset → no tool.
 	var imageCfg kernelruntime.ImageGen
-	if imgURL := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "IMAGE_URL")); imgURL != "" {
-		if imgModel := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "IMAGE_MODEL")); imgModel == "" {
-			fmt.Fprintf(stderr, "%s: %sIMAGE_URL is set but %sIMAGE_MODEL is empty — image generation disabled\n", brand.Binary, brand.EnvPrefix, brand.EnvPrefix)
-		} else {
-			imageCfg = image.New(imgURL, imgModel, strings.TrimSpace(os.Getenv(brand.EnvPrefix+"IMAGE_KEY")))
-		}
+	if ic := dcfg.Sidecars.Image; ic.Enabled() {
+		imageCfg = image.New(ic.URL, ic.Model, ic.Key)
 	}
 
 	// Reranking (M997): when AGEZT_RERANK_URL + AGEZT_RERANK_MODEL are set, the
 	// `rerank` tool is registered, reordering candidate documents via a
 	// Cohere/Jina-style /rerank endpoint. Unset → no tool.
 	var rerankCfg kernelruntime.Reranker
-	if rrURL := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "RERANK_URL")); rrURL != "" {
-		if rrModel := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "RERANK_MODEL")); rrModel == "" {
-			fmt.Fprintf(stderr, "%s: %sRERANK_URL is set but %sRERANK_MODEL is empty — reranking disabled\n", brand.Binary, brand.EnvPrefix, brand.EnvPrefix)
-		} else {
-			rerankCfg = rerank.New(rrURL, rrModel, strings.TrimSpace(os.Getenv(brand.EnvPrefix+"RERANK_KEY")))
-		}
+	if rc := dcfg.Sidecars.Rerank; rc.Enabled() {
+		rerankCfg = rerank.New(rc.URL, rc.Model, rc.Key)
 	}
 
 	cfg := kernelruntime.Config{
@@ -639,7 +517,7 @@ func runDaemon(stdout, stderr io.Writer) int {
 		ToolCapabilities: pluginToolCaps, // M900: manifest-declared policy axes
 
 		Model:                      model,
-		System:                     os.Getenv(brand.EnvPrefix + "SYSTEM_PROMPT"),
+		System:                     dcfg.Misc.SystemPrompt, // AGEZT_SYSTEM_PROMPT
 		Warden:                     ward,
 		Edict:                      edictEng,
 		AutoApproveCapabilities:    autoApproveCaps,
@@ -697,16 +575,9 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// A malformed value is a hard startup error (fast feedback over silent
 	// misconfig); a non-positive value is treated as "off".
 	runTimeoutDesc := "disabled (set " + brand.EnvPrefix + "RUN_TIMEOUT, e.g. 5m)"
-	if spec := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "RUN_TIMEOUT")); spec != "" {
-		d, derr := time.ParseDuration(spec)
-		if derr != nil {
-			fmt.Fprintf(stderr, "%s: %sRUN_TIMEOUT: want a Go duration (e.g. 90s, 5m), got %q\n", brand.Binary, brand.EnvPrefix, spec)
-			return 1
-		}
-		if d > 0 {
-			cfg.MaxDuration = d
-			runTimeoutDesc = fmt.Sprintf("%s per run (task.failed reason=timeout on overrun)", d)
-		}
+	if d := dcfg.RunLoop.RunTimeout; d > 0 {
+		cfg.MaxDuration = d
+		runTimeoutDesc = fmt.Sprintf("%s per run (task.failed reason=timeout on overrun)", d)
 	}
 	// Per-run tool-round cap (M824): AGEZT_MAX_ITER sets how many tool-call rounds
 	// a single run may take before it stops with max_iters. Defaults to the agent
@@ -714,12 +585,7 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// error (fast feedback). Raise it for deep agentic tasks; the chat's "Continue"
 	// affordance resumes a run that still hit the cap.
 	maxIterDesc := fmt.Sprintf("%d per run (default; set %sMAX_ITER to change)", agent.DefaultMaxIter, brand.EnvPrefix)
-	if spec := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "MAX_ITER")); spec != "" {
-		n, perr := strconv.Atoi(spec)
-		if perr != nil || n <= 0 {
-			fmt.Fprintf(stderr, "%s: %sMAX_ITER: want a positive integer, got %q\n", brand.Binary, brand.EnvPrefix, spec)
-			return 1
-		}
+	if n := dcfg.RunLoop.MaxIter; n > 0 {
 		cfg.MaxIter = n
 		maxIterDesc = fmt.Sprintf("%d per run", n)
 	}
@@ -732,12 +598,8 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// then stops at the cap with max_iters). Set it high for long unattended jobs.
 	// AGEZT_AUTO_CONTINUE_WAIT tunes the breather before each continuation.
 	autoContinueDesc := fmt.Sprintf("%d×%d rounds (default; set %sMAX_AUTO_CONTINUE)", agent.DefaultMaxAutoContinue, cfg.MaxIter, brand.EnvPrefix)
-	if spec := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "MAX_AUTO_CONTINUE")); spec != "" {
-		n, perr := strconv.Atoi(spec)
-		if perr != nil {
-			fmt.Fprintf(stderr, "%s: %sMAX_AUTO_CONTINUE: want an integer, got %q\n", brand.Binary, brand.EnvPrefix, spec)
-			return 1
-		}
+	if dcfg.RunLoop.MaxAutoContinueSet {
+		n := dcfg.RunLoop.MaxAutoContinue
 		cfg.MaxAutoContinue = n
 		switch {
 		case n < 0:
@@ -748,73 +610,38 @@ func runDaemon(stdout, stderr io.Writer) int {
 			autoContinueDesc = fmt.Sprintf("%d×%d rounds", n, cfg.MaxIter)
 		}
 	}
-	if spec := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "AUTO_CONTINUE_WAIT")); spec != "" {
-		d, perr := time.ParseDuration(spec)
-		if perr != nil || d < 0 {
-			fmt.Fprintf(stderr, "%s: %sAUTO_CONTINUE_WAIT: want a non-negative duration, got %q\n", brand.Binary, brand.EnvPrefix, spec)
-			return 1
-		}
-		cfg.AutoContinueWait = d
-	}
+	cfg.AutoContinueWait = dcfg.RunLoop.AutoContinueWait
 
 	// In-turn parallel tool dispatch (M880): AGEZT_PARALLEL_TOOLS caps how many
 	// tool calls from ONE assistant turn execute concurrently. Defaults to the
 	// agent package's DefaultMaxParallelTools; 1 disables (strictly sequential).
-	// Malformed or non-positive is a hard startup error (fast feedback).
-	if spec := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "PARALLEL_TOOLS")); spec != "" {
-		n, perr := strconv.Atoi(spec)
-		if perr != nil || n <= 0 {
-			fmt.Fprintf(stderr, "%s: %sPARALLEL_TOOLS: want a positive integer, got %q\n", brand.Binary, brand.EnvPrefix, spec)
-			return 1
-		}
+	if n := dcfg.RunLoop.MaxParallelTools; n > 0 {
 		cfg.MaxParallelTools = n
 	}
 
 	// Tool discovery (CH-03): AGEZT_TOOL_DISCOVERY_MAX=N trims each provider
 	// request to the N most relevant tool schemas using the built-in lexical
-	// selector. Off by default so existing deployments keep offering every tool;
-	// malformed or negative is a hard startup error.
-	if spec := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "TOOL_DISCOVERY_MAX")); spec != "" {
-		n, perr := strconv.Atoi(spec)
-		if perr != nil || n < 0 {
-			fmt.Fprintf(stderr, "%s: %sTOOL_DISCOVERY_MAX: want a non-negative integer, got %q\n", brand.Binary, brand.EnvPrefix, spec)
-			return 1
-		}
-		cfg.ToolDiscoveryMax = n
-	}
+	// selector. Off by default so existing deployments keep offering every tool.
+	cfg.ToolDiscoveryMax = dcfg.RunLoop.ToolDiscoveryMax
 
 	// Per-tool-call timeout (M34): AGEZT_TOOL_TIMEOUT=<duration> bounds each
 	// individual tool invocation. Unlike the per-run cap, an overrun fails
 	// only that tool call (the model gets an error result and can adapt) —
-	// the run continues. Off by default; malformed = hard startup error.
+	// the run continues. Off by default.
 	toolTimeoutDesc := "disabled (set " + brand.EnvPrefix + "TOOL_TIMEOUT, e.g. 30s)"
-	if spec := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "TOOL_TIMEOUT")); spec != "" {
-		d, derr := time.ParseDuration(spec)
-		if derr != nil {
-			fmt.Fprintf(stderr, "%s: %sTOOL_TIMEOUT: want a Go duration (e.g. 30s, 2m), got %q\n", brand.Binary, brand.EnvPrefix, spec)
-			return 1
-		}
-		if d > 0 {
-			cfg.ToolTimeout = d
-			toolTimeoutDesc = fmt.Sprintf("%s per tool call (error result on overrun; run continues)", d)
-		}
+	if d := dcfg.RunLoop.ToolTimeout; d > 0 {
+		cfg.ToolTimeout = d
+		toolTimeoutDesc = fmt.Sprintf("%s per tool call (error result on overrun; run continues)", d)
 	}
 	// HITL approval window (M100): AGEZT_APPROVAL_TIMEOUT=<duration> sets how long
 	// a prompt-mode approval blocks waiting for an operator before it auto-denies
 	// (DecisionTimeout). Default is approval.DefaultTimeout (5m); right-size it for
 	// the deployment — a short window for unattended runs, longer for an operator
-	// at the console. Malformed = hard startup error; non-positive = use default.
+	// at the console. Non-positive = use default.
 	approvalTimeoutDesc := "default (5m; set " + brand.EnvPrefix + "APPROVAL_TIMEOUT, e.g. 2m)"
-	if spec := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "APPROVAL_TIMEOUT")); spec != "" {
-		d, derr := time.ParseDuration(spec)
-		if derr != nil {
-			fmt.Fprintf(stderr, "%s: %sAPPROVAL_TIMEOUT: want a Go duration (e.g. 2m, 30s), got %q\n", brand.Binary, brand.EnvPrefix, spec)
-			return 1
-		}
-		if d > 0 {
-			cfg.ApprovalTimeout = d
-			approvalTimeoutDesc = fmt.Sprintf("%s per HITL approval (auto-deny on overrun)", d)
-		}
+	if d := dcfg.Policy.ApprovalTimeout; d > 0 {
+		cfg.ApprovalTimeout = d
+		approvalTimeoutDesc = fmt.Sprintf("%s per HITL approval (auto-deny on overrun)", d)
 	}
 	// Secret redaction (M15 / SPEC-06): scrub secrets from every durably-published
 	// event before it enters the hash-chained (permanent) journal. On by default;
@@ -822,7 +649,7 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// literals) plus built-in high-confidence secret patterns.
 	var redactor *redact.Redactor
 	redactDesc := "disabled (" + brand.EnvPrefix + "REDACT=off)"
-	if !strings.EqualFold(os.Getenv(brand.EnvPrefix+"REDACT"), "off") {
+	if dcfg.Misc.Redact {
 		redactor = redact.New()
 		lits := credSecrets(credStore)
 		redactor.SetSecrets(lits)
@@ -930,6 +757,9 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// comma-separated model list) overrides. Built like VisionModel — the daemon
 	// owns the registered+credentialed set; never picks an unkeyed model.
 	cfg.CouncilMembers = func() []kernelruntime.CouncilMember {
+		// Deliberately a LIVE env read (not daemonconfig.Load): this closure runs
+		// on every council convocation, and the Config Center live-applies edits
+		// via os.Setenv — capturing at boot would regress restart-free changes.
 		if spec := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "COUNCIL_MEMBERS")); spec != "" {
 			var ms []kernelruntime.CouncilMember
 			for i, part := range strings.Split(spec, ",") {
@@ -971,7 +801,7 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// Ground the Council of Elders in current facts: today's date for every seat
 	// plus a shared web research brief (via the always-registered web_search tool).
 	// Default on; AGEZT_COUNCIL_WEBSEARCH=off convenes the panel with the date only.
-	cfg.CouncilWebSearch = !strings.EqualFold(os.Getenv(brand.EnvPrefix+"COUNCIL_WEBSEARCH"), "off")
+	cfg.CouncilWebSearch = dcfg.Misc.CouncilWebSearch
 
 	var openErr error
 	k, openErr = kernelruntime.Open(cfg)
@@ -996,7 +826,7 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// with `agt skill promote`). AGEZT_SKILL_AUTOQUARANTINE=off disables it.
 	autoQDesc := fmt.Sprintf("on (pull active skill after ≥%d failures at ≥%.0f%% rate; set %sSKILL_AUTOQUARANTINE=off to disable)",
 		skill.DefaultAutoQuarantineMinFailures, skill.DefaultAutoQuarantineRate*100, brand.EnvPrefix)
-	if strings.EqualFold(os.Getenv(brand.EnvPrefix+"SKILL_AUTOQUARANTINE"), "off") {
+	if !dcfg.Knowledge.SkillAutoQuarantine {
 		k.Forge().SetAutoQuarantine(0, 0)
 		autoQDesc = "off (set " + brand.EnvPrefix + "SKILL_AUTOQUARANTINE=on to enable)"
 	}
@@ -1004,7 +834,7 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// production is opt-in. When on, a freshly-authored draft that passes the
 	// deterministic shadow-test auto-advances to shadow. AGEZT_SKILL_AUTOSHADOW=on.
 	autoShadowDesc := "off (set " + brand.EnvPrefix + "SKILL_AUTOSHADOW=on to auto-stage drafts that pass the shadow-test)"
-	if strings.EqualFold(os.Getenv(brand.EnvPrefix+"SKILL_AUTOSHADOW"), "on") {
+	if dcfg.Knowledge.SkillAutoShadow {
 		k.Forge().SetAutoShadow(true)
 		autoShadowDesc = "on (auto-advance a well-formed draft to shadow on creation)"
 	}
@@ -1019,7 +849,7 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// shadow evaluation is feeding wins. AGEZT_SKILL_AUTOPROMOTE=off disables it.
 	autoPromoteDesc := fmt.Sprintf("on (promote a shadow skill after ≥%d helpful evals at ≥%.0f%% rate; set %sSKILL_AUTOPROMOTE=off to disable)",
 		skill.DefaultAutoPromoteMinWins, skill.DefaultAutoPromoteRate*100, brand.EnvPrefix)
-	if strings.EqualFold(os.Getenv(brand.EnvPrefix+"SKILL_AUTOPROMOTE"), "off") {
+	if !dcfg.Knowledge.SkillAutoPromote {
 		k.Forge().SetAutoPromote(0, 0)
 		autoPromoteDesc = "off (set " + brand.EnvPrefix + "SKILL_AUTOPROMOTE=on to enable)"
 	}
@@ -1058,7 +888,7 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// the engine overlay is a projection of it. Opt-in: a level *loosening*
 	// that silently persisted across a restart would be a footgun, so the
 	// operator asks for it explicitly. MUST run before any Run is dispatched.
-	if strings.EqualFold(os.Getenv(brand.EnvPrefix+"EDICT_DURABLE"), "on") {
+	if dcfg.Policy.EdictDurable {
 		overlay, rerr := replayPolicyOverlay(k)
 		if rerr != nil {
 			fmt.Fprintf(stderr, "%s: replay durable policy: %v\n", brand.Binary, rerr)
@@ -1153,7 +983,7 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// streaming `agt run` whose client drops (Ctrl-C / killed) cancels its run
 	// server-side instead of running on headless. Off by default so a
 	// backgrounded `agt run &` (client still alive) is unaffected.
-	cancelOnDisconnect := strings.EqualFold(os.Getenv(brand.EnvPrefix+"CANCEL_ON_DISCONNECT"), "on")
+	cancelOnDisconnect := dcfg.Lifecycle.CancelOnDisconnect
 	srv.SetCancelOnDisconnect(cancelOnDisconnect)
 	// Disk-space health (M131): inject the cross-platform disk-usage probe so the
 	// disk handler / doctor check can report free space without controlplane
@@ -1163,37 +993,19 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// AGEZT_UPDATE_GITHUB_OWNER/REPO is set. When not configured, update
 	// commands report "update is disabled" rather than erroring.
 	var updateSvc *update.Service
-	if endpoint := os.Getenv(brand.EnvPrefix + "UPDATE_ENDPOINT"); endpoint != "" {
+	if endpoint := dcfg.Lifecycle.UpdateEndpoint; endpoint != "" {
 		updateSvc = update.New(update.Config{
-			Source:   update.SourceEndpoint,
-			Endpoint: endpoint,
-			BaseDir:  baseDir,
-			DrainTimeout: func() time.Duration {
-				if t := os.Getenv(brand.EnvPrefix + "UPDATE_DRAIN_TIMEOUT"); t != "" {
-					if d, err := time.ParseDuration(t); err == nil {
-						return d
-					}
-				}
-				return 30 * time.Second
-			}(),
-			CheckInterval: func() time.Duration {
-				if t := os.Getenv(brand.EnvPrefix + "UPDATE_CHECK_INTERVAL"); t != "" {
-					if d, err := time.ParseDuration(t); err == nil && d > 0 {
-						return d
-					}
-				}
-				return 0 // disabled by default
-			}(),
+			Source:        update.SourceEndpoint,
+			Endpoint:      endpoint,
+			BaseDir:       baseDir,
+			DrainTimeout:  dcfg.Lifecycle.UpdateDrainTimeout,  // default 30s
+			CheckInterval: dcfg.Lifecycle.UpdateCheckInterval, // 0 = disabled by default
 		})
-	} else if owner := os.Getenv(brand.EnvPrefix + "UPDATE_GITHUB_OWNER"); owner != "" {
-		repo := os.Getenv(brand.EnvPrefix + "UPDATE_GITHUB_REPO")
-		if repo == "" {
-			repo = brand.Binary // default repo to the binary name
-		}
+	} else if owner := dcfg.Lifecycle.UpdateGitHubOwner; owner != "" {
 		updateSvc = update.New(update.Config{
 			Source:        update.SourceGitHub,
 			GitHubOwner:   owner,
-			GitHubRepo:    repo,
+			GitHubRepo:    dcfg.Lifecycle.UpdateGitHubRepo, // defaulted to the binary name in Load
 			BaseDir:       baseDir,
 			DrainTimeout:  30 * time.Second,
 			CheckInterval: 0,
@@ -1220,34 +1032,24 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// `agt tenant` manages the registry over the control plane.
 	tenantsDesc := "disabled (set " + brand.EnvPrefix + "MULTITENANT=on)"
 	var tenantReg *tenant.Registry
-	if strings.EqualFold(os.Getenv(brand.EnvPrefix+"MULTITENANT"), "on") {
+	if dcfg.Tenancy.Multitenant {
 		// Per-tenant daily spend ceiling (M14 quotas). Each tenant gets its OWN
 		// governor (independent ledger) so one tenant exhausting its cap can
 		// never block another's runs, while the provider pool stays shared. The
 		// ceiling defaults to the primary's; AGEZT_TENANT_DAILY_CEILING (USD)
-		// overrides it for every tenant.
+		// overrides it for every tenant (malformed = daemonconfig.Load error).
 		tenantCeiling := gov.DailyCeilingMicrocents()
 		ceilingDesc := "inherited"
-		if spec := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "TENANT_DAILY_CEILING")); spec != "" {
-			usd, perr := strconv.ParseFloat(spec, 64)
-			if perr != nil || usd < 0 {
-				fmt.Fprintf(stderr, "%s: %sTENANT_DAILY_CEILING: want a non-negative USD amount, got %q\n", brand.Binary, brand.EnvPrefix, spec)
-				return 1
-			}
-			tenantCeiling = int64(usd * 1e9)
-			ceilingDesc = fmt.Sprintf("$%.2f/day", usd)
+		if dcfg.Tenancy.DailyCeilingSet {
+			tenantCeiling = dcfg.Tenancy.DailyCeilingMicrocents
+			ceilingDesc = fmt.Sprintf("$%.2f/day", dcfg.Tenancy.DailyCeilingUSD)
 		}
 		// Per-tenant per-minute call rate cap (M14 quotas). 0 = unlimited.
 		tenantRate := 0
 		rateDesc := "unlimited"
-		if spec := strings.TrimSpace(os.Getenv(brand.EnvPrefix + "TENANT_RATE_PER_MIN")); spec != "" {
-			n, perr := strconv.Atoi(spec)
-			if perr != nil || n < 0 {
-				fmt.Fprintf(stderr, "%s: %sTENANT_RATE_PER_MIN: want a non-negative integer, got %q\n", brand.Binary, brand.EnvPrefix, spec)
-				return 1
-			}
-			tenantRate = n
-			rateDesc = fmt.Sprintf("%d/min", n)
+		if dcfg.Tenancy.RatePerMinSet {
+			tenantRate = dcfg.Tenancy.RatePerMin
+			rateDesc = fmt.Sprintf("%d/min", tenantRate)
 		}
 		reg, terr := tenant.New(filepath.Join(baseDir, "tenants"), func(id, tdir string) (io.Closer, error) {
 			tgov, gerr := gov.WithLimits(tenantCeiling, tenantRate)
@@ -1274,7 +1076,10 @@ func runDaemon(stdout, stderr io.Writer) int {
 			// changes survive a restart, exactly as the primary does — each
 			// tenant's journal is its own source of truth. Best-effort: a
 			// journal read error leaves the tenant on its boot policy rather
-			// than failing the lazy open. Gated on the same AGEZT_EDICT_DURABLE.
+			// than failing the lazy open. Gated on the same AGEZT_EDICT_DURABLE —
+			// deliberately a LIVE env read (not daemonconfig.Load): this closure
+			// runs at lazy tenant-open time, and the Config Center live-applies
+			// edits via os.Setenv.
 			if strings.EqualFold(os.Getenv(brand.EnvPrefix+"EDICT_DURABLE"), "on") {
 				if overlay, rerr := replayPolicyOverlay(tk); rerr == nil {
 					tk.Edict().ApplyOverlay(overlay)
@@ -1759,7 +1564,7 @@ func runDaemon(stdout, stderr io.Writer) int {
 	// operator's configured channels, so a proactive digest reaches them rather than
 	// only landing in the journal. Reuses the channel allowlists + sender.
 	var onScheduledAnswer func(context.Context, string, string)
-	if strings.TrimSpace(os.Getenv(brand.EnvPrefix+"SCHEDULE_NOTIFY")) == "on" && len(notifyTargets) > 0 {
+	if dcfg.Misc.ScheduleNotify && len(notifyTargets) > 0 {
 		onScheduledAnswer = func(dctx context.Context, id, answer string) {
 			deliverScheduled(dctx, channelSend, notifyTargets, id, answer)
 		}
@@ -1795,7 +1600,7 @@ func runDaemon(stdout, stderr io.Writer) int {
 		briefTargets[kind] = ids
 	}
 	if _, ok := liveChannels["webhook"]; ok {
-		if wh := splitNonEmpty(os.Getenv(brand.EnvPrefix + "WEBHOOK_CHANNELS")); len(wh) > 0 {
+		if wh := dcfg.Misc.WebhookChannels; len(wh) > 0 {
 			briefTargets["webhook"] = wh
 		}
 	}
@@ -1894,6 +1699,9 @@ func runDaemon(stdout, stderr io.Writer) int {
 			fmt.Fprintf(stdout, "  suspend: %d in-flight run(s) marked to resume on restart\n", n)
 		}
 	}
+	// Deliberately a LIVE env read at shutdown time (not daemonconfig.Load):
+	// the Config Center live-applies edits via os.Setenv, so an operator can
+	// retune the drain window without a restart.
 	drainTimeout := 15 * time.Second
 	if v := os.Getenv(brand.EnvPrefix + "DRAIN_TIMEOUT"); v != "" {
 		if d, err := time.ParseDuration(v); err == nil && d >= 0 {

--- a/kernel/controlplane/config_inventory_test.go
+++ b/kernel/controlplane/config_inventory_test.go
@@ -36,6 +36,10 @@ func TestConfigEnvVars_CoversCmdAgeztReads(t *testing.T) {
 	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
 	roots := []string{
 		filepath.Join(repoRoot, "cmd", "agezt"),
+		// Phase 2.5: the typed boot-config package the inline runDaemon env
+		// parsing moved into (the ReadDir scan below is non-recursive, so the
+		// subdirectory needs its own root).
+		filepath.Join(repoRoot, "cmd", "agezt", "internal", "daemonconfig"),
 		filepath.Join(repoRoot, "plugins", "providerboot"),
 		filepath.Join(repoRoot, "plugins", "builtinchannels"),
 		filepath.Join(repoRoot, "plugins", "builtintools"),


### PR DESCRIPTION
Phase 2.5 of docs/REFACTORING-SCAN-2026-08.md.

- **cmd/agezt/internal/daemonconfig**: 74 AGEZT_* env names across 10 clusters (policy, knowledge, run loop, sub-agents, context budget, 5 sidecar model services, guards, tenancy, lifecycle, misc) parsed by one `Load(get, warn) (Config, error)` — finally unit-testable without booting a daemon. 11 table tests cover defaults, all 12 fatal parse cases with exact error strings in the original fail-fast order, warn+default paths, tenancy-off-ignores-malformed-quotas, and native-voice-provider gating.
- Fatal-vs-warn semantics, every default, and every warning string preserved byte-identically. Load runs at the injectConfig point (config-store values visible).
- **Deliberately kept inline** (documented per site): FORCE_START (pre-injectConfig), and the LIVE reads — COUNCIL_MEMBERS, tenant EDICT_DURABLE, shutdown DRAIN_TIMEOUT — because the Config Center applies edits via os.Setenv at runtime; boot-time capture would regress restart-free reconfiguration.
- config_inventory_test gains the new dir as a scan root. main.go −192 (now 4,885 — was 7,455 at program start).

Verified: whole-tree build+vet, full Go suite, isolated boot smoke with env overrides (MAX_ITER/RUN_TIMEOUT) rendering correctly through the typed path. (CI runners offline.)