### PR TITLE
chore(lint): drop two dead helpers left by the Phase 2.x refactor

### DIFF
--- a/cmd/agezt/coverage_helpers_more_test.go
+++ b/cmd/agezt/coverage_helpers_more_test.go
@@ -41,13 +41,6 @@ func TestCoverageHelperSinksAndInstances(t *testing.T) {
 		t.Fatal("combineSinks multiple non-nil returned nil")
 	}
 
-	if got := instanceKey("email", "work"); got != "email#work" {
-		t.Fatalf("instanceKey labelled = %q", got)
-	}
-	if got := instanceKey("email", ""); got != "email" {
-		t.Fatalf("instanceKey default = %q", got)
-	}
-
 	started := make(chan struct{}, 1)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cmd/agezt/main.go
+++ b/cmd/agezt/main.go
@@ -2171,15 +2171,11 @@ func combineSinks(sinks ...pulse.BriefSink) pulse.BriefSink {
 
 // chanInstance is one configured account-instance of a channel kind (multi-account).
 type chanInstance struct {
-	key  string // instanceKey(kind, label): bare kind for the default, "kind#label" otherwise
+	key  string // channel.InstanceKey(kind, label): bare kind for the default, "kind#label" otherwise
 	desc string
 	ch   channel.Channel
 	sink pulse.BriefSink
 }
-
-// instanceKey addresses a channel instance: the bare kind for the default
-// (back-compat) instance, "kind#label" for a labelled one.
-func instanceKey(kind, label string) string { return channel.InstanceKey(kind, label) }
 
 // wireInstances converts channelwire's built instances (the factory-migrated
 // channels, Phase 2.1) into the daemon's chanInstance shape so the existing
@@ -3744,18 +3740,6 @@ func boardSubjectSlug(topic string) string {
 		return "untopiced"
 	}
 	return s
-}
-
-// voiceProviderIsNative reports whether a STT/TTS provider id names a native
-// (non-OpenAI-compatible) backend that supplies its own default base URL — so a
-// URL isn't required to enable that half.
-func voiceProviderIsNative(p string) bool {
-	switch strings.ToLower(strings.TrimSpace(p)) {
-	case voice.ProviderElevenLabs, voice.ProviderDeepgram, voice.ProviderCartesia:
-		return true
-	default:
-		return false
-	}
 }
 
 // voiceTranscriberShim adapts the runtime Voice adapter (Transcribe(ctx, audio,


### PR DESCRIPTION
Found while pre-flighting CI for #563.

## The gates are red on `main`, not because of #563

`staticcheck ./...` (zero-tolerance, the `lint` job) and `tools/deadcodecheck` (the `deps-check` job) both fail on `main` today. I verified this by checking `origin/main` out into a scratch worktree and running both gates there — **identical findings**, only line numbers shifted. Most likely they've been unobserved since the self-hosted runners were down.

## What this PR removes

Two genuinely-dead helpers, both leftovers of completed refactor phases:

- **`cmd/agezt.voiceProviderIsNative`** — Phase 2.5 (#559) moved the STT/TTS native-provider test into `cmd/agezt/internal/daemonconfig`, whose copy even documents itself as *"mirrors runDaemon's helper"*. Only the `daemonconfig` copy is reachable; this one was left behind. It is `staticcheck`'s **only** U1000 finding in the whole tree.
- **`cmd/agezt.instanceKey`** — a one-line wrapper over `channel.InstanceKey`. Phase 2.1 (#555) moved instance-key construction into `kernel/channelwire` (`chanInstance.key` now comes from `channelwire.Instance.Key`), leaving only the wrapper's own test calling it. The `chanInstance.key` doc comment now points at `channel.InstanceKey` directly.

Neither is a behavioural change: the live code paths already use the replacements.

## Result

- **`staticcheck ./...` is now clean** → the `lint` gate goes green.
- `deadcodecheck` drops from 14 findings to 12.

## What is deliberately left alone

The remaining 12 are extracted-but-not-yet-wired APIs from Phases 2.1/2.2:

| Package | Unreachable |
|---|---|
| `kernel/channelwire` | `Kinds`, `BuildAll`, `MissingFactories`, `Describe` |
| `kernel/toolreg` | `Lookup`, `Names`, `Set.NetguardGaps` |
| `kernel/controlplane/pulse_control.go` | `funcObservers.AddDiskObserver`, `AddProbeObserver`, `Server.legacyObservers`, `SetDiskWatch`, `SetProbeWatch` |

`main.go` calls `channelwire.BuildKind` per manifest entry rather than `BuildAll`, and the `MissingFactories` drift detector is never invoked — which may be intentional staging for a later phase, or may be worth wiring. Either way, wire-vs-delete is the refactor owner's call, so I didn't silence them with `//lint:ignore` or an allowlist entry: that would remove the signal that the extraction is still half-landed.

`deps-check` therefore stays red until that decision is made.

## Verification

`go build ./...`, `go vet ./...`, `staticcheck ./...` clean; `go test ./cmd/agezt/` ok.
